### PR TITLE
Default to (and only officially support) containerized build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,6 @@
+language: generic
 sudo: required
 services:
-  - docker
-language: go
-go:
-  - 1.7.3
-go_import_path: github.com/kubernetes-incubator/service-catalog
-install:
-  - wget "https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz"
-  - mkdir -p $HOME/bin
-  - tar -vxz -C $HOME/bin --strip=1 -f glide-v0.12.3-linux-amd64.tar.gz
-  - export PATH="$HOME/bin:$PATH"
-  - go get -u github.com/golang/lint/golint
+- docker
 script:
-  - make build test verify images
-  - DOCKER=1 make clean build test verify images
+- make build test verify images

--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,12 @@ GO_BUILD       = env GOOS=linux GOARCH=amd64 go build -i -v \
 BASE_PATH      = $(ROOT:/src/github.com/kubernetes-incubator/service-catalog/=)
 export GOPATH  = $(BASE_PATH):$(ROOT)/vendor
 
-ifneq ($(origin DOCKER),undefined)
-  # If DOCKER is defined then define the full docker cmd line we want to use
-  DOCKER_FLAG  = DOCKER=1
-  DOCKER_CMD   = docker run --rm -ti -v $(PWD):/go/src/$(SC_PKG) scbuildimage
-  # Setting scBuildImageTarget will force the Docker image to be built
-  # in the .init rule
-  scBuildImageTarget=.scBuildImage
+ifeq ("$(NO_DOCKER)", "1")
+	DOCKER_CMD =
+	scBuildImageTarget =
+else
+	DOCKER_CMD = docker run --rm -ti -v $(PWD):/go/src/$(SC_PKG) scbuildimage
+	scBuildImageTarget = .scBuildImage
 endif
 
 # This section builds the output binaries.


### PR DESCRIPTION
Alternative to #231 and #238 

Previously, containerized build was opt-in. After this PR, it's the default and opt-out.

This PR also documents that out-of-container build, while possible, is not officially supported. The procedure for opting-out of the containerized build is purposely left undocumented so as not to encourage it.

This PR updates the dev guide accordingly and also transitions Travis to running in-container builds only.

cc @duglin @arschles 