### PR TITLE
Add ServiceProducer resource

### DIFF
--- a/docs/v1/api.md
+++ b/docs/v1/api.md
@@ -35,3 +35,9 @@ upon successful execution.
 
 Successfully executed claims will also serve as a record of an application that's
 bound to a backing service.
+
+## `ServiceProducer`
+
+This resource represents an entity that may publish one or more service
+classes into the catalog.  The `ServiceProducer` resource is global to the
+catalog.


### PR DESCRIPTION
Adds a new resource to the API document called `ServiceProducer` to represent a producer of one of more services in the catalog.

@arschles @judkowitz @bgrant0607 @slack @duglin 