### PR TITLE
Compiling the cmd/service-catalog binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ DIRS := \
   pkg \
   pkg/apis/servicecatalog \
   pkg/apis/servicecatalog/v1alpha1 \
-  pkg/controller/catalog
+  pkg/controller/catalog \
+  cmd/service-catalog
 
 ALL := all build build-linux build-darwin clean docker push test lint coverage
 SUB := $(addsuffix .sub, $(ALL))

--- a/cmd/service-catalog/Makefile
+++ b/cmd/service-catalog/Makefile
@@ -1,0 +1,20 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BIN=service-catalog
+PKG=github.com/kubernetes-incubator/service-catalog/cmd/service-catalog
+
+include ../../hack/Makefile.mk
+
+include ../../hack/Common.mk


### PR DESCRIPTION
The binary at `./cmd/service-catalog` wasn't being built by the top-level `Makefile`. This PR adds the component to that `Makefile` and also adds the required `Makefile` inside the component directory.