### PR TITLE
Fixing imports in ./pkg/api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ DIRS := \
   contrib/broker/k8s \
   contrib/broker/user_provided \
   contrib/broker/server \
-  controller
+  controller \
+  pkg \
+  pkg/api
 
 ALL := all build build-linux build-darwin clean docker push test lint coverage
 SUB := $(addsuffix .sub, $(ALL))

--- a/controller/server/in_mem_service_storage_test.go
+++ b/controller/server/in_mem_service_storage_test.go
@@ -261,7 +261,7 @@ func TestDeleteBrokerMultiple(t *testing.T) {
 		t.Fatalf("Failed to get inventory: %#v", err)
 	}
 	if len(catRet.Services) != 2 {
-		t.Fatalf("Expected 2 services from GetInventory, got %s ", len(catRet.Services))
+		t.Fatalf("Expected 2 services from GetInventory, got %d ", len(catRet.Services))
 	}
 
 	err = s.DeleteBroker(brokerOneUUID)
@@ -292,6 +292,6 @@ func TestDeleteBrokerMultiple(t *testing.T) {
 		t.Fatalf("Failed to get inventory: %#v", err)
 	}
 	if len(catRet.Services) != 1 {
-		t.Fatalf("Expected 1 service from GetInventory, got %s ", len(catRet.Services))
+		t.Fatalf("Expected 1 service from GetInventory, got %d ", len(catRet.Services))
 	}
 }

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,0 +1,19 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PKG=github.com/kubernetes-incubator/service-catalog/pkg
+
+include ../hack/Makefile.mk
+
+include ../hack/Common.mk

--- a/pkg/api/Makefile
+++ b/pkg/api/Makefile
@@ -1,0 +1,20 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BIN=api
+PKG=github.com/kubernetes-incubator/service-catalog/pkg/api
+
+include ../../hack/Makefile.mk
+
+include ../../hack/Common.mk

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -68,12 +68,15 @@ type BrokerCondition struct {
 	Message string
 }
 
+// BrokerConditionType represents a broker condition value
 type BrokerConditionType string
 
 const (
+	// BrokerConditionReady represents the fact that a given broker condition is in ready state
 	BrokerConditionReady BrokerConditionType = "Ready"
 )
 
+// ConditionStatus represents a condition's status
 type ConditionStatus string
 
 // These are valid condition statuses. "ConditionTrue" means a resource is in
@@ -82,8 +85,11 @@ type ConditionStatus string
 // condition or not. In the future, we could add other intermediate
 // conditions, e.g. ConditionDegraded.
 const (
-	ConditionTrue    ConditionStatus = "True"
-	ConditionFalse   ConditionStatus = "False"
+	// ConditionTrue represents the fact that a given condition is true
+	ConditionTrue ConditionStatus = "True"
+	// ConditionFalse represents the fact that a given condition is false
+	ConditionFalse ConditionStatus = "False"
+	// ConditionUnknown represents the fact that a given condition is unknown
 	ConditionUnknown ConditionStatus = "Unknown"
 )
 
@@ -178,13 +184,24 @@ type InstanceCondition struct {
 	Message string
 }
 
+// InstanceConditionType represents a instance condition value
 type InstanceConditionType string
 
 const (
-	InstanceConditionProvisioning      InstanceConditionType = "Provisioning"
-	InstanceConditionReady             InstanceConditionType = "Ready"
-	InstanceConditionProvisionFailed   InstanceConditionType = "ProvisionFailed"
-	InstanceConditionDeprovisioning    InstanceConditionType = "Deprovisioning"
+	// InstanceConditionProvisioning represents that a given instance condition is in
+	// provisioning state
+	InstanceConditionProvisioning InstanceConditionType = "Provisioning"
+	// InstanceConditionReady represents that a given instance condition is in
+	// ready state
+	InstanceConditionReady InstanceConditionType = "Ready"
+	// InstanceConditionProvisionFailed represents that a given instance condition is in
+	// failed state
+	InstanceConditionProvisionFailed InstanceConditionType = "ProvisionFailed"
+	// InstanceConditionDeprovisioning represents that a given instance condition is in
+	// deprovisioning state
+	InstanceConditionDeprovisioning InstanceConditionType = "Deprovisioning"
+	// InstanceConditionDeprovisionFailed represents that a given instance condition is in
+	// deprovision failed state
 	InstanceConditionDeprovisionFailed InstanceConditionType = "DeprovisioningFailed"
 )
 
@@ -236,9 +253,12 @@ type BindingCondition struct {
 	Message string
 }
 
+// BindingConditionType represents a binding condition value
 type BindingConditionType string
 
 const (
-	BindingConditionReady  BindingConditionType = "Ready"
+	// BindingConditionReady represents a binding condition is in ready state
+	BindingConditionReady BindingConditionType = "Ready"
+	// BindingConditionFailed represents a binding condition is in failed state
 	BindingConditionFailed BindingConditionType = "Failed"
 )

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -205,7 +205,7 @@ type BindingSpec struct {
 	InstanceRef kapi.ObjectReference
 	// AppLabelSelector selects the pods in the Binding's namespace that
 	// should be injected with the results of the binding.  Immutable.
-	AppLabelSelector kapi.LabelSelector
+	AppLabelSelector kunversioned.LabelSelector
 
 	Parameters map[string]interface{}
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -17,8 +17,8 @@ limitations under the License.
 package api
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
-	kunversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	kapi "k8s.io/client-go/1.5/pkg/api"
+	kunversioned "k8s.io/client-go/1.5/pkg/api/unversioned"
 )
 
 // +nonNamespaced=true

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 package pkg
 
+// VERSION is the version string for built artifacts. It's set by the build system, and should
+// not be changed in this codebase
 var VERSION = "UNKNOWN"


### PR DESCRIPTION
`./pkg/api/types.go` imports packages inside `k8s/kubernetes`. Since we don't depend on this package, this PR fixes those imports to refer to similar packages inside `k8s.io/client-go`.

This patch also:

- Adds/modifies appropriate `Makefile`s to add `./pkg/...` to the build
- Adds the godoc comments necessary to pass the lint checks

n.b. `k8s.io/client-go` accidentally depended on `k8s.io/kubernetes` (https://github.com/kubernetes/client-go/issues/31), but that issue has since been fixed.