### PR TITLE
Remove CF markers from API files

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -49,9 +49,9 @@ type BrokerSpec struct {
 	AuthUsername string
 	AuthPassword string
 
-	// CF-specific; move to annotation
-	// CFGUID is the identity of this object for use with the CF SB API.
-	CFGUID string
+	// OSB-specific
+	// OSBGUID is the identity of this object for use with the OSB API.
+	OSBGUID string
 }
 
 // BrokerStatus represents the current status of a Broker.
@@ -105,19 +105,19 @@ type ServiceClass struct {
 	Plans         []ServicePlan
 	PlanUpdatable bool // Do we support this?
 
-	// CF-specific; move to annotation
-	// CFGUID is the identity of this object for use with the CF SB API.
+	// OSB-specific
+	// OSBGUID is the identity of this object for use with the OSB API.
 	// Immutable.
-	CFGUID string
+	OSBGUID string
 
-	// CF-specific; move to annotations
-	CFTags                    []string
-	CFRequires                []string
-	CFMaxDBPerNode            string
-	CFMetadata                interface{}
-	CFDashboardOAuth2ClientID string
-	CFDashboardSecret         string
-	CFDashboardRedirectURI    string
+	// OSB-specific
+	OSBTags                    []string
+	OSBRequires                []string
+	OSBMaxDBPerNode            string
+	OSBMetadata                interface{}
+	OSBDashboardOAuth2ClientID string
+	OSBDashboardSecret         string
+	OSBDashboardRedirectURI    string
 }
 
 // ServicePlan represents a tier of a ServiceClass.
@@ -125,14 +125,14 @@ type ServicePlan struct {
 	// CLI-friendly name of this plan
 	Name string
 
-	// CF-specific; move to annotation
-	// CFGUID is the identity of this object for use with the CF SB API.
+	// OSB-specific
+	// OSBGUID is the identity of this object for use with the OSB API.
 	// Immutable.
-	CFGUID string
+	OSBGUID string
 
-	// CF-specific; move to annotations
-	CFMetadata interface{}
-	CFFree     bool
+	// OSB-specific
+	OSBMetadata interface{}
+	OSBFree     bool
 }
 
 // Instance represents a provisioned instance of a ServiceClass.
@@ -154,20 +154,20 @@ type InstanceSpec struct {
 
 	Parameters map[string]interface{}
 
-	// CF-specific; move to annotation
-	// CFGUID is the identity of this object for use with the CF SB API.
+	// OSB-specific
+	// OSBGUID is the identity of this object for use with the OSB API.
 	// Immutable.
-	CFGUID string
+	OSBGUID string
 
-	// CF-specific; move to annotations
-	CFCredentials   string
-	CFDashboardURL  string
-	CFInternalID    string
-	CFServiceID     string
-	CFPlanID        string
-	CFType          string
-	CFSpaceGUID     string
-	CFLastOperation string
+	// OSB-specific
+	OSBCredentials   string
+	OSBDashboardURL  string
+	OSBInternalID    string
+	OSBServiceID     string
+	OSBPlanID        string
+	OSBType          string
+	OSBSpaceGUID     string
+	OSBLastOperation string
 }
 
 // InstanceStatus represents the current status of an Instance.
@@ -231,10 +231,10 @@ type BindingSpec struct {
 	ConfigMapRef              string
 	ServiceInjectionPolicyRef string
 
-	// CF-specific; move to annotation
-	// CFGUID is the identity of this object for use with the CF SB API.
+	// OSB-specific
+	// OSBGUID is the identity of this object for use with the OSB API.
 	// Immutable.
-	CFGUID string
+	OSBGUID string
 
 	// TODO: allow the svc consumer to tell the SIP how to expose CM and secret (env or volume)
 }

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -50,9 +50,9 @@ type BrokerSpec struct {
 	AuthUsername string
 	AuthPassword string
 
-	// CF-specific; move to annotation
-	// CFGUID is the identity of this object for use with the CF SB API.
-	CFGUID string
+	// OSB-specific
+	// OSBGUID is the identity of this object for use with the OSB API.
+	OSBGUID string
 }
 
 // BrokerStatus represents the current status of a Broker.
@@ -106,19 +106,19 @@ type ServiceClass struct {
 	Plans         []ServicePlan
 	PlanUpdatable bool // Do we support this?
 
-	// CF-specific; move to annotation
-	// CFGUID is the identity of this object for use with the CF SB API.
+	// OSB-specific
+	// OSBGUID is the identity of this object for use with the OSB API.
 	// Immutable.
-	CFGUID string
+	OSBGUID string
 
-	// CF-specific; move to annotations
-	CFTags                    []string
-	CFRequires                []string
-	CFMaxDBPerNode            string
-	CFMetadata                interface{}
-	CFDashboardOAuth2ClientID string
-	CFDashboardSecret         string
-	CFDashboardRedirectURI    string
+	// OSB-specific
+	OSBTags                    []string
+	OSBRequires                []string
+	OSBMaxDBPerNode            string
+	OSBMetadata                interface{}
+	OSBDashboardOAuth2ClientID string
+	OSBDashboardSecret         string
+	OSBDashboardRedirectURI    string
 }
 
 // ServicePlan represents a tier of a ServiceClass.
@@ -126,14 +126,14 @@ type ServicePlan struct {
 	// CLI-friendly name of this plan
 	Name string
 
-	// CF-specific; move to annotation
-	// CFGUID is the identity of this object for use with the CF SB API.
+	// OSB-specific
+	// OSBGUID is the identity of this object for use with the OSB API.
 	// Immutable.
-	CFGUID string
+	OSBGUID string
 
-	// CF-specific; move to annotations
-	CFMetadata interface{}
-	CFFree     bool
+	// OSB-specific
+	OSBMetadata interface{}
+	OSBFree     bool
 }
 
 // Instance represents a provisioned instance of a ServiceClass.
@@ -155,20 +155,20 @@ type InstanceSpec struct {
 
 	Parameters map[string]interface{}
 
-	// CF-specific; move to annotation
-	// CFGUID is the identity of this object for use with the CF SB API.
+	// OSB-specific
+	// OSBGUID is the identity of this object for use with the OSB SB API.
 	// Immutable.
-	CFGUID string
+	OSBGUID string
 
-	// CF-specific; move to annotations
-	CFCredentials   string
-	CFDashboardURL  string
-	CFInternalID    string
-	CFServiceID     string
-	CFPlanID        string
-	CFType          string
-	CFSpaceGUID     string
-	CFLastOperation string
+	// OSB-specific
+	OSBCredentials   string
+	OSBDashboardURL  string
+	OSBInternalID    string
+	OSBServiceID     string
+	OSBPlanID        string
+	OSBType          string
+	OSBSpaceGUID     string
+	OSBLastOperation string
 }
 
 // InstanceStatus represents the current status of an Instance.
@@ -232,10 +232,10 @@ type BindingSpec struct {
 	ConfigMapRef              string
 	ServiceInjectionPolicyRef string
 
-	// CF-specific; move to annotation
-	// CFGUID is the identity of this object for use with the CF SB API.
+	// OSB-specific
+	// OSBGUID is the identity of this object for use with the OSB API.
 	// Immutable.
-	CFGUID string
+	OSBGUID string
 
 	// TODO: allow the svc consumer to tell the SIP how to expose CM and secret (env or volume)
 }

--- a/pkg/controller/catalog/server/controller.go
+++ b/pkg/controller/catalog/server/controller.go
@@ -68,11 +68,11 @@ func (c *controller) createServiceInstance(in *servicecatalog.Instance) error {
 
 	// Make the request to instantiate.
 	createReq := &sbmodel.ServiceInstanceRequest{
-		ServiceID:  in.Spec.CFServiceID,
-		PlanID:     in.Spec.CFPlanID,
+		ServiceID:  in.Spec.OSBServiceID,
+		PlanID:     in.Spec.OSBPlanID,
 		Parameters: in.Spec.Parameters,
 	}
-	_, err = client.CreateServiceInstance(in.Spec.CFGUID, createReq)
+	_, err = client.CreateServiceInstance(in.Spec.OSBGUID, createReq)
 	return err
 }
 
@@ -89,11 +89,11 @@ func (c *controller) CreateServiceInstance(in *servicecatalog.Instance) (*servic
 		glog.Errorf("Error fetching service ID: %v", err)
 		return nil, err
 	}
-	in.Spec.CFServiceID = serviceID
-	in.Spec.CFPlanID = planID
+	in.Spec.OSBServiceID = serviceID
+	in.Spec.OSBPlanID = planID
 	in.Spec.PlanName = planName
-	if in.Spec.CFGUID == "" {
-		in.Spec.CFGUID = uuid.NewV4().String()
+	if in.Spec.OSBGUID == "" {
+		in.Spec.OSBGUID = uuid.NewV4().String()
 	}
 
 	glog.Infof("Instantiating service %s using service/plan %s : %s", in.Name, serviceID, planID)
@@ -148,15 +148,15 @@ func (c *controller) CreateServiceBinding(in *servicecatalog.Binding) (*servicec
 	client := openservicebroker.NewClient(broker)
 
 	// Assign UUID to binding.
-	in.Spec.CFGUID = uuid.NewV4().String()
+	in.Spec.OSBGUID = uuid.NewV4().String()
 
 	// Make the request to bind.
 	createReq := &sbmodel.BindingRequest{
-		ServiceID:  instance.Spec.CFServiceID,
-		PlanID:     instance.Spec.CFPlanID,
+		ServiceID:  instance.Spec.OSBServiceID,
+		PlanID:     instance.Spec.OSBPlanID,
 		Parameters: in.Spec.Parameters,
 	}
-	sbr, err := client.CreateServiceBinding(instance.Spec.CFGUID, in.Spec.CFGUID, createReq)
+	sbr, err := client.CreateServiceBinding(instance.Spec.OSBGUID, in.Spec.OSBGUID, createReq)
 
 	in.Status = servicecatalog.BindingStatus{}
 	if err != nil {

--- a/pkg/controller/catalog/storage/storage_util.go
+++ b/pkg/controller/catalog/storage/storage_util.go
@@ -52,16 +52,16 @@ func GetServicePlanInfo(storage ServiceClassStorage, service string, plan string
 	}
 	// No plan specified and only one plan, use it.
 	if plan == "" && len(s.Plans) == 1 {
-		planID := s.Plans[0].CFGUID
+		planID := s.Plans[0].OSBGUID
 		planName := s.Plans[0].Name
 		log.Printf("Found Service Plan GUID as %s for %s : %s", planID, service, planName)
-		return s.CFGUID, planID, planName, nil
+		return s.OSBGUID, planID, planName, nil
 	}
 	for _, p := range s.Plans {
 		if p.Name == plan {
-			planID := p.CFGUID
+			planID := p.OSBGUID
 			log.Printf("Found Service Plan GUID as %s for %s : %s", planID, service, plan)
-			return s.CFGUID, planID, p.Name, nil
+			return s.OSBGUID, planID, p.Name, nil
 		}
 	}
 	return "", "", "", servicePlanNotFound{service, plan}

--- a/pkg/controller/catalog/util/converter.go
+++ b/pkg/controller/catalog/util/converter.go
@@ -25,10 +25,10 @@ func convertServicePlans(plans []sbmodel.ServicePlan) []servicecatalog.ServicePl
 	ret := make([]servicecatalog.ServicePlan, len(plans))
 	for i, plan := range plans {
 		ret[i] = servicecatalog.ServicePlan{
-			Name:       plan.Name,
-			CFGUID:     plan.ID,
-			CFMetadata: plan.Metadata,
-			CFFree:     plan.Free,
+			Name:        plan.Name,
+			OSBGUID:     plan.ID,
+			OSBMetadata: plan.Metadata,
+			OSBFree:     plan.Free,
 		}
 	}
 	return ret
@@ -43,10 +43,10 @@ func ConvertCatalog(in *sbmodel.Catalog) ([]*servicecatalog.ServiceClass, error)
 			Bindable:      svc.Bindable,
 			Plans:         plans,
 			PlanUpdatable: svc.PlanUpdateable,
-			CFGUID:        svc.ID,
-			CFTags:        svc.Tags,
-			CFRequires:    svc.Requires,
-			CFMetadata:    svc.Metadata,
+			OSBGUID:       svc.ID,
+			OSBTags:       svc.Tags,
+			OSBRequires:   svc.Requires,
+			OSBMetadata:   svc.Metadata,
 		}
 	}
 	return ret, nil


### PR DESCRIPTION
Rename the OSB-specific fields in the API.  

You will note that old comments about moving fields to annotations have been removed.  This is because we will need strong validations around these fields and the best way to do that is with first-class fields.  I will open another PR once the code stabilizes a bit, but wanted to rename away from 'CF' for now.