### PR TITLE
Add test stubs for all packages

### DIFF
--- a/contrib/broker/k8s/broker_test.go
+++ b/contrib/broker/k8s/broker_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestInit(t *testing.T) {
+	// No test here, making sure package init runs.
+}

--- a/contrib/broker/k8s/controller/controller.go
+++ b/contrib/broker/k8s/controller/controller.go
@@ -62,9 +62,6 @@ type k8sController struct {
 	reifier Reifier
 }
 
-// Verify that Controller implements the broker Controller interface.
-var _ controller.Controller = (*k8sController)(nil)
-
 // CreateController creates an instance of a Kubernetes broker controller.
 func CreateController(host string, port int, reifier Reifier) (controller.Controller, error) {
 	return &k8sController{

--- a/contrib/broker/k8s/controller/controller_test.go
+++ b/contrib/broker/k8s/controller/controller_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/kubernetes-incubator/service-catalog/contrib/broker/controller"
+)
+
+func TestController(t *testing.T) {
+	// Verify that Controller implements the broker Controller interface.
+	var _ controller.Controller = (*k8sController)(nil)
+}

--- a/contrib/broker/k8s/controller/helm_reifier.go
+++ b/contrib/broker/k8s/controller/helm_reifier.go
@@ -52,9 +52,6 @@ type helmReifier struct {
 	cmd    string
 }
 
-// Verify that HelmReifier implements the Reifier interface
-var _ Reifier = (*helmReifier)(nil)
-
 // NewHelmReifier creates an instance of a Reifier interface which uses Helm
 // as the underlying deployment implementation.
 func NewHelmReifier(client string, server string) Reifier {

--- a/contrib/broker/k8s/controller/helm_reifier_test.go
+++ b/contrib/broker/k8s/controller/helm_reifier_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import "testing"
+
+func TestHelmReifier(t *testing.T) {
+	// Verify that HelmReifier implements the Reifier interface
+	var _ Reifier = (*helmReifier)(nil)
+}

--- a/contrib/broker/user_provided/broker_test.go
+++ b/contrib/broker/user_provided/broker_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestInit(t *testing.T) {
+	// No test here, making sure package init runs.
+}

--- a/contrib/broker/user_provided/controller/controller.go
+++ b/contrib/broker/user_provided/controller/controller.go
@@ -35,9 +35,6 @@ type userProvidedController struct {
 	instanceMap map[string]*userProvidedServiceInstance
 }
 
-// Verify that Controller implements the broker Controller interface.
-var _ controller.Controller = (*userProvidedController)(nil)
-
 // CreateController creates an instance of a User Provided service broker controller.
 func CreateController() controller.Controller {
 	var instanceMap = make(map[string]*userProvidedServiceInstance)

--- a/contrib/broker/user_provided/controller/controller_test.go
+++ b/contrib/broker/user_provided/controller/controller_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/kubernetes-incubator/service-catalog/contrib/broker/controller"
+)
+
+func TestController(t *testing.T) {
+	// Verify that Controller implements the broker Controller interface.
+	var _ controller.Controller = (*userProvidedController)(nil)
+}

--- a/controller/service_controller_test.go
+++ b/controller/service_controller_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestInit(t *testing.T) {
+	// No test here, making sure package init runs.
+}

--- a/controller/utility/utils_test.go
+++ b/controller/utility/utils_test.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils_test
+
+import (
+	"testing"
+)
+
+func TestUtility(t *testing.T) {
+	// TODO: implement
+}

--- a/controller/watch/watch_test.go
+++ b/controller/watch/watch_test.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch_test
+
+import (
+	"testing"
+)
+
+func TestWatch(t *testing.T) {
+	// TODO: implement
+}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestInit(t *testing.T) {
+	// No test here, making sure package init runs.
+}


### PR DESCRIPTION
Once code coverage is enabled, all packages will be accounted for
(perhaps with 0 test coverage) in the code coverage runs.