### PR TITLE
Move pkg/api to pkg/apis/servicecatalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ DIRS := \
   contrib/broker/server \
   controller \
   pkg \
-  pkg/api
+  pkg/apis/servicecatalog
 
 ALL := all build build-linux build-darwin clean docker push test lint coverage
 SUB := $(addsuffix .sub, $(ALL))

--- a/pkg/apis/servicecatalog/Makefile
+++ b/pkg/apis/servicecatalog/Makefile
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 BIN=api
-PKG=github.com/kubernetes-incubator/service-catalog/pkg/api
+PKG=github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog
 
-include ../../hack/Makefile.mk
+include ../../../hack/Makefile.mk
 
-include ../../hack/Common.mk
+include ../../../hack/Common.mk

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package api
+package servicecatalog
 
 import (
 	kapi "k8s.io/client-go/1.5/pkg/api"


### PR DESCRIPTION
In accordance with how API groups are handled in Kubernetes per #79 