### PR TITLE
Adding reviewing process document

### DIFF
--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -9,7 +9,8 @@ PRs may only be merged after the following criteria are met:
 
 1. It has been open for at least 1 business day
 1. It has no `veto` label on it
-1. It has been 'LGTM'-ed by 3 different reviewers
+1. It has been 'LGTM'-ed by 3 different reviewers, each from a different
+  organization
 
 ## LGTMs
 

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,7 +1,9 @@
 # Reviewing and Merging Pull Requests
 
 This document is a guideline for how core contributors should review and merge
-pull requests (PRs).
+pull requests (PRs). It is intended to outline the lightweight process that
+we’ll use for now. It’s assumed that we’ll operate on good faith for now in
+situations for which process is not specified.
 
 PRs may only be merged after the following criteria are met:
 

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -11,8 +11,8 @@ PRs may only be merged after the following criteria are met:
 
 ## LGTMs
 
-When a reviewer deems a PR ready for review, they should add a comment to the PR
-thread that simply reads 'LGTM'. If they do not deem it ready for review,
+When a reviewer deems a PR good enough to merge, they should add a comment to the PR
+thread that simply reads 'LGTM'. If they do not deem it ready for merge,
 they should add comments -- either inline or on the PR thread -- that indicate
 changes they believe should be made before merge.
 

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,0 +1,29 @@
+# Reviewing and Merging Pull Requests
+
+This document is a guideline for how core contributors should review and merge
+pull requests (PRs).
+
+PRs may only be merged after the following criteria are met:
+
+1. It has been open for at least 1 business day
+1. It has no `veto` label on it
+1. It has been 'LGTM'-ed by 3 different reviewers
+
+## LGTMs
+
+When a reviewer deems a PR ready for review, they should add a comment to the PR
+thread that simply reads 'LGTM'. If they do not deem it ready for review,
+they should add comments -- either inline or on the PR thread -- that indicate
+changes they believe should be made before merge.
+
+## Vetoing
+
+If a reviewer decides that a PR should not be merged in its current state,
+even if it gets 3 'LGTM' approvals from others, they should mark that PR with
+`veto` label.
+
+This label should only be used by a reviewer when that person believes there
+is a fundamental problem with the PR. The reviewer should summarize that problem
+in the PR comments and a longer discussion may be required.
+
+We expect this label to be used infrequently.


### PR DESCRIPTION
This document is intended to outline the lightweight process that we’ll use for now. It’s assumed that we’ll operate on good faith for now in situations for which process is not specified.

Also note that this document mentions a `veto` label. It's created [here](https://github.com/kubernetes-incubator/service-catalog/labels/veto)

Makes progress against https://github.com/kubernetes-incubator/service-catalog/issues/50