### PR TITLE
Adding skeleton resources and API specification

### DIFF
--- a/docs/v1/api.md
+++ b/docs/v1/api.md
@@ -32,15 +32,15 @@ service broker has made available.
 *TODO: what happens in the below cases?*
 
 1. *The `Broker` that caused the `ServiceClass` was deleted*
-2. *The `ServiceClass` itself was deleted*
+1. *The `ServiceClass` itself was deleted*
 
 ## `Instance`
 
 This resource is created by a service consumer to indicate their desire to
 provision a service. When the service catalog's controller event loop sees an
 `Instance` created, it calls the provision endpoint on the backing CF service
-broker and writes the provision response back into the `Instance`'s `status`
-section.
+broker and writes `provisioned` into the `status.status` field of the
+`Instance`.
 
 *TODO: what happens when an `Instance` resource is deleted?*
 
@@ -51,9 +51,10 @@ should be bound to an instance. When the service catalog's controller event
 loop sees a `Binding` created, it calls the bind endpoint on the backing CF
 service broker. When a successful response is returned, it does the following:
 
+1. Writes `bound` into the `status.status` field of the `Binding`
 1. Writes the contents of `credentials` map into a secret (naming of the secret
    to be discussed later)
-2. Updates the `Binding`'s status section with the fully qualified path to the
+1. Updates the `Binding`'s status section with the fully qualified path to the
    aforementioned secret
-  
+
 *TODO: what happens when a `Binding` resource is deleted?*

--- a/docs/v1/api.md
+++ b/docs/v1/api.md
@@ -6,9 +6,9 @@ This document contains the Kubernetes resource types for the v1 service catalog.
 
 This section lists descriptions of the resources in the service catalog API.
 
-_ __Note:__ All names herein are tentative, and should be considered placeholders
+*__Note:__ All names herein are tentative, and should be considered placeholders
 and used as placeholders for purposes of discussion only. This note will be
-removed when names are finalized._
+removed when names are finalized.*
 
 ## `Broker`
 

--- a/docs/v1/api.md
+++ b/docs/v1/api.md
@@ -10,34 +10,31 @@ _ __Note:__ All names herein are tentative, and should be considered placeholder
 and used as placeholders for purposes of discussion only. This note will be
 removed when names are finalized._
 
+## `Broker`
+
+This resource is created by an administrator to instruct the service catalog's
+controller event loop to do the following:
+
+1. Make a request against a given CF service broker's catalog endpoint
+   (`GET /v2/catalog`)
+2. Translate the response to a list of `ServiceClass`es
+3. Write each translated `ServiceClass` to stable storage
+
+TODO: should we call out what happens when a `Broker` resource is deleted?
+
 ## `ServiceClass`
 
-This resource indicates a general kind of backing service that a consumer
-may request. The 'service kind' concept is purposefully arbitrary. We expect
-each cluster operator team to assign specific meaning to the ones they choose.
+This resource is created by the service catalog's controller event loop to
+represent a service ID & plan ID that a CF service broker has made available.
 
-## `ServiceInstance`
+## `Instance`
 
-This resource indicates that a request by a consumer for a usable `ServiceClass`
-has been successfully executed. Consumers may reference these resources to
-begin using the backing service it represents.
+This resource is created by a service consumer to indicate that the service
+catalog's controller event loop should provision the backing CF service broker
+and write the provision response back into the `Instance`'s `status` section.
 
-## `ServiceClaim`
+## `Binding`
 
-This resource is used by the consumer to get credentials for a backing service.
-
-The byproducts of a successfully executed claim will be binding information
-in the form of other, standard Kubernetes resources. We expect these to be
-`ConfigMap`s and `Secret`s initially, but the number and types of these
-resources will be implementation-dependent. The claim will contain
-Kubernetes-style reference links for each Kubernetes resource that was created
-upon successful execution.
-
-Successfully executed claims will also serve as a record of an application that's
-bound to a backing service.
-
-## `ServiceProducer`
-
-This resource represents an entity that may publish one or more service
-classes into the catalog.  The `ServiceProducer` resource is global to the
-catalog.
+This resource is created by a service consumer to indicate that the service
+catalog's controller event loop should issue a bind request on the backing CF
+service broker.

--- a/docs/v1/api.md
+++ b/docs/v1/api.md
@@ -1,6 +1,8 @@
 # V1 API
 
-This document contains the Kubernetes resource types for the v1 service catalog.
+This document contains resource types and their standard usage in v1 service
+catalog. Although this API will be implemented in Kubernetes, other systems
+are not precluded from implementing it as well.
 
 # Resource Types
 

--- a/docs/v1/api.md
+++ b/docs/v1/api.md
@@ -20,21 +20,40 @@ controller event loop to do the following:
 2. Translate the response to a list of `ServiceClass`es
 3. Write each translated `ServiceClass` to stable storage
 
-TODO: should we call out what happens when a `Broker` resource is deleted?
+*TODO: should we call out what happens when a `Broker` resource is deleted?*
 
 ## `ServiceClass`
 
-This resource is created by the service catalog's controller event loop to
-represent a service ID & plan ID that a CF service broker has made available.
+This resource is created by the service catalog's controller event loop after
+it has received a `Broker` resource and successfully called the backing CF
+broker's catalog endpoint. It represents a service ID & plan ID that a CF
+service broker has made available.
+
+*TODO: what happens in the below cases?*
+
+1. *The `Broker` that caused the `ServiceClass` was deleted*
+2. *The `ServiceClass` itself was deleted*
 
 ## `Instance`
 
-This resource is created by a service consumer to indicate that the service
-catalog's controller event loop should provision the backing CF service broker
-and write the provision response back into the `Instance`'s `status` section.
+This resource is created by a service consumer to indicate their desire to
+provision a service. When the service catalog's controller event loop sees an
+`Instance` created, it calls the provision endpoint on the backing CF service
+broker and writes the provision response back into the `Instance`'s `status`
+section.
+
+*TODO: what happens when an `Instance` resource is deleted?*
 
 ## `Binding`
 
-This resource is created by a service consumer to indicate that the service
-catalog's controller event loop should issue a bind request on the backing CF
-service broker.
+This resource is created by a service consumer to indicate that an application
+should be bound to an instance. When the service catalog's controller event
+loop sees a `Binding` created, it calls the bind endpoint on the backing CF
+service broker. When a successful response is returned, it does the following:
+
+1. Writes the contents of `credentials` map into a secret (naming of the secret
+   to be discussed later)
+2. Updates the `Binding`'s status section with the fully qualified path to the
+   aforementioned secret
+  
+*TODO: what happens when a `Binding` resource is deleted?*

--- a/docs/v1/api.md
+++ b/docs/v1/api.md
@@ -28,8 +28,8 @@ controller event loop to do the following:
 
 This resource is created by the service catalog's controller event loop after
 it has received a `Broker` resource and successfully called the backing CF
-broker's catalog endpoint. It represents a service ID & plan ID that a CF
-service broker has made available.
+broker's catalog endpoint. It represents a single (serviceID, planID) pair that
+a CF service broker has made available.
 
 *TODO: what happens in the below cases?*
 
@@ -41,7 +41,7 @@ service broker has made available.
 This resource is created by a service consumer to indicate their desire to
 provision a service. When the service catalog's controller event loop sees an
 `Instance` created, it calls the provision endpoint on the backing CF service
-broker and writes `provisioned` into the `status.status` field of the
+broker and writes `provisioned` into a `status` field of the
 `Instance`.
 
 *TODO: what happens when an `Instance` resource is deleted?*
@@ -51,9 +51,10 @@ broker and writes `provisioned` into the `status.status` field of the
 This resource is created by a service consumer to indicate that an application
 should be bound to an instance. When the service catalog's controller event
 loop sees a `Binding` created, it calls the bind endpoint on the backing CF
-service broker. When a successful response is returned, it does the following:
+service broker. When a successful response is returned, the event loop does
+the following:
 
-1. Writes `bound` into the `status.status` field of the `Binding`
+1. Writes `bound` into a `status` field of the `Binding`
 1. Writes the contents of `credentials` map into a secret (naming of the secret
    to be discussed later)
 1. Updates the `Binding`'s status section with the fully qualified path to the


### PR DESCRIPTION
This patch introduces resources and a high-level overview of the standard API defined on those resources. The document herein reflects what was discussed at the SIG-service-catalog face-to-face meeting on 11/2 and 11/3/2016. It is a replacement for the more complicated and out-of-date #13.

Closes #13 

@pmorie @slack @duglin @MHBauer @vaikas-google @pwittrock @bmelville