### PR TITLE
Start adding an API group to the server

### DIFF
--- a/pkg/apis/servicecatalog/v1alpha1/register.go
+++ b/pkg/apis/servicecatalog/v1alpha1/register.go
@@ -1,0 +1,15 @@
+package v1alpha1
+
+import (
+	"k8s.io/kubernetes/pkg/runtime/schema"
+)
+
+const (
+	// GroupNameString is the name of the group
+	GroupNameString = "catalog.k8s.io"
+	// VersionString is the version of the group
+	VersionString = "v1alpha1"
+)
+
+// GroupVersion is the official schema GroupVersion for this API server
+var GroupVersion = schema.GroupVersion{Group: GroupNameString, Version: VersionString}

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -4,12 +4,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/spf13/cobra"
-
 	"github.com/kubernetes-incubator/service-catalog/pkg/apiserver"
-
-	//"k8s.io/kubernetes/pkg/api"
-	//"k8s.io/kubernetes/pkg/apimachinery/registered"
+	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/genericapiserver"
 	genericserveroptions "k8s.io/kubernetes/pkg/genericapiserver/options"
 )
@@ -36,9 +32,6 @@ const (
 	// are any restrictions on the format or structure beyond text
 	// separated by slashes.
 	etcdPathPrefix = "/k8s.io/incubator/service-catalog"
-
-	// GroupName I made this up. Maybe we'll need it.
-	GroupName = "service-catalog.incubator.k8s.io"
 )
 
 // NewCommandServer creates a new cobra command to run our server.
@@ -146,6 +139,14 @@ func (serverOptions ServiceCatalogServerOptions) runServer() error {
 	fmt.Println("make the server")
 	server, err := completedconfig.New()
 	if err != nil {
+		return err
+	}
+
+	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(GroupName)
+	apiGroupInfo.GroupMeta.GroupVersion = v1alpha1.GroupVersion
+	// TODO: do more API group setup before installing it
+	// apiGroupInfo.GroupMeta.GroupVersion = projectapiv1.SchemeGroupVersion
+	if err := server.GenericAPIServer.InstallAPIGroup(apiGroupInfo); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apiserver"
 	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/genericapiserver"
@@ -142,7 +143,7 @@ func (serverOptions ServiceCatalogServerOptions) runServer() error {
 		return err
 	}
 
-	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(GroupName)
+	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(v1alpha1.GroupNameString)
 	apiGroupInfo.GroupMeta.GroupVersion = v1alpha1.GroupVersion
 	// TODO: do more API group setup before installing it
 	// apiGroupInfo.GroupMeta.GroupVersion = projectapiv1.SchemeGroupVersion

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -147,7 +147,7 @@ func (serverOptions ServiceCatalogServerOptions) runServer() error {
 	apiGroupInfo.GroupMeta.GroupVersion = v1alpha1.GroupVersion
 	// TODO: do more API group setup before installing it
 	// apiGroupInfo.GroupMeta.GroupVersion = projectapiv1.SchemeGroupVersion
-	if err := server.GenericAPIServer.InstallAPIGroup(apiGroupInfo); err != nil {
+	if err := server.GenericAPIServer.InstallAPIGroup(&apiGroupInfo); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -159,19 +159,3 @@ func (serverOptions ServiceCatalogServerOptions) runServer() error {
 	preparedserver.Run(stop)
 	return nil
 }
-
-/*
-type restOptionsFactory struct {
-	storageConfig *storagebackend.Config
-}
-*/
-/*
-func (f restOptionsFactory) NewFor(resource schema.GroupResource) generic.RESTOptions {
-	return generic.RESTOptions{
-		StorageConfig:           f.storageConfig,
-		Decorator:               registry.StorageWithCacher,
-		DeleteCollectionWorkers: 1,
-		EnableGarbageCollection: false,
-		ResourcePrefix:          f.storageConfig.Prefix + "/" + resource.Group + "/" + resource.Resource,
-	}
-}*/

--- a/pkg/controller/catalog/service_controller.go
+++ b/pkg/controller/catalog/service_controller.go
@@ -23,9 +23,9 @@ import (
 	"path"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg"
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/controller/catalog/server"
 	"github.com/kubernetes-incubator/service-catalog/pkg/controller/catalog/watch"
-
 	"k8s.io/client-go/1.5/dynamic"
 	"k8s.io/client-go/1.5/kubernetes"
 	"k8s.io/client-go/1.5/pkg/api/unversioned"
@@ -63,7 +63,11 @@ func main() {
 		panic(fmt.Sprintf("Failed to create a kubernets client\n:%v\n", err))
 	}
 
-	config.ContentConfig.GroupVersion = &unversioned.GroupVersion{Group: watch.GroupName, Version: watch.APIVersion}
+	// this conversion is probably gonna be done in generated code later. for now, manual :(
+	config.ContentConfig.GroupVersion = &unversioned.GroupVersion{
+		Group:   v1alpha1.GroupVersion.Group,
+		Version: v1alpha1.GroupVersion.Version,
+	}
 	config.APIPath = "apis"
 
 	dynClient, err := dynamic.NewClient(config)

--- a/pkg/controller/catalog/watch/watcher.go
+++ b/pkg/controller/catalog/watch/watcher.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/client-go/1.5/dynamic"
 	// Need this for gcp auth
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
 	"k8s.io/client-go/1.5/kubernetes"
 	deployments "k8s.io/client-go/1.5/kubernetes/typed/extensions/v1beta1"
 	"k8s.io/client-go/1.5/pkg/api"
@@ -54,21 +55,17 @@ var resourceTypeNames = []string{
 	"ServiceBinding",
 	"ServiceBroker",
 	"ServiceClass",
-	"Deployment"}
+	"Deployment",
+}
 
 // These resources _must_ exist in the cluster before proceeding. ManagedService is not
 // used yet.
 var resourceTypes = []resourceType{ServiceInstance, ServiceBinding, ServiceBroker, ServiceType}
 
 const (
-	// GroupName is a name of a Kubernetes API extension implemented by the service catalog.
-	GroupName = "catalog.k8s.io"
-
-	// APIVersion is a version of the Kubernetes API extension implemented by the service catalog.
-	APIVersion = "v1alpha1"
 
 	// FullAPIVersion is a fully qualified name of the Kubernetes API extension implemented by the service catalog.
-	FullAPIVersion = GroupName + "/" + APIVersion
+	FullAPIVersion = v1alpha1.GroupNameString + "/" + v1alpha1.VersionString
 
 	// ServiceBrokerKind is a name of a Service Broker resource, a Kubernetes third party resource.
 	ServiceBrokerKind = "ServiceBroker"
@@ -87,22 +84,22 @@ var thirdPartyResourceTypes = map[string]v1beta1.ThirdPartyResource{
 	"service-broker.catalog.k8s.io": {
 		ObjectMeta:  v1.ObjectMeta{Name: "service-broker.catalog.k8s.io"},
 		Description: "A Service Broker representation. Adds a service broker and fetches its catalog",
-		Versions:    []v1beta1.APIVersion{{Name: "v1alpha1"}},
+		Versions:    []v1beta1.APIVersion{{Name: v1alpha1.VersionString}},
 	},
 	"service-class.catalog.k8s.io": {
 		ObjectMeta:  v1.ObjectMeta{Name: "service-class.catalog.k8s.io"},
 		Description: "A Service Type representation. Something that a customer can instantiate",
-		Versions:    []v1beta1.APIVersion{{Name: "v1alpha1"}},
+		Versions:    []v1beta1.APIVersion{{Name: v1alpha1.VersionString}},
 	},
 	"service-instance.catalog.k8s.io": {
 		ObjectMeta:  v1.ObjectMeta{Name: "service-instance.catalog.k8s.io"},
 		Description: "A Service Instance representation, creates a Service Instance",
-		Versions:    []v1beta1.APIVersion{{Name: "v1alpha1"}},
+		Versions:    []v1beta1.APIVersion{{Name: v1alpha1.VersionString}},
 	},
 	"service-binding.catalog.k8s.io": {
 		ObjectMeta:  v1.ObjectMeta{Name: "service-binding.catalog.k8s.io"},
 		Description: "A Service Binding representation, creates a Service Binding",
-		Versions:    []v1beta1.APIVersion{{Name: "v1alpha1"}},
+		Versions:    []v1beta1.APIVersion{{Name: v1alpha1.VersionString}},
 	},
 }
 


### PR DESCRIPTION
This is the beginning of code to add an API group to the existing API server. It does not aim to be comprehensive, just a start.

This PR also moves the group name and version from the `./pkg/controller/catalog/watch` package to `pkg/apis/servicecatalog/v1alpha1`

After this is merged, the #172 should be rebased and finished. It fills out the `VersionedResourcesStorageMap` field in the [`APIGroupInfo`](https://godoc.org/k8s.io/kubernetes/pkg/genericapiserver#APIGroupInfo) that's created herein. See [here](https://github.com/kubernetes/kubernetes/blob/master/examples/apiserver/apiserver.go#L140) for an example.

cc/ @MHBauer 