### PR TITLE
Move utils_test to correct location.

### DIFF
--- a/controller/util/util_test.go
+++ b/controller/util/util_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils_test
+package util
 
 import (
 	"testing"


### PR DESCRIPTION
Follow-up on the util package naming alignment which left this file
accidentally behind.