### PR TITLE
add BrokerStatus structs

### DIFF
--- a/pkg/apis/servicecatalog/validation/broker.go
+++ b/pkg/apis/servicecatalog/validation/broker.go
@@ -90,3 +90,10 @@ func ValidateBrokerUpdate(new *sc.Broker, old *sc.Broker) field.ErrorList {
 	// allErrs = append(allErrs, validateBrokerStatusUpdate(new, old)...)
 	return allErrs
 }
+
+// ValidateBrokerStatusUpdate checks that when changing from an older broker to a newer broker is okay.
+func ValidateBrokerStatusUpdate(new *sc.Broker, old *sc.Broker) field.ErrorList {
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, ValidateBrokerUpdate(new, old)...)
+	return allErrs
+}

--- a/pkg/registry/servicecatalog/broker/storage.go
+++ b/pkg/registry/servicecatalog/broker/storage.go
@@ -58,7 +58,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 
 // NewStorage creates a new rest.Storage responsible for accessing Instance
 // resources
-func NewStorage(opts generic.RESTOptions) rest.Storage {
+func NewStorage(opts generic.RESTOptions) (brokers, brokersStatus rest.Storage) {
 	prefix := "/" + opts.ResourcePrefix
 
 	store := registry.Store{
@@ -93,5 +93,8 @@ func NewStorage(opts generic.RESTOptions) rest.Storage {
 		DeleteStrategy: brokerRESTStrategies,
 	}
 
-	return &store
+	statusStore := store
+	statusStore.UpdateStrategy = brokerStatusUpdateStrategy
+
+	return &store, &statusStore
 }

--- a/pkg/registry/servicecatalog/rest/storage_servicecatalog.go
+++ b/pkg/registry/servicecatalog/rest/storage_servicecatalog.go
@@ -46,8 +46,10 @@ func (p StorageProvider) NewRESTStorage(apiResourceConfigSource genericapiserver
 }
 
 func (p StorageProvider) v1alpha1Storage(apiResourceConfigSource genericapiserver.APIResourceConfigSource, restOptionsGetter registry.RESTOptionsGetter) map[string]rest.Storage {
+	brokers, brokersStatus := broker.NewStorage(restOptionsGetter(servicecatalog.Resource("brokers")))
 	return map[string]rest.Storage{
-		"brokers":        broker.NewStorage(restOptionsGetter(servicecatalog.Resource("brokers"))),
+		"brokers":        brokers,
+		"brokers/status": brokersStatus,
 		"serviceclasses": serviceclass.NewStorage(restOptionsGetter(servicecatalog.Resource("serviceclasses"))),
 		"instances":      instance.NewStorage(restOptionsGetter(servicecatalog.Resource("instances"))),
 		"bindings":       binding.NewStorage(restOptionsGetter(servicecatalog.Resource("bindings"))),


### PR DESCRIPTION
I cribbed off of statefulSet and Node. Both of those create a sort of sub-strategy object, and only override the UpdateRESTStrategy related functions.

It's not clear what the status endpoint must do. 