### PR TITLE
Fix k8s example broker Dockerfile

### DIFF
--- a/contrib/broker/k8s/Dockerfile
+++ b/contrib/broker/k8s/Dockerfile
@@ -31,4 +31,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
+COPY k8s-broker /opt/services/
+
 ENTRYPOINT ["/opt/services/k8s-broker", "--helm_binary", "/opt/services/helm"]


### PR DESCRIPTION
Add back the copy of the k8s-broker binary to the Docker image;
it was accidentally deleted.