### PR TITLE
Make cleaning up cluster work for cluster not in current context

### DIFF
--- a/hack/cluster_utilities.sh
+++ b/hack/cluster_utilities.sh
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -ux
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 . "${ROOT}/hack/utilities.sh" || { echo 'Cannot load Bash utilities'; exit 1; }
 
@@ -33,4 +35,14 @@ function wipe_cluster() {
       kubectl delete namespace "${namespace}"
     fi
   done
+
+  kubectl delete serviceinstances,serviceclasses,servicebindings,servicebrokers --all #TODO: Eventually this should work.
+
+  # Temporarily, delete all by name.
+  kubectl delete serviceinstances backend frontend
+  kubectl delete serviceclasses binding-consumer booksbe booksfe user-provided-service
+  kubectl delete servicebindings database
+  kubectl delete servicebrokers k8s ups
+
+  return 0
 }


### PR DESCRIPTION
Makes the cluster cleanup script a bit more versatile/predictable. By passing in a kubeconfig file, it'll use the current Kubernetes context as the target cluster to cleanup. Otherwise, passing project, zone, and cluster flags will target a specific cluster and will get credentials in a temporary kubeconfig file.

Previously, there was unexpected behavior if your current Kubernetes context and the cluster targeted were different.