### PR TITLE
changes for code-generation to work

### DIFF
--- a/pkg/apis/servicecatalog/register.go
+++ b/pkg/apis/servicecatalog/register.go
@@ -24,9 +24,11 @@ func Resource(resource string) schema.GroupResource {
 }
 
 var (
-	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	// SchemeBuilder needs to be exported as `SchemeBuilder` so
+	// the code-generation can find it.
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 	// AddToScheme is exposed for API installation
-	AddToScheme = schemeBuilder.AddToScheme
+	AddToScheme = SchemeBuilder.AddToScheme
 )
 
 func addKnownTypes(scheme *runtime.Scheme) error {

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -17,8 +17,7 @@ limitations under the License.
 package servicecatalog
 
 import (
-	kapi "k8s.io/client-go/1.5/pkg/api"
-	kunversioned "k8s.io/client-go/1.5/pkg/api/unversioned"
+	kapi "k8s.io/kubernetes/pkg/api"
 	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 )
 
@@ -28,8 +27,6 @@ import (
 // service catalog.
 type Broker struct {
 	metav1.TypeMeta
-	// ObjectMeta fulfills the meta.ObjectMetaAccessor interface so that the stock
-	// REST handler paths work
 	kapi.ObjectMeta
 
 	Spec   BrokerSpec
@@ -97,7 +94,7 @@ const (
 
 // ServiceClass represents an offering in the service catalog.
 type ServiceClass struct {
-	kunversioned.TypeMeta
+	metav1.TypeMeta
 	kapi.ObjectMeta
 
 	// BrokerName is the reference to the Broker that provides this service.
@@ -140,7 +137,7 @@ type ServicePlan struct {
 
 // Instance represents a provisioned instance of a ServiceClass.
 type Instance struct {
-	kunversioned.TypeMeta
+	metav1.TypeMeta
 	kapi.ObjectMeta
 
 	Spec   InstanceSpec
@@ -210,7 +207,7 @@ const (
 // Binding represents a "used by" relationship between an application and an
 // Instance.
 type Binding struct {
-	kunversioned.TypeMeta
+	metav1.TypeMeta
 	kapi.ObjectMeta
 
 	Spec   BindingSpec
@@ -224,7 +221,7 @@ type BindingSpec struct {
 	InstanceRef kapi.ObjectReference
 	// AppLabelSelector selects the pods in the Binding's namespace that
 	// should be injected with the results of the binding.  Immutable.
-	AppLabelSelector kunversioned.LabelSelector
+	AppLabelSelector metav1.LabelSelector
 
 	Parameters map[string]interface{}
 

--- a/pkg/apis/servicecatalog/v1alpha1/register.go
+++ b/pkg/apis/servicecatalog/v1alpha1/register.go
@@ -24,9 +24,11 @@ func Resource(resource string) schema.GroupResource {
 }
 
 var (
-	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	// SchemeBuilder needs to be exported as `SchemeBuilder` so
+	// the code-generation can find it.
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 	// AddToScheme is exposed for API installation
-	AddToScheme = schemeBuilder.AddToScheme
+	AddToScheme = SchemeBuilder.AddToScheme
 )
 
 func addKnownTypes(scheme *runtime.Scheme) error {

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -17,8 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	kunversioned "k8s.io/client-go/1.5/pkg/api/unversioned"
-	kapi "k8s.io/client-go/1.5/pkg/api/v1"
+	kapi "k8s.io/kubernetes/pkg/api"
 	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 )
 
@@ -96,7 +95,7 @@ const (
 
 // ServiceClass represents an offering in the service catalog.
 type ServiceClass struct {
-	kunversioned.TypeMeta
+	metav1.TypeMeta
 	kapi.ObjectMeta
 
 	// BrokerName is the reference to the Broker that provides this service.
@@ -139,7 +138,7 @@ type ServicePlan struct {
 
 // Instance represents a provisioned instance of a ServiceClass.
 type Instance struct {
-	kunversioned.TypeMeta
+	metav1.TypeMeta
 	kapi.ObjectMeta
 
 	Spec   InstanceSpec
@@ -209,7 +208,7 @@ const (
 // Binding represents a "used by" relationship between an application and an
 // Instance.
 type Binding struct {
-	kunversioned.TypeMeta
+	metav1.TypeMeta
 	kapi.ObjectMeta
 
 	Spec   BindingSpec
@@ -223,7 +222,7 @@ type BindingSpec struct {
 	InstanceRef kapi.ObjectReference
 	// AppLabelSelector selects the pods in the Binding's namespace that
 	// should be injected with the results of the binding.  Immutable.
-	AppLabelSelector kunversioned.LabelSelector
+	AppLabelSelector metav1.LabelSelector
 
 	Parameters map[string]interface{}
 


### PR DESCRIPTION
 - SchemeBuilder needs to be exported with that exact name
 - use the internal versions of meta objects


Generation is going to need this stuff set as it is, or else things blow up. 

Not sure how we're supposed to know that...