### PR TITLE
Rename *Ref to *Name in BindingSpec

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -257,11 +257,12 @@ type BindingSpec struct {
 
 	Parameters map[string]interface{}
 
-	// References to objects to create
-	SecretRef                 string
-	ServiceRef                string
-	ConfigMapRef              string
-	ServiceInjectionPolicyRef string
+	// Names of subordinate objects to create
+	SecretName    string
+	ServiceName   string
+	ConfigMapName string
+	// Placeholder for future SIP support
+	// ServiceInjectionPolicyName string
 
 	// OSB-specific
 	// OSBGUID is the identity of this object for use with the OSB API.

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -258,11 +258,12 @@ type BindingSpec struct {
 
 	Parameters map[string]interface{}
 
-	// References to objects to create
-	SecretRef                 string
-	ServiceRef                string
-	ConfigMapRef              string
-	ServiceInjectionPolicyRef string
+	// Names of subordinate objects to create
+	SecretName    string
+	ServiceName   string
+	ConfigMapName string
+	// Placeholder for future SIP support
+	// ServiceInjectionPolicyName string
 
 	// OSB-specific
 	// OSBGUID is the identity of this object for use with the OSB API.


### PR DESCRIPTION
To make it clear that the user can specify the name of the
subordinate objects we create - otherwise we'll default to the
name of the Binding

Signed-off-by: Doug Davis <dug@us.ibm.com>