### PR TITLE
Upgrade Helm to v2.0.0

### DIFF
--- a/contrib/broker/k8s/Dockerfile
+++ b/contrib/broker/k8s/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM debian
 
-ENV HELM_VERSION=v2.0.0-rc.2
+ENV HELM_VERSION=v2.0.0
 
 RUN export DEBIAN_FRONTEND=noninteractive \
  && apt-get update \


### PR DESCRIPTION
Upgrades Helm used by the k8s broker to the final 2.0 release version