### PR TITLE
Improve logging during deploy and poll endpoints

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -ux
+set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -57,7 +57,24 @@ function print_logs() {
   fi
 }
 
-trap print_logs EXIT
+function wait_for_service_host() {
+    if [[ "${#}" -ne 2 ]]; then
+      echo 'Unexpected number of arguments passed.'
+      return 1
+    fi
+
+    local name="${1}"
+    local path="${2}"
+    local services_output="$(kubectl get services --namespace "${NAMESPACE}" | xargs echo -n)"
+    local host="$(echo "${services_output}" | sed "s/.*${name} [0-9.]* \([0-9.]*\) \([0-9]*\).*/\1:\2/")"
+
+    retry -n 20 -s 10 -t 60 \
+        curl --silent --fail "http://${host}/${path}" > /dev/null \
+      && return 0
+
+    echo "Could not communicate with ${host}/${path}. Response: $(curl "http://${host}/${path}")"
+    return 1
+}
 
 GCR="${GCR:-gcr.io/${PROJECT}/catalog}"
 VERSION="${VERSION:-$(git rev-parse --verify HEAD)}" \
@@ -71,27 +88,53 @@ kubectl create namespace "${NAMESPACE}"
 
 retry -n 10 -s 10 -t 60 \
     helm install "${ROOT}/deploy/catalog" \
-    --set "registry=${GCR},version=${VERSION}" \
+    --set "registry=${GCR},version=${VERSION},debug=true" \
     --namespace "${NAMESPACE}" \
   || error_exit 'Error deploying to Kubernetes cluster.'
 
+# CREATE SERVICES
+
+trap print_logs EXIT
+
+# Wait for pods to be up
 echo 'Waiting on services to spin up...'
 
-# CREATE SERVICES
-wait_for_expected_output -x -e 'ContainerCreating' -n 20 -s 10 -t 60  \
-    kubectl get pods --namespace ${NAMESPACE} \
+wait_for_expected_output -x -e 'ContainerCreating' -n 20 -s 10 -t 60 \
+    kubectl get pods --namespace "${NAMESPACE}" \
   || error_exit 'Services took an unexpected amount of time to spin up.'
 
-# Check to see if Kubernetes resources have finished being created.
-retry kubectl get serviceclasses,serviceinstances,servicebrokers,servicebindings \
-  || error_exit 'Kubernetes resources took an unexpected amount of time to spin up.'
+kubectl get pods --namespace "${NAMESPACE}" --no-headers  | grep -v Running \
+  && error_exit 'Pods failed to spin up successfully.'
+
+# Wait for services to respond
+echo 'Waiting on services to respond...'
+
+wait_for_expected_output -x -e 'pending' -n 20 -s 10 -t 60 \
+    kubectl get services --namespace "${NAMESPACE}" \
+  || error_exit 'Services took an unexpected amount of time to spin up.'
+
+echo 'Waiting on services to get external IP...'
+
+wait_for_service_host 'registry' 'services' \
+  || error_exit 'Error when trying to communicate with registry.'
+
+wait_for_service_host 'k8s-broker' 'v2/catalog' \
+  || error_exit 'Error when trying to communicate with k8s broker.'
+
+wait_for_service_host 'ups-broker' 'v2/catalog' \
+  || error_exit 'Error when trying to communicate with ups broker.'
+
+#wait_for_service_host 'controller' 'v2/service_brokers' \
+#  || error_exit 'Error when trying to communicate with controller.'
 
 echo 'Creating resources...'
 
 kubectl create -f "${ROOT}/contrib/examples/walkthrough/broker.yaml" \
-  || error_exit 'Cannot create broker.'
+  || error_exit 'Cannot create brokers.'
 
-sleep 10 #TODO: check that the broker actually came up.
+wait_for_expected_output -e 'booksbe' -n 20 -s 1 -t 60 \
+    kubectl get serviceclasses \
+  || error_exit 'Could not retrieve service classes from broker.'
 
 kubectl create -f "${ROOT}/contrib/examples/walkthrough/backend.yaml" \
   || error_exit 'Cannot create backend.'
@@ -106,8 +149,7 @@ sleep 10
 kubectl create -f "${ROOT}/contrib/examples/walkthrough/frontend.yaml" \
   || error_exit 'Cannot create frontend.'
 
-echo 'Waiting for frontend service to come up...'
-wait_for_expected_output -e 'booksfe' -n 20 -s 10 -t 60 \
+wait_for_expected_output -e 'booksfe' -n 20 -s 2 -t 60 \
     kubectl get services \
   || error_exit 'Frontend service took unexpected amount of time to come up.'
 
@@ -116,11 +158,11 @@ wait_for_expected_output -x -e 'pending' -n 20 -s 10 -t 60 \
     kubectl get services \
   || error_exit 'Frontend service took unexpected amount of time to get external IP.'
 
-IP=$(echo $(kubectl get services) | sed 's/.*booksfe [0-9.]* \([0-9.]*\).*/\1/')
+IP="$(kubectl get services | xargs echo -n | sed 's/.*booksfe [0-9.]* \([0-9.]*\).*/\1/')"
 
 echo 'Waiting for frontend service to unblock...'
 wait_for_expected_output -x -e 'blocked' -n 20 -s 30 -t 60 \
-    curl --silent "http://${IP}:8080/shelves" \
+    curl "http://${IP}:8080/shelves" \
   || error_exit 'Access to frontend service still blocked after unexpected amount of time.'
 
 echo 'Deployment to Kubernetes cluster succeeded.'

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -68,7 +68,7 @@ function wait_for_service_host() {
     local services_output="$(kubectl get services --namespace "${NAMESPACE}" | xargs echo -n)"
     local host="$(echo "${services_output}" | sed "s/.*${name} [0-9.]* \([0-9.]*\) \([0-9]*\).*/\1:\2/")"
 
-    retry -n 20 -s 10 -t 60 \
+    retry -n 10 -s 10 -t 60 \
         curl --silent --fail "http://${host}/${path}" > /dev/null \
       && return 0
 
@@ -107,13 +107,13 @@ kubectl get pods --namespace "${NAMESPACE}" --no-headers  | grep -v Running \
   && error_exit 'Pods failed to spin up successfully.'
 
 # Wait for services to respond
-echo 'Waiting on services to respond...'
+echo 'Waiting on services to get external IP...'
 
 wait_for_expected_output -x -e 'pending' -n 20 -s 10 -t 60 \
     kubectl get services --namespace "${NAMESPACE}" \
   || error_exit 'Services took an unexpected amount of time to spin up.'
 
-echo 'Waiting on services to get external IP...'
+echo 'Waiting on services to respond...'
 
 wait_for_service_host 'registry' 'services' \
   || error_exit 'Error when trying to communicate with registry.'
@@ -146,10 +146,10 @@ kubectl create -f "${ROOT}/contrib/examples/walkthrough/binding.yaml" \
 
 sleep 10
 
-kubectl create -f "${ROOT}/contrib/examples/walkthrough/frontend.yaml" \
+kubectl create -f "${ROOT}/contrib/examples/user-bookstore-client/bookstore.yaml" \
   || error_exit 'Cannot create frontend.'
 
-wait_for_expected_output -e 'booksfe' -n 20 -s 2 -t 60 \
+wait_for_expected_output -e 'user-bookstore-fe' -n 20 -s 2 -t 60 \
     kubectl get services \
   || error_exit 'Frontend service took unexpected amount of time to come up.'
 

--- a/hack/test_deploy.sh
+++ b/hack/test_deploy.sh
@@ -22,8 +22,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ${ROOT}/hack/deploy.sh "${@}" \
   || error_exit 'Deployment to Kubernetes cluster failed.'
 
-IP=$(echo $(kubectl get services) | sed 's/.*booksfe [0-9.]* \([0-9.]*\).*/\1/')
+IP="$(kubectl get services | xargs echo -n | sed 's/.*booksfe [0-9.]* \([0-9.]*\).*/\1/')"
 
-${ROOT}/hack/bookstore_client.py --host="${IP}:8080" \
-    --verify --count=1 \
+${ROOT}/hack/bookstore_client.py --host="${IP}:8080" --api_key=123 \
+    --verify --verbose=true --count=1 \
   || error_exit 'Tests failed.'

--- a/hack/utilities.sh
+++ b/hack/utilities.sh
@@ -106,13 +106,19 @@ function wait_for_expected_output() {
 
   if [[ -n "${negate:-}" ]]; then
     retry -n ${count} -s ${sleep_amount} -t ${max_sleep} \
-        output_does_not_contain_substring -e "${expected}" "${@}" \
-      || { echo 'Retry timed out.'; return 1; }
+        output_does_not_contain_substring -e "${expected}" "${@}" > /dev/null \
+      && return 0
+
+    echo "Waited unsuccessfully for no occurrence of \"${expected}\" in: \"$("${@}")\""
   else
     retry -n ${count} -s ${sleep_amount} -t ${max_sleep} \
-        output_contains_substring -e "${expected}" "${@}" \
-      || { echo 'Retry timed out.'; return 1; }
+        output_contains_substring -e "${expected}" "${@}" > /dev/null \
+      && return 0
+
+    echo "Waited unsuccessfully for occurrence of \"${expected}\" in: \"$("${@}")\""
   fi
+
+  return 1
 }
 
 function output_contains_substring() {


### PR DESCRIPTION
Improves the logging of the demo project deployment script, used by Jenkins. Currently, it was using a debug flag that was extremely verbose in output, especially during the waiting loops. This version should strike a bit better balance.

Also polls the endpoints of the services to make sure they're up before continuing with deployment.