### PR TITLE
Add support for code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ go:
   - 1.7.3
 go_import_path: github.com/kubernetes-incubator/service-catalog
 install: make init
+script: make build test coverage lint

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ DIRS := \
   contrib/broker/server \
   controller
 
-ALL := all build build-linux build-darwin clean docker push test lint
+ALL := all build build-linux build-darwin clean docker push test lint coverage
 SUB := $(addsuffix .sub, $(ALL))
 .PHONY: $(ALL) $(SUB) format
 
@@ -45,3 +45,6 @@ init:
 
 format:
 	$(ECHO) gofmt -w -s $(addprefix ./,$(DIRS))
+
+coverage:
+	$(ECHO) $(ROOT)/script/coverage.sh --html "$(COVERAGE)" $(addprefix ./,$(DIRS))

--- a/script/Common.mk
+++ b/script/Common.mk
@@ -68,5 +68,8 @@ lint: $(BINDIR)/$(GOLINT)
 	$(ECHO) $(BINDIR)/$(GOLINT) --set_exit_status "$(PKG)/..."
 	$(ECHO) $(GO) vet "$(PKG)/..."
 
+coverage:
+	$(ECHO) $(ROOT)/script/coverage.sh --html "$(CURDIR)/$(BIN)-coverage.html" "$(PKG)"
+
 %:
 	$(ECHO) echo "Not building $* in $(CURDIR)"

--- a/script/Makefile.mk
+++ b/script/Makefile.mk
@@ -33,6 +33,7 @@ GO_VERSION     := 1.7.3
 BINDIR         := $(GOPATH)/bin
 PKG_ROOT       := github.com/kubernetes-incubator/service-catalog
 ARCH           := amd64
+COVERAGE       ?= $(CURDIR)/coverage.html
 
 ifeq "$(V)" "1"
   $(info Makefile.mk included from $(CURDIR))

--- a/script/coverage.sh
+++ b/script/coverage.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "${ROOT}/script/utilities.sh" || { echo 'Cannot load utilities.'; exit 1; }
+
+function usage() {
+  [[ -n "${1:-}" ]] && { echo "${1}"; echo ; }
+
+  cat <<__EOF__
+Usage: coverage.sh [options] packages ...
+
+Runs test code coverage on specified packages and aggregates results.
+
+Supported options:
+
+  --out:  aggregated coverage profile output file name
+  --html: aggregated coverage html output file name
+
+__EOF__
+
+  exit 1
+}
+
+while [[ $# -ne 0 ]]; do
+  case "$1" in
+    --out)     OUT="$2";  shift ;;
+    --html)    HTML="$2"; shift ;;
+    -*)        usage "Unrecognized command line argument $1" ;;
+    *)         break;
+  esac
+  shift
+done
+
+[[ -z "${OUT:-}" && -z "${HTML:-}" ]] \
+  && usage "Either --out or --html must be specified"
+
+PACKAGES=( ${@+"${@}"} )
+OUT=${OUT:-${TMP:=$(mktemp)}}
+
+function cleanup() {
+  local tmp="${TMP:-}"
+  [[ -n "${tmp}" ]] && rm -f "${tmp}"
+}
+trap cleanup EXIT
+
+function run-coverage() {
+  local packages=(${!1+"${!1}"})
+  local package subpackage
+  local result=0
+
+  echo 'mode: set' > "${OUT}"
+
+  for package in ${packages[@]+"${packages[@]}"}; do
+    for subpackage in $(go list "${package}/..."); do
+      local out="$(mktemp)"
+      go test -cover "${subpackage}" -coverprofile "${out}" \
+        || result=1
+      grep -h -v '^mode: ' "${out}" >> "${OUT}"
+      rm "${out}"
+    done
+  done
+
+  [[ ${result} -eq 0 && -n "${HTML:-}" ]] \
+    && go tool cover -html "${OUT}" -o "${HTML}"
+
+  return ${result}
+}
+
+run-coverage PACKAGES[@]


### PR DESCRIPTION
`make coverage` will run tests with code coverage enabled,
and will generate a coverage.html report (when run from the root
directory), or $(BIN)-coverage.html when run inside an individual
package.