### PR TITLE
Run script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ coverage.html
 .idea/
 .DS_Store
 .glide
-.scBuildImage
 .init
 .generate*
 **/zz*.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ install:
   - go get -u github.com/golang/lint/golint
 script:
   - make build test verify images
-  - DOCKER=1 make clean build test verify images
+  - DOCKER=1 make clean build test verify
+  - make images

--- a/build/make-clean.sh
+++ b/build/make-clean.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker rmi -f scbuildimage > /dev/null 2>&1 || true

--- a/build/run.sh
+++ b/build/run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GO_VERSION=${GO_VERSION:-1.7.3}
+
+sed "s/GO_VERSION/$GO_VERSION/g" < build/build-image/Dockerfile | \
+	docker build -t scbuildimage -
+
+docker run --rm -it \
+	-v $(pwd):/go/src/github.com/kubernetes-incubator/service-catalog \
+	scbuildimage $@

--- a/docs/DEVGUIDE.md
+++ b/docs/DEVGUIDE.md
@@ -45,7 +45,7 @@ To clone the repository:
 First `cd` to the root of the cloned repository tree.
 To build the service-catalog you have two options:
 * `make build`
-* `DOCKER=1 make build`
+* `build/run.sh make build`
 
 Both will build all of the executables, into the `bin` directory. However,
 the second option will do the build within a Docker container - meaning you
@@ -74,13 +74,13 @@ To deploy to Kubernetes, see the
 
 Currently, we only have unit testcases within this repo:
 * `make test`
-* `DOCKER=1 make test`
+* `build/run.sh make test`
 
 These will execute any `*_test.go` files within the source tree.
 
 To see how well these tests cover the source code, you can use:
 * `make coverage`
-* `DOCKER=1 make coverage`
+* `build/run.sh make coverage`
 
 These will execute the tests and perform an analysis of how well they
 cover all code paths. The results are put into a file called:


### PR DESCRIPTION
This is an alternative to #231, which I am now closing.

Instead of _not_ supporting non-containerized builds, this PR takes a page directly from k8s' playbook by adding a script that executes _whatever you want_ inside a build container.

The benefit is that make targets (and the whole build process) stop caring about where they're executing (i.e. they won't respect `DOCKER=1` anymore) and it becomes simply your choice where you run things... and it makes us more like k8s.

Two things to note:

1. Building out-of-container really shouldn't be encouraged, imo. It's retained as an option merely for the sake of avoiding D-in-D scenarios with containerized Jenkins build slaves and the like.

1. While I've taken a page from k8s' playbook, the implementation of the `run.sh` script is different than theirs. k8s uses hundreds (thousands?) of lines to manage the lifecycle of build containers, data containers, etc. and uses rsync instead of volume mounts to get source code into the build containers and binaries out of those containers. That approach allows them to build using a remote Docker daemon. While that's neat-o, it's also complex, and I couldn't actually get those scripts to work in our repo. (I tried for many hours.) I think it's something we can adopt in the future... if we care. In the meantime, at least this PR moves us closer to k8s philosophically.