### PR TITLE
Removing code that tests interface conformance

### DIFF
--- a/contrib/broker/k8s/controller/controller_test.go
+++ b/contrib/broker/k8s/controller/controller_test.go
@@ -23,6 +23,4 @@ import (
 )
 
 func TestController(t *testing.T) {
-	// Verify that Controller implements the broker Controller interface.
-	var _ controller.Controller = (*k8sController)(nil)
 }

--- a/contrib/broker/k8s/controller/controller_test.go
+++ b/contrib/broker/k8s/controller/controller_test.go
@@ -18,8 +18,6 @@ package controller
 
 import (
 	"testing"
-
-	"github.com/kubernetes-incubator/service-catalog/contrib/broker/controller"
 )
 
 func TestController(t *testing.T) {

--- a/contrib/broker/k8s/controller/helm_reifier_test.go
+++ b/contrib/broker/k8s/controller/helm_reifier_test.go
@@ -19,6 +19,4 @@ package controller
 import "testing"
 
 func TestHelmReifier(t *testing.T) {
-	// Verify that HelmReifier implements the Reifier interface
-	var _ Reifier = (*helmReifier)(nil)
 }

--- a/contrib/broker/server/server_test.go
+++ b/contrib/broker/server/server_test.go
@@ -30,9 +30,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// Check tha our controller satisfies the interface.
-var _ controller.Controller = (*Controller)(nil)
-
 var _ = Describe("Server", func() {
 
 	Describe("/v2/catalog", func() {

--- a/contrib/broker/server/server_test.go
+++ b/contrib/broker/server/server_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/kubernetes-incubator/service-catalog/contrib/broker/controller"
 	. "github.com/kubernetes-incubator/service-catalog/contrib/broker/server"
 	brokerModel "github.com/kubernetes-incubator/service-catalog/model/service_broker"
 

--- a/contrib/broker/user_provided/controller/controller_test.go
+++ b/contrib/broker/user_provided/controller/controller_test.go
@@ -23,6 +23,4 @@ import (
 )
 
 func TestController(t *testing.T) {
-	// Verify that Controller implements the broker Controller interface.
-	var _ controller.Controller = (*userProvidedController)(nil)
 }

--- a/contrib/broker/user_provided/controller/controller_test.go
+++ b/contrib/broker/user_provided/controller/controller_test.go
@@ -18,8 +18,6 @@ package controller
 
 import (
 	"testing"
-
-	"github.com/kubernetes-incubator/service-catalog/contrib/broker/controller"
 )
 
 func TestController(t *testing.T) {

--- a/controller/server/in_mem_service_storage.go
+++ b/controller/server/in_mem_service_storage.go
@@ -41,8 +41,6 @@ type inMemServiceStorage struct {
 	bindings map[string]*bindingPair
 }
 
-var _ ServiceStorage = (*inMemServiceStorage)(nil)
-
 // CreateInMemServiceStorage creates an instance of ServiceStorage interface,
 // backed by memory.
 func CreateInMemServiceStorage() ServiceStorage {

--- a/controller/server/third_party_service_storage.go
+++ b/controller/server/third_party_service_storage.go
@@ -26,8 +26,6 @@ func NewThirdPartyServiceStorage(w *watch.Watcher) ServiceStorage {
 	}
 }
 
-var _ ServiceStorage = (*thirdPartyServiceStorage)(nil)
-
 func (s *thirdPartyServiceStorage) ListBrokers() ([]*scmodel.ServiceBroker, error) {
 	l, err := s.watcher.GetResourceClient(watch.ServiceBroker, "default").List(&v1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
Test code ensures interface conformance, but we can eventually remove that code because the “constructor” functions for both of the types herein confirm the interface conformance