### PR TITLE
Improve logging during deploy and poll endpoints

### DIFF
--- a/hack/test_deploy.sh
+++ b/hack/test_deploy.sh
@@ -22,8 +22,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ${ROOT}/hack/deploy.sh "${@}" \
   || error_exit 'Deployment to Kubernetes cluster failed.'
 
-IP=$(echo $(kubectl get services) | sed 's/.*booksfe [0-9.]* \([0-9.]*\).*/\1/')
+IP="$(kubectl get services | xargs echo -n | sed 's/.*booksfe [0-9.]* \([0-9.]*\).*/\1/')"
 
-${ROOT}/hack/bookstore_client.py --host="${IP}:8080" \
-    --verify --count=1 \
+${ROOT}/hack/bookstore_client.py --host="${IP}:8080" --api_key=123 \
+    --verify --verbose=true --count=1 \
   || error_exit 'Tests failed.'

--- a/hack/utilities.sh
+++ b/hack/utilities.sh
@@ -106,13 +106,19 @@ function wait_for_expected_output() {
 
   if [[ -n "${negate:-}" ]]; then
     retry -n ${count} -s ${sleep_amount} -t ${max_sleep} \
-        output_does_not_contain_substring -e "${expected}" "${@}" \
-      || { echo 'Retry timed out.'; return 1; }
+        output_does_not_contain_substring -e "${expected}" "${@}" > /dev/null \
+      && return 0
+
+    echo "Waited unsuccessfully for no occurrence of \"${expected}\" in: \"$("${@}")\""
   else
     retry -n ${count} -s ${sleep_amount} -t ${max_sleep} \
-        output_contains_substring -e "${expected}" "${@}" \
-      || { echo 'Retry timed out.'; return 1; }
+        output_contains_substring -e "${expected}" "${@}" > /dev/null \
+      && return 0
+
+    echo "Waited unsuccessfully for occurrence of \"${expected}\" in: \"$("${@}")\""
   fi
+
+  return 1
 }
 
 function output_contains_substring() {


### PR DESCRIPTION
Improves the logging of the demo project deployment script. Currently, it was using a debug flag that was extremely verbose in output, especially during the waiting loops. This version should strike a bit better a balance between information shown and logic executed.

Also polls the endpoints of the services to make sure they're up before continuing with deployment.