### PR TITLE
apiserver storage and resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ $(BINDIR)/user-broker: contrib/broker/k8s $(shell find contrib/broker/k8s -type 
 
 # We'll rebuild apiserver if any go file has changed (ie. NEWEST_GO_FILE)
 apiserver: $(BINDIR)/apiserver
+#.PHONY: $(BINDIR)/apiserver
 $(BINDIR)/apiserver: .generate_files cmd/service-catalog $(NEWEST_GO_FILE)
 	$(DOCKER) $(GO_BUILD) -o $@ $(SC_PKG)/cmd/service-catalog
 

--- a/docs/api-server-walkthrough.md
+++ b/docs/api-server-walkthrough.md
@@ -18,7 +18,10 @@ Compile `cmd/service-catalog/server.go` with `go build -o apiserver -v`
 
 Start with:
 ```
-$ ./apiserver --etcd-servers localhost
+# run etcd locally on the default port
+$ etcd 
+# switch to another shell and run
+$ ./apiserver --etcd-servers localhost:2379
 ```
 An etcd server is not hooked into yet, and is not required to be running.
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8f38c9409c1f1310461c4082316fd99ab1a6738d00cee9217f36d7185c33d648
-updated: 2017-01-03T16:43:20.986074952Z
+hash: cf90869b1903cc2aac4f0558d807dcceaadfb6d184ecce33b7d8f59b364280d3
+updated: 2017-01-04T13:14:52.525198173-08:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -14,6 +14,61 @@ imports:
   - quantile
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
+- name: github.com/coreos/etcd
+  version: 8a37349097a592db79ba3087f3cae9cd4b0af21c
+  subpackages:
+  - alarm
+  - auth
+  - auth/authpb
+  - client
+  - clientv3
+  - compactor
+  - discovery
+  - error
+  - etcdserver
+  - etcdserver/api
+  - etcdserver/api/v2http
+  - etcdserver/api/v2http/httptypes
+  - etcdserver/api/v3rpc
+  - etcdserver/api/v3rpc/rpctypes
+  - etcdserver/auth
+  - etcdserver/etcdserverpb
+  - etcdserver/membership
+  - etcdserver/stats
+  - integration
+  - lease
+  - lease/leasehttp
+  - lease/leasepb
+  - mvcc
+  - mvcc/backend
+  - mvcc/mvccpb
+  - pkg/adt
+  - pkg/contention
+  - pkg/crc
+  - pkg/fileutil
+  - pkg/httputil
+  - pkg/idutil
+  - pkg/ioutil
+  - pkg/logutil
+  - pkg/netutil
+  - pkg/pathutil
+  - pkg/pbutil
+  - pkg/runtime
+  - pkg/schedule
+  - pkg/testutil
+  - pkg/tlsutil
+  - pkg/transport
+  - pkg/types
+  - pkg/wait
+  - raft
+  - raft/raftpb
+  - rafthttp
+  - snap
+  - snap/snappb
+  - store
+  - version
+  - wal
+  - wal/walpb
 - name: github.com/coreos/go-oidc
   version: 5644a2f50e2d2d5ba0b474bc5bc55fea1925936d
   subpackages:
@@ -117,7 +172,13 @@ imports:
 - name: github.com/gorilla/handlers
   version: 3a5767ca75ece5f7f1440b1d16975247f8d8b221
 - name: github.com/gorilla/mux
-  version: 757bef944d0f21880861c2dd9c871ca543023cba
+  version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
+- name: github.com/grpc-ecosystem/grpc-gateway
+  version: f52d055dc48aec25854ed7d31862f78913cf17d1
+  subpackages:
+  - runtime
+  - runtime/internal
+  - utilities
 - name: github.com/howeyc/gopass
   version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
 - name: github.com/imdario/mergo
@@ -144,6 +205,10 @@ imports:
   - pbutil
 - name: github.com/mitchellh/mapstructure
   version: 740c764bc6149d3f1806231418adb9f52c11bcbf
+- name: github.com/mxk/go-flowrate
+  version: cca7078d478f8520f85629ad7c68962d31ed7682
+  subpackages:
+  - flowrate
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/pkg/errors
@@ -207,7 +272,7 @@ imports:
   - testhelper
   - testhelper/client
 - name: github.com/satori/go.uuid
-  version: b061729afc07e77a8aa4fad0a2fd840958f1942a
+  version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/spf13/cobra
   version: f62e98d28ab7ad31d707ba837a966378465c7b57
 - name: github.com/spf13/pflag
@@ -278,6 +343,17 @@ imports:
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
+- name: google.golang.org/grpc
+  version: 231b4cfea0e79843053a33f5fe90bd4d84b23cd3
+  subpackages:
+  - codes
+  - credentials
+  - grpclog
+  - internal
+  - metadata
+  - naming
+  - peer
+  - transport
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/natefinch/lumberjack.v2
@@ -407,15 +483,15 @@ imports:
   - parser
   - types
 - name: k8s.io/kubernetes
-  version: 6b9a9442855d16e0ff0c02ab0c82b1c1665cccaf
+  version: 12147a3cd6f52b1831c8af34d14d52e2811a4668
   subpackages:
   - pkg/admission
   - pkg/api
   - pkg/api/endpoints
   - pkg/api/errors
+  - pkg/api/errors/storage
   - pkg/api/install
   - pkg/api/meta
-  - pkg/api/meta/metatypes
   - pkg/api/pod
   - pkg/api/resource
   - pkg/api/rest
@@ -457,6 +533,7 @@ imports:
   - pkg/apis/extensions/install
   - pkg/apis/extensions/v1beta1
   - pkg/apis/meta/v1
+  - pkg/apis/meta/v1/unstructured
   - pkg/apis/meta/v1/validation
   - pkg/apis/policy
   - pkg/apis/policy/install
@@ -544,6 +621,9 @@ imports:
   - pkg/master/ports
   - pkg/probe
   - pkg/probe/http
+  - pkg/registry/cachesize
+  - pkg/registry/generic
+  - pkg/registry/generic/registry
   - pkg/runtime
   - pkg/runtime/schema
   - pkg/runtime/serializer
@@ -557,8 +637,12 @@ imports:
   - pkg/serviceaccount
   - pkg/ssh
   - pkg/storage
+  - pkg/storage/etcd
   - pkg/storage/etcd/metrics
+  - pkg/storage/etcd/util
+  - pkg/storage/etcd3
   - pkg/storage/storagebackend
+  - pkg/storage/storagebackend/factory
   - pkg/types
   - pkg/util
   - pkg/util/cache

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,7 @@ import:
 - package: github.com/kubernetes/repo-infra
   version: fe0ddb2a8c18deeb18515b9412e459599e6d7f3a
 - package: k8s.io/kubernetes
-  version: 6b9a9442855d16e0ff0c02ab0c82b1c1665cccaf
+  version: 12147a3cd6f52b1831c8af34d14d52e2811a4668
   subpackages:
   - pkg/genericapiserver
 - package: k8s.io/client-go
@@ -28,3 +28,6 @@ import:
   - 1.5/pkg/util/intstr
   - 1.5/pkg/watch
   - 1.5/tools/clientcmd
+- package: github.com/mxk/go-flowrate
+  subpackages:
+  - flowrate

--- a/pkg/apis/servicecatalog/register.go
+++ b/pkg/apis/servicecatalog/register.go
@@ -17,8 +17,6 @@ limitations under the License.
 package servicecatalog
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/runtime/schema"
 )
@@ -50,12 +48,13 @@ var (
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		// TODO are all of these needed? What do they do?
-		&api.ListOptions{},
-		&api.DeleteOptions{},
-		&metav1.ExportOptions{},
-		&metav1.GetOptions{},
+		// &api.ListOptions{},
+		// &api.DeleteOptions{},
+		// &metav1.ExportOptions{},
+		// &metav1.GetOptions{},
 
 		&Broker{},
+		&BrokerList{},
 	)
 	return nil
 }

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -23,10 +23,20 @@ import (
 
 // +nonNamespaced=true
 
+// BrokerList is a list of brokers
+type BrokerList struct {
+	metav1.TypeMeta
+	metav1.ListMeta
+
+	Items []Broker
+}
+
 // Broker represents an entity that provides ServiceClasses for use in the
 // service catalog.
 type Broker struct {
 	metav1.TypeMeta
+	// ObjectMeta fulfills the meta.ObjectMetaAccessor interface so that the stock
+	// REST handler paths work
 	kapi.ObjectMeta
 
 	Spec   BrokerSpec

--- a/pkg/apis/servicecatalog/v1alpha1/register.go
+++ b/pkg/apis/servicecatalog/v1alpha1/register.go
@@ -17,10 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/watch/versioned"
 )
 
 // GroupName is the group name use in this package
@@ -50,12 +49,14 @@ var (
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		// TODO are all of these needed? What do they do?
-		&api.ListOptions{},
-		&api.DeleteOptions{},
-		&metav1.ExportOptions{},
-		&metav1.GetOptions{},
+		// &api.ListOptions{},
+		// &api.DeleteOptions{},
+		// &metav1.ExportOptions{},
+		// &metav1.GetOptions{},
 
 		&Broker{},
+		&BrokerList{},
 	)
+	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -23,6 +23,14 @@ import (
 
 // +nonNamespaced=true
 
+// BrokerList is a list of brokers, COME ON.
+type BrokerList struct {
+	metav1.TypeMeta
+	metav1.ListMeta
+
+	Items []Broker
+}
+
 // Broker represents an entity that provides ServiceClasses for use in the
 // service catalog.
 type Broker struct {

--- a/pkg/apis/servicecatalog/validation/validation.go
+++ b/pkg/apis/servicecatalog/validation/validation.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+// this contains stubs of nothing until it is understood how it works
+
+import (
+	// commented out until we use the base validation utilities
+	// "k8s.io/kubernetes/pkg/api/validation"
+	// "k8s.io/kubernetes/pkg/api/validation/path"
+	// utilvalidation "k8s.io/kubernetes/pkg/util/validation"
+	"k8s.io/kubernetes/pkg/util/validation/field"
+
+	discoveryapi "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+)
+
+// for both of these assuming a nil non-error is ok
+
+// ValidateBroker makes sure a broker object is okay?
+func ValidateBroker(apiServer *discoveryapi.Broker) field.ErrorList {
+	return nil
+}
+
+// ValidateBrokerUpdate checks that when changing from an older broker to a newer broker is okay ?
+func ValidateBrokerUpdate(new *discoveryapi.Broker, old *discoveryapi.Broker) field.ErrorList {
+	return nil
+}

--- a/pkg/registry/servicecatalog/etcd/etcd.go
+++ b/pkg/registry/servicecatalog/etcd/etcd.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package etcd
 
 import (

--- a/pkg/registry/servicecatalog/etcd/etcd.go
+++ b/pkg/registry/servicecatalog/etcd/etcd.go
@@ -1,0 +1,39 @@
+package etcd
+
+import (
+	"k8s.io/kubernetes/pkg/registry/generic"
+	genericregistry "k8s.io/kubernetes/pkg/registry/generic/registry"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	apis "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	registry "github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog"
+)
+
+// REST implements a RESTStorage for API services against etcd
+type REST struct {
+	*genericregistry.Store
+}
+
+// NewREST returns a RESTStorage object that will work against API services.
+//
+// this seems like it needs to be specifically written for each resource?
+func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
+	store := &genericregistry.Store{
+		NewFunc:     func() runtime.Object { return &apis.Broker{} },
+		NewListFunc: func() runtime.Object { return &apis.BrokerList{} },
+		ObjectNameFunc: func(obj runtime.Object) (string, error) {
+			return obj.(*apis.Broker).Name, nil
+		},
+		PredicateFunc:     registry.MatchAPIService,
+		QualifiedResource: apis.Resource("servicecatalog"),
+
+		CreateStrategy: registry.Strategy,
+		UpdateStrategy: registry.Strategy,
+		DeleteStrategy: registry.Strategy,
+	}
+	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: registry.GetAttrs}
+	if err := store.CompleteWithOptions(options); err != nil {
+		panic(err) // TODO: Propagate error up
+	}
+	return &REST{store}
+}

--- a/pkg/registry/servicecatalog/strategy.go
+++ b/pkg/registry/servicecatalog/strategy.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package servicecatalog
 
 // this was copied from where else and edited to fit our objects

--- a/pkg/registry/servicecatalog/strategy.go
+++ b/pkg/registry/servicecatalog/strategy.go
@@ -1,0 +1,84 @@
+package servicecatalog
+
+// this was copied from where else and edited to fit our objects
+
+import (
+	"fmt"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
+	"k8s.io/kubernetes/pkg/util/validation/field"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation"
+)
+
+type apiServerStrategy struct {
+	runtime.ObjectTyper
+	kapi.NameGenerator
+}
+
+// Strategy implements the call backs for the generic store
+var Strategy = apiServerStrategy{kapi.Scheme, kapi.SimpleNameGenerator}
+
+func (apiServerStrategy) NamespaceScoped() bool {
+	return false
+}
+
+func (apiServerStrategy) PrepareForCreate(ctx kapi.Context, obj runtime.Object) {
+	_ = obj.(*servicecatalog.Broker)
+}
+
+func (apiServerStrategy) PrepareForUpdate(ctx kapi.Context, new, old runtime.Object) {
+	newAPIService := new.(*servicecatalog.Broker)
+	oldAPIService := old.(*servicecatalog.Broker)
+	newAPIService.Status = oldAPIService.Status
+}
+
+func (apiServerStrategy) Validate(ctx kapi.Context, obj runtime.Object) field.ErrorList {
+	return validation.ValidateBroker(obj.(*servicecatalog.Broker))
+}
+
+func (apiServerStrategy) AllowCreateOnUpdate() bool {
+	return false
+}
+
+func (apiServerStrategy) AllowUnconditionalUpdate() bool {
+	return false
+}
+
+func (apiServerStrategy) Canonicalize(obj runtime.Object) {
+}
+
+func (apiServerStrategy) ValidateUpdate(ctx kapi.Context, new, old runtime.Object) field.ErrorList {
+	return validation.ValidateBrokerUpdate(new.(*servicecatalog.Broker), old.(*servicecatalog.Broker))
+}
+
+// GetAttrs returns attrs.
+func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
+	apiserver, ok := obj.(*servicecatalog.Broker)
+	if !ok {
+		return nil, nil, fmt.Errorf("given object is not a broker, COME ON")
+	}
+	return labels.Set(apiserver.ObjectMeta.Labels), aPIServiceToSelectableFields(apiserver), nil
+}
+
+// MatchAPIService is the filter used by the generic etcd backend to watch events
+// from etcd to clients of the apiserver only interested in specific labels/fields.
+func MatchAPIService(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+	return storage.SelectionPredicate{
+		Label:    label,
+		Field:    field,
+		GetAttrs: GetAttrs,
+	}
+}
+
+// APIServiceToSelectableFields returns a field set that represents the object.
+// no reason for this to be exported that I can see.
+func aPIServiceToSelectableFields(obj *servicecatalog.Broker) fields.Set {
+	return generic.ObjectMetaFieldsSet(&obj.ObjectMeta, true)
+}


### PR DESCRIPTION
next 'simplest change that achieves something'. I'm not sure valid this is as forward progress, and I don't really understand most of it. I was copying stuff from `kubernetes-discovery` and the `federation` servers.

if you go back one commit, you can see a different storageFactory. I don't understand the difference, but this final version is simpler/less code.

unfortunately it breaks all the kubectl communication. error is `error: server does not support API version "v1"`. Error even for `kubectl version`, which worked before.

It does look for etcd, so that has to be running. remember to have set your ` --etcd-servers` flag e.g.  `--etcd-servers http://localhost:2379` for the default etcd listener.


More stuff shows up in curl, which I took as progress. I do not know how to manipulate it if it can be manipulated.
```
#  curl --cacert /var/run/kubernetes/apiserver.crt https://localhost:6443/apis/servicecatalog.k8s.io/v1alpha1
{
  "kind": "APIResourceList",
  "apiVersion": "v1",
  "groupVersion": "servicecatalog.k8s.io/v1alpha1",
  "resources": [
    {
      "name": "servicecatalog",
      "namespaced": true,
      "kind": "Broker",
      "verbs": [
        "create",
        "delete",
        "deletecollection",
        "get",
        "list",
        "patch",
        "update",
        "watch"
      ]
    }
  ]
}
```

I don't like that the smallest I can make this is a several hundred line change, but please help me to understand it more.
