### PR TITLE
Add async provisioning/deprovisioning handling in broker client

### DIFF
--- a/contrib/pkg/broker/controller/controller.go
+++ b/contrib/pkg/broker/controller/controller.go
@@ -25,7 +25,7 @@ type Controller interface {
 	Catalog() (*brokerapi.Catalog, error)
 
 	GetServiceInstance(id string) (string, error)
-	CreateServiceInstance(id string, req *brokerapi.ServiceInstanceRequest) (*brokerapi.CreateServiceInstanceResponse, error)
+	CreateServiceInstance(id string, req *brokerapi.CreateServiceInstanceRequest) (*brokerapi.CreateServiceInstanceResponse, error)
 	RemoveServiceInstance(id string) error
 
 	Bind(instanceID string, bindingID string, req *brokerapi.BindingRequest) (*brokerapi.CreateServiceBindingResponse, error)

--- a/contrib/pkg/broker/k8s/controller/controller.go
+++ b/contrib/pkg/broker/k8s/controller/controller.go
@@ -103,7 +103,7 @@ func (c *k8sController) Catalog() (*brokerapi.Catalog, error) {
 	return &brokerapi.Catalog{Services: services}, nil
 }
 
-func (c *k8sController) CreateServiceInstance(instanceID string, req *brokerapi.ServiceInstanceRequest) (*brokerapi.CreateServiceInstanceResponse, error) {
+func (c *k8sController) CreateServiceInstance(instanceID string, req *brokerapi.CreateServiceInstanceRequest) (*brokerapi.CreateServiceInstanceResponse, error) {
 	// Fetch the type that should be used for this service/plan
 	t, err := c.getType(req.ServiceID, req.PlanID)
 	if err != nil {

--- a/contrib/pkg/broker/k8s/controller/helm_reifier.go
+++ b/contrib/pkg/broker/k8s/controller/helm_reifier.go
@@ -75,7 +75,7 @@ func shortenInstanceID(instanceID string) string {
 }
 
 // CreateServiceInstance creates a new Service Instance
-func (h *helmReifier) CreateServiceInstance(instanceID string, tmpl string, sir *brokerapi.ServiceInstanceRequest) (*brokerapi.CreateServiceInstanceResponse, error) {
+func (h *helmReifier) CreateServiceInstance(instanceID string, tmpl string, sir *brokerapi.CreateServiceInstanceRequest) (*brokerapi.CreateServiceInstanceResponse, error) {
 	values := ""
 	if len(sir.Parameters) > 0 {
 		y, err := yaml.Marshal(sir.Parameters)

--- a/contrib/pkg/broker/k8s/controller/reifier.go
+++ b/contrib/pkg/broker/k8s/controller/reifier.go
@@ -30,7 +30,7 @@ type Reifier interface {
 	RemoveServiceInstance(instanceID string) error
 
 	// CreateServiceInstance creates a new Service Instance
-	CreateServiceInstance(instanceID string, template string, sir *brokerapi.ServiceInstanceRequest) (*brokerapi.CreateServiceInstanceResponse, error)
+	CreateServiceInstance(instanceID string, template string, sir *brokerapi.CreateServiceInstanceRequest) (*brokerapi.CreateServiceInstanceResponse, error)
 
 	// CreateBinding creates a new Service Binding for a given instanceId
 	CreateServiceBinding(instanceID string, sir *brokerapi.BindingRequest) (*brokerapi.CreateServiceBindingResponse, error)

--- a/contrib/pkg/broker/server/server.go
+++ b/contrib/pkg/broker/server/server.go
@@ -87,7 +87,7 @@ func (s *server) createServiceInstance(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["instance_id"]
 	glog.Infof("CreateServiceInstance %s...\n", id)
 
-	var req brokerapi.ServiceInstanceRequest
+	var req brokerapi.CreateServiceInstanceRequest
 	if err := util.BodyToObject(r, &req); err != nil {
 		glog.Errorf("error unmarshalling: %v", err)
 		util.WriteResponse(w, http.StatusBadRequest, err)

--- a/contrib/pkg/broker/server/server_test.go
+++ b/contrib/pkg/broker/server/server_test.go
@@ -119,7 +119,7 @@ type Controller struct {
 
 	catalog               func() (*brokerapi.Catalog, error)
 	getServiceInstance    func(id string) (string, error)
-	createServiceInstance func(id string, req *brokerapi.ServiceInstanceRequest) (*brokerapi.CreateServiceInstanceResponse, error)
+	createServiceInstance func(id string, req *brokerapi.CreateServiceInstanceRequest) (*brokerapi.CreateServiceInstanceResponse, error)
 	removeServiceInstance func(id string) error
 	bind                  func(instanceID string, bindingID string, req *brokerapi.BindingRequest) (*brokerapi.CreateServiceBindingResponse, error)
 	unBind                func(instanceID string, bindingID string) error
@@ -141,7 +141,7 @@ func (controller *Controller) GetServiceInstance(id string) (string, error) {
 	return controller.getServiceInstance(id)
 }
 
-func (controller *Controller) CreateServiceInstance(id string, req *brokerapi.ServiceInstanceRequest) (*brokerapi.CreateServiceInstanceResponse, error) {
+func (controller *Controller) CreateServiceInstance(id string, req *brokerapi.CreateServiceInstanceRequest) (*brokerapi.CreateServiceInstanceResponse, error) {
 	if controller.createServiceInstance == nil {
 		controller.t.Error("Test failed to provide 'createServiceInstance' handler")
 	}

--- a/contrib/pkg/broker/user_provided/controller/controller.go
+++ b/contrib/pkg/broker/user_provided/controller/controller.go
@@ -61,7 +61,7 @@ func (c *userProvidedController) Catalog() (*brokerapi.Catalog, error) {
 	}, nil
 }
 
-func (c *userProvidedController) CreateServiceInstance(id string, req *brokerapi.ServiceInstanceRequest) (*brokerapi.CreateServiceInstanceResponse, error) {
+func (c *userProvidedController) CreateServiceInstance(id string, req *brokerapi.CreateServiceInstanceRequest) (*brokerapi.CreateServiceInstanceResponse, error) {
 	credString, ok := req.Parameters["credentials"]
 	if !ok {
 		glog.Errorf("Didn't find creds\n %+v\n", req)

--- a/pkg/brokerapi/broker_client.go
+++ b/pkg/brokerapi/broker_client.go
@@ -45,15 +45,15 @@ type InstanceClient interface {
 
 	// CreateServiceInstance creates a service instance in the respective broker.
 	// This method handles all asynchronous request handling.
-	CreateServiceInstance(ID string, req *ServiceInstanceRequest) (*ServiceInstance, error)
+	CreateServiceInstance(ID string, req *CreateServiceInstanceRequest) (*CreateServiceInstanceResponse, error)
 
 	// UpdateServiceInstance updates an existing service instance in the respective
 	// broker. This method handles all asynchronous request handling.
-	UpdateServiceInstance(ID string, req *ServiceInstanceRequest) (*ServiceInstance, error)
+	UpdateServiceInstance(ID string, req *CreateServiceInstanceRequest) (*ServiceInstance, error)
 
 	// DeleteServiceInstance deletes an existing service instance in the respective
 	// broker. This method handles all asynchronous request handling.
-	DeleteServiceInstance(ID string) error
+	DeleteServiceInstance(ID string, req *DeleteServiceInstanceRequest) error
 }
 
 // BindingClient defines the interface for managing service bindings with a

--- a/pkg/brokerapi/fake/fake.go
+++ b/pkg/brokerapi/fake/fake.go
@@ -80,11 +80,11 @@ func NewInstanceClient() *InstanceClient {
 
 // CreateServiceInstance returns i.CreateErr if non-nil. If it is nil, checks if id already exists
 // in i.Instances and returns ErrInstanceAlreadyExists if so. If not, converts req to a
-// ServiceInstance, adds it to i.Instances and returns it
+// ServiceInstance and adds it to i.Instances
 func (i *InstanceClient) CreateServiceInstance(
 	id string,
-	req *brokerapi.ServiceInstanceRequest,
-) (*brokerapi.ServiceInstance, error) {
+	req *brokerapi.CreateServiceInstanceRequest,
+) (*brokerapi.CreateServiceInstanceResponse, error) {
 
 	if i.CreateErr != nil {
 		return nil, i.CreateErr
@@ -94,7 +94,7 @@ func (i *InstanceClient) CreateServiceInstance(
 	}
 
 	i.Instances[id] = convertInstanceRequest(req)
-	return i.Instances[id], nil
+	return &brokerapi.CreateServiceInstanceResponse{}, nil
 }
 
 // UpdateServiceInstance returns i.UpdateErr if it was non-nil. Otherwise, returns
@@ -102,7 +102,7 @@ func (i *InstanceClient) CreateServiceInstance(
 // a ServiceInstance, adds it to i.Instances and returns it
 func (i *InstanceClient) UpdateServiceInstance(
 	id string,
-	req *brokerapi.ServiceInstanceRequest,
+	req *brokerapi.CreateServiceInstanceRequest,
 ) (*brokerapi.ServiceInstance, error) {
 
 	if i.UpdateErr != nil {
@@ -119,7 +119,7 @@ func (i *InstanceClient) UpdateServiceInstance(
 // DeleteServiceInstance returns i.DeleteErr if it was non-nil. Otherwise returns
 // ErrInstanceNotFound if id didn't already exist in i.Instances. If it it did already exist,
 // removes i.Instances[id] from the map and returns nil
-func (i *InstanceClient) DeleteServiceInstance(id string) error {
+func (i *InstanceClient) DeleteServiceInstance(id string, req *brokerapi.DeleteServiceInstanceRequest) error {
 
 	if i.DeleteErr != nil {
 		return i.DeleteErr
@@ -136,7 +136,7 @@ func (i *InstanceClient) exists(id string) bool {
 	return ok
 }
 
-func convertInstanceRequest(req *brokerapi.ServiceInstanceRequest) *brokerapi.ServiceInstance {
+func convertInstanceRequest(req *brokerapi.CreateServiceInstanceRequest) *brokerapi.ServiceInstance {
 	return &brokerapi.ServiceInstance{
 		ID:               uuid.NewV4().String(),
 		DashboardURL:     "https://github.com/kubernetes-incubator/service-catalog",

--- a/pkg/brokerapi/openservicebroker/open_service_broker_client.go
+++ b/pkg/brokerapi/openservicebroker/open_service_broker_client.go
@@ -19,6 +19,7 @@ package openservicebroker
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -26,16 +27,53 @@ import (
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/brokerapi"
-	"github.com/kubernetes-incubator/service-catalog/pkg/controller/util"
+	"github.com/kubernetes-incubator/service-catalog/pkg/util"
 )
 
 const (
 	catalogFormatString         = "%s/v2/catalog"
 	serviceInstanceFormatString = "%s/v2/service_instances/%s"
+	pollingFormatString         = "%s/v2/service_instances/%s/last_operation"
 	bindingFormatString         = "%s/v2/service_instances/%s/service_bindings/%s"
 
-	httpTimeoutSeconds = 15
+	httpTimeoutSeconds     = 15
+	pollingIntervalSeconds = 1
+	pollingAmountLimit     = 30
 )
+
+var (
+	errConflict       = errors.New("Service instance with same id but different attributes exists")
+	errAsynchronous   = errors.New("Broker only supports this action asynchronously")
+	errFailedState    = errors.New("Failed state received from broker")
+	errUnknownState   = errors.New("Unknown state received from broker")
+	errPollingTimeout = errors.New("Timed out while polling broker")
+)
+
+type (
+	errRequest struct {
+		message string
+	}
+
+	errResponse struct {
+		message string
+	}
+
+	errStatusCode struct {
+		statusCode int
+	}
+)
+
+func (e errRequest) Error() string {
+	return fmt.Sprintf("Failed to send request: %s", e.message)
+}
+
+func (e errResponse) Error() string {
+	return fmt.Sprintf("Failed to parse broker response: %s", e.message)
+}
+
+func (e errStatusCode) Error() string {
+	return fmt.Sprintf("Unexpected status code from broker response: %v", e.statusCode)
+}
 
 type openServiceBrokerClient struct {
 	broker *servicecatalog.Broker
@@ -78,59 +116,77 @@ func (c *openServiceBrokerClient) GetCatalog() (*brokerapi.Catalog, error) {
 	return &catalog, nil
 }
 
-func (c *openServiceBrokerClient) CreateServiceInstance(ID string, req *brokerapi.ServiceInstanceRequest) (*brokerapi.ServiceInstance, error) {
-	jsonBytes, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-
+func (c *openServiceBrokerClient) CreateServiceInstance(ID string, req *brokerapi.CreateServiceInstanceRequest) (*brokerapi.CreateServiceInstanceResponse, error) {
 	url := fmt.Sprintf(serviceInstanceFormatString, c.broker.Spec.URL, ID)
-
 	// TODO: Handle the auth
-	createHTTPReq, err := http.NewRequest("PUT", url, bytes.NewReader(jsonBytes))
+	resp, err := util.SendRequest(c.client, http.MethodPut, url, req)
 	if err != nil {
-		return nil, err
-	}
-
-	glog.Infof("Doing a request to: %s", url)
-	resp, err := c.client.Do(createHTTPReq)
-	if err != nil {
-		return nil, err
+		return nil, errRequest{message: err.Error()}
 	}
 	defer resp.Body.Close()
 
-	// TODO: Align this with the actual response model.
-	si := brokerapi.ServiceInstance{}
-	if err := util.ResponseBodyToObject(resp, &si); err != nil {
-		return nil, err
+	createServiceInstanceResponse := brokerapi.CreateServiceInstanceResponse{}
+	if err := util.ResponseBodyToObject(resp, &createServiceInstanceResponse); err != nil {
+		return nil, errResponse{message: err.Error()}
 	}
-	return &si, nil
+
+	switch resp.StatusCode {
+	case http.StatusCreated:
+		return &createServiceInstanceResponse, nil
+	case http.StatusOK:
+		return &createServiceInstanceResponse, nil
+	case http.StatusAccepted:
+		glog.V(3).Infof("Asynchronous response received. Polling broker.")
+		if err := c.pollBroker(ID, createServiceInstanceResponse.Operation); err != nil {
+			return nil, err
+		}
+
+		return &createServiceInstanceResponse, nil
+	case http.StatusConflict:
+		return nil, errConflict
+	case http.StatusUnprocessableEntity:
+		return nil, errAsynchronous
+	default:
+		return nil, errStatusCode{statusCode: resp.StatusCode}
+	}
 }
 
-func (c *openServiceBrokerClient) UpdateServiceInstance(ID string, req *brokerapi.ServiceInstanceRequest) (*brokerapi.ServiceInstance, error) {
+func (c *openServiceBrokerClient) UpdateServiceInstance(ID string, req *brokerapi.CreateServiceInstanceRequest) (*brokerapi.ServiceInstance, error) {
 	// TODO: https://github.com/kubernetes-incubator/service-catalog/issues/114
 	return nil, fmt.Errorf("Not implemented")
 }
 
-func (c *openServiceBrokerClient) DeleteServiceInstance(ID string) error {
+func (c *openServiceBrokerClient) DeleteServiceInstance(ID string, req *brokerapi.DeleteServiceInstanceRequest) error {
 	url := fmt.Sprintf(serviceInstanceFormatString, c.broker.Spec.URL, ID)
-
 	// TODO: Handle the auth
-	deleteHTTPReq, err := http.NewRequest("DELETE", url, nil)
+	resp, err := util.SendRequest(c.client, http.MethodDelete, url, req)
 	if err != nil {
-		glog.Errorf("Failed to create new HTTP request: %v", err)
-		return err
-	}
-
-	glog.Infof("Doing a request to: %s", url)
-	resp, err := c.client.Do(deleteHTTPReq)
-	if err != nil {
-		glog.Errorf("Failed to DELETE: %#v", err)
-		return err
+		return errRequest{message: err.Error()}
 	}
 	defer resp.Body.Close()
 
-	return nil
+	deleteServiceInstanceResponse := brokerapi.DeleteServiceInstanceResponse{}
+	if err := util.ResponseBodyToObject(resp, &deleteServiceInstanceResponse); err != nil {
+		return errResponse{message: err.Error()}
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusAccepted:
+		glog.V(3).Infof("Asynchronous response received. Polling broker.")
+		if err := c.pollBroker(ID, deleteServiceInstanceResponse.Operation); err != nil {
+			return err
+		}
+
+		return nil
+	case http.StatusGone:
+		return nil
+	case http.StatusUnprocessableEntity:
+		return errAsynchronous
+	default:
+		return errStatusCode{statusCode: resp.StatusCode}
+	}
 }
 
 func (c *openServiceBrokerClient) CreateServiceBinding(sID, bID string, req *brokerapi.BindingRequest) (*brokerapi.CreateServiceBindingResponse, error) {
@@ -185,4 +241,40 @@ func (c *openServiceBrokerClient) DeleteServiceBinding(sID, bID string) error {
 	defer resp.Body.Close()
 
 	return nil
+}
+
+func (c *openServiceBrokerClient) pollBroker(ID string, operation string) error {
+	pollReq := brokerapi.LastOperationRequest{}
+	if operation != "" {
+		pollReq.Operation = operation
+	}
+
+	url := fmt.Sprintf(pollingFormatString, c.broker.Spec.URL, ID)
+	for i := 0; i < pollingAmountLimit; i++ {
+		glog.V(3).Infof("Polling attempt #%v: %s", i+1, url)
+		pollResp, err := util.SendRequest(c.client, http.MethodGet, url, pollReq)
+		if err != nil {
+			return err
+		}
+		defer pollResp.Body.Close()
+
+		lo := brokerapi.LastOperationResponse{}
+		if err := util.ResponseBodyToObject(pollResp, &lo); err != nil {
+			return err
+		}
+
+		switch lo.State {
+		case brokerapi.StateInProgress:
+		case brokerapi.StateSucceeded:
+			return nil
+		case brokerapi.StateFailed:
+			return errFailedState
+		default:
+			return errUnknownState
+		}
+
+		time.Sleep(pollingIntervalSeconds * time.Second)
+	}
+
+	return errPollingTimeout
 }

--- a/pkg/brokerapi/openservicebroker/open_service_broker_client_test.go
+++ b/pkg/brokerapi/openservicebroker/open_service_broker_client_test.go
@@ -17,22 +17,194 @@ limitations under the License.
 package openservicebroker
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/brokerapi"
+	"github.com/kubernetes-incubator/service-catalog/pkg/brokerapi/openservicebroker/util"
 )
 
-func TestUpdateServiceInstance(t *testing.T) {
-	cli := NewClient(&servicecatalog.Broker{})
-
-	_, err := cli.UpdateServiceInstance("foo", &brokerapi.ServiceInstanceRequest{})
-	if err == nil {
-		t.Fatalf("Expected not implemented")
-	}
-	if err.Error() != "Not implemented" {
-		t.Errorf("Expected not implemented, got %v", err)
+func setup() (*util.FakeBrokerServer, *servicecatalog.Broker) {
+	fbs := &util.FakeBrokerServer{}
+	url := fbs.Start()
+	fakeBroker := &servicecatalog.Broker{
+		Spec: servicecatalog.BrokerSpec{
+			URL: url,
+		},
 	}
 
-	// TODO: test against fake/test broker.
+	return fbs, fakeBroker
+}
+
+// Provision
+
+func TestProvisionInstanceCreated(t *testing.T) {
+	fbs, fakeBroker := setup()
+	defer fbs.Stop()
+
+	c := NewClient(fakeBroker)
+
+	fbs.SetResponseStatus(http.StatusCreated)
+	if _, err := c.CreateServiceInstance("1", &brokerapi.CreateServiceInstanceRequest{}); err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestProvisionInstanceOK(t *testing.T) {
+	fbs, fakeBroker := setup()
+	defer fbs.Stop()
+
+	c := NewClient(fakeBroker)
+
+	fbs.SetResponseStatus(http.StatusOK)
+	if _, err := c.CreateServiceInstance("1", &brokerapi.CreateServiceInstanceRequest{}); err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestProvisionInstanceConflict(t *testing.T) {
+	fbs, fakeBroker := setup()
+	defer fbs.Stop()
+
+	c := NewClient(fakeBroker)
+
+	fbs.SetResponseStatus(http.StatusConflict)
+	_, err := c.CreateServiceInstance("1", &brokerapi.CreateServiceInstanceRequest{})
+	switch {
+	case err == nil:
+		t.Errorf("Expected '%v'", errConflict)
+	case err != errConflict:
+		t.Errorf("Expected '%v', got '%v'", errConflict, err)
+	}
+}
+
+func TestProvisionInstanceUnprocessableEntity(t *testing.T) {
+	fbs, fakeBroker := setup()
+	defer fbs.Stop()
+
+	c := NewClient(fakeBroker)
+
+	fbs.SetResponseStatus(http.StatusUnprocessableEntity)
+	_, err := c.CreateServiceInstance("1", &brokerapi.CreateServiceInstanceRequest{})
+	switch {
+	case err == nil:
+		t.Errorf("Expected '%v'", errAsynchronous)
+	case err != errAsynchronous:
+		t.Errorf("Expected '%v', got '%v'", errAsynchronous, err)
+	}
+}
+
+func TestProvisionInstanceAcceptedSuccessAsynchronous(t *testing.T) {
+	fbs, fakeBroker := setup()
+	defer fbs.Stop()
+
+	c := NewClient(fakeBroker)
+
+	fbs.SetAsynchronous(2, true, "succeed_async")
+	req := brokerapi.CreateServiceInstanceRequest{
+		AcceptsIncomplete: true,
+	}
+
+	if _, err := c.CreateServiceInstance("1", &req); err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestProvisionInstanceAcceptedFailureAsynchronous(t *testing.T) {
+	fbs, fakeBroker := setup()
+	defer fbs.Stop()
+
+	c := NewClient(fakeBroker)
+
+	fbs.SetAsynchronous(2, false, "fail_async")
+	req := brokerapi.CreateServiceInstanceRequest{
+		AcceptsIncomplete: true,
+	}
+
+	_, err := c.CreateServiceInstance("1", &req)
+	switch {
+	case err == nil:
+		t.Errorf("Expected '%v'", errFailedState)
+	case err != errFailedState:
+		t.Errorf("Expected '%v', got '%v'", errFailedState, err)
+	}
+}
+
+// Deprovision
+
+func TestDeprovisionInstanceOK(t *testing.T) {
+	fbs, fakeBroker := setup()
+	defer fbs.Stop()
+
+	c := NewClient(fakeBroker)
+
+	fbs.SetResponseStatus(http.StatusOK)
+	if err := c.DeleteServiceInstance("1", &brokerapi.DeleteServiceInstanceRequest{}); err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestDeprovisionInstanceGone(t *testing.T) {
+	fbs, fakeBroker := setup()
+	defer fbs.Stop()
+
+	c := NewClient(fakeBroker)
+
+	fbs.SetResponseStatus(http.StatusGone)
+	if err := c.DeleteServiceInstance("1", &brokerapi.DeleteServiceInstanceRequest{}); err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestDeprovisionInstanceUnprocessableEntity(t *testing.T) {
+	fbs, fakeBroker := setup()
+	defer fbs.Stop()
+
+	c := NewClient(fakeBroker)
+
+	fbs.SetResponseStatus(http.StatusUnprocessableEntity)
+	err := c.DeleteServiceInstance("1", &brokerapi.DeleteServiceInstanceRequest{})
+	switch {
+	case err == nil:
+		t.Errorf("Expected '%v'", errAsynchronous)
+	case err != errAsynchronous:
+		t.Errorf("Expected '%v', got '%v'", errAsynchronous, err)
+	}
+}
+
+func TestDeprovisionInstanceAcceptedSuccessAsynchronous(t *testing.T) {
+	fbs, fakeBroker := setup()
+	defer fbs.Stop()
+
+	c := NewClient(fakeBroker)
+
+	fbs.SetAsynchronous(2, true, "succeed_async")
+	req := brokerapi.DeleteServiceInstanceRequest{
+		AcceptsIncomplete: true,
+	}
+
+	if err := c.DeleteServiceInstance("1", &req); err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestDeprovisionInstanceAcceptedFailureAsynchronous(t *testing.T) {
+	fbs, fakeBroker := setup()
+	defer fbs.Stop()
+
+	c := NewClient(fakeBroker)
+
+	fbs.SetAsynchronous(2, false, "fail_async")
+	req := brokerapi.DeleteServiceInstanceRequest{
+		AcceptsIncomplete: true,
+	}
+
+	err := c.DeleteServiceInstance("1", &req)
+	switch {
+	case err == nil:
+		t.Errorf("Expected '%v'", errFailedState)
+	case err != errFailedState:
+		t.Errorf("Expected '%v', got '%v'", errFailedState, err)
+	}
 }

--- a/pkg/brokerapi/openservicebroker/util/fake_broker_server.go
+++ b/pkg/brokerapi/openservicebroker/util/fake_broker_server.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gorilla/mux"
+	"github.com/kubernetes-incubator/service-catalog/pkg/brokerapi"
+	"github.com/kubernetes-incubator/service-catalog/pkg/util"
+)
+
+// FakeBrokerServer is a fake service broker server meant for testing that allows for customizing the response behavior
+type FakeBrokerServer struct {
+	responseStatus     int
+	pollsRemaining     int
+	shouldSucceedAsync bool
+	operation          string
+	server             *httptest.Server
+}
+
+// Start starts the fake broker server listening on a random port, passing back the server's URL
+func (f *FakeBrokerServer) Start() string {
+	router := mux.NewRouter()
+	router.HandleFunc("/v2/catalog", f.catalogHandler).Methods("GET")
+	router.HandleFunc("/v2/service_instances/{id}/last_operation", f.lastOperationHandler).Methods("GET")
+	router.HandleFunc("/v2/service_instances/{id}", f.provisionHandler).Methods("PUT")
+	router.HandleFunc("/v2/service_instances/{id}", f.updateHandler).Methods("PATCH")
+	router.HandleFunc("/v2/service_instances/{instance_id}/service_bindings/{binding_id}", f.bindHandler).Methods("PUT")
+	router.HandleFunc("/v2/service_instances/{instance_id}/service_bindings/{binding_id}", f.unbindHandler).Methods("DELETE")
+	router.HandleFunc("/v2/service_instances/{id}", f.deprovisionHandler).Methods("DELETE")
+	f.server = httptest.NewServer(router)
+	return f.server.URL
+}
+
+// Stop shuts down the server
+func (f *FakeBrokerServer) Stop() {
+	f.server.Close()
+}
+
+// SetResponseStatus sets the default response status of the broker to the given HTTP status code
+func (f *FakeBrokerServer) SetResponseStatus(status int) {
+	f.responseStatus = status
+}
+
+// SetAsynchronous sets the number of polls before finished, final state, and operation for asynchronous operations
+func (f *FakeBrokerServer) SetAsynchronous(numPolls int, shouldSucceed bool, operation string) {
+	f.pollsRemaining = numPolls
+	f.shouldSucceedAsync = shouldSucceed
+	f.operation = operation
+}
+
+// HANDLERS
+
+func (f *FakeBrokerServer) catalogHandler(w http.ResponseWriter, r *http.Request) {
+	util.WriteResponse(w, http.StatusOK, &brokerapi.Catalog{})
+}
+
+func (f *FakeBrokerServer) lastOperationHandler(w http.ResponseWriter, r *http.Request) {
+	req := &brokerapi.LastOperationRequest{}
+	if err := util.BodyToObject(r, req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	var state string
+	switch {
+	case f.pollsRemaining > 0:
+		f.pollsRemaining--
+		state = brokerapi.StateInProgress
+	case f.shouldSucceedAsync:
+		state = brokerapi.StateSucceeded
+	default:
+		state = brokerapi.StateFailed
+	}
+
+	resp := brokerapi.LastOperationResponse{
+		State: state,
+	}
+	util.WriteResponse(w, http.StatusOK, &resp)
+}
+
+func (f *FakeBrokerServer) provisionHandler(w http.ResponseWriter, r *http.Request) {
+	req := &brokerapi.CreateServiceInstanceRequest{}
+	if err := util.BodyToObject(r, req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if !req.AcceptsIncomplete {
+		// Synchronous
+		util.WriteResponse(w, f.responseStatus, &brokerapi.CreateServiceInstanceResponse{})
+	} else {
+		// Asynchronous
+		resp := brokerapi.CreateServiceInstanceResponse{
+			Operation: f.operation,
+		}
+		util.WriteResponse(w, http.StatusAccepted, &resp)
+	}
+}
+
+func (f *FakeBrokerServer) deprovisionHandler(w http.ResponseWriter, r *http.Request) {
+	req := &brokerapi.DeleteServiceInstanceRequest{}
+	if err := util.BodyToObject(r, req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if !req.AcceptsIncomplete {
+		// Synchronous
+		util.WriteResponse(w, f.responseStatus, &brokerapi.DeleteServiceInstanceResponse{})
+	} else {
+		// Asynchronous
+		resp := brokerapi.CreateServiceInstanceResponse{
+			Operation: f.operation,
+		}
+		util.WriteResponse(w, http.StatusAccepted, &resp)
+	}
+}
+
+func (f *FakeBrokerServer) updateHandler(w http.ResponseWriter, r *http.Request) {
+	// TODO: Implement
+	util.WriteResponse(w, http.StatusForbidden, nil)
+}
+
+func (f *FakeBrokerServer) bindHandler(w http.ResponseWriter, r *http.Request) {
+	// TODO: Implement
+	util.WriteResponse(w, http.StatusForbidden, nil)
+}
+
+func (f *FakeBrokerServer) unbindHandler(w http.ResponseWriter, r *http.Request) {
+	// TODO: Implement
+	util.WriteResponse(w, http.StatusForbidden, nil)
+}

--- a/pkg/brokerapi/service_instance.go
+++ b/pkg/brokerapi/service_instance.go
@@ -26,22 +26,14 @@ type ServiceInstance struct {
 	OrganizationGUID string `json:"organization_guid"`
 	SpaceGUID        string `json:"space_guid"`
 
-	LastOperation *LastOperation `json:"last_operation, omitempty"`
+	LastOperation *LastOperationResponse `json:"last_operation, omitempty"`
 
 	Parameters map[string]interface{} `json:"parameters, omitempty"`
 }
 
-// LastOperation represents the state of a discrete action that the broker is
-// completing asynchronously
-type LastOperation struct {
-	State                    string `json:"state"`
-	Description              string `json:"description"`
-	AsyncPollIntervalSeconds int    `json:"async_poll_interval_seconds, omitempty"`
-}
-
-// ServiceInstanceRequest represents a request to a broker to provision an
+// CreateServiceInstanceRequest represents a request to a broker to provision an
 // instance of a service
-type ServiceInstanceRequest struct {
+type CreateServiceInstanceRequest struct {
 	OrgID             string                 `json:"organization_guid,omitempty"`
 	PlanID            string                 `json:"plan_id,omitempty"`
 	ServiceID         string                 `json:"service_id,omitempty"`
@@ -53,6 +45,42 @@ type ServiceInstanceRequest struct {
 // CreateServiceInstanceResponse represents the response from a broker after a
 // request to provision an instance of a service
 type CreateServiceInstanceResponse struct {
-	DashboardURL  string         `json:"dashboard_url, omitempty"`
-	LastOperation *LastOperation `json:"last_operation, omitempty"`
+	DashboardURL string `json:"dashboard_url, omitempty"`
+	Operation    string `json:"operation, omitempty"`
 }
+
+// DeleteServiceInstanceRequest represents a request to a broker to deprovision an
+// instance of a service
+type DeleteServiceInstanceRequest struct {
+	ServiceID         string `json:"service_id"`
+	PlanID            string `json:"plan_id"`
+	AcceptsIncomplete bool   `json:"accepts_incomplete,omitempty"`
+}
+
+// DeleteServiceInstanceResponse represents the response from a broker after a request
+// to deprovision an instance of a service
+type DeleteServiceInstanceResponse struct {
+	Operation string `json:"operation,omitempty"`
+}
+
+// LastOperationRequest represents a request to a broker to give the state of the action
+// it is completing asynchronously
+type LastOperationRequest struct {
+	ServiceID string `json:"service_id,omitempty"`
+	PlanID    string `json:"plan_id,omitempty"`
+	Operation string `json:"operation,omitempty"`
+}
+
+// LastOperationResponse represents the broker response with the state of a discrete action
+// that the broker is completing asynchronously
+type LastOperationResponse struct {
+	State       string `json:"state"`
+	Description string `json:"description,omitempty"`
+}
+
+// Defines the possible states of an asynchronous request to a broker
+const (
+	StateInProgress = "in progress"
+	StateSucceeded  = "succeeded"
+	StateFailed     = "failed"
+)

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -84,7 +84,7 @@ func (h *handler) createServiceInstance(in *servicecatalog.Instance) error {
 
 	// TODO: uncomment parameters line once parameters types are refactored.
 	// Make the request to instantiate.
-	createReq := &brokerapi.ServiceInstanceRequest{
+	createReq := &brokerapi.CreateServiceInstanceRequest{
 		ServiceID: in.Spec.OSBServiceID,
 		PlanID:    in.Spec.OSBPlanID,
 		// Parameters: in.Spec.Parameters,

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,7 +30,28 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// WriteResponse will serialize 'object' to the HTTP RespsonseWriter
+// SendRequest will serialize 'object' and send it using the given method to
+// the given URL, through the provided client
+func SendRequest(c *http.Client, method string, url string, object interface{}) (*http.Response, error) {
+	data, err := json.Marshal(object)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal request: %s", err.Error())
+	}
+
+	req, err := http.NewRequest(method, url, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create request object: %s", err.Error())
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to send request: %s", err.Error())
+	}
+
+	return resp, nil
+}
+
+// WriteResponse will serialize 'object' to the HTTP ResponseWriter
 // using the 'code' as the HTTP status code
 func WriteResponse(w http.ResponseWriter, code int, object interface{}) {
 	data, err := json.Marshal(object)


### PR DESCRIPTION
Adds a control loop to the broker client that, should on provisioning/deprovisioning it receive an asynchronous operation response back, polls the broker waiting for the final state.

First steps at fleshing out our implementation of the OSB API as per [#133](https://github.com/kubernetes-incubator/service-catalog/issues/133). Includes work on a fake service broker server that can be used to test the broker client. I will be updating this server piecemeal as I work to finish implementing the spec.

API spec I am following may be found here: [Service Broker API](https://docs.cloudfoundry.org/services/api.html)