### PR TITLE
Add a fake broker client

### DIFF
--- a/pkg/brokerapi/fake/doc.go
+++ b/pkg/brokerapi/fake/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fake contains fake implementations of each of the CF broker API clients. They are
+// all basic, in-memory implementations and are intended to be used in unit tests only
+package fake

--- a/pkg/brokerapi/fake/doc.go
+++ b/pkg/brokerapi/fake/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package fake contains fake implementations of each of the CF broker API clients. They are
+// Package fake contains fake implementations of each of the CF broker APIs. They are
 // all basic, in-memory implementations and are intended to be used in unit tests only
 package fake

--- a/pkg/brokerapi/fake/errors.go
+++ b/pkg/brokerapi/fake/errors.go
@@ -5,8 +5,16 @@ import (
 )
 
 var (
-	ErrInstanceNotFound      = errors.New("instance not found")
+	// ErrInstanceNotFound is returned by the fake client when an instance was expected in its
+	// internal storage but it wasn't found
+	ErrInstanceNotFound = errors.New("instance not found")
+	// ErrInstanceAlreadyExists is returned by the fake client when an instance was found in
+	// internal storage but it wasn't expected
 	ErrInstanceAlreadyExists = errors.New("instance already exists")
-	ErrBindingNotFound       = errors.New("binding not found")
-	ErrBindingAlreadyExists  = errors.New("binding already exists")
+	// ErrBindingNotFound is returned by the fake client when a binding was expected in internal
+	// storage but it wasn't found
+	ErrBindingNotFound = errors.New("binding not found")
+	// ErrBindingAlreadyExists is returned by the fake client when a binding was found in internal
+	// storage but it wasn't expected
+	ErrBindingAlreadyExists = errors.New("binding already exists")
 )

--- a/pkg/brokerapi/fake/errors.go
+++ b/pkg/brokerapi/fake/errors.go
@@ -1,0 +1,12 @@
+package fake
+
+import (
+	"errors"
+)
+
+var (
+	ErrInstanceNotFound      = errors.New("instance not found")
+	ErrInstanceAlreadyExists = errors.New("instance already exists")
+	ErrBindingNotFound       = errors.New("binding not found")
+	ErrBindingAlreadyExists  = errors.New("binding already exists")
+)

--- a/pkg/brokerapi/fake/errors.go
+++ b/pkg/brokerapi/fake/errors.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fake
 
 import (

--- a/pkg/brokerapi/fake/fake.go
+++ b/pkg/brokerapi/fake/fake.go
@@ -7,21 +7,26 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+// Client implements a fake broker API client, useful for unit testing. None of the methods on
+// the client are concurrency-safe
 type Client struct {
 	CatalogClient
 	InstanceClient
 	BindingClient
 }
 
+// CatalogClient implements a fake CF catalog API client
 type CatalogClient struct {
 	RetCatalog *brokerapi.Catalog
 	RetErr     error
 }
 
+// GetCatalog just returns c.RetCatalog and c.RetErr
 func (c *CatalogClient) GetCatalog() (*brokerapi.Catalog, error) {
 	return c.RetCatalog, c.RetErr
 }
 
+// InstanceClient implements a fake CF instance API client
 type InstanceClient struct {
 	Instances map[string]*brokerapi.ServiceInstance
 	CreateErr error
@@ -29,6 +34,9 @@ type InstanceClient struct {
 	DeleteErr error
 }
 
+// CreateServiceInstance returns i.CreateErr if non-nil. If it is nil, checks if id already exists
+// in i.Instances and returns ErrInstanceAlreadyExists if so. If not, converts req to a
+// ServiceInstance, adds it to i.Instances and returns it
 func (i *InstanceClient) CreateServiceInstance(
 	id string,
 	req *brokerapi.ServiceInstanceRequest,
@@ -42,9 +50,12 @@ func (i *InstanceClient) CreateServiceInstance(
 	}
 
 	i.Instances[id] = convertInstanceRequest(req)
-	return inst, nil
+	return i.Instances[id], nil
 }
 
+// UpdateServiceInstance returns i.UpdateErr if it was non-nil. Otherwise, returns
+// ErrInstanceNotFound if id already exists in i.Instances. If it didn't exist, converts req into
+// a ServiceInstance, adds it to i.Instances and returns it
 func (i *InstanceClient) UpdateServiceInstance(
 	id string,
 	req *brokerapi.ServiceInstanceRequest,
@@ -58,9 +69,12 @@ func (i *InstanceClient) UpdateServiceInstance(
 	}
 
 	i.Instances[id] = convertInstanceRequest(req)
-	return inst, nil
+	return i.Instances[id], nil
 }
 
+// DeleteServiceInstance returns i.DeleteErr if it was non-nil. Otherwise returns
+// ErrInstanceNotFound if id didn't already exist in i.Instances. If it it did already exist,
+// removes i.Instances[id] from the map and returns nil
 func (i *InstanceClient) DeleteServiceInstance(id string) error {
 
 	if i.DeleteErr != nil {
@@ -92,6 +106,7 @@ func convertInstanceRequest(req *brokerapi.ServiceInstanceRequest) *brokerapi.Se
 	}
 }
 
+// BindingClient implements a fake CF binding API client
 type BindingClient struct {
 	Bindings    map[string]struct{}
 	CreateCreds brokerapi.Credential
@@ -99,6 +114,10 @@ type BindingClient struct {
 	DeleteErr   error
 }
 
+// CreateServiceBinding returns b.CreateErr if it was non-nil. Otherwise, returns
+// ErrBindingAlreadyExists if the IDs already existed in b.Bindings. If they didn't already exist,
+// adds the IDs to b.Bindings and returns a new CreateServiceBindingResponse with b.CreateCreds in
+// it
 func (b *BindingClient) CreateServiceBinding(
 	sID,
 	bID string,
@@ -116,10 +135,18 @@ func (b *BindingClient) CreateServiceBinding(
 	return &brokerapi.CreateServiceBindingResponse{Credentials: b.CreateCreds}, nil
 }
 
+// DeleteServiceBinding returns b.DeleteErr if it was non-nil. Otherwise, if the binding associated
+// with the given IDs didn't exist, returns ErrBindingNotFound. If it did exist, removes it and
+// returns nil
 func (b *BindingClient) DeleteServiceBinding(sID, bID string) error {
 	if b.DeleteErr != nil {
 		return b.DeleteErr
 	}
+	if !b.exists(sID, bID) {
+		return ErrBindingNotFound
+	}
+
+	delete(b.Bindings, bindingsMapKey(sID, bID))
 	return nil
 }
 

--- a/pkg/brokerapi/fake/fake.go
+++ b/pkg/brokerapi/fake/fake.go
@@ -1,7 +1,10 @@
 package fake
 
 import (
+	"fmt"
+
 	"github.com/kubernetes-incubator/service-catalog/pkg/brokerapi"
+	uuid "github.com/satori/go.uuid"
 )
 
 type Client struct {
@@ -20,27 +23,80 @@ func (c *CatalogClient) GetCatalog() (*brokerapi.Catalog, error) {
 }
 
 type InstanceClient struct {
+	Instances map[string]*brokerapi.ServiceInstance
+	CreateErr error
+	UpdateErr error
+	DeleteErr error
 }
 
 func (i *InstanceClient) CreateServiceInstance(
-	ID string,
+	id string,
 	req *brokerapi.ServiceInstanceRequest,
 ) (*brokerapi.ServiceInstance, error) {
-	return nil, nil
+
+	if i.CreateErr != nil {
+		return nil, i.CreateErr
+	}
+	if i.exists(id) {
+		return nil, ErrInstanceAlreadyExists
+	}
+
+	i.Instances[id] = convertInstanceRequest(req)
+	return inst, nil
 }
 
 func (i *InstanceClient) UpdateServiceInstance(
-	ID string,
-	req *ServiceInstanceRequest,
-) (*ServiceInstance, error) {
-	return nil, nil
+	id string,
+	req *brokerapi.ServiceInstanceRequest,
+) (*brokerapi.ServiceInstance, error) {
+
+	if i.UpdateErr != nil {
+		return nil, i.UpdateErr
+	}
+	if !i.exists(id) {
+		return nil, ErrInstanceNotFound
+	}
+
+	i.Instances[id] = convertInstanceRequest(req)
+	return inst, nil
 }
 
-func (i *InstanceClient) DeleteServiceInstance(ID string) error {
+func (i *InstanceClient) DeleteServiceInstance(id string) error {
+
+	if i.DeleteErr != nil {
+		return i.DeleteErr
+	}
+	if !i.exists(id) {
+		return ErrInstanceNotFound
+	}
+	delete(i.Instances, id)
 	return nil
 }
 
+func (i *InstanceClient) exists(id string) bool {
+	_, ok := i.Instances[id]
+	return ok
+}
+
+func convertInstanceRequest(req *brokerapi.ServiceInstanceRequest) *brokerapi.ServiceInstance {
+	return &brokerapi.ServiceInstance{
+		ID:               uuid.NewV4().String(),
+		DashboardURL:     "https://github.com/kubernetes-incubator/service-catalog",
+		InternalID:       uuid.NewV4().String(),
+		ServiceID:        req.ServiceID,
+		PlanID:           req.PlanID,
+		OrganizationGUID: uuid.NewV4().String(),
+		SpaceGUID:        req.SpaceID,
+		LastOperation:    nil,
+		Parameters:       req.Parameters,
+	}
+}
+
 type BindingClient struct {
+	Bindings    map[string]struct{}
+	CreateCreds brokerapi.Credential
+	CreateErr   error
+	DeleteErr   error
 }
 
 func (b *BindingClient) CreateServiceBinding(
@@ -48,9 +104,30 @@ func (b *BindingClient) CreateServiceBinding(
 	bID string,
 	req *brokerapi.BindingRequest,
 ) (*brokerapi.CreateServiceBindingResponse, error) {
-	return nil, nil
+
+	if b.CreateErr != nil {
+		return nil, b.CreateErr
+	}
+	if b.exists(sID, bID) {
+		return nil, ErrBindingAlreadyExists
+	}
+
+	b.Bindings[bindingsMapKey(sID, bID)] = struct{}{}
+	return &brokerapi.CreateServiceBindingResponse{Credentials: b.CreateCreds}, nil
 }
 
 func (b *BindingClient) DeleteServiceBinding(sID, bID string) error {
+	if b.DeleteErr != nil {
+		return b.DeleteErr
+	}
 	return nil
+}
+
+func (b *BindingClient) exists(sID, bID string) bool {
+	_, ok := b.Bindings[bindingsMapKey(sID, bID)]
+	return ok
+}
+
+func bindingsMapKey(sID, bID string) string {
+	return fmt.Sprintf("%s:%s", sID, bID)
 }

--- a/pkg/brokerapi/fake/fake.go
+++ b/pkg/brokerapi/fake/fake.go
@@ -1,0 +1,56 @@
+package fake
+
+import (
+	"github.com/kubernetes-incubator/service-catalog/pkg/brokerapi"
+)
+
+type Client struct {
+	CatalogClient
+	InstanceClient
+	BindingClient
+}
+
+type CatalogClient struct {
+	RetCatalog *brokerapi.Catalog
+	RetErr     error
+}
+
+func (c *CatalogClient) GetCatalog() (*brokerapi.Catalog, error) {
+	return c.RetCatalog, c.RetErr
+}
+
+type InstanceClient struct {
+}
+
+func (i *InstanceClient) CreateServiceInstance(
+	ID string,
+	req *brokerapi.ServiceInstanceRequest,
+) (*brokerapi.ServiceInstance, error) {
+	return nil, nil
+}
+
+func (i *InstanceClient) UpdateServiceInstance(
+	ID string,
+	req *ServiceInstanceRequest,
+) (*ServiceInstance, error) {
+	return nil, nil
+}
+
+func (i *InstanceClient) DeleteServiceInstance(ID string) error {
+	return nil
+}
+
+type BindingClient struct {
+}
+
+func (b *BindingClient) CreateServiceBinding(
+	sID,
+	bID string,
+	req *brokerapi.BindingRequest,
+) (*brokerapi.CreateServiceBindingResponse, error) {
+	return nil, nil
+}
+
+func (b *BindingClient) DeleteServiceBinding(sID, bID string) error {
+	return nil
+}

--- a/pkg/brokerapi/fake/fake.go
+++ b/pkg/brokerapi/fake/fake.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fake
 
 import (


### PR DESCRIPTION
Fixes #90 
This patch adds a fake broker client, to be used in unit tests in future work.

#141 approached this work differently. It created an in-process server to act as a broker, allowing more integration-style tests. We could go that route, but the fake client seems more suitable for unit tests. We'll likely tackle the former strategy in end-to-end tests, so #141 will be closed when this PR is merged.

Note that this client is not used in this PR. Follow-ups will write unit tests that will use it.

Closes #141