### PR TITLE
Remove hack/ from repo layout description

### DIFF
--- a/docs/DEVGUIDE.md
+++ b/docs/DEVGUIDE.md
@@ -15,7 +15,6 @@ layout:
     ├── deploy
     │   └── catalog    # Helm chart for deploying service catalog
     ├── docs           # Documentation
-    ├── hack           # Contains scripts useful for development
     ├── pkg            # Contains all non-"main" Go packages
     └── vendor         # Glide-managed dependencies (untracked)
 


### PR DESCRIPTION
Ugh... I believed this change to have been included in an amendment to #246, but I was mistaken. (Must have amended the commit and force pushed, but forgot to `git add` the change first. Damnit!)

A million apologies!

cc @duglin 