### PR TITLE
Explicitly specify GLIDE_HOME

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -18,7 +18,8 @@ FROM golang:GO_VERSION
 RUN printf "[trusted]\nusers = *\n" > /root/.hgrc
 
 # Install glide as root
-ENV GLIDE_VERSION=v0.12.3
+ENV GLIDE_VERSION=v0.12.3 \
+    GLIDE_HOME=/go/src/github.com/kubernetes-incubator/service-catalog/.glide
 RUN curl -sSL https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.tar.gz \
     | tar -vxz -C /usr/local/bin --strip=1
 


### PR DESCRIPTION
Before this PR, we don't explicitly set the location of "glide home" via the `GLIDE_HOME` env var. Per glide documentation, this _should_ then resolve "glide home" to `$HOME/.glide`. Due to a bug, however, on Linux (which includes our build container, of course) this will actually resolve to `$(pwd)/.glide` instead.

Without setting `GLIDE_HOME` explicitly, when this bug is corrected (and we someday upgrade glide), our "glide home" would move suddenly from `.glide` (relative to this repo's directory) to
`/root/.glide`... and that would have a deleterious effect on CI since we're caching `.glide` for performance.

To avoid such fallout from the correction of the bug, which we essentially rely on, to a limited extent, this PR explicitly sets `GLIDE_HOME` to future-proof us.

See https://github.com/Masterminds/glide/issues/736 for further details.

cc @arschles 