### PR TITLE
Enable full build in Docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ vendor/**
 .idea/
 .DS_Store
 .glide
+.scBuildImage
+.dockerInit

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ install:
   - make init
 script:
   - make build test lint coverage
+  - make docker-all
   - make docker

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.7.3
+ENV GLIDE_VERSION=v0.12.3
+RUN curl -sSL https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.tar.gz \
+    | tar -vxz -C /usr/local/bin --strip=1
+WORKDIR /go/src/github.com/kubernetes-incubator/service-catalog


### PR DESCRIPTION
Add a target to build *everything* (even glide stuff) via Docker

Also adds "--strip-vendor" to glide stuff.

Signed-off-by: Doug Davis <dug@us.ibm.com>