### PR TITLE
Add some rules for what PRs needs to include (tests, docs)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,25 @@ This document should concisely express the project development status,
 methodology, and contribution process.  As the community makes progress, we
 should keep this document in sync with reality.
 
+## Submitting a Pull Request (PR)
+
+The following outlines the general rules we follow:
+
+- All PRs must have the appropriate documentation changes made within the
+same PR. Note, not all PRs will necessarily require a documentation change
+but if it does please include it in the same PR so the PR is complete and
+not just a partial solution.
+- All PRs must have the appropriate testcases. For example, bug fixes should
+include tests that demonstrates the issue w/o your fix. New features should
+include as many testcases, within reason, to cover any variants of use of the
+feature.
+- PR authors will need to have CLA on-file with the Linux Foundation before 
+the PR will be merged.
+See Kubernete's [contributing guidelines](https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md) for more information.
+
+See our [reviewing PRs](REVIEWING.md) documentation for how your PR will
+be reviewed.
+
 ## Development status
 
 We're currently collecting use-cases and requirements for our [v1 milestone](./docs/v1).

--- a/README.md
+++ b/README.md
@@ -43,4 +43,3 @@ check out the [community site](https://github.com/kubernetes/community/tree/mast
 
 Participation in the Kubernetes community is governed by the
 [Kubernetes Code of Conduct](./code-of-conduct.md).
-

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -11,6 +11,7 @@ PRs may only be merged after the following criteria are met:
 1. It has no `veto` label on it
 1. It has been 'LGTM'-ed by 3 different reviewers, each from a different
   organization
+1. It has all appropriate corresponding documentation and testcases
 
 ## LGTMs
 


### PR DESCRIPTION
While I'm not sure we're 100% ready to enforce all of these rules yet
we should include this as part of our stated set of rules/goals and
slowly "up" our bar as do we add the infrastructure.

Signed-off-by: Doug Davis <dug@us.ibm.com>