### PR TITLE
Enable Jenkins to run e2e tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,6 +92,9 @@ node {
         -base64 100 | tr -dc a-z0-9 | cut -c -25''']).trim()
 
     try {
+      // Initialize build, for example, updating installed software.
+      sh """${env.ROOT}/hack/jenkins/init_build.sh"""
+
       // These are done in parallel since creating the cluster takes a while,
       // and the build doesn't depend on it.
       parallel(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,8 @@ node {
         },
         'Build': {
           sh """${env.ROOT}/hack/build.sh --no-docker-compile \
-                --project ${test_project}"""
+                --project ${test_project} \
+                --coverage '${env.WORKSPACE}/coverage.html'"""
         }
       )
 
@@ -95,4 +96,6 @@ node {
       error 'Build failed.'
     }
   }
+
+  archiveArtifacts artifacts: 'coverage.html', allowEmptyArchive: true, onlyIfSuccessful: true
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,8 +23,6 @@ limitations under the License.
 // TEST_PROJECT:   Google Cloud Project ID of the project to use for testing.
 // TEST_ZONE:      GCP Zone in which to create test GKE cluster
 // TEST_ACCOUNT:   GCP service account credentials (JSON file) to use for testing.
-// GERRIT_ACCOUNT: GCP service account credentials (from metadata) to use for
-//                 Gerrit API access.
 
 // Verify required parameters
 if (! params.TEST_PROJECT) {
@@ -35,46 +33,11 @@ if (! params.TEST_ACCOUNT) {
   error 'Missing required parameter TEST_ACCOUNT'
 }
 
-if (! params.GERRIT_ACCOUNT) {
-  error 'Missing required parameter GERRIT_ACCOUNT'
-}
-
 def test_project = params.TEST_PROJECT
 def test_account = params.TEST_ACCOUNT
 def test_zone    = params.TEST_ZONE ?: 'us-west1-b'
 def namespace    = 'catalog'
 def root_path    = 'src/github.com/kubernetes-incubator/service-catalog'
-
-def notifyBuild(buildStatus) {
-  def gerrit_credentials = params.GERRIT_ACCOUNT
-  def gerrit_url         = 'https://plori-review.googlesource.com'
-
-  buildStatus = buildStatus ?: 'SUCCESS'
-  def message = "Jenkins ${env.JOB_NAME} build ${currentBuild.displayName} status: " +
-      "${buildStatus}. View log at: ${currentBuild.absoluteUrl}consoleFull"
-
-  def BUILD_RESULTS = [SUCCESS: 1, FAILURE: -1, STARTED: 0]
-  def verified = BUILD_RESULTS.get(buildStatus)
-  if (verified == null) verified = -1
-
-  def label = verified == 0 ? '' : """, "labels": { "Verified": ${verified}}"""
-  def payload = """{"message": "${message}"${label}}"""
-
-  withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "source:${gerrit_credentials}",
-      passwordVariable: 'PASS', usernameVariable: 'USER']]) {
-
-    sh """
-CHANGE_ID="\$(git log --format=%B -n 1 HEAD | awk '/^Change-Id: / {print \$2}')"
-HEAD_SHA="\$(git rev-parse --verify HEAD)"
-
-curl --request POST --silent \
-     --header 'Content-type: application/json' \
-     --header 'Authorization: Bearer ${env.PASS}' \
-     --url "${gerrit_url}/a/changes/\${CHANGE_ID}/revisions/\${HEAD_SHA}/review" \
-     --data '${payload}'
-"""
-  }
-}
 
 node {
   // Checkout the source code.
@@ -86,7 +49,6 @@ node {
 
   dir([path: env.ROOT]) {
     // Run build.
-    notifyBuild('STARTED')
 
     def clustername = "jenkins-" + sh([returnStdout: true, script: '''openssl rand \
         -base64 100 | tr -dc a-z0-9 | cut -c -25''']).trim()
@@ -128,8 +90,6 @@ node {
         currentBuild.result = 'FAILURE'
       }
     }
-
-    notifyBuild(currentBuild.result)
 
     if (currentBuild.result == 'FAILURE') {
       error 'Build failed.'

--- a/hack/Common.mk
+++ b/hack/Common.mk
@@ -73,3 +73,4 @@ coverage:
 
 %:
 	$(ECHO) echo "Not building $* in $(CURDIR)"
+

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -25,8 +25,9 @@ GOPATH="${GOPATH:-${ROOT%/src/github.com/kubernetes-incubator/service-catalog}}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --no-docker-compile) NO_DOCKER_COMPILE=yes ;;
-    --project)           PROJECT="${2}" ; shift ;;
-    --version)           VERSION="${2}" ; shift ;;
+    --project)           PROJECT="${2:-}" ; shift ;;
+    --version)           VERSION="${2:-}" ; shift ;;
+    --coverage)          COVERAGE="${2:-}"; shift ;;
 
     *) error_exit "Unrecognized command line flag $1" ;;
   esac
@@ -45,6 +46,11 @@ make V=1 build \
 
 make V=1 test \
   || error_exit 'make test failed.'
+
+if [[ -n "${COVERAGE:-}" ]]; then
+  make V=1 COVERAGE="${COVERAGE}" coverage \
+    || error_exit 'make coverage failed'
+fi
 
 make V=1 lint \
   || error_exit 'make lint failed.'

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -120,7 +120,7 @@ IP=$(echo $(kubectl get services) | sed 's/.*booksfe [0-9.]* \([0-9.]*\).*/\1/')
 
 echo 'Waiting for frontend service to unblock...'
 wait_for_expected_output -x -e 'blocked' -n 20 -s 30 -t 60 \
-    curl "http://${IP}:8080/shelves" \
+    curl --silent "http://${IP}:8080/shelves" \
   || error_exit 'Access to frontend service still blocked after unexpected amount of time.'
 
 echo 'Deployment to Kubernetes cluster succeeded.'

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -72,6 +72,7 @@ kubectl create namespace "${NAMESPACE}"
 retry -n 10 -s 10 -t 60 \
     helm install "${ROOT}/deploy/catalog" \
     --set "registry=${GCR},version=${VERSION}" \
+    --namespace "${NAMESPACE}" \
   || error_exit 'Error deploying to Kubernetes cluster.'
 
 echo 'Waiting on services to spin up...'

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -87,22 +87,22 @@ retry kubectl get serviceclasses,serviceinstances,servicebrokers,servicebindings
 
 echo 'Creating resources...'
 
-kubectl create -f "${ROOT}/examples/walkthrough/broker.yaml" \
+kubectl create -f "${ROOT}/contrib/examples/walkthrough/broker.yaml" \
   || error_exit 'Cannot create broker.'
 
 sleep 10 #TODO: check that the broker actually came up.
 
-kubectl create -f "${ROOT}/examples/walkthrough/backend.yaml" \
+kubectl create -f "${ROOT}/contrib/examples/walkthrough/backend.yaml" \
   || error_exit 'Cannot create backend.'
 
 sleep 10
 
-kubectl create -f "${ROOT}/examples/walkthrough/binding.yaml" \
+kubectl create -f "${ROOT}/contrib/examples/walkthrough/binding.yaml" \
   || error_exit 'Cannot create binding.'
 
 sleep 10
 
-kubectl create -f "${ROOT}/examples/walkthrough/frontend.yaml" \
+kubectl create -f "${ROOT}/contrib/examples/walkthrough/frontend.yaml" \
   || error_exit 'Cannot create frontend.'
 
 echo 'Waiting for frontend service to come up...'

--- a/hack/jenkins/init_build.sh
+++ b/hack/jenkins/init_build.sh
@@ -15,7 +15,7 @@
 
 set -u
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 . "${ROOT}/hack/utilities.sh" || { echo 'Cannot load bash utilities.'; exit 1; }
 
 GO_VERSION='1.7.3'


### PR DESCRIPTION
This change includes cleanup and small refactoring of the Jenkinsfile,
removing of Gerrit-specific code which doe not apply on GitHub,
and several tweaks to the e2e tests which got broken by changes
in the GitHub repository (mostly directory and variable names where
we made things more generic for any Kubernetes cluster).