### PR TITLE
Handle route for health check on catalog controller

### DIFF
--- a/pkg/controller/catalog/server/server.go
+++ b/pkg/controller/catalog/server/server.go
@@ -60,7 +60,7 @@ func (s *Server) Start(serverPort int) {
 
 	port := strconv.Itoa(serverPort)
 	glog.Infoln("Server started on port " + port)
-	err := http.ListenAndServe(":"+port, nil)
+	err := http.ListenAndServe(":"+port, router)
 	glog.Errorln(err)
 }
 


### PR DESCRIPTION
Fixes controller crash loop (issue [#181](https://github.com/kubernetes-incubator/service-catalog/issues/181)). The health check added in [#84](https://github.com/kubernetes-incubator/service-catalog/pull/84) never had its route handled, which caused the liveness probe added in [#91](https://github.com/kubernetes-incubator/service-catalog/pull/91) to always get a 404 response.

Closes: #181 