### PR TITLE
Add Docker builds to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
+sudo: required
+services:
+  - docker
 language: go
 go:
   - 1.7.3
 go_import_path: github.com/kubernetes-incubator/service-catalog
 install:
-- wget "https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz"
-- mkdir -p $HOME/bin
-- tar -vxz -C $HOME/bin --strip=1 -f glide-v0.12.3-linux-amd64.tar.gz
-- export PATH="$HOME/bin:$PATH"
-- make init
-script: make build test coverage lint
+  - wget "https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz"
+  - mkdir -p $HOME/bin
+  - tar -vxz -C $HOME/bin --strip=1 -f glide-v0.12.3-linux-amd64.tar.gz
+  - export PATH="$HOME/bin:$PATH"
+  - make init
+script:
+  - make build test lint coverage
+  - make docker


### PR DESCRIPTION
This adds both in-container build, including cross-compilation,
as well as build of Docker images for the catalog and example
brokers.