### PR TITLE
Reorganize use cases

### DIFF
--- a/docs/v1/use-cases.md
+++ b/docs/v1/use-cases.md
@@ -1,19 +1,30 @@
 # Service Catalog Use Cases
 
-## Catalog Management
+TODO: add glossary
+TODO: scrub doc post glossary
+TODO: add CF SB API as the lingua franca for blackbox services
 
-1. As a user, I want to be able to register a broker with the Kubernetes service
-   catalog, so that the catalog is aware of the services that broker offers
-2. As a user, I want to be able to update a registered broker so that the
-   catalog can maintain the most recent versions of services that broker offers
-3. As a user, I want to be able to delete a broker from the catalog, so that I
-   can keep the catalog clean of brokers I no longer want to support
+## Catalog Publishing/Curation/Discovery
 
-* Importing a list of brokers: If I have a remote cluster with a service
-  controller that has n brokers registered, how can I import those into my local
-  cluster?
+* As a user, I want to be able to register a broker with the Kubernetes service
+  catalog, so that the catalog is aware of the services that broker offers
+* As a user, I want to be able to update a registered broker so that the
+  catalog can maintain the most recent versions of services that broker offers
+* As a user, I want to be able to delete a broker from the catalog, so that I
+  can keep the catalog clean of brokers I no longer want to support
+
 * Can I export a list of service brokers and types from my service controller?
 * Is there an auth story for adding service brokers?
+* As a developer, working outside of the normal production cluster, I would like
+  to be able to use the services available to me from the production cluster
+  from my local environment without needing to establish a formal business
+  relationship with each service provider.
+
+
+* How are services identified: name, service name/id, plan name/id?
+* Who can see which services? (TODO: Include scope? Global/Namespaced)
+* Who can see which service instances? (TODO: Include scope? Global/Namespaced)
+* The Service Catalog should contain Services and not Service Instances
 
 ### Registering a service broker with the catalog
 
@@ -46,34 +57,23 @@ evaluate where all broker deletes should:
 2. Leave orphaned service instances in the catalog
 3. Fail if service instances still exist for the broker
 
-## Catalog Publishing/Curation/Discovery
-
-* How are services identified: name, service name/id, plan name/id?
-* Who can see which services? (TODO: Include scope? Global/Namespaced)
-* Who can see which service instances? (TODO: Include scope? Global/Namespaced)
-* Which service instances are globally visible?
-* Catalog curation: which broker-provided services are globally visible?
-* Catalog curation: which namespaces can see which catalog services?
-* Does my catalog list not only my service types but also my instances?
-  * E.g., I have a dev cluster running on my local machine and I want to connect
-    my application with a database that exists in a test cluster. How do I find
-    that database instance?
-
 ## Requesting Services (Consumer)
 
-* As a User, how do I ask for a new service from the Catalog?
+* As a User, how do I cause a new Service Instance to be created from the
+  Service Catalog?
 * As a User, how do I bind an application to an existing Service Instance?
 * How does the catalog support multiple consumers in different Kubernetes
-  namespaces of the same instance of a service?
+  namespaces of the same Service Instance?
+* As a User, who has requested a Service Instance, know that a request for a
+  service instance has been fulfilled?
+* As a User, I should be able to pass parameters to be used by the Service
+  Instance or Binding when causing a new Service Instance to be created, so that
+  I may change the attributes of the Service Instance or Binding.
 
 ## Provisioning a Service Instance
 
 * As a Broker operator, I want to control the number of instances of my Service,
-  so that I can control resource footprint of my Service.
-* As an implementer of a service provider on k8s, where may I provision
-  Kubernetes resources so that I may provide the requested service.
-* As an implementer of a service provider on k8s, what credentials should I use
-  to provision Kubernetes resources so that I may provide the requested service.
+  so that I can control the resource footprint of my Service.
 
 ## Binding to a Service Instance
 
@@ -83,50 +83,59 @@ evaluate where all broker deletes should:
 * As a user of a service instance, I want a predictable set of Kubernetes
   resources (Secrets, ConfigMap) created after binding, so that I know how to
   configure my application to use the Service Instance.
-* As a service operator, I want to be able to discover what applications are
+* As a catalog operator, I want to be able to discover what applications are
   bound to services I am responsible for, so that I may operate the service
   properly.
+* As a User I should be able to see what service instances my applications are
+  bound to.
+* As a User I should be able to pass paramters when binding to a service
+  instance so that I may indicate what type of binding my application needs.
+  (e.g. credential type, admin binding, ro binding, rw binding)
+
+As a User, I should be able to accomplish the following sets of bindings:
+
+* One application may binding to many Service Instances
+* Many different applications may bind to a single Service Instance
+  * ...with unique credentials
+  * ...with identical credentials
+* One application, binding multiple times to the same Service Instance
 
 ## Using/Consuming a Service Instance
 
-* What is the unit of consumption of a service? Namespace? Pod? Something else?
-  (brian to comment)
-* As a User consuming a Service, I need to be able to understand the structure
+* As a User consuming a Service Instance, I need to be able to understand the structure
   of the Kubernetes resources that are created when a new binding to a service
   instance is created, so that I can configure my application appropriately.
 * As a User, I want to be able to understand the relationship between a Secret
   and Service Instance, so that I can properly configure my application (e.g.
   app connecting to sharded database).
-
-### Consuming bound services
-
-Consumers of a service provisioned through the Service Catalog should be able
-to access credentials for the new Service Instance using standard Kubernetes
-mechanisms.
-
-1. The Secret should be written into the consuming application's namespace
-2. The Secret should contain enough information for the consuming application
-   to successfully find, connect, and authenticate to the Service Instance
-   (e.g. hostname, port, protocol, username, password, etc.)
-3. The consuming application may safely assume that network connectivity to the
-   Service Instance is available
+* The consuming application may safely assume that network connectivity to the
+  Service Instance is available
 
 Consuming applications that need specific handling of credentials or
 configuration should be able to use additional Kubernetes facilities to
-adapt/transform the contents of the Secret. This includes, but is not limited
-to, side-car and init containers.
+adapt/transform the contents of the the credentials/configuration. This
+includes, but is not limited to, side-car and init containers.
 
-## Lifecycle of Service Instance
+If the user were willing to change the application, then we could
+drop the credentials in some "standard" place by convention. This would be
+similar to how K8s service accounts work (service-account secrets are mounted at
+`/var/run/secrets/kubernetes.io/serviceaccount`), as well as `VCAP_SERVICES` in
+CF.
 
-* As a Service Provider, I should be able to indicate that a Service _may_ be
-  upgraded, so that I can communicate Service capabilities to end users.
-* As a User of a Service, I want to be able to upgrade or downgrade that Service
-  so that I may size it appropriately for my needs.
-* (TODO: this should be turned into a thing): What is the update story for
-  bindings to a service instance?
-* (TODO: this should be turned into a thing): What is the versioning and update
-  story for a service: what happens when a broker changes the services it
-  provides?
+If the user were willing to change the configuration instead, they could specify
+how the credentials were surfaced to the application -- which environment
+variables, volumes, etc.
+
+## Lifecycle of Service Instances
+
+* As a Service Provider, I should be able to indicate that a Service Instance
+  _may_ be upgraded (plan updateable), so that I can communicate Service
+  capabilities to end users.
+* As a User of a Service Instance, I want to be able to change the Service
+  Instance plan so that I may size it appropriately for my needs.
+* What is the update story for bindings to a service instance?
+* What is the versioning and update story for a service instance: what happens
+  when a broker changes the services it provides?
 
 ## Unbinding from a Service Instance
 
@@ -135,8 +144,3 @@ to, side-car and init containers.
 ## Deprovisioning a Service Instance
 
 * TODO
-
-## Removing a Catalog Entry
-
-* TODO
-

--- a/docs/v1/use-cases.md
+++ b/docs/v1/use-cases.md
@@ -62,7 +62,7 @@ evaluate where all broker deletes should:
 ## Requesting Services (Consumer)
 
 * As a User, how do I ask for a new service from the Catalog?
-* As a User, how do I ask for access to an existing service?
+* As a User, how do I bind an application to an existing Service Instance?
 * How does the catalog support multiple consumers in different Kubernetes
   namespaces of the same instance of a service?
 

--- a/docs/v1/use-cases.md
+++ b/docs/v1/use-cases.md
@@ -104,7 +104,6 @@ Consumers of a service provisioned through the Service Catalog should be able
 to access credentials for the new Service Instance using standard Kubernetes
 mechanisms.
 
-1. A Secret maintains a 1:1 relationship with a Service Instance Binding
 1. The Secret should be written into the consuming application's namespace
 1. The Secret should contain enough information for the consuming application
    to successfully find, connect, and authenticate to the Service Instance

--- a/docs/v1/use-cases.md
+++ b/docs/v1/use-cases.md
@@ -17,7 +17,7 @@
 
 ### Registering a service broker with the catalog
 
-An user must register each service broker with the service catalog to advertise
+A user must register each service broker with the service catalog to advertise
 the services it offers to the catalog. After the broker has been registered
 with the catalog, the catalog makes a call to the service broker's `/v2/catalog`
 endpoint. The broker's returns a list of services offered by that broker. Each

--- a/docs/v1/use-cases.md
+++ b/docs/v1/use-cases.md
@@ -105,10 +105,10 @@ to access credentials for the new Service Instance using standard Kubernetes
 mechanisms.
 
 1. The Secret should be written into the consuming application's namespace
-1. The Secret should contain enough information for the consuming application
+2. The Secret should contain enough information for the consuming application
    to successfully find, connect, and authenticate to the Service Instance
    (e.g. hostname, port, protocol, username, password, etc.)
-1. The consuming application may safely assume that network connectivity to the
+3. The consuming application may safely assume that network connectivity to the
    Service Instance is available
 
 Consuming applications that need specific handling of credentials or

--- a/docs/v1/use-cases.md
+++ b/docs/v1/use-cases.md
@@ -1,96 +1,143 @@
-## V1 Use Cases
+# Service Catalog Use Cases
 
-This document contains the complete list of accepted use-cases for the v1
-version of the service catalog.
+## Catalog Management
 
-## High-Level Use Cases
+1. As a user, I want to be able to register a broker with the Kubernetes service
+   catalog, so that the catalog is aware of the services that broker offers
+2. As a user, I want to be able to update a registered broker so that the
+   catalog can maintain the most recent versions of services that broker offers
+3. As a user, I want to be able to delete a broker from the catalog, so that I
+   can keep the catalog clean of brokers I no longer want to support
 
-These are the high-level, user-facing use cases the v1 service catalog will
-implement.
+* Importing a list of brokers: If I have a remote cluster with a service
+  controller that has n brokers registered, how can I import those into my local
+  cluster?
+* Can I export a list of service brokers and types from my service controller?
+* Is there an auth story for adding service brokers?
 
-1.  Sharing services:
-    1.  (Blackbox services) As a SaaS provider that already runs a service
-        broker, I want users of Kubernetes to be able to use my service
-        via the service broker API, so that I can grow my user base to
-        include users of Kubernetes
-    2.  As the operator of an existing service running in Kubernetes, I want to
-        be able to publish my services using a service broker, so that users
-        external to my Kubernetes cluster can use my service
+### Registering a service broker with the catalog
 
-### Sharing blackbox services
+An user must register each service broker with the service catalog to advertise
+the services it offers to the catalog. After the broker has been registered
+with the catalog, the catalog makes a call to the service broker's `/v2/catalog`
+endpoint. The broker's returns a list of services offered by that broker. Each
+Service has a set of plans that differentiate the tiers of that service.
 
-There are numerous SaaS providers that already operate service brokers today.
-It should be possible for the operator of an existing service broker to
-publish their services into the catalog and have them consumed by users of
-Kubernetes.  This offers a new set of users to the service operator and offers
-a wide variety of SaaS products to users of Kubernetes.
+### Updating a service broker
 
-### Exposing Kubernetes services outside the cluster
-
-It should be possible for service operators whose services are deployed in a
-Kubernetes cluster to publish their services using a service broker.  This
-would allow these operators to participate in the existing service broker
-ecosystem and grow their user base accordingly.
-
-## CF Service Broker `v2` API Use Cases
-
-Initially, the catalog should support the current [CF Service Broker
-API](https://docs.cloudfoundry.org/services/api.html) These are the use cases
-that the service catalog has to implement in order to use that API.
-
-### Managing service brokers
-
-1.  As user, I want to be able to register a broker with the Kubernetes service
-    catalog, so that the catalog is aware of the services that broker offers
-2.  As a user, I want to be able to update a registered broker so that the
-    catalog can maintain the most recent versions of services that broker offers
-3.  As a user, I want to be able to delete a broker from the catalog, so that I
-    can keep the catalog clean of brokers I no longer want to support
-
-#### Registering a service broker with the catalog
-
-An user must register each service broker with the service catalog to
-advertise the services it offers to the catalog.  After the broker has been
-registered with the catalog, the catalog makes a call to the service broker's
-`/v2/catalog` endpoint.  The broker's returns a list of services offered by
-that broker.  Each Service has a set of plans that differentiate the tiers of
-that service.
-
-#### Updating a service broker
-
-Broker authors make changes to the services their brokers offer.  To refresh the
+Broker authors make changes to the services their brokers offer. To refresh the
 services a broker offers, the catalog should re-list the `/v2/catalog` endpoint.
 The catalog should apply the result of re-listing the broker to its internal
 representation of that broker's services:
 
-1.  New service present in the re-list results are added
-2.  Existing services are updated if a diff is present
-3.  Existing services missing from the re-list are deleted
+1. New service present in the re-list results are added
+2. Existing services are updated if a diff is present
+3. Existing services missing from the re-list are deleted
 
 TODO: spell out various update scenarios and how they affect end-users
 
-#### Delete a service broker
+### Delete a service broker
 
-There must be a way to delete brokers from the catalog.  In Cloud Foundry, it is
-possible to delete a broker and leave orphaned service instances.  We should
+There must be a way to delete brokers from the catalog. In Cloud Foundry, it is
+possible to delete a broker and leave orphaned service instances. We should
 evaluate where all broker deletes should:
 
-1.  Cascade down to the service instances for the broker
-2.  Leave orphaned service instances in the catalog
-3.  Fail if service instances still exist for the broker
+1. Cascade down to the service instances for the broker
+2. Leave orphaned service instances in the catalog
+3. Fail if service instances still exist for the broker
 
-## Supporting multiple backend APIs
+## Catalog Publishing/Curation/Discovery
 
-The CF service broker API is under active development, leading to two
-possibilities that may both occur:
+* How are services identified: name, service name/id, plan name/id?
+* Who can see which services? (TODO: Include scope? Global/Namespaced)
+* Who can see which service instances? (TODO: Include scope? Global/Namespaced)
+* Which service instances are globally visible?
+* Catalog curation: which broker-provided services are globally visible?
+* Catalog curation: which namespaces can see which catalog services?
+* Does my catalog list not only my service types but also my instances?
+  * E.g., I have a dev cluster running on my local machine and I want to connect
+    my application with a database that exists in a test cluster. How do I find
+    that database instance?
 
-1.  The `v2` API undergoes backward-compatible changes
-2.  There is a new `v3` API that is not backward-compatible
+## Requesting Services (Consumer)
 
-The service catalog should be able to support new backward-compatible fields or
-a new backend API without a major rewrite.  This should be kept in mind when
-designing the architecture of the catalog.
+* As a User, how do I ask for a new service from the Catalog?
+* As a User, how do I ask for access to an existing service?
+* How does the catalog support multiple consumers in different Kubernetes
+  namespaces of the same instance of a service?
 
+## Provisioning a Service Instance
 
-For more information, see the
-[Cloud Foundry documentation on registering service brokers](https://docs.cloudfoundry.org/services/managing-service-brokers.html#register-broker).
+* As a Broker operator, I want to control the number of instances of my Service,
+  so that I can control resource footprint of my Service.
+* As an implementer of a service provider on k8s, where may I provision
+  Kubernetes resources so that I may provide the requested service.
+* As an implementer of a service provider on k8s, what credentials should I use
+  to provision Kubernetes resources so that I may provide the requested service.
+
+## Binding to a Service Instance
+
+* As a Broker operator, I want to control the number of bindings to a Service
+  Instance so that I may provide limits for services (e.g. free plan with 3
+  bindings). (TODO: Do we care?)
+* As a user of a service instance, I want a predictable set of Kubernetes
+  resources (Secrets, ConfigMap) created after binding, so that I know how to
+  configure my application to use the Service Instance.
+* As a service operator, I want to be able to discover what applications are
+  bound to services I am responsible for, so that I may operate the service
+  properly.
+
+## Using/Consuming a Service Instance
+
+* What is the unit of consumption of a service? Namespace? Pod? Something else?
+  (brian to comment)
+* As a User consuming a Service, I need to be able to understand the structure
+  of the resources that I get, so that I can configure my application
+  appropriately.
+* As a User, I want to be able to understand the relationship between a Secret
+  and Service Instance, so that I can properly configure my application (e.g.
+  app connecting to sharded database).
+
+### Consuming bound services
+
+Consumers of a service provisioned through the Service Catalog should be able
+to access credentials for the new Service Instance using standard Kubernetes
+mechanisms.
+
+1. A Secret maintains a 1:1 relationship with a Service Instance Binding
+1. The Secret should be written into the consuming application's namespace
+1. The Secret should contain enough information for the consuming application
+   to successfully find, connect, and authenticate to the Service Instance
+   (e.g. hostname, port, protocol, username, password, etc.)
+1. The consuming application may safely assume that network connectivity to the
+   Service Instance is available
+
+Consuming applications that need specific handling of credentials or
+configuration should be able to use additional Kubernetes facilities to
+adapt/transform the contents of the Secret. This includes, but is not limited
+to, side-car and init containers.
+
+## Lifecycle of Service Instance
+
+* As a Service Provider, I should be able to indicate that a Service _may_ be
+  upgraded, so that I can communicate Service capabilities to end users.
+* As a User of a Service, I want to be able to upgrade or downgrade that Service
+  so that I may size it appropriately for my needs.
+* (TODO: this should be turned into a thing): What is the update story for
+  bindings to a service instance?
+* (TODO: this should be turned into a thing): What is the versioning and update
+  story for a service: what happens when a broker changes the services it
+  provides?
+
+## Unbinding from a Service Instance
+
+* TODO
+
+## Deprovisioning a Service Instance
+
+* TODO
+
+## Removing a Catalog Entry
+
+* TODO
+

--- a/docs/v1/use-cases.md
+++ b/docs/v1/use-cases.md
@@ -92,8 +92,8 @@ evaluate where all broker deletes should:
 * What is the unit of consumption of a service? Namespace? Pod? Something else?
   (brian to comment)
 * As a User consuming a Service, I need to be able to understand the structure
-  of the resources that I get, so that I can configure my application
-  appropriately.
+  of the Kubernetes resources that are created when a new binding to a service
+  instance is created, so that I can configure my application appropriately.
 * As a User, I want to be able to understand the relationship between a Secret
   and Service Instance, so that I can properly configure my application (e.g.
   app connecting to sharded database).


### PR DESCRIPTION
This pull request reorganizes the use cases. Still a WIP as there are many
moving pieces.

I worked on this with @pmorie, questions raised in #20 are now integrated with
the existing use cases.

Each of the section headers are organized in a roughly chronological order:

1. There is a Service Catalog
1. Request services from the Catalog
1. Services are provisioned and bound
1. Requester consumes the service
1. Time passes
1. etc...

Hopefully this helps us think about concerns in each of the "phases" more
precisely.

This could also be organized along the axis of "actor/persona" but we'll start
here first. :D

Closes #20
Refs #22