### PR TITLE
[WIP] Create some testing scripts - for e2e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ coverage.html
 .envrc
 build/*/tmp/*
 contrib/build/*/tmp/*
+.helm

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ cache:
   directories:
   - .glide
 script:
-- make build test verify images
+- make build test-unit verify images

--- a/Makefile
+++ b/Makefile
@@ -158,11 +158,17 @@ coverage: .init
 	$(DOCKER_CMD) contrib/hack/coverage.sh --html "$(COVERAGE)" \
 	  $(addprefix ./,$(TEST_DIRS))
 
-test: .init
+test: test-unit test-e2e
+
+test-unit: .init
 	@echo Running tests:
 	@for i in $(addprefix $(SC_PKG)/,$(TEST_DIRS)); do \
 	  $(DOCKER_CMD) go test $$i || exit $$? ; \
 	done
+
+test-e2e: .init images
+	@echo Running e2e tests:
+	contrib/bin/walkthru
 
 clean:
 	rm -rf $(BINDIR)

--- a/contrib/bin/helm
+++ b/contrib/bin/helm
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+docker run --rm -ti --net host -e HELM_HOST -e HELM_HOME -e KUBECONFIG \
+	-v $ROOT:/root/service-catalog helm $*

--- a/contrib/bin/kubectl
+++ b/contrib/bin/kubectl
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+docker run --rm -ti --net host -e KUBECONFIG \
+	-v $ROOT:/root/service-catalog kubectl $*

--- a/contrib/bin/makeHelm
+++ b/contrib/bin/makeHelm
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker build -t helm --build-arg HELM_VERSION=${HELM_VERSION} - <<EOF
+FROM ubuntu
+ARG HELM_VERSION=v2.1.3
+RUN apt-get -y update
+RUN apt-get -y upgrade
+RUN apt-get install -y curl
+RUN curl -L -o helm.gz http://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz && \
+	tar -xf helm.gz  --strip-components=1 linux-amd64/helm && \
+	rm helm.gz
+WORKDIR /root/service-catalog
+ENTRYPOINT [ "/helm" ]
+EOF

--- a/contrib/bin/makeKubectl
+++ b/contrib/bin/makeKubectl
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker build -t kubectl - <<EOF
+FROM ubuntu
+RUN apt-get -y update
+RUN apt-get -y upgrade
+RUN apt-get install -y curl sudo
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+RUN chmod +x kubectl
+ENTRYPOINT [ "/kubectl" ]
+EOF

--- a/contrib/bin/startKube
+++ b/contrib/bin/startKube
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+echo Running hyperkube version: $K8S_VERSION
+mkdir -p /tmp/kubelet
+docker run \
+    --volume=/sys:/sys:rw \
+    --volume=/var/lib/docker/:/var/lib/docker:rw,shared \
+    --volume=/tmp/kubelet/:/var/lib/kubelet:Z \
+    --volume=/var/run:/var/run:rw \
+    --net=host \
+    --pid=host \
+    --privileged=true \
+    --name=kubelet \
+    -d \
+    gcr.io/google_containers/hyperkube-amd64:${K8S_VERSION} \
+    /hyperkube kubelet \
+        --hostname-override="127.0.0.1" \
+        --api-servers=http://localhost:8080 \
+        --config=/etc/kubernetes/manifests \
+        --cluster-dns=127.0.0.1 \
+        --cluster-domain=cluster.local \
+        --allow-privileged=true --v=2
+
+# Now wait for it to be ready
+while ! kubectl get pods > /dev/null 2>&1 ; do
+	sleep 1
+done

--- a/contrib/bin/stopKube
+++ b/contrib/bin/stopKube
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+while true ; do
+  docker ps -a | grep gcr.io/google_containers > .out && \
+    cat .out | while read id rest ; do
+      docker rm -f ${id}
+    done && continue
+  break
+done
+rm .out

--- a/contrib/bin/walkthru
+++ b/contrib/bin/walkthru
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This script will run through the "walkthru" process described in the
+# DEVGUIDE.md file
+
+set -ex
+
+# cleanKube will erase our namespace and wait for it vanish
+function cleanKube() {
+	kubectl delete namespace catalog > /dev/null 2>&1 || true
+	while kubectl get namespace catalog > /dev/null 2>&1 ; do
+		sleep 1
+	done
+}
+
+export ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export PATH=${ROOT}/contrib/bin:$PATH
+export VERSION=$(git describe --tags --always --abbrev=7 --dirty)
+export HELM_VERSION=v2.1.3
+export HELM_HOST=localhost:44134
+cd ${ROOT}
+
+# Make our dockerized version of some exes
+makeKubectl
+makeHelm
+
+# Start Kube if not already running
+if ! curl http://localhost:8080/api ; then
+	startKube
+fi
+
+# Clean our old stuff
+cleanKube
+
+# Install/prep helm
+docker rm -f tiller > /dev/null 2>&1 || true    # delete old one if there
+docker run --name tiller -d --net host \
+	gcr.io/kubernetes-helm/tiller:${HELM_VERSION}
+helm init --client-only
+
+# Wait until helm to be ready
+while ! helm version ; do
+	sleep 1
+	docker logs tiller
+done
+
+# Sometimes tiller isn't really ready
+sleep 1
+
+helm install \
+	--set "registry=${REGISTRY},version=${VERSION}" \
+	--namespace catalog \
+	deploy/catalog
+
+kubectl get deployments,services --namespace catalog
+
+# Clean up our stuff and stop kube
+docker rm -f tiller
+cleanKube
+stopKube

--- a/contrib/hack/helm
+++ b/contrib/hack/helm
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+docker run --rm -ti --net host -e HELM_HOST -e HELM_HOME -e KUBECONFIG \
+	-v $ROOT:/root/service-catalog helm $*

--- a/contrib/hack/kubectl
+++ b/contrib/hack/kubectl
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+docker run --rm -ti --net host -e KUBECONFIG \
+	-w /root/service-catalog \
+	-v $ROOT:/root/service-catalog kubectl $*

--- a/contrib/hack/makeHelm
+++ b/contrib/hack/makeHelm
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker build -t helm --build-arg HELM_VERSION=${HELM_VERSION} - <<EOF
+FROM ubuntu
+ARG HELM_VERSION=v2.1.3
+RUN apt-get -y update
+RUN apt-get -y upgrade
+RUN apt-get install -y curl
+RUN curl -L -o helm.gz http://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz && \
+	tar -xf helm.gz  --strip-components=1 linux-amd64/helm && \
+	rm helm.gz
+WORKDIR /root/service-catalog
+ENTRYPOINT [ "/helm" ]
+EOF

--- a/contrib/hack/makeKubectl
+++ b/contrib/hack/makeKubectl
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker build -t kubectl - <<EOF
+FROM ubuntu
+RUN apt-get -y update
+RUN apt-get -y upgrade
+RUN apt-get install -y curl sudo
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+RUN chmod +x kubectl
+ENTRYPOINT [ "/kubectl" ]
+EOF

--- a/contrib/hack/startKube
+++ b/contrib/hack/startKube
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+echo Running hyperkube version: $K8S_VERSION
+mkdir -p /tmp/kubelet
+docker run \
+    --volume=/sys:/sys:rw \
+    --volume=/var/lib/docker/:/var/lib/docker:rw,shared \
+    --volume=/tmp/kubelet/:/var/lib/kubelet:Z \
+    --volume=/var/run:/var/run:rw \
+    --net=host \
+    --pid=host \
+    --privileged=true \
+    --name=kubelet \
+    -d \
+    gcr.io/google_containers/hyperkube-amd64:${K8S_VERSION} \
+    /hyperkube kubelet \
+        --hostname-override="127.0.0.1" \
+        --api-servers=http://localhost:8080 \
+        --config=/etc/kubernetes/manifests \
+        --cluster-dns=127.0.0.1 \
+        --cluster-domain=cluster.local \
+        --allow-privileged=true --v=2
+
+# Now wait for it to be ready
+while ! kubectl get pods > /dev/null 2>&1 ; do
+	sleep 1
+done

--- a/contrib/hack/stopKube
+++ b/contrib/hack/stopKube
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+while true ; do
+  docker ps -a | grep gcr.io/google_containers > .out && \
+    cat .out | while read id rest ; do
+      docker rm -f ${id}
+    done && continue
+  break
+done
+rm .out

--- a/contrib/hack/walkthru
+++ b/contrib/hack/walkthru
@@ -27,39 +27,42 @@ function cleanKube() {
 	done
 }
 
+# apt-get install socat
+# DNS_SERVER_IP=172.17.0.3 KUBE_ENABLE_CLUSTER_DNS=true hack/local-up-cluster.sh
+
 export ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-export PATH=${ROOT}/contrib/bin:$PATH
+export PATH=${ROOT}/contrib/hack:$PATH
 export VERSION=$(git describe --tags --always --abbrev=7 --dirty)
 export HELM_VERSION=v2.1.3
-export HELM_HOST=localhost:44134
+export HELM_HOST=172.17.0.3:44134
 cd ${ROOT}
 
 # Make our dockerized version of some exes
 makeKubectl
 makeHelm
 
-# Start Kube if not already running
-if ! curl http://localhost:8080/api ; then
-	startKube
-fi
-
-# Clean our old stuff
-cleanKube
+# # Start Kube if not already running
+# if ! curl http://localhost:8080/api ; then
+# 	startKube
+# fi
+# 
+# # Clean our old stuff
+# cleanKube
 
 # Install/prep helm
-docker rm -f tiller > /dev/null 2>&1 || true    # delete old one if there
-docker run --name tiller -d --net host \
-	gcr.io/kubernetes-helm/tiller:${HELM_VERSION}
-helm init --client-only
+# docker rm -f tiller > /dev/null 2>&1 || true    # delete old one if there
+# docker run --name tiller -d --net host \
+	# gcr.io/kubernetes-helm/tiller:${HELM_VERSION}
+helm init # --client-only
 
 # Wait until helm to be ready
-while ! helm version ; do
-	sleep 1
-	docker logs tiller
-done
+#while ! helm version ; do
+	#sleep 1
+	# docker logs tiller
+#done
 
 # Sometimes tiller isn't really ready
-sleep 1
+#sleep 1
 
 helm install \
 	--set "registry=${REGISTRY},version=${VERSION}" \
@@ -67,8 +70,20 @@ helm install \
 	deploy/catalog
 
 kubectl get deployments,services --namespace catalog
+sleep 5
+kubectl get deployments,services --namespace catalog
 
-exit
+kubectl create -f contrib/examples/walkthrough/broker.yaml
+sleep 5
+
+kubectl get serviceclasses
+
+kubectl create -f contrib/examples/walkthrough/backend.yaml
+kubectl create -f contrib/examples/walkthrough/binding.yaml
+
+kubectl get servicebrokers,serviceclasses,serviceinstances
+
+exit 0
 
 # Clean up our stuff and stop kube
 docker rm -f tiller

--- a/deploy/catalog/templates/broker.yaml
+++ b/deploy/catalog/templates/broker.yaml
@@ -11,8 +11,8 @@ spec:
     spec:
       containers:
       - name: k8s-broker
-        image: {{ .Values.registry }}/k8s-broker:{{ if .Values.k8sBrokerVersion }}{{ .Values.k8sBrokerVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}
-        imagePullPolicy: Always
+        image: {{ if .Values.registry }}{{ .Values.registry }}/{{ end }}k8s-broker:{{ if .Values.k8sBrokerVersion }}{{ .Values.k8sBrokerVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}
+        imagePullPolicy: IfNotPresent
         args:
         - --registry_host
         - registry

--- a/deploy/catalog/templates/catalog.yaml
+++ b/deploy/catalog/templates/catalog.yaml
@@ -11,8 +11,8 @@ spec:
     spec:
       containers:
       - name: controller
-        image: {{ .Values.registry }}/controller:{{ if .Values.controllerVersion }}{{ .Values.controllerVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}
-        imagePullPolicy: Always
+        image: {{ if .Values.registry }}{{ .Values.registry }}/{{ end }}controller:{{ if .Values.controllerVersion }}{{ .Values.controllerVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 10000
         livenessProbe:

--- a/deploy/catalog/templates/registry.yaml
+++ b/deploy/catalog/templates/registry.yaml
@@ -11,8 +11,8 @@ spec:
     spec:
       containers:
       - name: registry
-        image: {{ .Values.registry }}/registry:{{ if .Values.registryVersion }}{{ .Values.registryVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}
-        imagePullPolicy: Always
+        image: {{ if .Values.registry }}{{ .Values.registry }}/{{ end }}registry:{{ if .Values.registryVersion }}{{ .Values.registryVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8001
 ---

--- a/deploy/catalog/templates/ups-broker.yaml
+++ b/deploy/catalog/templates/ups-broker.yaml
@@ -11,8 +11,8 @@ spec:
     spec:
       containers:
       - name: ups-broker
-        image: {{ .Values.registry }}/user-broker:{{ if .Values.upsBrokerVersion }}{{ .Values.upsBrokerVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}
-        imagePullPolicy: Always
+        image: {{ if .Values.registry }}{{ .Values.registry }}/{{ end }}user-broker:{{ if .Values.upsBrokerVersion }}{{ .Values.upsBrokerVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}
+        imagePullPolicy: IfNotPresent
         args:
         - --port
         - "8000"


### PR DESCRIPTION
Create some scripts in contrib/bin to:
- run helm from a container
- run kubectl from a container
- start hyperkube in docker
- create the helm and kubectl images used by above
- execute the "walkthru" example via a script

Added it to the e2e testing even though its not 100% complete yet.
The controller doesn't start yet.

To test it try: `make test-e2e`.

I put stuff under contrib/bin  since I wasn't sure where to push utility type of scripts.

Signed-off-by: Doug Davis <dug@us.ibm.com>