### PR TITLE
Eliminate bias toward GCR as Docker registry

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites and Setup
 
-You will need to have the following prerequisites:
+You will need to meet the following prerequisites:
 
 * [Docker](https://www.docker.com) installed locally
 * [Go](https://golang.org) set up locally (with proper `$GOPATH`
@@ -15,8 +15,9 @@ You will need to have the following prerequisites:
   and the `helm` binary in your `PATH`
 * Cluster credentials in ./kubeconfig file
 * GNU Make
-* Google Cloud SDK installed and `gcloud` in your `PATH`
 * [git](https://git-scm.com)
+* Must be pre-authenticated to any Docker registry to which you intend to push
+  images
 
 ## Getting Sources
 
@@ -35,9 +36,8 @@ Build the source. In order to build and push Docker images to Google
 Container Registry you are going to need Google Cloud Project ID:
 
     cd "${GOPATH}/src/github.com/kubernetes-incubator/service-catalog"
-    export PROJECT_ID=<your project id>
     export VERSION=$(git rev-parse --short --verify HEAD)
-    export GCR=gcr.io/${PROJECT_ID}/catalog
+    export REGISTRY=<registry URL> # Up to, but excluding the image name and its preceding slash
 
     make init build docker push
 
@@ -57,7 +57,7 @@ be deployed. Here, we will use `catalog`.
 Use Helm to create the Kubernetes deployments:
 
     helm install \
-        --set "registry=gcr.io/${PROJECT_ID}/catalog,version=${VERSION}" \
+        --set "registry=${REGISTRY},version=${VERSION}" \
         --namespace catalog \
         ./deploy/catalog
 

--- a/script/Makefile.mk
+++ b/script/Makefile.mk
@@ -24,7 +24,6 @@ ROOT := $(ROOT:/script/=)
 export GOPATH := $(ROOT:/src/github.com/kubernetes-incubator/service-catalog=)
 
 export VERSION ?= $(shell git describe --always --abbrev=40 --dirty)
-export GCLOUD  ?= gcloud
 export HOST_OS ?= $(shell uname -s | tr A-Z a-z)
 
 GO             := go
@@ -42,26 +41,20 @@ else
 endif
 
 #
-# If PROJECT is defined, compute default GCR name (unless explicitly defined).
+# If REGISTRY is defined, prepare to push images.
 #
-ifneq ($(origin PROJECT),undefined)
-GCR ?= gcr.io/$(PROJECT)/catalog
-endif
-
-#
-# If GCR is defined, prepare to push images.
-#
-ifeq ($(origin GCR),undefined)
+ifeq ($(origin REGISTRY),undefined)
 define docker_push
-  $(info Not pushing $(PKG). Please set GCR or PROJECT variable.)
+  $(info Not pushing $(PKG). Please set REGISTRY variable.)
+  @false
 endef
 else
-export GCR
+export REGISTRY
 define docker_push
   $(ECHO) echo 'Pushing $(PKG)'
-  $(ECHO) echo '  tagging '$(1):$(VERSION)' as $(GCR)/$(1):$(VERSION)'
-  $(ECHO) docker tag '$(1):$(VERSION)' '$(GCR)/$(1):$(VERSION)'
-  $(ECHO) $(GCLOUD) docker -- push '$(GCR)/$(1):$(VERSION)'
+  $(ECHO) echo '  tagging '$(1):$(VERSION)' as $(REGISTRY)/$(1):$(VERSION)'
+  $(ECHO) docker tag '$(1):$(VERSION)' '$(REGISTRY)/$(1):$(VERSION)'
+  $(ECHO) docker push '$(REGISTRY)/$(1):$(VERSION)'
 endef
 endif
 
@@ -127,4 +120,3 @@ endif
 
 # The first target in the makefile is the default.
 all: build test lint
-


### PR DESCRIPTION
Closes #77 

After these changes, I am able to (easily) push images to a local registry and deploy to minikube-- although there's nothing minikube-specific about this.