### PR TITLE
Generate defaults and lift in necessary k8s repo infra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include ./hack/Makefile.mk
+#include ./hack/Makefile.mk
+
+# This section is required to have the variables in the generated makefile
+# It is prefaced by a period to avoid being the first target.
+# Constants used throughout.
+.EXPORT_ALL_VARIABLES:
+OUT_DIR ?= _output
+BIN_DIR := $(OUT_DIR)/bin
+# BABYNETES - hard coded project path
+PRJ_SRC_PATH := github.com/kubernetes-incubator/service-catalog
+GENERATED_FILE_PREFIX := zz_generated.
+
+# Used by ALL_GO_DIRS in Makefile.generated_files
+# Metadata for driving the build lives here.
+META_DIR := .make
+
+# This controls the verbosity of the build.  Higher numbers mean more output.
+KUBE_VERBOSE ?= 1
 
 # Directories that the make will recurse into.
 DIRS := \
@@ -43,6 +60,8 @@ clean: clean.sub
 	rm -rf $(BINDIR)
 	rm -f .dockerInit
 	rm -f .scBuildImage
+	rm -rf $(META_DIR)
+	rm -rf $(OUT_DIR)
 	docker rmi -f scbuildimage > /dev/null 2>&1 || true
 
 # Use this target when you want to build everything using docker containers.
@@ -83,3 +102,7 @@ coverage:
 apiserver:
 	go install -v github.com/kubernetes-incubator/service-catalog/cmd/service-catalog
 	go build -v -o $(BINDIR)/apiserver cmd/service-catalog/server.go
+
+.PHONY: generated_files
+generated_files:
+	$(MAKE) -f Makefile.generated_files $@ CALLED_FROM_MAIN_MAKEFILE=1

--- a/Makefile.generated_files
+++ b/Makefile.generated_files
@@ -1,0 +1,265 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# BABYNETES - not enabled upstream, but we need it for now
+DBG_MAKEFILE=1
+
+# Don't allow users to call this directly.  There are too many variables this
+# assumes to inherit from the main Makefile.  This is not a user-facing file.
+ifeq ($(CALLED_FROM_MAIN_MAKEFILE),)
+    $(error Please use the main Makefile, e.g. `make generated_files`)
+endif
+
+# Don't allow an implicit 'all' rule.  This is not a user-facing file.
+ifeq ($(MAKECMDGOALS),)
+    $(error This Makefile requires an explicit rule to be specified)
+endif
+
+ifeq ($(DBG_MAKEFILE),1)
+    $(warning ***** starting Makefile.generated_files for goal(s) "$(MAKECMDGOALS)")
+    $(warning ***** $(shell date))
+endif
+
+
+# It's necessary to set this because some environments don't link sh -> bash.
+SHELL := /bin/bash
+
+# This rule collects all the generated file sets into a single rule.  Other
+# rules should depend on this to ensure generated files are rebuilt.
+.PHONY: generated_files
+#generated_files: gen_deepcopy gen_defaulter gen_conversion gen_openapi
+generated_files: gen_defaulter
+
+# This variable holds a list of every directory that contains Go files in this
+# project.  Other rules and variables can use this as a starting point to
+# reduce filesystem accesses.
+ifeq ($(DBG_MAKEFILE),1)
+    $(warning ***** finding all *.go dirs)
+endif
+ALL_GO_DIRS := $(shell                                                   \
+    hack/make-rules/helpers/cache_go_dirs.sh $(META_DIR)/all_go_dirs.mk  \
+)
+
+# The name of the metadata file which lists *.go files in each pkg.
+GOFILES_META := gofiles.mk
+
+# Establish a dependency between the deps file and the dir.  Whenever a dir
+# changes (files added or removed) the deps file will be considered stale.
+#
+# The variable value was set in $(GOFILES_META) and included as part of the
+# dependency management logic.
+#
+# This is looser than we really need (e.g. we don't really care about non *.go
+# files or even *_test.go files), but this is much easier to represent.
+#
+# Because we 'sinclude' the deps file, it is considered for rebuilding, as part
+# of make's normal evaluation.  If it gets rebuilt, make will restart.
+#
+# The '$(eval)' is needed because this has a different RHS for each LHS, and
+# would otherwise produce results that make can't parse.
+$(foreach dir, $(ALL_GO_DIRS), $(eval           \
+    $(META_DIR)/$(dir)/$(GOFILES_META): $(dir)  \
+))
+
+# How to rebuild a deps file.  When make determines that the deps file is stale
+# (see above), it executes this rule, and then re-loads the deps file.
+#
+# This is looser than we really need (e.g. we don't really care about test
+# files), but this is MUCH faster than calling `go list`.
+#
+# We regenerate the output file in order to satisfy make's "newer than" rules,
+# but we only need to rebuild targets if the contents actually changed.  That
+# is what the .stamp file represents.
+$(foreach dir, $(ALL_GO_DIRS),  \
+    $(META_DIR)/$(dir)/$(GOFILES_META)):
+	FILES=$$(ls $</*.go | grep --color=never -v $(GENERATED_FILE_PREFIX));  \
+	mkdir -p $(@D);                                           \
+	echo "gofiles__$< := $$(echo $${FILES})" >$@.tmp;         \
+	cmp -s $@.tmp $@ || touch $@.stamp;                       \
+	mv $@.tmp $@
+# This is required to fill in the DAG, since some cases (e.g. 'make clean all')
+# will reference the .stamp file when it doesn't exist.  We don't need to
+# rebuild it in that case, just keep make happy.
+$(foreach dir, $(ALL_GO_DIRS),  \
+    $(META_DIR)/$(dir)/$(GOFILES_META).stamp):
+
+# Include any deps files as additional Makefile rules.  This triggers make to
+# consider the deps files for rebuild, which makes the whole
+# dependency-management logic work.  'sinclude' is "silent include" which does
+# not fail if the file does not exist.
+$(foreach dir, $(ALL_GO_DIRS), $(eval            \
+    sinclude $(META_DIR)/$(dir)/$(GOFILES_META)  \
+))
+
+# Generate a list of all files that have a `+k8s:` comment-tag.  This will be
+# used to derive lists of files/dirs for generation tools.
+ifeq ($(DBG_MAKEFILE),1)
+    $(warning ***** finding all +k8s: tags $(ALL_GO_DIRS))
+endif
+ALL_K8S_TAG_FILES := $(shell                             \
+    find $(ALL_GO_DIRS) -maxdepth 1 -type f -name \*.go  \
+        | xargs grep --color=never -l '^// *+k8s:'       \
+)
+
+#
+# Defaulter generation
+#
+# Any package that wants defaulter functions generated must include a
+# comment-tag in column 0 of one file of the form:
+#     // +k8s:defaulter-gen=<VALUE>
+#
+# The <VALUE> depends on context:
+#     on types:
+#       true:  always generate a defaulter for this type
+#       false: never generate a defaulter for this type
+#     on functions:
+#       covers: if the function name matches SetDefault_NAME, instructs
+#               the generator not to recurse
+#     on packages:
+#       FIELDNAME: any object with a field of this name is a candidate
+#                  for having a defaulter generated
+
+# The result file, in each pkg, of defaulter generation.
+DEFAULTER_BASENAME := $(GENERATED_FILE_PREFIX)defaults
+DEFAULTER_FILENAME := $(DEFAULTER_BASENAME).go
+
+# The tool used to generate defaulters.
+DEFAULTER_GEN := $(BIN_DIR)/defaulter-gen
+
+# All directories that request any form of defaulter generation.
+ifeq ($(DBG_MAKEFILE),1)
+    $(warning ***** finding all +k8s:defaulter-gen tags)
+endif
+DEFAULTER_DIRS := $(shell                                            \
+    grep --color=never -l '+k8s:defaulter-gen=' $(ALL_K8S_TAG_FILES) \
+        | xargs -n1 dirname                                          \
+        | LC_ALL=C sort -u                                           \
+)
+
+DEFAULTER_FILES := $(addsuffix /$(DEFAULTER_FILENAME), $(DEFAULTER_DIRS))
+
+RUN_GEN_DEFAULTER :=                                                         \
+    function run_gen_defaulter() {                                           \
+        if [[ -f $(META_DIR)/$(DEFAULTER_GEN).todo ]]; then                  \
+            ./hack/run-in-gopath.sh $(DEFAULTER_GEN)                         \
+                --v $(KUBE_VERBOSE)                                          \
+                --logtostderr                                                \
+                -i $$(cat $(META_DIR)/$(DEFAULTER_GEN).todo | paste -sd, -)  \
+                --extra-peer-dirs $$(echo $(addprefix $(PRJ_SRC_PATH)/, $(DEFAULTER_DIRS)) | sed 's/ /,/g') \
+                -O $(DEFAULTER_BASENAME)                                     \
+                "$$@";                                                       \
+        fi                                                                   \
+    };                                                                       \
+    run_gen_defaulter
+
+# This rule aggregates the set of files to generate and then generates them all
+# in a single run of the tool.
+.PHONY: gen_defaulter
+gen_defaulter: $(DEFAULTER_FILES) $(DEFAULTER_GEN)
+	$(RUN_GEN_DEFAULTER)
+
+.PHONY: verify_gen_deepcopy
+verify_gen_defaulter: $(DEFAULTER_GEN)
+	$(RUN_GEN_DEFAULTER) --verify-only
+
+# For each dir in DEFAULTER_DIRS, this establishes a dependency between the
+# output file and the input files that should trigger a rebuild.
+#
+# The variable value was set in $(GOFILES_META) and included as part of the
+# dependency management logic.
+#
+# Note that this is a deps-only statement, not a full rule (see below).  This
+# has to be done in a distinct step because wildcards don't work in static
+# pattern rules.
+#
+# The '$(eval)' is needed because this has a different RHS for each LHS, and
+# would otherwise produce results that make can't parse.
+#
+# We depend on the $(GOFILES_META).stamp to detect when the set of input files
+# has changed.  This allows us to detect deleted input files.
+$(foreach dir, $(DEFAULTER_DIRS), $(eval                                    \
+    $(dir)/$(DEFAULTER_FILENAME): $(META_DIR)/$(dir)/$(GOFILES_META).stamp  \
+                                   $(gofiles__$(dir))                       \
+))
+
+# For each dir in DEFAULTER_DIRS, for each target in $(defaulters__$(dir)),
+# this establishes a dependency between the output file and the input files
+# that should trigger a rebuild.
+#
+# The variable value was set in $(GOFILES_META) and included as part of the
+# dependency management logic.
+#
+# Note that this is a deps-only statement, not a full rule (see below).  This
+# has to be done in a distinct step because wildcards don't work in static
+# pattern rules.
+#
+# The '$(eval)' is needed because this has a different RHS for each LHS, and
+# would otherwise produce results that make can't parse.
+#
+# We depend on the $(GOFILES_META).stamp to detect when the set of input files
+# has changed.  This allows us to detect deleted input files.
+$(foreach dir, $(DEFAULTER_DIRS),                                               \
+    $(foreach tgt, $(defaulters__$(dir)), $(eval                                \
+        $(dir)/$(DEFAULTER_FILENAME): $(META_DIR)/$(tgt)/$(GOFILES_META).stamp  \
+                                       $(gofiles__$(tgt))                       \
+    ))                                                                          \
+)
+
+# Unilaterally remove any leftovers from previous runs.
+$(shell rm -f $(META_DIR)/$(DEFAULTER_GEN)*.todo)
+
+# How to regenerate defaulter code.  This is a little slow to run, so we batch
+# it up and trigger the batch from the 'generated_files' target.
+$(DEFAULTER_FILES): $(DEFAULTER_GEN)
+	mkdir -p $$(dirname $(META_DIR)/$(DEFAULTER_GEN))
+	echo $(PRJ_SRC_PATH)/$(@D) >> $(META_DIR)/$(DEFAULTER_GEN).todo
+
+# This calculates the dependencies for the generator tool, so we only rebuild
+# it when needed.  It is PHONY so that it always runs, but it only updates the
+# file if the contents have actually changed.  We 'sinclude' this later.
+.PHONY: $(META_DIR)/$(DEFAULTER_GEN).mk
+$(META_DIR)/$(DEFAULTER_GEN).mk:
+	mkdir -p $(@D);                                        \
+	(echo -n "$(DEFAULTER_GEN): ";                         \
+	 DIRECT=$$(go list -f '{{.Dir}} {{.Dir}}/*.go'         \
+	     ./cmd/libs/go2idl/defaulter-gen);                 \
+	 INDIRECT=$$(go list                                   \
+	     -f '{{range .Deps}}{{.}}{{"\n"}}{{end}}'          \
+	     ./cmd/libs/go2idl/defaulter-gen                   \
+	     | grep --color=never "^$(PRJ_SRC_PATH)"           \
+	     | sed 's|^$(PRJ_SRC_PATH)|./|'                    \
+	     | xargs go list -f '{{.Dir}} {{.Dir}}/*.go');     \
+	 echo $$DIRECT $$INDIRECT                              \
+	     | sed 's/ / \\=,/g'                               \
+	     | tr '=,' '\n\t';                                 \
+	) | sed "s|$$(pwd -P)/||" > $@.tmp;                    \
+	cmp -s $@.tmp $@ || cat $@.tmp > $@ && rm -f $@.tmp
+
+# Include dependency info for the generator tool.  This will cause the rule of
+# the same name to be considered and if it is updated, make will restart.
+sinclude $(META_DIR)/$(DEFAULTER_GEN).mk
+
+# How to build the generator tool.  The deps for this are defined in
+# the $(DEFAULTER_GEN).mk, above.
+#
+# A word on the need to touch: This rule might trigger if, for example, a
+# non-Go file was added or deleted from a directory on which this depends.
+# This target needs to be reconsidered, but Go realizes it doesn't actually
+# have to be rebuilt.  In that case, make will forever see the dependency as
+# newer than the binary, and try to rebuild it over and over.  So we touch it,
+# and make is happy.
+$(DEFAULTER_GEN):
+	hack/make-rules/build.sh cmd/libs/go2idl/defaulter-gen
+	touch $@
+

--- a/Makefile.generated_files
+++ b/Makefile.generated_files
@@ -39,7 +39,7 @@ SHELL := /bin/bash
 # rules should depend on this to ensure generated files are rebuilt.
 .PHONY: generated_files
 #generated_files: gen_deepcopy gen_defaulter gen_conversion gen_openapi
-generated_files: gen_defaulter
+generated_files: gen_deepcopy gen_defaulter
 
 # This variable holds a list of every directory that contains Go files in this
 # project.  Other rules and variables can use this as a starting point to
@@ -111,6 +111,125 @@ ALL_K8S_TAG_FILES := $(shell                             \
     find $(ALL_GO_DIRS) -maxdepth 1 -type f -name \*.go  \
         | xargs grep --color=never -l '^// *+k8s:'       \
 )
+
+#
+# Deep-copy generation
+#
+# Any package that wants deep-copy functions generated must include a
+# comment-tag in column 0 of one file of the form:
+#     // +k8s:deepcopy-gen=<VALUE>
+#
+# The <VALUE> may be one of:
+#     generate: generate deep-copy functions into the package
+#     register: generate deep-copy functions and register them with a
+#               scheme
+
+# The result file, in each pkg, of deep-copy generation.
+DEEPCOPY_BASENAME := $(GENERATED_FILE_PREFIX)deepcopy
+DEEPCOPY_FILENAME := $(DEEPCOPY_BASENAME).go
+
+# The tool used to generate deep copies.
+DEEPCOPY_GEN := $(BIN_DIR)/deepcopy-gen
+
+# Find all the directories that request deep-copy generation.
+ifeq ($(DBG_MAKEFILE),1)
+    $(warning ***** finding all +k8s:deepcopy-gen tags)
+endif
+DEEPCOPY_DIRS := $(shell                                             \
+    grep --color=never -l '+k8s:deepcopy-gen=' $(ALL_K8S_TAG_FILES)  \
+        | xargs -n1 dirname                                          \
+        | LC_ALL=C sort -u                                           \
+)
+DEEPCOPY_FILES := $(addsuffix /$(DEEPCOPY_FILENAME), $(DEEPCOPY_DIRS))
+
+# Shell function for reuse in rules.
+RUN_GEN_DEEPCOPY =                                                          \
+    function run_gen_deepcopy() {                                           \
+        if [[ -f $(META_DIR)/$(DEEPCOPY_GEN).todo ]]; then                  \
+            ./hack/run-in-gopath.sh $(DEEPCOPY_GEN)                         \
+                --v $(KUBE_VERBOSE)                                         \
+                --logtostderr                                               \
+                -i $$(cat $(META_DIR)/$(DEEPCOPY_GEN).todo | paste -sd, -)  \
+                --bounding-dirs $(PRJ_SRC_PATH)                             \
+                -O $(DEEPCOPY_BASENAME)                                     \
+                "$$@";                                                      \
+        fi                                                                  \
+    };                                                                      \
+    run_gen_deepcopy
+
+# This rule aggregates the set of files to generate and then generates them all
+# in a single run of the tool.
+.PHONY: gen_deepcopy
+gen_deepcopy: $(DEEPCOPY_FILES) $(DEEPCOPY_GEN)
+	$(RUN_GEN_DEEPCOPY)
+
+.PHONY: verify_gen_deepcopy
+verify_gen_deepcopy: $(DEEPCOPY_GEN)
+	$(RUN_GEN_DEEPCOPY) --verify-only
+
+# For each dir in DEEPCOPY_DIRS, this establishes a dependency between the
+# output file and the input files that should trigger a rebuild.
+#
+# Note that this is a deps-only statement, not a full rule (see below).  This
+# has to be done in a distinct step because wildcards don't work in static
+# pattern rules.
+#
+# The '$(eval)' is needed because this has a different RHS for each LHS, and
+# would otherwise produce results that make can't parse.
+#
+# We depend on the $(GOFILES_META).stamp to detect when the set of input files
+# has changed.  This allows us to detect deleted input files.
+$(foreach dir, $(DEEPCOPY_DIRS), $(eval                                    \
+    $(dir)/$(DEEPCOPY_FILENAME): $(META_DIR)/$(dir)/$(GOFILES_META).stamp  \
+                                 $(gofiles__$(dir))                        \
+))
+
+# Unilaterally remove any leftovers from previous runs.
+$(shell rm -f $(META_DIR)/$(DEEPCOPY_GEN)*.todo)
+
+# How to regenerate deep-copy code.  This is a little slow to run, so we batch
+# it up and trigger the batch from the 'generated_files' target.
+$(DEEPCOPY_FILES): $(DEEPCOPY_GEN)
+	mkdir -p $$(dirname $(META_DIR)/$(DEEPCOPY_GEN))
+	echo $(PRJ_SRC_PATH)/$(@D) >> $(META_DIR)/$(DEEPCOPY_GEN).todo
+
+# This calculates the dependencies for the generator tool, so we only rebuild
+# it when needed.  It is PHONY so that it always runs, but it only updates the
+# file if the contents have actually changed.  We 'sinclude' this later.
+.PHONY: $(META_DIR)/$(DEEPCOPY_GEN).mk
+$(META_DIR)/$(DEEPCOPY_GEN).mk:
+	mkdir -p $(@D);                                        \
+	(echo -n "$(DEEPCOPY_GEN): ";                          \
+	 DIRECT=$$(go list -f '{{.Dir}} {{.Dir}}/*.go'         \
+	     ./cmd/libs/go2idl/deepcopy-gen);                  \
+	 INDIRECT=$$(go list                                   \
+	     -f '{{range .Deps}}{{.}}{{"\n"}}{{end}}'          \
+	     ./cmd/libs/go2idl/deepcopy-gen                    \
+	     | grep --color=never "^$(PRJ_SRC_PATH)"           \
+	     | sed 's|^$(PRJ_SRC_PATH)|./|'                    \
+	     | xargs go list -f '{{.Dir}} {{.Dir}}/*.go');     \
+	 echo $$DIRECT $$INDIRECT                              \
+	     | sed 's/ / \\=,/g'                               \
+	     | tr '=,' '\n\t';                                 \
+	) | sed "s|$$(pwd -P)/||" > $@.tmp;                    \
+	cmp -s $@.tmp $@ || cat $@.tmp > $@ && rm -f $@.tmp
+
+# Include dependency info for the generator tool.  This will cause the rule of
+# the same name to be considered and if it is updated, make will restart.
+sinclude $(META_DIR)/$(DEEPCOPY_GEN).mk
+
+# How to build the generator tool.  The deps for this are defined in
+# the $(DEEPCOPY_GEN).mk, above.
+#
+# A word on the need to touch: This rule might trigger if, for example, a
+# non-Go file was added or deleted from a directory on which this depends.
+# This target needs to be reconsidered, but Go realizes it doesn't actually
+# have to be rebuilt.  In that case, make will forever see the dependency as
+# newer than the binary, and try to rebuild it over and over.  So we touch it,
+# and make is happy.
+$(DEEPCOPY_GEN):
+	hack/make-rules/build.sh cmd/libs/go2idl/deepcopy-gen
+	touch $@
 
 #
 # Defaulter generation

--- a/cluster/lib/logging.sh
+++ b/cluster/lib/logging.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Controls verbosity of the script output and logging.
+KUBE_VERBOSE="${KUBE_VERBOSE:-5}"
+
+# Handler for when we exit automatically on an error.
+# Borrowed from https://gist.github.com/ahendrix/7030300
+kube::log::errexit() {
+  local err="${PIPESTATUS[@]}"
+
+  # If the shell we are in doesn't have errexit set (common in subshells) then
+  # don't dump stacks.
+  set +o | grep -qe "-o errexit" || return
+
+  set +o xtrace
+  local code="${1:-1}"
+  kube::log::error_exit "'${BASH_COMMAND}' exited with status $err" "${1:-1}" 1
+}
+
+kube::log::install_errexit() {
+  # trap ERR to provide an error handler whenever a command exits nonzero  this
+  # is a more verbose version of set -o errexit
+  trap 'kube::log::errexit' ERR
+
+  # setting errtrace allows our ERR trap handler to be propagated to functions,
+  # expansions and subshells
+  set -o errtrace
+}
+
+# Print out the stack trace
+#
+# Args:
+#   $1 The number of stack frames to skip when printing.
+kube::log::stack() {
+  local stack_skip=${1:-0}
+  stack_skip=$((stack_skip + 1))
+  if [[ ${#FUNCNAME[@]} -gt $stack_skip ]]; then
+    echo "Call stack:" >&2
+    local i
+    for ((i=1 ; i <= ${#FUNCNAME[@]} - $stack_skip ; i++))
+    do
+      local frame_no=$((i - 1 + stack_skip))
+      local source_file=${BASH_SOURCE[$frame_no]}
+      local source_lineno=${BASH_LINENO[$((frame_no - 1))]}
+      local funcname=${FUNCNAME[$frame_no]}
+      echo "  $i: ${source_file}:${source_lineno} ${funcname}(...)" >&2
+    done
+  fi
+}
+
+# Log an error and exit.
+# Args:
+#   $1 Message to log with the error
+#   $2 The error code to return
+#   $3 The number of stack frames to skip when printing.
+kube::log::error_exit() {
+  local message="${1:-}"
+  local code="${2:-1}"
+  local stack_skip="${3:-0}"
+  stack_skip=$((stack_skip + 1))
+
+  if [[ ${KUBE_VERBOSE} -ge 4 ]]; then
+    local source_file=${BASH_SOURCE[$stack_skip]}
+    local source_line=${BASH_LINENO[$((stack_skip - 1))]}
+    echo "!!! Error in ${source_file}:${source_line}" >&2
+    [[ -z ${1-} ]] || {
+      echo "  ${1}" >&2
+    }
+
+    kube::log::stack $stack_skip
+
+    echo "Exiting with status ${code}" >&2
+  fi
+
+  exit "${code}"
+}
+
+# Log an error but keep going.  Don't dump the stack or exit.
+kube::log::error() {
+  timestamp=$(date +"[%m%d %H:%M:%S]")
+  echo "!!! $timestamp ${1-}" >&2
+  shift
+  for message; do
+    echo "    $message" >&2
+  done
+}
+
+# Print an usage message to stderr.  The arguments are printed directly.
+kube::log::usage() {
+  echo >&2
+  local message
+  for message; do
+    echo "$message" >&2
+  done
+  echo >&2
+}
+
+kube::log::usage_from_stdin() {
+  local messages=()
+  while read -r line; do
+    messages+=("$line")
+  done
+
+  kube::log::usage "${messages[@]}"
+}
+
+# Print out some info that isn't a top level status line
+kube::log::info() {
+  local V="${V:-0}"
+  if [[ $KUBE_VERBOSE < $V ]]; then
+    return
+  fi
+
+  for message; do
+    echo "$message"
+  done
+}
+
+# Just like kube::log::info, but no \n, so you can make a progress bar
+kube::log::progress() {
+  for message; do
+    echo -e -n "$message"
+  done
+}
+
+kube::log::info_from_stdin() {
+  local messages=()
+  while read -r line; do
+    messages+=("$line")
+  done
+
+  kube::log::info "${messages[@]}"
+}
+
+# Print a status line.  Formatted to show up in a stream of output.
+kube::log::status() {
+  local V="${V:-0}"
+  if [[ $KUBE_VERBOSE < $V ]]; then
+    return
+  fi
+
+  timestamp=$(date +"[%m%d %H:%M:%S]")
+  echo "+++ $timestamp $1"
+  shift
+  for message; do
+    echo "    $message"
+  done
+}

--- a/cluster/lib/util.sh
+++ b/cluster/lib/util.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wait for background jobs to finish. Return with
+# an error status if any of the jobs failed.
+kube::util::wait-for-jobs() {
+  local fail=0
+  local job
+  for job in $(jobs -p); do
+    wait "${job}" || fail=$((fail + 1))
+  done
+  return ${fail}
+}
+
+# kube::util::join <delim> <list...>
+# Concatenates the list elements with the delimiter passed as first parameter
+#
+# Ex: kube::util::join , a b c
+#  -> a,b,c
+function kube::util::join {
+  local IFS="$1"
+  shift
+  echo "$*"
+}
+
+# Some useful colors.
+if [[ -z "${color_start-}" ]]; then
+  declare -r color_start="\033["
+  declare -r color_red="${color_start}0;31m"
+  declare -r color_yellow="${color_start}0;33m"
+  declare -r color_green="${color_start}0;32m"
+  declare -r color_norm="${color_start}0m"
+fi

--- a/cmd/libs/go2idl/deepcopy-gen/main.go
+++ b/cmd/libs/go2idl/deepcopy-gen/main.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// deepcopy-gen is a tool for auto-generating DeepCopy functions.
+//
+// Given a list of input directories, it will generate functions that
+// efficiently perform a full deep-copy of each type.  For any type that
+// offers a `.DeepCopy()` method, it will simply call that.  Otherwise it will
+// use standard value assignment whenever possible.  If that is not possible it
+// will try to call its own generated copy function for the type, if the type is
+// within the allowed root packages.  Failing that, it will fall back on
+// `conversion.Cloner.DeepCopy(val)` to make the copy.  The resulting file will
+// be stored in the same directory as the processed source package.
+//
+// Generation is governed by comment tags in the source.  Any package may
+// request DeepCopy generation by including a comment in the file-comments of
+// one file, of the form:
+//   // +k8s:deepcopy-gen=package
+//
+// Packages can request that the generated DeepCopy functions be registered
+// with an `init()` function call to `Scheme.AddGeneratedDeepCopyFuncs()` by
+// changing the tag to:
+//   // +k8s:deepcopy-gen=package,register
+//
+// DeepCopy functions can be generated for individual types, rather than the
+// entire package by specifying a comment on the type definion of the form:
+//   // +k8s:deepcopy-gen=true
+//
+// When generating for a whole package, individual types may opt out of
+// DeepCopy generation by specifying a comment on the of the form:
+//   // +k8s:deepcopy-gen=false
+//
+// Note that registration is a whole-package option, and is not available for
+// individual types.
+package main
+
+import (
+	"path/filepath"
+
+	"k8s.io/gengo/args"
+	"k8s.io/gengo/examples/deepcopy-gen/generators"
+
+	"github.com/golang/glog"
+	"github.com/spf13/pflag"
+)
+
+func main() {
+	arguments := args.Default()
+
+	// Override defaults.
+	arguments.OutputFileBaseName = "deepcopy_generated"
+	// BABYNETES - hard coded path
+	arguments.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "github.com/kubernetes-incubator/service-catalog/hack/boilerplate/boilerplate.go.txt")
+
+	// Custom args.
+	customArgs := &generators.CustomArgs{}
+	pflag.CommandLine.StringSliceVar(&customArgs.BoundingDirs, "bounding-dirs", customArgs.BoundingDirs,
+		"Comma-separated list of import paths which bound the types for which deep-copies will be generated.")
+	arguments.CustomArgs = customArgs
+
+	// Run it.
+	if err := arguments.Execute(
+		generators.NameSystems(),
+		generators.DefaultNameSystem(),
+		generators.Packages,
+	); err != nil {
+		glog.Fatalf("Error: %v", err)
+	}
+	glog.V(2).Info("Completed successfully.")
+}

--- a/cmd/libs/go2idl/defaulter-gen/main.go
+++ b/cmd/libs/go2idl/defaulter-gen/main.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// defaulter-gen is a tool for auto-generating Defaulter functions.
+//
+// Given a list of input directories, it will scan for top level types
+// and generate efficient defaulters for an entire object from the sum
+// of the SetDefault_* methods contained in the object tree.
+//
+// Generation is governed by comment tags in the source.  Any package may
+// request defaulter generation by including one or more comment tags at
+// the package comment level:
+//
+//   // +k8s:defaulter-gen=<field-name-to-flag>
+//
+// which will create defaulters for any type that contains the provided
+// field name (if the type has defaulters). Any type may request explicit
+// defaulting by providing the comment tag:
+//
+//   // +k8s:defaulter-gen=true|false
+//
+// An existing defaulter method (`SetDefaults_TYPE`) can provide the
+// comment tag:
+//
+//   // +k8s:defaulter-gen=covers
+//
+// to indicate that the defaulter does not or should not call any nested
+// defaulters.
+package main
+
+import (
+	"path/filepath"
+
+	"k8s.io/gengo/args"
+	"k8s.io/gengo/examples/defaulter-gen/generators"
+
+	"github.com/golang/glog"
+	"github.com/spf13/pflag"
+)
+
+func main() {
+	arguments := args.Default()
+
+	// Override defaults.
+	arguments.OutputFileBaseName = "zz_generated.defaults"
+	// BABYNETES - hard coded project path
+	arguments.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "github.com/kubernetes-incubator/service-catalog/hack/boilerplate/boilerplate.go.txt")
+
+	// Custom args.
+	customArgs := &generators.CustomArgs{
+		ExtraPeerDirs: []string{},
+	}
+	pflag.CommandLine.StringSliceVar(&customArgs.ExtraPeerDirs, "extra-peer-dirs", customArgs.ExtraPeerDirs,
+		"Comma-separated list of import paths which are considered, after tag-specified peers, for conversions.")
+	arguments.CustomArgs = customArgs
+
+	// Run it.
+	if err := arguments.Execute(
+		generators.NameSystems(),
+		generators.DefaultNameSystem(),
+		generators.Packages,
+	); err != nil {
+		glog.Fatalf("Error: %v", err)
+	}
+	glog.V(2).Info("Completed successfully.")
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 05f68454875f0d6f90fea9cbcfc5cb853b7f1ac874ed27e485d161481daa9f41
-updated: 2016-12-08T01:02:02.362613515-08:00
+hash: 73f5831575d57b171c4bb809d6a58fdcbe148eebb70b776c897c1b424b9b5c48
+updated: 2016-12-15T17:07:13.904331338-05:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -14,61 +14,6 @@ imports:
   - quantile
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
-- name: github.com/coreos/etcd
-  version: 8a37349097a592db79ba3087f3cae9cd4b0af21c
-  subpackages:
-  - alarm
-  - auth
-  - auth/authpb
-  - client
-  - clientv3
-  - compactor
-  - discovery
-  - error
-  - etcdserver
-  - etcdserver/api
-  - etcdserver/api/v2http
-  - etcdserver/api/v2http/httptypes
-  - etcdserver/api/v3rpc
-  - etcdserver/api/v3rpc/rpctypes
-  - etcdserver/auth
-  - etcdserver/etcdserverpb
-  - etcdserver/membership
-  - etcdserver/stats
-  - integration
-  - lease
-  - lease/leasehttp
-  - lease/leasepb
-  - mvcc
-  - mvcc/backend
-  - mvcc/mvccpb
-  - pkg/adt
-  - pkg/contention
-  - pkg/crc
-  - pkg/fileutil
-  - pkg/httputil
-  - pkg/idutil
-  - pkg/ioutil
-  - pkg/logutil
-  - pkg/netutil
-  - pkg/pathutil
-  - pkg/pbutil
-  - pkg/runtime
-  - pkg/schedule
-  - pkg/testutil
-  - pkg/tlsutil
-  - pkg/transport
-  - pkg/types
-  - pkg/wait
-  - raft
-  - raft/raftpb
-  - rafthttp
-  - snap
-  - snap/snappb
-  - store
-  - version
-  - wal
-  - wal/walpb
 - name: github.com/coreos/go-oidc
   version: 5644a2f50e2d2d5ba0b474bc5bc55fea1925936d
   subpackages:
@@ -80,17 +25,10 @@ imports:
 - name: github.com/coreos/go-systemd
   version: 4484981625c1a6a2ecb40a390fcb6a9bcfee76e3
   subpackages:
-  - activation
   - daemon
-  - dbus
-  - journal
-  - unit
-  - util
 - name: github.com/coreos/pkg
   version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
   subpackages:
-  - capnslog
-  - dlopen
   - health
   - httputil
   - timeutil
@@ -140,7 +78,6 @@ imports:
 - name: github.com/golang/protobuf
   version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
   subpackages:
-  - jsonpb
   - proto
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
@@ -150,12 +87,6 @@ imports:
   version: 3a5767ca75ece5f7f1440b1d16975247f8d8b221
 - name: github.com/gorilla/mux
   version: 757bef944d0f21880861c2dd9c871ca543023cba
-- name: github.com/grpc-ecosystem/grpc-gateway
-  version: f52d055dc48aec25854ed7d31862f78913cf17d1
-  subpackages:
-  - runtime
-  - runtime/internal
-  - utilities
 - name: github.com/howeyc/gopass
   version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
 - name: github.com/imdario/mergo
@@ -164,6 +95,8 @@ imports:
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jonboulle/clockwork
   version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
+- name: github.com/jteeuwen/go-bindata
+  version: a0ff2567cfb70903282db057e799fd826784d41d
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/mailru/easyjson
@@ -205,39 +138,11 @@ imports:
   version: e00690e87603abe613e9f02c816c7c4bef82e063
   subpackages:
   - openstack
-  - openstack/blockstorage/v1/volumes
-  - openstack/common/extensions
-  - openstack/compute/v2/extensions/bootfromvolume
-  - openstack/compute/v2/extensions/diskconfig
-  - openstack/compute/v2/extensions/volumeattach
-  - openstack/compute/v2/flavors
-  - openstack/compute/v2/images
-  - openstack/compute/v2/servers
   - openstack/identity/v2/tenants
   - openstack/identity/v2/tokens
-  - openstack/identity/v3/extensions/trust
   - openstack/identity/v3/tokens
-  - openstack/networking/v2/extensions
-  - openstack/networking/v2/extensions/layer3/floatingips
-  - openstack/networking/v2/extensions/layer3/routers
-  - openstack/networking/v2/extensions/lbaas/members
-  - openstack/networking/v2/extensions/lbaas/monitors
-  - openstack/networking/v2/extensions/lbaas/pools
-  - openstack/networking/v2/extensions/lbaas/vips
-  - openstack/networking/v2/extensions/lbaas_v2/listeners
-  - openstack/networking/v2/extensions/lbaas_v2/loadbalancers
-  - openstack/networking/v2/extensions/lbaas_v2/monitors
-  - openstack/networking/v2/extensions/lbaas_v2/pools
-  - openstack/networking/v2/extensions/security/groups
-  - openstack/networking/v2/extensions/security/rules
-  - openstack/networking/v2/ports
   - openstack/utils
   - pagination
-  - rackspace
-  - rackspace/blockstorage/v1/volumes
-  - rackspace/compute/v2/servers
-  - rackspace/compute/v2/volumeattach
-  - rackspace/identity/v2/tokens
   - testhelper
   - testhelper/client
 - name: github.com/satori/go.uuid
@@ -253,11 +158,7 @@ imports:
 - name: golang.org/x/crypto
   version: 1f22c0103821b9390939b6776727195525381532
   subpackages:
-  - bcrypt
-  - blowfish
   - curve25519
-  - pkcs12
-  - pkcs12/internal/rc2
   - ssh
   - ssh/terminal
 - name: golang.org/x/net
@@ -270,9 +171,7 @@ imports:
   - http2
   - http2/hpack
   - idna
-  - internal/timeseries
   - lex/httplex
-  - trace
   - websocket
 - name: golang.org/x/oauth2
   version: 3c3a985cb79f52a3190fbc056984415ca6763d01
@@ -310,17 +209,6 @@ imports:
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
-- name: google.golang.org/grpc
-  version: 231b4cfea0e79843053a33f5fe90bd4d84b23cd3
-  subpackages:
-  - codes
-  - credentials
-  - grpclog
-  - internal
-  - metadata
-  - naming
-  - peer
-  - transport
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/natefinch/lumberjack.v2
@@ -438,6 +326,15 @@ imports:
   - 1.5/tools/clientcmd/api/v1
   - 1.5/tools/metrics
   - 1.5/transport
+- name: k8s.io/gengo
+  version: 1408ff498e5d40a6dde29ece12ae36a1982fd697
+  subpackages:
+  - args
+  - examples/defaulter-gen/generators
+  - generator
+  - namer
+  - parser
+  - types
 - name: k8s.io/kubernetes
   version: 6b9a9442855d16e0ff0c02ab0c82b1c1665cccaf
   subpackages:
@@ -452,7 +349,6 @@ imports:
   - pkg/api/resource
   - pkg/api/rest
   - pkg/api/service
-  - pkg/api/unversioned
   - pkg/api/util
   - pkg/api/v1
   - pkg/api/validation
@@ -577,7 +473,6 @@ imports:
   - pkg/master/ports
   - pkg/probe
   - pkg/probe/http
-  - pkg/registry/generic
   - pkg/runtime
   - pkg/runtime/schema
   - pkg/runtime/serializer
@@ -591,12 +486,8 @@ imports:
   - pkg/serviceaccount
   - pkg/ssh
   - pkg/storage
-  - pkg/storage/etcd
   - pkg/storage/etcd/metrics
-  - pkg/storage/etcd/util
-  - pkg/storage/etcd3
   - pkg/storage/storagebackend
-  - pkg/storage/storagebackend/factory
   - pkg/types
   - pkg/util
   - pkg/util/cache

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,8 +4,10 @@ import:
 - package: github.com/gorilla/handlers
 - package: github.com/gorilla/mux
 - package: github.com/satori/go.uuid
+- package: github.com/jteeuwen/go-bindata
 - package: github.com/spf13/cobra
   version: f62e98d28ab7ad31d707ba837a966378465c7b57
+- package: k8s.io/gengo/args
 - package: k8s.io/kubernetes
   subpackages:
   - pkg/genericapiserver

--- a/hack/cmd/teststale/teststale.go
+++ b/hack/cmd/teststale/teststale.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// teststale checks the staleness of a test binary. go test -c builds a test
+// binary but it does no staleness check. In other words, every time one runs
+// go test -c, it compiles the test packages and links the binary even when
+// nothing has changed. This program helps to mitigate that problem by allowing
+// to check the staleness of a given test package and its binary.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+const usageHelp = "" +
+	`This program checks the staleness of a given test package and its test
+binary so that one can make a decision about re-building the test binary.
+
+Usage:
+  teststale -binary=/path/to/test/binary -package=package
+
+Example:
+  teststale -binary="$HOME/gosrc/bin/e2e.test" -package="k8s.io/kubernetes/test/e2e"
+
+`
+
+var (
+	binary  = flag.String("binary", "", "filesystem path to the test binary file. Example: \"$HOME/gosrc/bin/e2e.test\"")
+	pkgPath = flag.String("package", "", "import path of the test package in the format used while importing packages. Example: \"k8s.io/kubernetes/test/e2e\"")
+)
+
+func usage() {
+	fmt.Fprintln(os.Stderr, usageHelp)
+	fmt.Fprintln(os.Stderr, "Flags:")
+	flag.PrintDefaults()
+	os.Exit(2)
+}
+
+// golist is an interface emulating the `go list` command to get package information.
+// TODO: Evaluate using `go/build` package instead. It doesn't provide staleness
+// information, but we can probably run `go list` and `go/build.Import()` concurrently
+// in goroutines and merge the results. Evaluate if that's faster.
+type golist interface {
+	pkgInfo(pkgPaths []string) ([]pkg, error)
+}
+
+// execmd implements the `golist` interface.
+type execcmd struct {
+	cmd  string
+	args []string
+	env  []string
+}
+
+func (e *execcmd) pkgInfo(pkgPaths []string) ([]pkg, error) {
+	args := append(e.args, pkgPaths...)
+	cmd := exec.Command(e.cmd, args...)
+	cmd.Env = e.env
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to obtain the metadata output stream: %v", err)
+	}
+
+	dec := json.NewDecoder(stdout)
+
+	// Start executing the command
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("command did not start: %v", err)
+	}
+
+	var pkgs []pkg
+	for {
+		var p pkg
+		if err := dec.Decode(&p); err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal metadata for package %s: %v", p.ImportPath, err)
+		}
+		pkgs = append(pkgs, p)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return nil, fmt.Errorf("command did not complete: %v", err)
+	}
+	return pkgs, nil
+}
+
+type pkg struct {
+	Dir          string
+	ImportPath   string
+	Target       string
+	Stale        bool
+	TestGoFiles  []string
+	TestImports  []string
+	XTestGoFiles []string
+	XTestImports []string
+}
+
+func (p *pkg) isNewerThan(cmd golist, buildTime time.Time) bool {
+	// If the package itself is stale, then we have to rebuild the whole thing anyway.
+	if p.Stale {
+		return true
+	}
+
+	// Test for file staleness
+	for _, f := range p.TestGoFiles {
+		if isNewerThan(filepath.Join(p.Dir, f), buildTime) {
+			glog.V(4).Infof("test Go file %s is stale", f)
+			return true
+		}
+	}
+	for _, f := range p.XTestGoFiles {
+		if isNewerThan(filepath.Join(p.Dir, f), buildTime) {
+			glog.V(4).Infof("external test Go file %s is stale", f)
+			return true
+		}
+	}
+
+	imps := []string{}
+	imps = append(imps, p.TestImports...)
+	imps = append(imps, p.XTestImports...)
+
+	// This calls `go list` the second time. This is required because the first
+	// call to `go list` checks the staleness of the package in question by
+	// looking the non-test dependencies, but it doesn't look at the test
+	// dependencies. However, it returns the list of test dependencies. This
+	// second call to `go list` checks the staleness of all the test
+	// dependencies.
+	pkgs, err := cmd.pkgInfo(imps)
+	if err != nil || len(pkgs) < 1 {
+		glog.V(4).Infof("failed to obtain metadata for packages %s: %v", imps, err)
+		return true
+	}
+
+	for _, p := range pkgs {
+		if p.Stale {
+			glog.V(4).Infof("import %q is stale", p.ImportPath)
+			return true
+		}
+	}
+
+	return false
+}
+
+func isNewerThan(filename string, buildTime time.Time) bool {
+	stat, err := os.Stat(filename)
+	if err != nil {
+		return true
+	}
+	return stat.ModTime().After(buildTime)
+}
+
+// isTestStale checks if the test binary is stale and needs to rebuilt.
+// Some of the ideas here are inspired by how Go does staleness checks.
+func isTestStale(cmd golist, binPath, pkgPath string) bool {
+	bStat, err := os.Stat(binPath)
+	if err != nil {
+		glog.V(4).Infof("Couldn't obtain the modified time of the binary %s: %v", binPath, err)
+		return true
+	}
+	buildTime := bStat.ModTime()
+
+	pkgs, err := cmd.pkgInfo([]string{pkgPath})
+	if err != nil || len(pkgs) < 1 {
+		glog.V(4).Infof("Couldn't retrieve test package information for package %s: %v", pkgPath, err)
+		return false
+	}
+
+	return pkgs[0].isNewerThan(cmd, buildTime)
+}
+
+func main() {
+	flag.Usage = usage
+	flag.Parse()
+
+	cmd := &execcmd{
+		cmd: "go",
+		args: []string{
+			"list",
+			"-json",
+		},
+		env: os.Environ(),
+	}
+	if !isTestStale(cmd, *binary, *pkgPath) {
+		os.Exit(1)
+	}
+}

--- a/hack/cmd/teststale/teststale_test.go
+++ b/hack/cmd/teststale/teststale_test.go
@@ -1,0 +1,325 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const (
+	// seed for rand.Source to generate data for files
+	seed int64 = 42
+
+	// 1K binary file
+	binLen = 1024
+
+	// Directory of the test package relative to $GOPATH
+	testImportDir = "example.com/proj/pkg"
+)
+
+var (
+	pastHour = time.Now().Add(-1 * time.Hour)
+
+	// The test package we are testing against
+	testPkg = path.Join(testImportDir, "test")
+)
+
+// fakegolist implements the `golist` interface providing fake package information for testing.
+type fakegolist struct {
+	dir       string
+	importMap map[string]pkg
+	testFiles []string
+	binfile   string
+}
+
+func newFakegolist() (*fakegolist, error) {
+	dir, err := ioutil.TempDir("", "teststale")
+	if err != nil {
+		// test can't proceed without a temp directory.
+		return nil, fmt.Errorf("failed to create a temp directory for testing: %v", err)
+	}
+
+	// Set the temp directory as the $GOPATH
+	if err := os.Setenv("GOPATH", dir); err != nil {
+		// can't proceed without pointing the $GOPATH to the temp directory.
+		return nil, fmt.Errorf("failed to set \"$GOPATH\" pointing to %q: %v", dir, err)
+	}
+
+	// Setup $GOPATH directory layout.
+	// Yeah! I am bored of repeatedly writing "if err != nil {}"!
+	if os.MkdirAll(filepath.Join(dir, "bin"), 0750) != nil ||
+		os.MkdirAll(filepath.Join(dir, "pkg", "linux_amd64"), 0750) != nil ||
+		os.MkdirAll(filepath.Join(dir, "src"), 0750) != nil {
+		return nil, fmt.Errorf("failed to setup the $GOPATH directory structure")
+	}
+
+	// Create a temp file to represent the test binary.
+	binfile, err := ioutil.TempFile("", "testbin")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the temp file to represent the test binary: %v", err)
+	}
+
+	// Could have used crypto/rand instead, but it doesn't matter.
+	rr := rand.New(rand.NewSource(42))
+	bin := make([]byte, binLen)
+	if _, err = rr.Read(bin); err != nil {
+		return nil, fmt.Errorf("couldn't read from the random source: %v", err)
+	}
+	if _, err := binfile.Write(bin); err != nil {
+		return nil, fmt.Errorf("couldn't write to the binary file %q: %v", binfile.Name(), err)
+	}
+	if err := binfile.Close(); err != nil {
+		// It is arguable whether this should be fatal.
+		return nil, fmt.Errorf("failed to close the binary file %q: %v", binfile.Name(), err)
+	}
+
+	if err := os.Chtimes(binfile.Name(), time.Now(), time.Now()); err != nil {
+		return nil, fmt.Errorf("failed to modify the mtime of the binary file %q: %v", binfile.Name(), err)
+	}
+
+	// Create test source files directory.
+	testdir := filepath.Join(dir, "src", testPkg)
+	if err := os.MkdirAll(testdir, 0750); err != nil {
+		return nil, fmt.Errorf("failed to create test source directory %q: %v", testdir, err)
+	}
+
+	fgl := &fakegolist{
+		dir: dir,
+		importMap: map[string]pkg{
+			"example.com/proj/pkg/test": {
+				Dir:        path.Join(dir, "src", testPkg),
+				ImportPath: testPkg,
+				Target:     path.Join(dir, "pkg", "linux_amd64", testImportDir, "test.a"),
+				Stale:      false,
+				TestGoFiles: []string{
+					"foo_test.go",
+					"bar_test.go",
+				},
+				TestImports: []string{
+					"example.com/proj/pkg/p1",
+					"example.com/proj/pkg/p1/c11",
+					"example.com/proj/pkg/p2",
+					"example.com/proj/cmd/p3/c12/c23",
+					"strings",
+					"testing",
+				},
+				XTestGoFiles: []string{
+					"xfoo_test.go",
+					"xbar_test.go",
+					"xbaz_test.go",
+				},
+				XTestImports: []string{
+					"example.com/proj/pkg/test",
+					"example.com/proj/pkg/p1",
+					"example.com/proj/cmd/p3/c12/c23",
+					"os",
+					"testing",
+				},
+			},
+			"example.com/proj/pkg/p1":         {Stale: false},
+			"example.com/proj/pkg/p1/c11":     {Stale: false},
+			"example.com/proj/pkg/p2":         {Stale: false},
+			"example.com/proj/cmd/p3/c12/c23": {Stale: false},
+			"strings":                         {Stale: false},
+			"testing":                         {Stale: false},
+			"os":                              {Stale: false},
+		},
+		testFiles: []string{
+			"foo_test.go",
+			"bar_test.go",
+			"xfoo_test.go",
+			"xbar_test.go",
+			"xbaz_test.go",
+		},
+		binfile: binfile.Name(),
+	}
+
+	// Create test source files.
+	for _, fn := range fgl.testFiles {
+		fp := filepath.Join(testdir, fn)
+		if _, err := os.Create(fp); err != nil {
+			return nil, fmt.Errorf("failed to create the test file %q: %v", fp, err)
+		}
+		if err := os.Chtimes(fp, time.Now(), pastHour); err != nil {
+			return nil, fmt.Errorf("failed to modify the mtime of the test file %q: %v", binfile.Name(), err)
+		}
+	}
+
+	return fgl, nil
+}
+
+func (fgl *fakegolist) pkgInfo(pkgPaths []string) ([]pkg, error) {
+	var pkgs []pkg
+	for _, path := range pkgPaths {
+		p, ok := fgl.importMap[path]
+		if !ok {
+			return nil, fmt.Errorf("package %q not found", path)
+		}
+		pkgs = append(pkgs, p)
+	}
+	return pkgs, nil
+}
+
+func (fgl *fakegolist) chMtime(filename string, mtime time.Time) error {
+	for _, fn := range fgl.testFiles {
+		if fn == filename {
+			fp := filepath.Join(fgl.dir, "src", testPkg, fn)
+			if err := os.Chtimes(fp, time.Now(), mtime); err != nil {
+				return fmt.Errorf("failed to modify the mtime of %q: %v", filename, err)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("file %q not found", filename)
+}
+
+func (fgl *fakegolist) chStale(pkg string, stale bool) error {
+	if p, ok := fgl.importMap[pkg]; ok {
+		p.Stale = stale
+		fgl.importMap[pkg] = p
+		return nil
+	}
+	return fmt.Errorf("package %q not found", pkg)
+}
+
+func (fgl *fakegolist) cleanup() {
+	os.RemoveAll(fgl.dir)
+	os.Remove(fgl.binfile)
+}
+
+func TestIsTestStale(t *testing.T) {
+	cases := []struct {
+		fileMtime    map[string]time.Time
+		pkgStaleness map[string]bool
+		result       bool
+	}{
+		// Basic test: binary is fresh, all modifications were before the binary was built.
+		{
+			result: false,
+		},
+		// A local test file is new, hence binary must be stale.
+		{
+			fileMtime: map[string]time.Time{
+				"foo_test.go": time.Now().Add(1 * time.Hour),
+			},
+			result: true,
+		},
+		// Test package is new, so binary must be stale.
+		{
+			pkgStaleness: map[string]bool{
+				"example.com/proj/pkg/test": true,
+			},
+			result: true,
+		},
+		// Test package dependencies are new, so binary must be stale.
+		{
+			pkgStaleness: map[string]bool{
+				"example.com/proj/cmd/p3/c12/c23": true,
+				"strings":                         true,
+			},
+			result: true,
+		},
+		// External test files are new, hence binary must be stale.
+		{
+			fileMtime: map[string]time.Time{
+				"xfoo_test.go": time.Now().Add(1 * time.Hour),
+				"xbar_test.go": time.Now().Add(2 * time.Hour),
+			},
+			result: true,
+		},
+		// External test dependency is new, so binary must be stale.
+		{
+			pkgStaleness: map[string]bool{
+				"os": true,
+			},
+			result: true,
+		},
+		// Multiple source files and dependencies are new, so binary must be stale.
+		{
+			fileMtime: map[string]time.Time{
+				"foo_test.go":  time.Now().Add(1 * time.Hour),
+				"xfoo_test.go": time.Now().Add(2 * time.Hour),
+				"xbar_test.go": time.Now().Add(3 * time.Hour),
+			},
+			pkgStaleness: map[string]bool{
+				"example.com/proj/pkg/p1":         true,
+				"example.com/proj/pkg/p1/c11":     true,
+				"example.com/proj/pkg/p2":         true,
+				"example.com/proj/cmd/p3/c12/c23": true,
+				"strings":                         true,
+				"os":                              true,
+			},
+			result: true,
+		},
+		// Everything is new, so binary must be stale.
+		{
+			fileMtime: map[string]time.Time{
+				"foo_test.go":  time.Now().Add(3 * time.Hour),
+				"bar_test.go":  time.Now().Add(1 * time.Hour),
+				"xfoo_test.go": time.Now().Add(2 * time.Hour),
+				"xbar_test.go": time.Now().Add(1 * time.Hour),
+				"xbaz_test.go": time.Now().Add(2 * time.Hour),
+			},
+			pkgStaleness: map[string]bool{
+				"example.com/proj/pkg/p1":         true,
+				"example.com/proj/pkg/p1/c11":     true,
+				"example.com/proj/pkg/p2":         true,
+				"example.com/proj/cmd/p3/c12/c23": true,
+				"example.com/proj/pkg/test":       true,
+				"strings":                         true,
+				"testing":                         true,
+				"os":                              true,
+			},
+			result: true,
+		},
+	}
+
+	for _, tc := range cases {
+		fgl, err := newFakegolist()
+		if err != nil {
+			t.Fatalf("failed to setup the test: %v", err)
+		}
+		defer fgl.cleanup()
+
+		for fn, mtime := range tc.fileMtime {
+			if err := fgl.chMtime(fn, mtime); err != nil {
+				t.Fatalf("failed to change the mtime of %q: %v", fn, err)
+			}
+		}
+
+		for pkg, stale := range tc.pkgStaleness {
+			if err := fgl.chStale(pkg, stale); err != nil {
+				t.Fatalf("failed to change the staleness of %q: %v", pkg, err)
+			}
+		}
+
+		if tc.result != isTestStale(fgl, fgl.binfile, testPkg) {
+			if tc.result {
+				t.Errorf("Expected test package %q to be stale", testPkg)
+			} else {
+				t.Errorf("Expected test package %q to be not stale", testPkg)
+			}
+		}
+	}
+}

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A set of helpers for starting/running etcd for tests
+
+ETCD_VERSION=${ETCD_VERSION:-3.0.14}
+ETCD_HOST=${ETCD_HOST:-127.0.0.1}
+ETCD_PORT=${ETCD_PORT:-2379}
+
+kube::etcd::start() {
+  which etcd >/dev/null || {
+    kube::log::usage "etcd must be in your PATH"
+    exit 1
+  }
+
+  if pgrep etcd >/dev/null 2>&1; then
+    kube::log::usage "etcd appears to already be running on this machine (`pgrep -l etcd`) (or its a zombie and you need to kill its parent)."
+    kube::log::usage "retry after you resolve this etcd error."
+    exit 1
+  fi
+
+  version=$(etcd --version | tail -n +1 | head -n 1 | cut -d " " -f 3)
+  if [[ "${version}" < "${ETCD_VERSION}" ]]; then
+   export PATH=$KUBE_ROOT/third_party/etcd:$PATH
+   hash etcd
+   echo $PATH
+   ls $KUBE_ROOT/third_party/etcd
+   version=$(etcd --version | head -n 1 | cut -d " " -f 3)
+   if [[ "${version}" < "${ETCD_VERSION}" ]]; then
+    kube::log::usage "etcd version ${ETCD_VERSION} or greater required."
+    kube::log::info "You can use 'hack/install-etcd.sh' to install a copy in third_party/."
+    exit 1
+   fi
+  fi
+
+  # Start etcd
+  ETCD_DIR=${ETCD_DIR:-$(mktemp -d 2>/dev/null || mktemp -d -t test-etcd.XXXXXX)}
+  if [[ -d "${ARTIFACTS_DIR:-}" ]]; then
+    ETCD_LOGFILE="${ARTIFACTS_DIR}/etcd.$(uname -n).$(id -un).log.DEBUG.$(date +%Y%m%d-%H%M%S).$$"
+  else
+    ETCD_LOGFILE=/dev/null
+  fi
+  kube::log::info "etcd --advertise-client-urls http://${ETCD_HOST}:${ETCD_PORT} --data-dir ${ETCD_DIR} --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} --debug > \"${ETCD_LOGFILE}\" 2>/dev/null"
+  etcd --advertise-client-urls http://${ETCD_HOST}:${ETCD_PORT} --data-dir ${ETCD_DIR} --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} --debug 2> "${ETCD_LOGFILE}" >/dev/null &
+  ETCD_PID=$!
+
+  echo "Waiting for etcd to come up."
+  kube::util::wait_for_url "http://${ETCD_HOST}:${ETCD_PORT}/v2/machines" "etcd: " 0.25 80
+  curl -fs -X PUT "http://${ETCD_HOST}:${ETCD_PORT}/v2/keys/_test"
+}
+
+kube::etcd::stop() {
+  kill "${ETCD_PID-}" >/dev/null 2>&1 || :
+  wait "${ETCD_PID-}" >/dev/null 2>&1 || :
+}
+
+kube::etcd::clean_etcd_dir() {
+  rm -rf "${ETCD_DIR-}"
+}
+
+kube::etcd::cleanup() {
+  kube::etcd::stop
+  kube::etcd::clean_etcd_dir
+}
+
+kube::etcd::install() {
+  (
+    cd "${KUBE_ROOT}/third_party"
+    if [[ $(uname) == "Darwin" ]]; then
+      download_file="etcd-v${ETCD_VERSION}-darwin-amd64.zip"
+      url="https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/${download_file}"
+      kube::util::download_file "${url}" "${download_file}"
+      unzip -o "${download_file}"
+      ln -fns "etcd-v${ETCD_VERSION}-darwin-amd64" etcd
+      rm "${download_file}"
+    else
+      url="https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz"
+      download_file="etcd-v${ETCD_VERSION}-linux-amd64.tar.gz"
+      kube::util::download_file "${url}" "${download_file}"
+      tar xzf "${download_file}"
+      ln -fns "etcd-v${ETCD_VERSION}-linux-amd64" etcd
+    fi
+    kube::log::info "etcd v${ETCD_VERSION} installed. To use:"
+    kube::log::info "export PATH=$(pwd)/etcd:\${PATH}"
+  )
+}

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -1,0 +1,711 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The golang package that we are building.
+# BABYNETES - hard coded project path
+readonly KUBE_GO_PACKAGE=github.com/kubernetes-incubator/service-catalog
+readonly KUBE_GOPATH="${KUBE_OUTPUT}/go"
+
+# The set of server targets that we are only building for Linux
+# Note: if you are adding something here, you might need to add it to
+# kube::build::source_targets in build-tools/common.sh as well.
+kube::golang::server_targets() {
+  local targets=(
+    cmd/kube-dns
+    cmd/kube-proxy
+    cmd/kube-apiserver
+    cmd/kube-controller-manager
+    cmd/kubelet
+    cmd/kubeadm
+    cmd/hyperkube
+    cmd/kube-discovery
+    plugin/cmd/kube-scheduler
+  )
+  echo "${targets[@]}"
+}
+
+readonly KUBE_SERVER_TARGETS=($(kube::golang::server_targets))
+readonly KUBE_SERVER_BINARIES=("${KUBE_SERVER_TARGETS[@]##*/}")
+
+if [[ "${KUBE_FASTBUILD:-}" == "true" ]]; then
+  readonly KUBE_SERVER_PLATFORMS=(linux/amd64)
+  if [[ "${KUBE_BUILDER_OS:-}" == "darwin"* ]]; then
+    readonly KUBE_TEST_PLATFORMS=(
+      darwin/amd64
+      linux/amd64
+    )
+    readonly KUBE_CLIENT_PLATFORMS=(
+      darwin/amd64
+      linux/amd64
+    )
+  else
+    readonly KUBE_TEST_PLATFORMS=(linux/amd64)
+    readonly KUBE_CLIENT_PLATFORMS=(linux/amd64)
+  fi
+else
+
+  # The server platform we are building on.
+  KUBE_SERVER_PLATFORMS=(
+    linux/amd64
+    linux/arm
+    linux/arm64
+    linux/s390x
+  )
+  if [[ "${KUBE_BUILD_PPC64LE:-}" =~ ^[yY]$ ]]; then
+    KUBE_SERVER_PLATFORMS+=(linux/ppc64le)
+  fi
+  readonly KUBE_SERVER_PLATFORMS
+
+  # If we update this we should also update the set of golang compilers we build
+  # in 'build-tools/build-image/cross/Dockerfile'. However, it's only a bit faster since go 1.5, not mandatory
+  KUBE_CLIENT_PLATFORMS=(
+    linux/amd64
+    linux/386
+    linux/arm
+    linux/arm64
+    darwin/amd64
+    darwin/386
+    windows/amd64
+    windows/386
+    linux/s390x
+  )
+  if [[ "${KUBE_BUILD_PPC64LE:-}" =~ ^[yY]$ ]]; then
+    KUBE_CLIENT_PLATFORMS+=(linux/ppc64le)
+  fi
+  readonly KUBE_CLIENT_PLATFORMS
+
+  # Which platforms we should compile test targets for. Not all client platforms need these tests
+  readonly KUBE_TEST_PLATFORMS=(
+    linux/amd64
+    darwin/amd64
+    windows/amd64
+  )
+fi
+
+# The set of client targets that we are building for all platforms
+readonly KUBE_CLIENT_TARGETS=(
+  cmd/kubectl
+  federation/cmd/kubefed
+)
+readonly KUBE_CLIENT_BINARIES=("${KUBE_CLIENT_TARGETS[@]##*/}")
+readonly KUBE_CLIENT_BINARIES_WIN=("${KUBE_CLIENT_BINARIES[@]/%/.exe}")
+
+# The set of test targets that we are building for all platforms
+kube::golang::test_targets() {
+  local targets=(
+    cmd/gendocs
+    cmd/genkubedocs
+    cmd/genman
+    cmd/genyaml
+    cmd/mungedocs
+    cmd/genswaggertypedocs
+    cmd/linkcheck
+    examples/k8petstore/web-server/src
+    federation/cmd/genfeddocs
+    vendor/github.com/onsi/ginkgo/ginkgo
+    test/e2e/e2e.test
+  )
+  echo "${targets[@]}"
+}
+readonly KUBE_TEST_TARGETS=($(kube::golang::test_targets))
+readonly KUBE_TEST_BINARIES=("${KUBE_TEST_TARGETS[@]##*/}")
+readonly KUBE_TEST_BINARIES_WIN=("${KUBE_TEST_BINARIES[@]/%/.exe}")
+readonly KUBE_TEST_PORTABLE=(
+  test/e2e/testing-manifests
+  test/kubemark
+  hack/e2e.go
+  hack/e2e-internal
+  hack/get-build.sh
+  hack/ginkgo-e2e.sh
+  hack/federated-ginkgo-e2e.sh
+  hack/lib
+)
+
+# Test targets which run on the Kubernetes clusters directly, so we only
+# need to target server platforms.
+# These binaries will be distributed in the kubernetes-test tarball.
+readonly KUBE_TEST_SERVER_TARGETS=(
+  cmd/kubemark
+  vendor/github.com/onsi/ginkgo/ginkgo
+  test/e2e_node/e2e_node.test
+)
+readonly KUBE_TEST_SERVER_BINARIES=("${KUBE_TEST_SERVER_TARGETS[@]##*/}")
+readonly KUBE_TEST_SERVER_PLATFORMS=("${KUBE_SERVER_PLATFORMS[@]}")
+
+# Gigabytes desired for parallel platform builds. 11 is fairly
+# arbitrary, but is a reasonable splitting point for 2015
+# laptops-versus-not.
+readonly KUBE_PARALLEL_BUILD_MEMORY=11
+
+readonly KUBE_ALL_TARGETS=(
+  "${KUBE_SERVER_TARGETS[@]}"
+  "${KUBE_CLIENT_TARGETS[@]}"
+  "${KUBE_TEST_TARGETS[@]}"
+  "${KUBE_TEST_SERVER_TARGETS[@]}"
+)
+readonly KUBE_ALL_BINARIES=("${KUBE_ALL_TARGETS[@]##*/}")
+
+readonly KUBE_STATIC_LIBRARIES=(
+  kube-apiserver
+  kube-controller-manager
+  kube-dns
+  kube-scheduler
+  kube-proxy
+  kube-discovery
+  kubeadm
+  kubectl
+)
+
+# Add any files with those //generate annotations in the array below.
+readonly KUBE_BINDATAS=(
+  test/e2e/generated/gobindata_util.go
+)
+
+kube::golang::is_statically_linked_library() {
+  local e
+  for e in "${KUBE_STATIC_LIBRARIES[@]}"; do [[ "$1" == *"/$e" ]] && return 0; done;
+  # Allow individual overrides--e.g., so that you can get a static build of
+  # kubectl for inclusion in a container.
+  if [ -n "${KUBE_STATIC_OVERRIDES:+x}" ]; then
+    for e in "${KUBE_STATIC_OVERRIDES[@]}"; do [[ "$1" == *"/$e" ]] && return 0; done;
+  fi
+  return 1;
+}
+
+# kube::binaries_from_targets take a list of build targets and return the
+# full go package to be built
+kube::golang::binaries_from_targets() {
+  local target
+  for target; do
+    # If the target starts with what looks like a domain name, assume it has a
+    # fully-qualified package name rather than one that needs the Kubernetes
+    # package prepended.
+    if [[ "${target}" =~ ^([[:alnum:]]+".")+[[:alnum:]]+"/" ]]; then
+      echo "${target}"
+    else
+      echo "${KUBE_GO_PACKAGE}/${target}"
+    fi
+  done
+}
+
+# Asks golang what it thinks the host platform is. The go tool chain does some
+# slightly different things when the target platform matches the host platform.
+kube::golang::host_platform() {
+  echo "$(go env GOHOSTOS)/$(go env GOHOSTARCH)"
+}
+
+kube::golang::current_platform() {
+  local os="${GOOS-}"
+  if [[ -z $os ]]; then
+    os=$(go env GOHOSTOS)
+  fi
+
+  local arch="${GOARCH-}"
+  if [[ -z $arch ]]; then
+    arch=$(go env GOHOSTARCH)
+  fi
+
+  echo "$os/$arch"
+}
+
+# Takes the the platform name ($1) and sets the appropriate golang env variables
+# for that platform.
+kube::golang::set_platform_envs() {
+  [[ -n ${1-} ]] || {
+    kube::log::error_exit "!!! Internal error. No platform set in kube::golang::set_platform_envs"
+  }
+
+  export GOOS=${platform%/*}
+  export GOARCH=${platform##*/}
+
+  # Do not set CC when building natively on a platform, only if cross-compiling from linux/amd64
+  if [[ $(kube::golang::host_platform) == "linux/amd64" ]]; then
+
+    # Dynamic CGO linking for other server architectures than linux/amd64 goes here
+    # If you want to include support for more server platforms than these, add arch-specific gcc names here
+    case "${platform}" in
+      "linux/arm")
+        export CGO_ENABLED=1
+        export CC=arm-linux-gnueabi-gcc
+        # See https://github.com/kubernetes/kubernetes/issues/29904
+        export GOROOT=${K8S_PATCHED_GOROOT}
+        ;;
+      "linux/arm64")
+        export CGO_ENABLED=1
+        export CC=aarch64-linux-gnu-gcc
+        ;;
+      "linux/ppc64le")
+        export CGO_ENABLED=1
+        export CC=powerpc64le-linux-gnu-gcc
+        ;;
+      "linux/s390x")
+        export CGO_ENABLED=1
+        export CC=s390x-linux-gnu-gcc
+        ;;
+    esac
+  fi
+}
+
+kube::golang::unset_platform_envs() {
+  unset GOOS
+  unset GOARCH
+  unset GOROOT
+  unset CGO_ENABLED
+  unset CC
+}
+
+# Create the GOPATH tree under $KUBE_OUTPUT
+kube::golang::create_gopath_tree() {
+  local go_pkg_dir="${KUBE_GOPATH}/src/${KUBE_GO_PACKAGE}"
+  local go_pkg_basedir=$(dirname "${go_pkg_dir}")
+
+  mkdir -p "${go_pkg_basedir}"
+
+  # TODO: This symlink should be relative.
+  if [[ ! -e "${go_pkg_dir}" || "$(readlink ${go_pkg_dir})" != "${KUBE_ROOT}" ]]; then
+    ln -snf "${KUBE_ROOT}" "${go_pkg_dir}"
+  fi
+}
+
+# Ensure the godep tool exists and is a viable version.
+kube::golang::verify_godep_version() {
+  local -a godep_version_string
+  local godep_version
+  local godep_min_version="63"
+
+  if ! which godep &>/dev/null; then
+    kube::log::usage_from_stdin <<EOF
+Can't find 'godep' in PATH, please fix and retry.
+See https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md#godep-and-dependency-management for installation instructions.
+EOF
+    return 2
+  fi
+
+  godep_version_string=($(godep version))
+  godep_version=${godep_version_string[1]/v/}
+  if ((godep_version<$godep_min_version)); then
+    kube::log::usage_from_stdin <<EOF
+Detected godep version: ${godep_version_string[*]}.
+Kubernetes requires godep v$godep_min_version or greater.
+Please update:
+go get -u github.com/tools/godep
+EOF
+    return 2
+  fi
+}
+
+# Ensure the go tool exists and is a viable version.
+kube::golang::verify_go_version() {
+  if [[ -z "$(which go)" ]]; then
+    kube::log::usage_from_stdin <<EOF
+Can't find 'go' in PATH, please fix and retry.
+See http://golang.org/doc/install for installation instructions.
+EOF
+    return 2
+  fi
+
+  local go_version
+  go_version=($(go version))
+  if [[ "${go_version[2]}" < "go1.6" && "${go_version[2]}" != "devel" ]]; then
+    kube::log::usage_from_stdin <<EOF
+Detected go version: ${go_version[*]}.
+Kubernetes requires go version 1.6 or greater.
+Please install Go version 1.6 or later.
+EOF
+    return 2
+  fi
+}
+
+# kube::golang::setup_env will check that the `go` commands is available in
+# ${PATH}. It will also check that the Go version is good enough for the
+# Kubernetes build.
+#
+# Inputs:
+#   KUBE_EXTRA_GOPATH - If set, this is included in created GOPATH
+#
+# Outputs:
+#   env-var GOPATH points to our local output dir
+#   env-var GOBIN is unset (we want binaries in a predictable place)
+#   env-var GO15VENDOREXPERIMENT=1
+#   current directory is within GOPATH
+kube::golang::setup_env() {
+  kube::golang::verify_go_version
+
+  kube::golang::create_gopath_tree
+
+  export GOPATH=${KUBE_GOPATH}
+
+  # Append KUBE_EXTRA_GOPATH to the GOPATH if it is defined.
+  if [[ -n ${KUBE_EXTRA_GOPATH:-} ]]; then
+    GOPATH="${GOPATH}:${KUBE_EXTRA_GOPATH}"
+  fi
+
+  # Change directories so that we are within the GOPATH.  Some tools get really
+  # upset if this is not true.  We use a whole fake GOPATH here to collect the
+  # resultant binaries.  Go will not let us use GOBIN with `go install` and
+  # cross-compiling, and `go install -o <file>` only works for a single pkg.
+  local subdir
+  subdir=$(kube::realpath . | sed "s|$KUBE_ROOT||")
+  cd "${KUBE_GOPATH}/src/${KUBE_GO_PACKAGE}/${subdir}"
+
+  # Set GOROOT so binaries that parse code can work properly.
+  export GOROOT=$(go env GOROOT)
+
+  # Unset GOBIN in case it already exists in the current session.
+  unset GOBIN
+
+  # This seems to matter to some tools (godep, ugorji, ginkgo...)
+  export GO15VENDOREXPERIMENT=1
+}
+
+# This will take binaries from $GOPATH/bin and copy them to the appropriate
+# place in ${KUBE_OUTPUT_BINDIR}
+#
+# Ideally this wouldn't be necessary and we could just set GOBIN to
+# KUBE_OUTPUT_BINDIR but that won't work in the face of cross compilation.  'go
+# install' will place binaries that match the host platform directly in $GOBIN
+# while placing cross compiled binaries into `platform_arch` subdirs.  This
+# complicates pretty much everything else we do around packaging and such.
+kube::golang::place_bins() {
+  local host_platform
+  host_platform=$(kube::golang::host_platform)
+
+  V=2 kube::log::status "Placing binaries"
+
+  local platform
+  for platform in "${KUBE_CLIENT_PLATFORMS[@]}"; do
+    # The substitution on platform_src below will replace all slashes with
+    # underscores.  It'll transform darwin/amd64 -> darwin_amd64.
+    local platform_src="/${platform//\//_}"
+    if [[ $platform == $host_platform ]]; then
+      platform_src=""
+      rm -f "${THIS_PLATFORM_BIN}"
+      ln -s "${KUBE_OUTPUT_BINPATH}/${platform}" "${THIS_PLATFORM_BIN}"
+    fi
+
+    local full_binpath_src="${KUBE_GOPATH}/bin${platform_src}"
+    if [[ -d "${full_binpath_src}" ]]; then
+      mkdir -p "${KUBE_OUTPUT_BINPATH}/${platform}"
+      find "${full_binpath_src}" -maxdepth 1 -type f -exec \
+        rsync -pc {} "${KUBE_OUTPUT_BINPATH}/${platform}" \;
+    fi
+  done
+}
+
+kube::golang::fallback_if_stdlib_not_installable() {
+  local go_root_dir=$(go env GOROOT);
+  local go_host_os=$(go env GOHOSTOS);
+  local go_host_arch=$(go env GOHOSTARCH);
+  local cgo_pkg_dir=${go_root_dir}/pkg/${go_host_os}_${go_host_arch}_cgo;
+
+  if [ -e ${cgo_pkg_dir} ]; then
+    return 0;
+  fi
+
+  if [ -w ${go_root_dir}/pkg ]; then
+    return 0;
+  fi
+
+  kube::log::status "+++ Warning: stdlib pkg with cgo flag not found.";
+  kube::log::status "+++ Warning: stdlib pkg cannot be rebuilt since ${go_root_dir}/pkg is not writable by `whoami`";
+  kube::log::status "+++ Warning: Make ${go_root_dir}/pkg writable for `whoami` for a one-time stdlib install, Or"
+  kube::log::status "+++ Warning: Rebuild stdlib using the command 'CGO_ENABLED=0 go install -a -installsuffix cgo std'";
+  kube::log::status "+++ Falling back to go build, which is slower";
+
+  use_go_build=true
+}
+
+# Builds the toolchain necessary for building kube. This needs to be
+# built only on the host platform.
+# TODO: Find this a proper home.
+# Ideally, not a shell script because testing shell scripts is painful.
+kube::golang::build_kube_toolchain() {
+  local targets=(
+    hack/cmd/teststale
+    vendor/github.com/jteeuwen/go-bindata/go-bindata
+  )
+
+  local binaries
+  binaries=($(kube::golang::binaries_from_targets "${targets[@]}"))
+
+  kube::log::status "Building the toolchain targets:" "${binaries[@]}"
+  go install "${goflags[@]:+${goflags[@]}}" \
+        -gcflags "${gogcflags}" \
+        -ldflags "${goldflags}" \
+        "${binaries[@]:+${binaries[@]}}"
+}
+
+# Try and replicate the native binary placement of go install without
+# calling go install.
+kube::golang::output_filename_for_binary() {
+  local binary=$1
+  local platform=$2
+  local output_path="${KUBE_GOPATH}/bin"
+  if [[ $platform != $host_platform ]]; then
+    output_path="${output_path}/${platform//\//_}"
+  fi
+  local bin=$(basename "${binary}")
+  if [[ ${GOOS} == "windows" ]]; then
+    bin="${bin}.exe"
+  fi
+  echo "${output_path}/${bin}"
+}
+
+kube::golang::build_binaries_for_platform() {
+  local platform=$1
+  local use_go_build=${2-}
+
+  local -a statics=()
+  local -a nonstatics=()
+  local -a tests=()
+
+  V=2 kube::log::info "Env for ${platform}: GOOS=${GOOS-} GOARCH=${GOARCH-} GOROOT=${GOROOT-} CGO_ENABLED=${CGO_ENABLED-} CC=${CC-}"
+
+  for binary in "${binaries[@]}"; do
+
+    if [[ "${binary}" =~ ".test"$ ]]; then
+      tests+=($binary)
+    elif kube::golang::is_statically_linked_library "${binary}"; then
+      statics+=($binary)
+    else
+      nonstatics+=($binary)
+    fi
+  done
+
+  if [[ "${#statics[@]}" != 0 ]]; then
+      kube::golang::fallback_if_stdlib_not_installable;
+  fi
+
+  # TODO: Remove this temporary workaround when we have the official golang linker working
+  if [[ ${platform} == "linux/arm" ]]; then
+    gogcflags="${gogcflags} -largemodel"
+  fi
+
+  if [[ -n ${use_go_build:-} ]]; then
+    kube::log::progress "    "
+    for binary in "${statics[@]:+${statics[@]}}"; do
+      local outfile=$(kube::golang::output_filename_for_binary "${binary}" "${platform}")
+      CGO_ENABLED=0 go build -o "${outfile}" \
+        "${goflags[@]:+${goflags[@]}}" \
+        -gcflags "${gogcflags}" \
+        -ldflags "${goldflags}" \
+        "${binary}"
+      kube::log::progress "*"
+    done
+    for binary in "${nonstatics[@]:+${nonstatics[@]}}"; do
+      local outfile=$(kube::golang::output_filename_for_binary "${binary}" "${platform}")
+      go build -o "${outfile}" \
+        "${goflags[@]:+${goflags[@]}}" \
+        -gcflags "${gogcflags}" \
+        -ldflags "${goldflags}" \
+        "${binary}"
+      kube::log::progress "*"
+    done
+    kube::log::progress "\n"
+  else
+    # Use go install.
+    if [[ "${#nonstatics[@]}" != 0 ]]; then
+      go install "${goflags[@]:+${goflags[@]}}" \
+        -gcflags "${gogcflags}" \
+        -ldflags "${goldflags}" \
+        "${nonstatics[@]:+${nonstatics[@]}}"
+    fi
+    if [[ "${#statics[@]}" != 0 ]]; then
+      CGO_ENABLED=0 go install -installsuffix cgo "${goflags[@]:+${goflags[@]}}" \
+        -gcflags "${gogcflags}" \
+        -ldflags "${goldflags}" \
+        "${statics[@]:+${statics[@]}}"
+    fi
+  fi
+
+  for test in "${tests[@]:+${tests[@]}}"; do
+    local outfile=$(kube::golang::output_filename_for_binary "${test}" \
+      "${platform}")
+
+    local testpkg="$(dirname ${test})"
+
+    # Staleness check always happens on the host machine, so we don't
+    # have to locate the `teststale` binaries for the other platforms.
+    # Since we place the host binaries in `$KUBE_GOPATH/bin`, we can
+    # assume that the binary exists there, if it exists at all.
+    # Otherwise, something has gone wrong with building the `teststale`
+    # binary and we should safely proceed building the test binaries
+    # assuming that they are stale. There is no good reason to error
+    # out.
+    if test -x "${KUBE_GOPATH}/bin/teststale" && ! "${KUBE_GOPATH}/bin/teststale" -binary "${outfile}" -package "${testpkg}"
+    then
+      continue
+    fi
+
+    # `go test -c` below directly builds the binary. It builds the packages,
+    # but it never installs them. `go test -i` only installs the dependencies
+    # of the test, but not the test package itself. So neither `go test -c`
+    # nor `go test -i` installs, for example, test/e2e.a. And without that,
+    # doing a staleness check on k8s.io/kubernetes/test/e2e package always
+    # returns true (always stale). And that's why we need to install the
+    # test package.
+    go install "${goflags[@]:+${goflags[@]}}" \
+        -gcflags "${gogcflags}" \
+        -ldflags "${goldflags}" \
+        "${testpkg}"
+
+    mkdir -p "$(dirname ${outfile})"
+    go test -i -c \
+      "${goflags[@]:+${goflags[@]}}" \
+      -gcflags "${gogcflags}" \
+      -ldflags "${goldflags}" \
+      -o "${outfile}" \
+      "${testpkg}"
+  done
+}
+
+# Return approximate physical memory available in gigabytes.
+kube::golang::get_physmem() {
+  local mem
+
+  # Linux kernel version >=3.14, in kb
+  if mem=$(grep MemAvailable /proc/meminfo | awk '{ print $2 }'); then
+    echo $(( ${mem} / 1048576 ))
+    return
+  fi
+
+  # Linux, in kb
+  if mem=$(grep MemTotal /proc/meminfo | awk '{ print $2 }'); then
+    echo $(( ${mem} / 1048576 ))
+    return
+  fi
+
+  # OS X, in bytes. Note that get_physmem, as used, should only ever
+  # run in a Linux container (because it's only used in the multiple
+  # platform case, which is a Dockerized build), but this is provided
+  # for completeness.
+  if mem=$(sysctl -n hw.memsize 2>/dev/null); then
+    echo $(( ${mem} / 1073741824 ))
+    return
+  fi
+
+  # If we can't infer it, just give up and assume a low memory system
+  echo 1
+}
+
+# Build binaries targets specified
+#
+# Input:
+#   $@ - targets and go flags.  If no targets are set then all binaries targets
+#     are built.
+#   KUBE_BUILD_PLATFORMS - Incoming variable of targets to build for.  If unset
+#     then just the host architecture is built.
+kube::golang::build_binaries() {
+  # Create a sub-shell so that we don't pollute the outer environment
+  (
+    # Check for `go` binary and set ${GOPATH}.
+    kube::golang::setup_env
+    V=2 kube::log::info "Go version: $(go version)"
+
+    local host_platform
+    host_platform=$(kube::golang::host_platform)
+
+    # Use eval to preserve embedded quoted strings.
+    local goflags goldflags gogcflags
+    eval "goflags=(${KUBE_GOFLAGS:-})"
+    goldflags="${KUBE_GOLDFLAGS:-} $(kube::version::ldflags)"
+    gogcflags="${KUBE_GOGCFLAGS:-}"
+
+    local use_go_build
+    local -a targets=()
+    local arg
+
+    for arg; do
+      if [[ "${arg}" == "--use_go_build" ]]; then
+        use_go_build=true
+      elif [[ "${arg}" == -* ]]; then
+        # Assume arguments starting with a dash are flags to pass to go.
+        goflags+=("${arg}")
+      else
+        targets+=("${arg}")
+      fi
+    done
+
+    if [[ ${#targets[@]} -eq 0 ]]; then
+      targets=("${KUBE_ALL_TARGETS[@]}")
+    fi
+
+    local -a platforms=(${KUBE_BUILD_PLATFORMS:-})
+    if [[ ${#platforms[@]} -eq 0 ]]; then
+      platforms=("${host_platform}")
+    fi
+
+    local binaries
+    binaries=($(kube::golang::binaries_from_targets "${targets[@]}"))
+
+    local parallel=false
+    if [[ ${#platforms[@]} -gt 1 ]]; then
+      local gigs
+      gigs=$(kube::golang::get_physmem)
+
+      if [[ ${gigs} -ge ${KUBE_PARALLEL_BUILD_MEMORY} ]]; then
+        kube::log::status "Multiple platforms requested and available ${gigs}G >= threshold ${KUBE_PARALLEL_BUILD_MEMORY}G, building platforms in parallel"
+        parallel=true
+      else
+        kube::log::status "Multiple platforms requested, but available ${gigs}G < threshold ${KUBE_PARALLEL_BUILD_MEMORY}G, building platforms in serial"
+        parallel=false
+      fi
+    fi
+
+    # First build the toolchain before building any other targets
+    kube::golang::build_kube_toolchain
+
+    kube::log::status "Generating bindata:" "${KUBE_BINDATAS[@]}"
+    for bindata in ${KUBE_BINDATAS[@]}; do
+      # Only try to generate bindata if the file exists, since in some cases
+      # one-off builds of individual directories may exclude some files.
+      if [[ -f "${KUBE_ROOT}/${bindata}" ]]; then
+        go generate "${goflags[@]:+${goflags[@]}}" "${KUBE_ROOT}/${bindata}"
+      fi
+    done
+
+    if [[ "${parallel}" == "true" ]]; then
+      kube::log::status "Building go targets for {${platforms[*]}} in parallel (output will appear in a burst when complete):" "${targets[@]}"
+      local platform
+      for platform in "${platforms[@]}"; do (
+          kube::golang::set_platform_envs "${platform}"
+          kube::log::status "${platform}: go build started"
+          kube::golang::build_binaries_for_platform ${platform} ${use_go_build:-}
+          kube::log::status "${platform}: go build finished"
+        ) &> "/tmp//${platform//\//_}.build" &
+      done
+
+      local fails=0
+      for job in $(jobs -p); do
+        wait ${job} || let "fails+=1"
+      done
+
+      for platform in "${platforms[@]}"; do
+        cat "/tmp//${platform//\//_}.build"
+      done
+
+      exit ${fails}
+    else
+      for platform in "${platforms[@]}"; do
+        kube::log::status "Building go targets for ${platform}:" "${targets[@]}"
+        (
+          kube::golang::set_platform_envs "${platform}"
+          kube::golang::build_binaries_for_platform ${platform} ${use_go_build:-}
+        )
+      done
+    fi
+  )
+}

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# The root of the build/dist directory
+KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE}")/../.." && pwd -P)"
+
+KUBE_OUTPUT_SUBPATH="${KUBE_OUTPUT_SUBPATH:-_output/local}"
+KUBE_OUTPUT="${KUBE_ROOT}/${KUBE_OUTPUT_SUBPATH}"
+KUBE_OUTPUT_BINPATH="${KUBE_OUTPUT}/bin"
+
+# This controls rsync compression. Set to a value > 0 to enable rsync
+# compression for build container
+KUBE_RSYNC_COMPRESS="${KUBE_RSYNC_COMPRESS:-0}"
+
+# Set no_proxy for localhost if behind a proxy, otherwise, 
+# the connections to localhost in scripts will time out
+export no_proxy=127.0.0.1,localhost
+
+# This is a symlink to binaries for "this platform", e.g. build tools.
+THIS_PLATFORM_BIN="${KUBE_ROOT}/_output/bin"
+
+source "${KUBE_ROOT}/hack/lib/util.sh"
+source "${KUBE_ROOT}/cluster/lib/util.sh"
+source "${KUBE_ROOT}/cluster/lib/logging.sh"
+
+kube::log::install_errexit
+
+source "${KUBE_ROOT}/hack/lib/version.sh"
+source "${KUBE_ROOT}/hack/lib/golang.sh"
+source "${KUBE_ROOT}/hack/lib/etcd.sh"
+
+KUBE_OUTPUT_HOSTBIN="${KUBE_OUTPUT_BINPATH}/$(kube::util::host_platform)"
+
+# list of all available group versions.  This should be used when generated code
+# or when starting an API server that you want to have everything.
+# most preferred version for a group should appear first
+# BABYNETES - this was a list based on Kubernetes previously
+KUBE_AVAILABLE_GROUP_VERSIONS="${KUBE_AVAILABLE_GROUP_VERSIONS:-}"
+
+# not all group versions are exposed by the server.  This list contains those
+# which are not available so we don't generate clients or swagger for them
+# BABYNETES - fix it
+KUBE_NONSERVER_GROUP_VERSIONS="
+ abac.authorization.kubernetes.io/v0 \
+ abac.authorization.kubernetes.io/v1beta1 \
+ componentconfig/v1alpha1 \
+ imagepolicy.k8s.io/v1alpha1\
+"
+
+# This emulates "readlink -f" which is not available on MacOS X.
+# Test:
+# T=/tmp/$$.$RANDOM
+# mkdir $T
+# touch $T/file
+# mkdir $T/dir
+# ln -s $T/file $T/linkfile
+# ln -s $T/dir $T/linkdir
+# function testone() {
+#   X=$(readlink -f $1 2>&1)
+#   Y=$(kube::readlinkdashf $1 2>&1)
+#   if [ "$X" != "$Y" ]; then
+#     echo readlinkdashf $1: expected "$X", got "$Y"
+#   fi
+# }
+# testone /
+# testone /tmp
+# testone $T
+# testone $T/file
+# testone $T/dir
+# testone $T/linkfile
+# testone $T/linkdir
+# testone $T/nonexistant
+# testone $T/linkdir/file
+# testone $T/linkdir/dir
+# testone $T/linkdir/linkfile
+# testone $T/linkdir/linkdir
+function kube::readlinkdashf {
+  # run in a subshell for simpler 'cd'
+  (
+    if [[ -d "$1" ]]; then # This also catch symlinks to dirs.
+      cd "$1"
+      pwd -P
+    else
+      cd $(dirname "$1")
+      local f
+      f=$(basename "$1")
+      if [[ -L "$f" ]]; then
+        readlink "$f"
+      else
+        echo "$(pwd -P)/${f}"
+      fi
+    fi
+  )
+}
+
+# This emulates "realpath" which is not available on MacOS X
+# Test:
+# T=/tmp/$$.$RANDOM
+# mkdir $T
+# touch $T/file
+# mkdir $T/dir
+# ln -s $T/file $T/linkfile
+# ln -s $T/dir $T/linkdir
+# function testone() {
+#   X=$(realpath $1 2>&1)
+#   Y=$(kube::realpath $1 2>&1)
+#   if [ "$X" != "$Y" ]; then
+#     echo realpath $1: expected "$X", got "$Y"
+#   fi
+# }
+# testone /
+# testone /tmp
+# testone $T
+# testone $T/file
+# testone $T/dir
+# testone $T/linkfile
+# testone $T/linkdir
+# testone $T/nonexistant
+# testone $T/linkdir/file
+# testone $T/linkdir/dir
+# testone $T/linkdir/linkfile
+# testone $T/linkdir/linkdir
+kube::realpath() {
+  if [[ ! -e "$1" ]]; then
+    echo "$1: No such file or directory" >&2
+    return 1
+  fi
+  kube::readlinkdashf "$1"
+}

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -1,0 +1,580 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kube::util::sortable_date() {
+  date "+%Y%m%d-%H%M%S"
+}
+
+kube::util::wait_for_url() {
+  local url=$1
+  local prefix=${2:-}
+  local wait=${3:-1}
+  local times=${4:-30}
+
+  which curl >/dev/null || {
+    kube::log::usage "curl must be installed"
+    exit 1
+  }
+
+  local i
+  for i in $(seq 1 $times); do
+    local out
+    if out=$(curl --max-time 1 -gkfs $url 2>/dev/null); then
+      kube::log::status "On try ${i}, ${prefix}: ${out}"
+      return 0
+    fi
+    sleep ${wait}
+  done
+  kube::log::error "Timed out waiting for ${prefix} to answer at ${url}; tried ${times} waiting ${wait} between each"
+  return 1
+}
+
+# returns a random port
+kube::util::get_random_port() {
+  awk -v min=1024 -v max=65535 'BEGIN{srand(); print int(min+rand()*(max-min+1))}'
+}
+
+# use netcat to check if the host($1):port($2) is free (return 0 means free, 1 means used)
+kube::util::test_host_port_free() {
+  local host=$1
+  local port=$2
+  local success=0
+  local fail=1
+
+  which nc >/dev/null || {
+    kube::log::usage "netcat isn't installed, can't verify if ${host}:${port} is free, skipping the check..."
+    return ${success}
+  }
+
+  if [ ! $(nc -vz "${host}" "${port}") ]; then
+    kube::log::status "${host}:${port} is free, proceeding..."
+    return ${success}
+  else
+    kube::log::status "${host}:${port} is already used"
+    return ${fail}
+  fi
+}
+
+# Example:  kube::util::trap_add 'echo "in trap DEBUG"' DEBUG
+# See: http://stackoverflow.com/questions/3338030/multiple-bash-traps-for-the-same-signal
+kube::util::trap_add() {
+  local trap_add_cmd
+  trap_add_cmd=$1
+  shift
+
+  for trap_add_name in "$@"; do
+    local existing_cmd
+    local new_cmd
+
+    # Grab the currently defined trap commands for this trap
+    existing_cmd=`trap -p "${trap_add_name}" |  awk -F"'" '{print $2}'`
+
+    if [[ -z "${existing_cmd}" ]]; then
+      new_cmd="${trap_add_cmd}"
+    else
+      new_cmd="${existing_cmd};${trap_add_cmd}"
+    fi
+
+    # Assign the test
+    trap "${new_cmd}" "${trap_add_name}"
+  done
+}
+
+# Opposite of kube::util::ensure-temp-dir()
+kube::util::cleanup-temp-dir() {
+  rm -rf "${KUBE_TEMP}"
+}
+
+# Create a temp dir that'll be deleted at the end of this bash session.
+#
+# Vars set:
+#   KUBE_TEMP
+kube::util::ensure-temp-dir() {
+  if [[ -z ${KUBE_TEMP-} ]]; then
+    KUBE_TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t kubernetes.XXXXXX)
+    kube::util::trap_add kube::util::cleanup-temp-dir EXIT
+  fi
+}
+
+# This figures out the host platform without relying on golang.  We need this as
+# we don't want a golang install to be a prerequisite to building yet we need
+# this info to figure out where the final binaries are placed.
+kube::util::host_platform() {
+  local host_os
+  local host_arch
+  case "$(uname -s)" in
+    Darwin)
+      host_os=darwin
+      ;;
+    Linux)
+      host_os=linux
+      ;;
+    *)
+      kube::log::error "Unsupported host OS.  Must be Linux or Mac OS X."
+      exit 1
+      ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64*)
+      host_arch=amd64
+      ;;
+    i?86_64*)
+      host_arch=amd64
+      ;;
+    amd64*)
+      host_arch=amd64
+      ;;
+    aarch64*)
+      host_arch=arm64
+      ;;
+    arm64*)
+      host_arch=arm64
+      ;;
+    arm*)
+      host_arch=arm
+      ;;
+    i?86*)
+      host_arch=x86
+      ;;
+    s390x*)
+      host_arch=s390x
+      ;;
+    ppc64le*)
+      host_arch=ppc64le
+      ;;
+    *)
+      kube::log::error "Unsupported host arch. Must be x86_64, 386, arm, arm64, s390x or ppc64le."
+      exit 1
+      ;;
+  esac
+  echo "${host_os}/${host_arch}"
+}
+
+kube::util::find-binary-for-platform() {
+  local -r lookfor="$1"
+  local -r platform="$2"
+  local -r locations=(
+    "${KUBE_ROOT}/_output/bin/${lookfor}"
+    "${KUBE_ROOT}/_output/dockerized/bin/${platform}/${lookfor}"
+    "${KUBE_ROOT}/_output/local/bin/${platform}/${lookfor}"
+    "${KUBE_ROOT}/platforms/${platform}/${lookfor}"
+  )
+  local -r bin=$( (ls -t "${locations[@]}" 2>/dev/null || true) | head -1 )
+  echo -n "${bin}"
+}
+
+kube::util::find-binary() {
+  kube::util::find-binary-for-platform "$1" "$(kube::util::host_platform)"
+}
+
+# Run all known doc generators (today gendocs and genman for kubectl)
+# $1 is the directory to put those generated documents
+kube::util::gen-docs() {
+  local dest="$1"
+
+  # Find binary
+  gendocs=$(kube::util::find-binary "gendocs")
+  genkubedocs=$(kube::util::find-binary "genkubedocs")
+  genman=$(kube::util::find-binary "genman")
+  genyaml=$(kube::util::find-binary "genyaml")
+  genfeddocs=$(kube::util::find-binary "genfeddocs")
+
+  mkdir -p "${dest}/docs/user-guide/kubectl/"
+  "${gendocs}" "${dest}/docs/user-guide/kubectl/"
+  mkdir -p "${dest}/docs/admin/"
+  "${genkubedocs}" "${dest}/docs/admin/" "kube-apiserver"
+  "${genkubedocs}" "${dest}/docs/admin/" "kube-controller-manager"
+  "${genkubedocs}" "${dest}/docs/admin/" "kube-proxy"
+  "${genkubedocs}" "${dest}/docs/admin/" "kube-scheduler"
+  "${genkubedocs}" "${dest}/docs/admin/" "kubelet"
+
+  # We don't really need federation-apiserver and federation-controller-manager
+  # binaries to generate the docs. We just pass their names to decide which docs
+  # to generate. The actual binary for running federation is hyperkube.
+  "${genfeddocs}" "${dest}/docs/admin/" "federation-apiserver"
+  "${genfeddocs}" "${dest}/docs/admin/" "federation-controller-manager"
+
+  mkdir -p "${dest}/docs/man/man1/"
+  "${genman}" "${dest}/docs/man/man1/" "kube-apiserver"
+  "${genman}" "${dest}/docs/man/man1/" "kube-controller-manager"
+  "${genman}" "${dest}/docs/man/man1/" "kube-proxy"
+  "${genman}" "${dest}/docs/man/man1/" "kube-scheduler"
+  "${genman}" "${dest}/docs/man/man1/" "kubelet"
+  "${genman}" "${dest}/docs/man/man1/" "kubectl"
+
+  mkdir -p "${dest}/docs/yaml/kubectl/"
+  "${genyaml}" "${dest}/docs/yaml/kubectl/"
+
+  # create the list of generated files
+  pushd "${dest}" > /dev/null
+  touch .generated_docs
+  find . -type f | cut -sd / -f 2- | LC_ALL=C sort > .generated_docs
+  popd > /dev/null
+}
+
+# Puts a placeholder for every generated doc. This makes the link checker work.
+kube::util::set-placeholder-gen-docs() {
+  local list_file="${KUBE_ROOT}/.generated_docs"
+  if [ -e ${list_file} ]; then
+    # remove all of the old docs; we don't want to check them in.
+    while read file; do
+      if [[ "${list_file}" != "${KUBE_ROOT}/${file}" ]]; then
+        cp "${KUBE_ROOT}/hack/autogenerated_placeholder.txt" "${KUBE_ROOT}/${file}"
+      fi
+    done <"${list_file}"
+    # The .generated_docs file lists itself, so we don't need to explicitly
+    # delete it.
+  fi
+}
+
+# Removes previously generated docs-- we don't want to check them in. $KUBE_ROOT
+# must be set.
+kube::util::remove-gen-docs() {
+  if [ -e "${KUBE_ROOT}/.generated_docs" ]; then
+    # remove all of the old docs; we don't want to check them in.
+    while read file; do
+      rm "${KUBE_ROOT}/${file}" 2>/dev/null || true
+    done <"${KUBE_ROOT}/.generated_docs"
+    # The .generated_docs file lists itself, so we don't need to explicitly
+    # delete it.
+  fi
+}
+
+# Takes a path $1 to traverse for md files to append the ga-beacon tracking
+# link to, if needed. If $2 is set, just print files that are missing
+# the link.
+kube::util::gen-analytics() {
+  local path="$1"
+  local dryrun="${2:-}"
+  local mdfiles dir link
+  # find has some strange inconsistencies between darwin/linux. The
+  # path to search must end in '/' for linux, but darwin will put an extra
+  # slash in results if there is a trailing '/'.
+  if [[ $( uname ) == 'Linux' ]]; then
+    dir="${path}/"
+  else
+    dir="${path}"
+  fi
+  # We don't touch files in special dirs, and the kubectl docs are
+  # autogenerated by gendocs.
+  # Don't descend into .directories
+  mdfiles=($( find "${dir}" -name "*.md" -type f \
+              -not -path '*/\.*' \
+              -not -path "${path}/vendor/*" \
+              -not -path "${path}/staging/*" \
+              -not -path "${path}/third_party/*" \
+              -not -path "${path}/_gopath/*" \
+              -not -path "${path}/_output/*" \
+              -not -path "${path}/docs/user-guide/kubectl/kubectl*" ))
+  for f in "${mdfiles[@]}"; do
+    link=$(kube::util::analytics-link "${f#${path}/}")
+    if grep -q -F -x "${link}" "${f}"; then
+      continue
+    elif [[ -z "${dryrun}" ]]; then
+      echo -e "\n\n${link}" >> "${f}"
+    else
+      echo "$f"
+    fi
+  done
+}
+
+# Prints analytics link to append to a file at path $1.
+kube::util::analytics-link() {
+  local path="$1"
+  echo "[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/${path}?pixel)]()"
+}
+
+# Takes a group/version and returns the path to its location on disk, sans
+# "pkg". E.g.:
+# * default behavior: extensions/v1beta1 -> apis/extensions/v1beta1
+# * default behavior for only a group: experimental -> apis/experimental
+# * Special handling for empty group: v1 -> api/v1, unversioned -> api/unversioned
+# * Special handling for groups suffixed with ".k8s.io": foo.k8s.io/v1 -> apis/foo/v1
+# * Very special handling for when both group and version are "": / -> api
+kube::util::group-version-to-pkg-path() {
+  local group_version="$1"
+  # Special cases first.
+  # TODO(lavalamp): Simplify this by moving pkg/api/v1 and splitting pkg/api,
+  # moving the results to pkg/apis/api.
+  case "${group_version}" in
+    # both group and version are "", this occurs when we generate deep copies for internal objects of the legacy v1 API.
+    __internal)
+      echo "api"
+      ;;
+    v1)
+      echo "api/v1"
+      ;;
+    unversioned)
+      echo "api/unversioned"
+      ;;
+    *.k8s.io)
+      echo "apis/${group_version%.*k8s.io}"
+      ;;
+    *.k8s.io/*)
+      echo "apis/${group_version/.*k8s.io/}"
+      ;;
+    *)
+      echo "apis/${group_version%__internal}"
+      ;;
+  esac
+}
+
+# Takes a group/version and returns the swagger-spec file name.
+# default behavior: extensions/v1beta1 -> extensions_v1beta1
+# special case for v1: v1 -> v1
+kube::util::gv-to-swagger-name() {
+  local group_version="$1"
+  case "${group_version}" in
+    v1)
+      echo "v1"
+      ;;
+    *)
+      echo "${group_version%/*}_${group_version#*/}"
+      ;;
+  esac
+}
+
+
+# Fetches swagger spec from apiserver.
+# Assumed vars:
+# SWAGGER_API_PATH: Base path for swaggerapi on apiserver. Ex:
+# http://localhost:8080/swaggerapi.
+# SWAGGER_ROOT_DIR: Root dir where we want to to save the fetched spec.
+# VERSIONS: Array of group versions to include in swagger spec.
+kube::util::fetch-swagger-spec() {
+  for ver in ${VERSIONS}; do
+    if [[ " ${KUBE_NONSERVER_GROUP_VERSIONS} " == *" ${ver} "* ]]; then
+      continue
+    fi
+    # fetch the swagger spec for each group version.
+    if [[ ${ver} == "v1" ]]; then
+      SUBPATH="api"
+    else
+      SUBPATH="apis"
+    fi
+    SUBPATH="${SUBPATH}/${ver}"
+    SWAGGER_JSON_NAME="$(kube::util::gv-to-swagger-name ${ver}).json"
+    curl -w "\n" -fs "${SWAGGER_API_PATH}${SUBPATH}" > "${SWAGGER_ROOT_DIR}/${SWAGGER_JSON_NAME}"
+
+    # fetch the swagger spec for the discovery mechanism at group level.
+    if [[ ${ver} == "v1" ]]; then
+      continue
+    fi
+    SUBPATH="apis/"${ver%/*}
+    SWAGGER_JSON_NAME="${ver%/*}.json"
+    curl -w "\n" -fs "${SWAGGER_API_PATH}${SUBPATH}" > "${SWAGGER_ROOT_DIR}/${SWAGGER_JSON_NAME}"
+  done
+
+  # fetch swagger specs for other discovery mechanism.
+  curl -w "\n" -fs "${SWAGGER_API_PATH}" > "${SWAGGER_ROOT_DIR}/resourceListing.json"
+  curl -w "\n" -fs "${SWAGGER_API_PATH}version" > "${SWAGGER_ROOT_DIR}/version.json"
+  curl -w "\n" -fs "${SWAGGER_API_PATH}api" > "${SWAGGER_ROOT_DIR}/api.json"
+  curl -w "\n" -fs "${SWAGGER_API_PATH}apis" > "${SWAGGER_ROOT_DIR}/apis.json"
+  curl -w "\n" -fs "${SWAGGER_API_PATH}logs" > "${SWAGGER_ROOT_DIR}/logs.json"
+}
+
+# Returns the name of the upstream remote repository name for the local git
+# repo, e.g. "upstream" or "origin".
+kube::util::git_upstream_remote_name() {
+  git remote -v | grep fetch |\
+    # BABYNETES - hard coded project name
+    grep -E 'github.com[/:]kubernetes-incubator/service-catalog|k8s.io/kubernetes' |\
+    head -n 1 | awk '{print $1}'
+}
+
+# Checks whether there are any files matching pattern $2 changed between the
+# current branch and upstream branch named by $1.
+# Returns 1 (false) if there are no changes, 0 (true) if there are changes
+# detected.
+kube::util::has_changes_against_upstream_branch() {
+  local -r git_branch=$1
+  local -r pattern=$2
+  local full_branch
+
+  full_branch="$(kube::util::git_upstream_remote_name)/${git_branch}"
+  echo "Checking for '${pattern}' changes against '${full_branch}'"
+  # make sure the branch is valid, otherwise the check will pass erroneously.
+  if ! git describe "${full_branch}" >/dev/null; then
+    # abort!
+    exit 1
+  fi
+  # notice this uses ... to find the first shared ancestor
+  if git diff --name-only "${full_branch}...HEAD" | grep "${pattern}" > /dev/null; then
+    return 0
+  fi
+  # also check for pending changes
+  if git status --porcelain | grep "${pattern}" > /dev/null; then
+    echo "Detected '${pattern}' uncommitted changes."
+    return 0
+  fi
+  echo "No '${pattern}' changes detected."
+  return 1
+}
+
+kube::util::download_file() {
+  local -r url=$1
+  local -r destination_file=$2
+
+  rm  ${destination_file} 2&> /dev/null || true
+
+  for i in $(seq 5)
+  do
+    if ! curl -fsSL --retry 3 --keepalive-time 2 ${url} -o ${destination_file}; then
+      echo "Downloading ${url} failed. $((5-i)) retries left."
+      sleep 1
+    else
+      echo "Downloading ${url} succeed"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Test whether cfssl and cfssljson are installed.
+# Sets:
+#  CFSSL_BIN: The path of the installed cfssl binary
+#  CFSSLJSON_BIN: The path of the installed cfssljson binary
+function kube::util::test_cfssl_installed {
+    if ! command -v cfssl &>/dev/null || ! command -v cfssljson &>/dev/null; then
+      echo "Failed to successfully run 'cfssl', please verify that cfssl and cfssljson are in \$PATH."
+      echo "Hint: export PATH=\$PATH:\$GOPATH/bin; go get -u github.com/cloudflare/cfssl/cmd/..."
+      exit 1
+    fi
+    CFSSL_BIN=$(command -v cfssl)
+    CFSSLJSON_BIN=$(command -v cfssljson)
+}
+
+# Test whether openssl is installed.
+# Sets:
+#  OPENSSL_BIN: The path to the openssl binary to use
+function kube::util::test_openssl_installed {
+    openssl version >& /dev/null
+    if [ "$?" != "0" ]; then
+      echo "Failed to run openssl. Please ensure openssl is installed"
+      exit 1
+    fi
+    OPENSSL_BIN=$(command -v openssl)
+}
+
+# creates a client CA, args are sudo, dest-dir, ca-id, purpose
+# purpose is dropped in after "key encipherment", you usually want
+# '"client auth"'
+# '"server auth"'
+# '"client auth","server auth"'
+function kube::util::create_signing_certkey {
+    local sudo=$1
+    local dest_dir=$2
+    local id=$3
+    local purpose=$4
+    # Create client ca
+    ${sudo} /bin/bash -e <<EOF
+    rm -f "${dest_dir}/${id}-ca.crt" "${dest_dir}/${id}-ca.key"
+    ${OPENSSL_BIN} req -x509 -sha256 -new -nodes -days 365 -newkey rsa:2048 -keyout "${dest_dir}/${id}-ca.key" -out "${dest_dir}/${id}-ca.crt" -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=ca/emailAddress=x/"
+    echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment",${purpose}]}}}' > "${dest_dir}/${id}-ca-config.json"
+EOF
+}
+
+# signs a client certificate: args are sudo, dest-dir, CA, filename (roughly), username, groups...
+function kube::util::create_client_certkey {
+    local sudo=$1
+    local dest_dir=$2
+    local ca=$3
+    local id=$4
+    local cn=${5:-$4}
+    local groups=""
+    local SEP=""
+    shift 5
+    while [ -n "${1:-}" ]; do
+        groups+="${SEP}{\"O\":\"$1\"}"
+        SEP=","
+        shift 1
+    done
+    ${sudo} /bin/bash -e <<EOF
+    cd ${dest_dir}
+    echo '{"CN":"${cn}","names":[${groups}],"hosts":[""],"key":{"algo":"rsa","size":2048}}' | ${CFSSL_BIN} gencert -ca=${ca}.crt -ca-key=${ca}.key -config=${ca}-config.json - | ${CFSSLJSON_BIN} -bare client-${id}
+    mv "client-${id}-key.pem" "client-${id}.key"
+    mv "client-${id}.pem" "client-${id}.crt"
+    rm -f "client-${id}.csr"
+EOF
+}
+
+# signs a serving certificate: args are sudo, dest-dir, ca, filename (roughly), subject, hosts...
+function kube::util::create_serving_certkey {
+    local sudo=$1
+    local dest_dir=$2
+    local ca=$3
+    local id=$4
+    local cn=${5:-$4}
+    local hosts=""
+    local SEP=""
+    shift 5
+    while [ -n "${1:-}" ]; do
+        hosts+="${SEP}\"$1\""
+        SEP=","
+        shift 1
+    done
+    ${sudo} /bin/bash -e <<EOF
+    cd ${dest_dir}
+    echo '{"CN":"${cn}","hosts":[${hosts}],"key":{"algo":"rsa","size":2048}}' | ${CFSSL_BIN} gencert -ca=${ca}.crt -ca-key=${ca}.key -config=${ca}-config.json - | ${CFSSLJSON_BIN} -bare serving-${id}
+    mv "serving-${id}-key.pem" "serving-${id}.key"
+    mv "serving-${id}.pem" "serving-${id}.crt"
+    rm -f "serving-${id}.csr"
+EOF
+}
+
+# creates a self-contained kubeconfig: args are sudo, dest-dir, ca file, host, port, client id, token(optional)
+function kube::util::write_client_kubeconfig {
+    local sudo=$1
+    local dest_dir=$2
+    local ca_file=$3
+    local api_host=$4
+    local api_port=$5
+    local client_id=$6
+    local token=${7:-}
+    cat <<EOF | ${sudo} tee "${dest_dir}"/${client_id}.kubeconfig > /dev/null
+apiVersion: v1
+kind: Config
+clusters:
+  - cluster:
+      certificate-authority: ${ca_file}
+      server: https://${api_host}:${api_port}/
+    name: local-up-cluster
+users:
+  - user:
+      token: ${token}
+      client-certificate: ${dest_dir}/client-${client_id}.crt
+      client-key: ${dest_dir}/client-${client_id}.key
+    name: local-up-cluster
+contexts:
+  - context:
+      cluster: local-up-cluster
+      user: local-up-cluster
+    name: local-up-cluster
+current-context: local-up-cluster
+EOF
+
+    # flatten the kubeconfig files to make them self contained
+    username=$(whoami)
+    ${sudo} /bin/bash -e <<EOF
+    $(kube::util::find-binary kubectl) --kubeconfig="${dest_dir}/${client_id}.kubeconfig" config view --minify --flatten > "/tmp/${client_id}.kubeconfig"
+    mv -f "/tmp/${client_id}.kubeconfig" "${dest_dir}/${client_id}.kubeconfig"
+    chown ${username} "${dest_dir}/${client_id}.kubeconfig"
+EOF
+}
+
+
+# ex: ts=2 sw=2 et filetype=sh

--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------------------------
+# Version management helpers.  These functions help to set, save and load the
+# following variables:
+#
+#    KUBE_GIT_COMMIT - The git commit id corresponding to this
+#          source code.
+#    KUBE_GIT_TREE_STATE - "clean" indicates no changes since the git commit id
+#        "dirty" indicates source code changes after the git commit id
+#    KUBE_GIT_VERSION - "vX.Y" used to indicate the last release version.
+#    KUBE_GIT_MAJOR - The major part of the version
+#    KUBE_GIT_MINOR - The minor component of the version
+
+# Grovels through git to set a set of env variables.
+#
+# If KUBE_GIT_VERSION_FILE, this function will load from that file instead of
+# querying git.
+kube::version::get_version_vars() {
+  if [[ -n ${KUBE_GIT_VERSION_FILE-} ]]; then
+    kube::version::load_version_vars "${KUBE_GIT_VERSION_FILE}"
+    return
+  fi
+
+  local git=(git --work-tree "${KUBE_ROOT}")
+
+  if [[ -n ${KUBE_GIT_COMMIT-} ]] || KUBE_GIT_COMMIT=$("${git[@]}" rev-parse "HEAD^{commit}" 2>/dev/null); then
+    if [[ -z ${KUBE_GIT_TREE_STATE-} ]]; then
+      # Check if the tree is dirty.  default to dirty
+      if git_status=$("${git[@]}" status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
+        KUBE_GIT_TREE_STATE="clean"
+      else
+        KUBE_GIT_TREE_STATE="dirty"
+      fi
+    fi
+
+    # Use git describe to find the version based on annotated tags.
+    if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$("${git[@]}" describe --tags --abbrev=14 "${KUBE_GIT_COMMIT}^{commit}" 2>/dev/null); then
+      # This translates the "git describe" to an actual semver.org
+      # compatible semantic version that looks something like this:
+      #   v1.1.0-alpha.0.6+84c76d1142ea4d
+      #
+      # TODO: We continue calling this "git version" because so many
+      # downstream consumers are expecting it there.
+      DASHES_IN_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/[^-]//g")
+      if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
+        # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
+        KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
+      elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
+        # We have distance to base tag (v1.1.0-1-gCommitHash)
+        KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/+\1/")
+      fi
+      if [[ "${KUBE_GIT_TREE_STATE}" == "dirty" ]]; then
+        # git describe --dirty only considers changes to existing files, but
+        # that is problematic since new untracked .go files affect the build,
+        # so use our idea of "dirty" from git status instead.
+        KUBE_GIT_VERSION+="-dirty"
+      fi
+
+
+      # Try to match the "git describe" output to a regex to try to extract
+      # the "major" and "minor" versions and whether this is the exact tagged
+      # version or whether the tree is between two tagged versions.
+      if [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?$ ]]; then
+        KUBE_GIT_MAJOR=${BASH_REMATCH[1]}
+        KUBE_GIT_MINOR=${BASH_REMATCH[2]}
+        if [[ -n "${BASH_REMATCH[4]}" ]]; then
+          KUBE_GIT_MINOR+="+"
+        fi
+      fi
+    fi
+  fi
+}
+
+# Saves the environment flags to $1
+kube::version::save_version_vars() {
+  local version_file=${1-}
+  [[ -n ${version_file} ]] || {
+    echo "!!! Internal error.  No file specified in kube::version::save_version_vars"
+    return 1
+  }
+
+  cat <<EOF >"${version_file}"
+KUBE_GIT_COMMIT='${KUBE_GIT_COMMIT-}'
+KUBE_GIT_TREE_STATE='${KUBE_GIT_TREE_STATE-}'
+KUBE_GIT_VERSION='${KUBE_GIT_VERSION-}'
+KUBE_GIT_MAJOR='${KUBE_GIT_MAJOR-}'
+KUBE_GIT_MINOR='${KUBE_GIT_MINOR-}'
+EOF
+}
+
+# Loads up the version variables from file $1
+kube::version::load_version_vars() {
+  local version_file=${1-}
+  [[ -n ${version_file} ]] || {
+    echo "!!! Internal error.  No file specified in kube::version::load_version_vars"
+    return 1
+  }
+
+  source "${version_file}"
+}
+
+kube::version::ldflag() {
+  local key=${1}
+  local val=${2}
+
+  echo "-X ${KUBE_GO_PACKAGE}/pkg/version.${key}=${val}"
+}
+
+# Prints the value that needs to be passed to the -ldflags parameter of go build
+# in order to set the Kubernetes based on the git tree status.
+kube::version::ldflags() {
+  kube::version::get_version_vars
+
+  local -a ldflags=($(kube::version::ldflag "buildDate" "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"))
+  if [[ -n ${KUBE_GIT_COMMIT-} ]]; then
+    ldflags+=($(kube::version::ldflag "gitCommit" "${KUBE_GIT_COMMIT}"))
+    ldflags+=($(kube::version::ldflag "gitTreeState" "${KUBE_GIT_TREE_STATE}"))
+  fi
+
+  if [[ -n ${KUBE_GIT_VERSION-} ]]; then
+    ldflags+=($(kube::version::ldflag "gitVersion" "${KUBE_GIT_VERSION}"))
+  fi
+
+  if [[ -n ${KUBE_GIT_MAJOR-} && -n ${KUBE_GIT_MINOR-} ]]; then
+    ldflags+=(
+      $(kube::version::ldflag "gitMajor" "${KUBE_GIT_MAJOR}")
+      $(kube::version::ldflag "gitMinor" "${KUBE_GIT_MINOR}")
+    )
+  fi
+
+  # The -ldflags parameter takes a single string, so join the output.
+  echo "${ldflags[*]-}"
+}

--- a/hack/make-rules/build.sh
+++ b/hack/make-rules/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script sets up a go workspace locally and builds all go components.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+KUBE_VERBOSE="${KUBE_VERBOSE:-1}"
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+kube::golang::build_binaries "$@"
+kube::golang::place_bins

--- a/hack/make-rules/helpers/cache_go_dirs.sh
+++ b/hack/make-rules/helpers/cache_go_dirs.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script finds, caches, and prints a list of all directories that hold
+# *.go files.  If any directory is newer than the cache, re-find everything and
+# update the cache.  Otherwise use the cached file.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ -z "${1:-}" ]]; then
+    echo "usage: $0 <cache-file>"
+    exit 1
+fi
+CACHE="$1"; shift
+
+trap "rm -f '${CACHE}'" HUP INT TERM ERR
+
+# This is a partial 'find' command.  The caller is expected to pass the
+# remaining arguments.
+#
+# Example:
+#   kfind -type f -name foobar.go
+function kfind() {
+    find .                         \
+        -not \(                    \
+            \(                     \
+                -path ./vendor -o  \
+                -path ./staging -o \
+                -path ./_\* -o     \
+                -path ./.\* -o     \
+                -path ./docs -o    \
+                -path ./examples   \
+            \) -prune              \
+        \)                         \
+        "$@"
+}
+
+NEED_FIND=true
+# It's *significantly* faster to check whether any directories are newer than
+# the cache than to blindly rebuild it.
+if [[ -f "${CACHE}" ]]; then
+    N=$(kfind -type d -newer "${CACHE}" -print -quit | wc -l)
+    [[ "${N}" == 0 ]] && NEED_FIND=false
+fi
+mkdir -p $(dirname "${CACHE}")
+if $("${NEED_FIND}"); then
+    kfind -type f -name \*.go  \
+        | sed 's|/[^/]*$||'    \
+        | sed 's|^./||'        \
+        | LC_ALL=C sort -u     \
+        > "${CACHE}"
+fi
+cat "${CACHE}"

--- a/hack/run-in-gopath.sh
+++ b/hack/run-in-gopath.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script sets up a temporary Kubernetes GOPATH and runs an arbitrary
+# command under it.  Go tooling requires that the current directory be under
+# GOPATH or else it fails to find some things, such as the vendor directory for
+# the project.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+# This sets up a clean GOPATH and makes sure we are currently in it.
+kube::golang::setup_env
+
+# Run the user-provided command.
+"${@}"

--- a/pkg/apis/servicecatalog/doc.go
+++ b/pkg/apis/servicecatalog/doc.go
@@ -12,5 +12,6 @@ limitations under the License.
 */
 
 // +k8s:defaulter-gen=TypeMeta
+// +k8s:deepcopy-gen=package,register
 
 package servicecatalog

--- a/pkg/apis/servicecatalog/doc.go
+++ b/pkg/apis/servicecatalog/doc.go
@@ -1,0 +1,16 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +k8s:defaulter-gen=TypeMeta
+
+package servicecatalog

--- a/pkg/apis/servicecatalog/v1alpha1/doc.go
+++ b/pkg/apis/servicecatalog/v1alpha1/doc.go
@@ -12,5 +12,6 @@ limitations under the License.
 */
 
 // +k8s:defaulter-gen=TypeMeta
+// +k8s:deepcopy-gen=package,register
 
 package v1alpha1

--- a/pkg/apis/servicecatalog/v1alpha1/doc.go
+++ b/pkg/apis/servicecatalog/v1alpha1/doc.go
@@ -1,0 +1,16 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +k8s:defaulter-gen=TypeMeta
+
+package v1alpha1


### PR DESCRIPTION
Currently, "make generated_files" generates code for defaults
(zz_generated.defaults.go).

If marked JPEELER, that's a personal addition or project specific
difference from upstream. Files were fully copied over except for
Makefiles.

There's also some debugging left turned on for now, specifically
DBG_MAKEFILES in Makefile.

---

This is very much a work in progress! I plan on updating this with some more
analysis soon.