### PR TITLE
Block controller's Run() func from exiting

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -71,17 +71,15 @@ func Run(s *options.ControllerServer) error {
 		panic(fmt.Sprintf("Error creating server [%s]...", err.Error()))
 	}
 
-	go func() {
-		mux := http.NewServeMux()
-		healthz.InstallHandler(mux)
-		server := &http.Server{
-			Addr:    net.JoinHostPort(s.Address, strconv.Itoa(int(s.Port))),
-			Handler: mux,
-		}
-		glog.Fatal(server.ListenAndServe())
-	}()
-
 	c.Run()
 
-	panic("unreachable")
+	mux := http.NewServeMux()
+	healthz.InstallHandler(mux)
+	server := &http.Server{
+		Addr:    net.JoinHostPort(s.Address, strconv.Itoa(int(s.Port))),
+		Handler: mux,
+	}
+	glog.Fatal(server.ListenAndServe())
+
+	return nil
 }


### PR DESCRIPTION
Fixes #181 

I did the simplest thing that would work-- I moved the blocking `server.ListenAndServe()` call (which serves the healthcheck) into the main goroutine and to the end of the `Run()` func so that it will naturally block `Run()` from exiting.

After this PR, controller comes up clean and stays up.