### PR TITLE
Extract broker communication code to a client.

### DIFF
--- a/controller/util/Makefile
+++ b/controller/util/Makefile
@@ -1,0 +1,19 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PKG=github.com/kubernetes-incubator/service-catalog/controller/util
+
+include ../../hack/Makefile.mk
+
+include ../../hack/Common.mk

--- a/controller/util/broker_client.go
+++ b/controller/util/broker_client.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	model "github.com/kubernetes-incubator/service-catalog/model/service_broker"
+)
+
+// BrokerClient defines the interface for interacting with a broker for catalog
+// retrieval, service instance management, and service binding management.
+type BrokerClient interface {
+	CatalogClient
+	InstanceClient
+	BindingClient
+}
+
+// CatalogClient defines the interface for catalog interaction with a broker.
+type CatalogClient interface {
+	GetCatalog() (*model.Catalog, error)
+}
+
+// InstanceClient defines the interface for managing service instances with a
+// broker.
+type InstanceClient interface {
+	// TODO: these should return appropriate response objects.
+	CreateServiceInstance(ID string, req *model.ServiceInstanceRequest) (*model.ServiceInstance, error)
+	UpdateServiceInstance(ID string, req *model.ServiceInstanceRequest) (*model.ServiceInstance, error)
+
+	DeleteServiceInstance(ID string) error
+}
+
+// BindingClient defines the interface for managing service bindings with a
+// broker.
+type BindingClient interface {
+	CreateServiceBinding(sID, bID string, req *model.BindingRequest) (*model.CreateServiceBindingResponse, error)
+	DeleteServiceBinding(sID, bID string) error
+}

--- a/controller/util/broker_client.go
+++ b/controller/util/broker_client.go
@@ -33,16 +33,29 @@ type CatalogClient interface {
 // InstanceClient defines the interface for managing service instances with a
 // broker.
 type InstanceClient interface {
-	// TODO: these should return appropriate response objects.
+	// TODO: these should return appropriate response objects (https://github.com/kubernetes-incubator/service-catalog/issues/116).
+
+	// CreateServiceInstance creates a service instance in the respective broker.
+	// This method handles all asynchronous request handling.
 	CreateServiceInstance(ID string, req *model.ServiceInstanceRequest) (*model.ServiceInstance, error)
+
+	// UpdateServiceInstance updates an existing service instance in the respective
+	// broker. This method handles all asynchronous request handling.
 	UpdateServiceInstance(ID string, req *model.ServiceInstanceRequest) (*model.ServiceInstance, error)
 
+	// DeleteServiceInstance deletes an existing service instance in the respective
+	// broker. This method handles all asynchronous request handling.
 	DeleteServiceInstance(ID string) error
 }
 
 // BindingClient defines the interface for managing service bindings with a
 // broker.
 type BindingClient interface {
+	// CreateServiceBinding creates a service binding in the respective broker.
+	// This method handles all asynchronous request handling.
 	CreateServiceBinding(sID, bID string, req *model.BindingRequest) (*model.CreateServiceBindingResponse, error)
+
+	// DeleteServiceBinding deletes an existing service binding in the respective
+	// broker. This method handles all asynchronous request handling.
 	DeleteServiceBinding(sID, bID string) error
 }

--- a/controller/util/cf_v2_client.go
+++ b/controller/util/cf_v2_client.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	model "github.com/kubernetes-incubator/service-catalog/model/service_broker"
+	scmodel "github.com/kubernetes-incubator/service-catalog/model/service_controller"
+)
+
+const (
+	catalogFormatString         = "%s/v2/catalog"
+	serviceInstanceFormatString = "%s/v2/service_instances/%s"
+	bindingFormatString         = "%s/v2/service_instances/%s/service_bindings/%s"
+)
+
+type cfV2BrokerClient struct {
+	broker *scmodel.ServiceBroker
+}
+
+// CreateCFV2BrokerClient creates an instance of BrokerClient for communicating
+// with brokers which implement the Cloud Foundry Service Broker V2 API.
+func CreateCFV2BrokerClient(b *scmodel.ServiceBroker) BrokerClient {
+	return &cfV2BrokerClient{
+		broker: b,
+	}
+}
+
+func (c *cfV2BrokerClient) GetCatalog() (*model.Catalog, error) {
+	url := fmt.Sprintf(catalogFormatString, c.broker.BrokerURL)
+
+	req, err := http.NewRequest("GET", url, nil)
+	req.SetBasicAuth(c.broker.AuthUsername, c.broker.AuthPassword)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Printf("Failed to fetch catalog from %s\n%v", url, resp)
+		log.Printf("err: %#v", err)
+		return nil, err
+	}
+
+	var catalog model.Catalog
+	err = ResponseBodyToObject(resp, &catalog)
+	if err != nil {
+		log.Printf("Failed to unmarshal catalog: %#v", err)
+		return nil, err
+	}
+
+	return &catalog, nil
+}
+
+func (c *cfV2BrokerClient) CreateServiceInstance(ID string, req *model.ServiceInstanceRequest) (*model.ServiceInstance, error) {
+	jsonBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf(serviceInstanceFormatString, c.broker.BrokerURL, ID)
+
+	// TODO: Handle the auth
+	createHTTPReq, err := http.NewRequest("PUT", url, bytes.NewReader(jsonBytes))
+	client := &http.Client{}
+	log.Printf("Doing a request to: %s", url)
+	resp, err := client.Do(createHTTPReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// TODO: Align this with the actual response model.
+	si := model.ServiceInstance{}
+	if err := ResponseBodyToObject(resp, &si); err != nil {
+		return nil, err
+	}
+	return &si, nil
+}
+
+func (c *cfV2BrokerClient) UpdateServiceInstance(ID string, req *model.ServiceInstanceRequest) (*model.ServiceInstance, error) {
+	return nil, fmt.Errorf("Not implemented")
+}
+
+func (c *cfV2BrokerClient) DeleteServiceInstance(ID string) error {
+	url := fmt.Sprintf(serviceInstanceFormatString, c.broker.BrokerURL, ID)
+
+	// TODO: Handle the auth
+	deleteHTTPReq, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		log.Printf("Failed to create new HTTP request: %v", err)
+		return err
+	}
+
+	client := &http.Client{}
+	log.Printf("Doing a request to: %s", url)
+	resp, err := client.Do(deleteHTTPReq)
+	if err != nil {
+		log.Printf("Failed to DELETE: %#v", err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func (c *cfV2BrokerClient) CreateServiceBinding(sID, bID string, req *model.BindingRequest) (*model.CreateServiceBindingResponse, error) {
+	jsonBytes, err := json.Marshal(req)
+	if err != nil {
+		log.Printf("Failed to marshal: %#v", err)
+		return nil, err
+	}
+
+	url := fmt.Sprintf(bindingFormatString, c.broker.BrokerURL, sID, bID)
+
+	// TODO: Handle the auth
+	createHTTPReq, err := http.NewRequest("PUT", url, bytes.NewReader(jsonBytes))
+	client := &http.Client{}
+	log.Printf("Doing a request to: %s", url)
+	resp, err := client.Do(createHTTPReq)
+	if err != nil {
+		log.Printf("Failed to PUT: %#v", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	sbr := model.CreateServiceBindingResponse{}
+	err = ResponseBodyToObject(resp, &sbr)
+	if err != nil {
+		log.Printf("Failed to unmarshal: %#v", err)
+		return nil, err
+	}
+
+	return &sbr, nil
+}
+
+func (c *cfV2BrokerClient) DeleteServiceBinding(sID, bID string) error {
+	url := fmt.Sprintf(bindingFormatString, c.broker.BrokerURL, sID, bID)
+
+	// TODO: Handle the auth
+	deleteHTTPReq, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		log.Printf("Failed to create new HTTP request: %v", err)
+		return err
+	}
+
+	client := &http.Client{}
+	log.Printf("Doing a request to: %s", url)
+	resp, err := client.Do(deleteHTTPReq)
+	if err != nil {
+		log.Printf("Failed to DELETE: %#v", err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}

--- a/controller/util/cf_v2_client.go
+++ b/controller/util/cf_v2_client.go
@@ -53,6 +53,10 @@ func (c *cfV2BrokerClient) GetCatalog() (*model.Catalog, error) {
 	url := fmt.Sprintf(catalogFormatString, c.broker.BrokerURL)
 
 	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	req.SetBasicAuth(c.broker.AuthUsername, c.broker.AuthPassword)
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -80,6 +84,10 @@ func (c *cfV2BrokerClient) CreateServiceInstance(ID string, req *model.ServiceIn
 
 	// TODO: Handle the auth
 	createHTTPReq, err := http.NewRequest("PUT", url, bytes.NewReader(jsonBytes))
+	if err != nil {
+		return nil, err
+	}
+
 	log.Printf("Doing a request to: %s", url)
 	resp, err := c.client.Do(createHTTPReq)
 	if err != nil {
@@ -132,6 +140,10 @@ func (c *cfV2BrokerClient) CreateServiceBinding(sID, bID string, req *model.Bind
 
 	// TODO: Handle the auth
 	createHTTPReq, err := http.NewRequest("PUT", url, bytes.NewReader(jsonBytes))
+	if err != nil {
+		return nil, err
+	}
+
 	log.Printf("Doing a request to: %s", url)
 	resp, err := c.client.Do(createHTTPReq)
 	if err != nil {

--- a/controller/util/cf_v2_client_test.go
+++ b/controller/util/cf_v2_client_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	model "github.com/kubernetes-incubator/service-catalog/model/service_broker"
+	scmodel "github.com/kubernetes-incubator/service-catalog/model/service_controller"
+)
+
+func TestUpdateServiceInstance(t *testing.T) {
+	cli := CreateCFV2BrokerClient(&scmodel.ServiceBroker{})
+
+	_, err := cli.UpdateServiceInstance("foo", &model.ServiceInstanceRequest{})
+	if err == nil {
+		t.Fatalf("Expected not implemented")
+	}
+	if err.Error() != "Not implemented" {
+		t.Errorf("Expected not implemented, got %v", err)
+	}
+
+	// TODO: test against fake/test broker.
+}

--- a/controller/util/converter.go
+++ b/controller/util/converter.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"encoding/json"
+
+	sbmodel "github.com/kubernetes-incubator/service-catalog/model/service_broker"
+	scmodel "github.com/kubernetes-incubator/service-catalog/model/service_controller"
+)
+
+// ConvertCredential converts a Credential object from the broker model to the
+// controller model.
+func ConvertCredential(in *sbmodel.Credential) (*scmodel.Credential, error) {
+	j, err := json.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &scmodel.Credential{}
+	if err := json.Unmarshal([]byte(j), out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// ConvertCatalog converts a Catalog object from the broker model to the
+// controller model.
+func ConvertCatalog(in *sbmodel.Catalog) (*scmodel.Catalog, error) {
+	j, err := json.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &scmodel.Catalog{}
+	if err := json.Unmarshal([]byte(j), out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}


### PR DESCRIPTION
This introduces a broker client interface and extracts the communcation
code from the controller into a CF Service Broker V2 API client.

Signed-off-by: Brendan Melville <bmelville@google.com>