### PR TITLE
Remove controller service

### DIFF
--- a/deploy/catalog/templates/catalog.yaml
+++ b/deploy/catalog/templates/catalog.yaml
@@ -15,18 +15,3 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 10000
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: controller
-spec:
-{{ if .Values.debug }}
-  type: LoadBalancer
-{{ end }}
-  selector:
-    app: controller
-  ports:
-  - protocol: TCP
-    port: 10000
-    targetPort: 10000


### PR DESCRIPTION
The only HTTP endpoint the controller responds to now is `/healthz`, which is used for liveness probes. The controller doesn't receive HTTP traffic from any other source (this will be the apiserver's job in the future). This being the case, there's no reason for the controller to have a `service` resource.