### PR TITLE
add goflags so glog flags work

### DIFF
--- a/cmd/apiserver/app/server/server.go
+++ b/cmd/apiserver/app/server/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"flag"
 	"fmt"
 	"io"
 
@@ -89,6 +90,7 @@ func NewCommandServer(out io.Writer) *cobra.Command {
 	//
 	// repeated pattern seems like it should be refactored if all
 	// options were of an interface type that specified AddFlags.
+	flags.AddGoFlagSet(flag.CommandLine)
 	options.GenericServerRunOptions.AddUniversalFlags(flags)
 	options.SecureServingOptions.AddFlags(flags)
 	options.EtcdOptions.AddFlags(flags)


### PR DESCRIPTION
now -v 10 will work for verbose logging

example
```
λ ./apiserver -v 10 --etcd-servers http://localhost:2379
I0112 21:32:59.912784   38042 logs.go:51] INIT THE LOGS
I0112 21:32:59.913090   38042 server.go:106] Preparing to run API server
I0112 21:32:59.913184   38042 interface.go:194] Choosing interface en0 (IP 192.168.0.12) as default
I0112 21:32:59.913195   38042 server.go:114] Setting up secure serving options
I0112 21:32:59.913224   38042 server.go:127] Configuring generic API server
I0112 21:32:59.914014   38042 server.go:136] Setting up authn (disabled)
I0112 21:32:59.914023   38042 server.go:145] Setting up authz (disabled)
I0112 21:32:59.914026   38042 server.go:154] Creating storage factory
I0112 21:32:59.914059   38042 server.go:193] Completing API server configuration
W0112 21:32:59.914159   38042 authorization.go:33] Authorization is disabled
W0112 21:32:59.914170   38042 handlers.go:50] Authentication is disabled
I0112 21:32:59.914182   38042 apiserver.go:91] Creating API server
I0112 21:32:59.914186   38042 apiserver.go:114] Installing API groups
I0112 21:32:59.914213   38042 storage_factory.go:241] storing {servicecatalog.k8s.io brokers} in servicecatalog.k8s.io/v1alpha1, reading as servicecatalog.k8s.io/__internal from { /k8s.io/service-catalog [http://localhost:2379]    false 0 <nil>}
I0112 21:32:59.914236   38042 storage_factory.go:241] storing {servicecatalog.k8s.io serviceclasses} in servicecatalog.k8s.io/v1alpha1, reading as servicecatalog.k8s.io/__internal from { /k8s.io/service-catalog [http://localhost:2379]    false 0 <nil>}
I0112 21:32:59.914246   38042 storage_factory.go:241] storing {servicecatalog.k8s.io instances} in servicecatalog.k8s.io/v1alpha1, reading as servicecatalog.k8s.io/__internal from { /k8s.io/service-catalog [http://localhost:2379]    false 0 <nil>}
I0112 21:32:59.914255   38042 storage_factory.go:241] storing {servicecatalog.k8s.io bindings} in servicecatalog.k8s.io/v1alpha1, reading as servicecatalog.k8s.io/__internal from { /k8s.io/service-catalog [http://localhost:2379]    false 0 <nil>}
I0112 21:32:59.914263   38042 apiserver.go:121] Installing API group servicecatalog.k8s.io
I0112 21:32:59.916555   38042 apiserver.go:127] Finished installing API groups
[restful] 2017/01/12 21:32:59 log.go:30: [restful/swagger] listing is available at https://192.168.0.12:6443/swaggerapi/
[restful] 2017/01/12 21:32:59 log.go:30: [restful/swagger] https://192.168.0.12:6443/swaggerui/ is mapped to folder /swagger-ui/
I0112 21:32:59.917670   38042 server.go:203] Running the API server
I0112 21:32:59.917677   38042 serve.go:79] Serving securely on 0.0.0.0:6443
```