### PR TITLE
Add unit tests to k8s_binding_injector

### DIFF
--- a/pkg/controller/injector/k8s_binding_injector.go
+++ b/pkg/controller/injector/k8s_binding_injector.go
@@ -30,7 +30,7 @@ import (
 )
 
 type k8sBindingInjector struct {
-	client *kubernetes.Clientset
+	client kubernetes.Interface
 }
 
 // CreateK8sBindingInjector creates an instance of a BindingInjector which

--- a/pkg/controller/injector/k8s_binding_injector_test.go
+++ b/pkg/controller/injector/k8s_binding_injector_test.go
@@ -30,7 +30,7 @@ func TestInjectOne(t *testing.T) {
 	binding := createBindings(1)[0]
 	cred := createCreds(1)[0]
 	injector := fakeK8sBindingInjector()
-	if err := inject(t, injector, binding, cred); err != nil {
+	if err := inject(injector, binding, cred); err != nil {
 		t.Fatal(err)
 	}
 
@@ -39,7 +39,7 @@ func TestInjectOne(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error when getting secret: %s", err)
 	}
-	if err := testCredentialsInjected(t, secret.Data, cred); err != nil {
+	if err := testCredentialsInjected(secret.Data, cred); err != nil {
 		t.Error(err)
 	}
 }
@@ -49,10 +49,10 @@ func TestInjectTwo(t *testing.T) {
 	creds := createCreds(2)
 
 	injector := fakeK8sBindingInjector()
-	if err := inject(t, injector, bindings[0], creds[0]); err != nil {
+	if err := inject(injector, bindings[0], creds[0]); err != nil {
 		t.Fatal(err)
 	}
-	if err := inject(t, injector, bindings[1], creds[1]); err != nil {
+	if err := inject(injector, bindings[1], creds[1]); err != nil {
 		t.Fatal(err)
 	}
 
@@ -61,7 +61,7 @@ func TestInjectTwo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error when getting secret: %s", err)
 	}
-	if err := testCredentialsInjected(t, secret.Data, creds[0]); err != nil {
+	if err := testCredentialsInjected(secret.Data, creds[0]); err != nil {
 		t.Error(err)
 	}
 
@@ -70,7 +70,7 @@ func TestInjectTwo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error when getting secret: %s", err)
 	}
-	if err := testCredentialsInjected(t, secret.Data, creds[1]); err != nil {
+	if err := testCredentialsInjected(secret.Data, creds[1]); err != nil {
 		t.Error(err)
 	}
 }
@@ -80,12 +80,12 @@ func TestUninjectOne(t *testing.T) {
 	cred := createCreds(1)[0]
 
 	injector := fakeK8sBindingInjector()
-	if err := inject(t, injector, binding, cred); err != nil {
+	if err := inject(injector, binding, cred); err != nil {
 		t.Fatal(err)
 	}
 	injector.Uninject(binding)
 
-	if err := testCredentialsUninjected(t, injector, binding); err != nil {
+	if err := testCredentialsUninjected(injector, binding); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -95,17 +95,17 @@ func TestUninjectTwo(t *testing.T) {
 	creds := createCreds(2)
 
 	injector := fakeK8sBindingInjector()
-	if err := inject(t, injector, bindings[0], creds[0]); err != nil {
+	if err := inject(injector, bindings[0], creds[0]); err != nil {
 		t.Fatal(err)
 	}
-	if err := inject(t, injector, bindings[1], creds[1]); err != nil {
+	if err := inject(injector, bindings[1], creds[1]); err != nil {
 		t.Fatal(err)
 	}
 
 	injector.Uninject(bindings[0])
 
 	// test that bindings[0] is gone
-	if err := testCredentialsUninjected(t, injector, bindings[0]); err != nil {
+	if err := testCredentialsUninjected(injector, bindings[0]); err != nil {
 		t.Fatal(err)
 	}
 
@@ -115,14 +115,14 @@ func TestUninjectTwo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error when getting secret: %s", err)
 	}
-	if err := testCredentialsInjected(t, secret.Data, creds[1]); err != nil {
+	if err := testCredentialsInjected(secret.Data, creds[1]); err != nil {
 		t.Error(err)
 	}
 
 	// test that bindings[1] is gone after uninject
 	injector.Uninject(bindings[1])
 
-	if err := testCredentialsUninjected(t, injector, bindings[1]); err != nil {
+	if err := testCredentialsUninjected(injector, bindings[1]); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -159,7 +159,7 @@ func fakeK8sBindingInjector() *k8sBindingInjector {
 	}
 }
 
-func inject(t *testing.T, injector BindingInjector,
+func inject(injector BindingInjector,
 	binding *servicecatalog.Binding, cred *brokerapi.Credential) error {
 
 	err := injector.Inject(binding, cred)
@@ -170,7 +170,7 @@ func inject(t *testing.T, injector BindingInjector,
 }
 
 // tests all fields of credentials are there and also the same value
-func testCredentialsInjected(t *testing.T, data map[string][]byte, cred *brokerapi.Credential) error {
+func testCredentialsInjected(data map[string][]byte, cred *brokerapi.Credential) error {
 	testField := func(key string, expectedValue string) error {
 		val, ok := data[key]
 		if !ok {
@@ -199,7 +199,7 @@ func testCredentialsInjected(t *testing.T, data map[string][]byte, cred *brokera
 }
 
 // test that credential is no longer there
-func testCredentialsUninjected(t *testing.T, injector *k8sBindingInjector, binding *servicecatalog.Binding) error {
+func testCredentialsUninjected(injector *k8sBindingInjector, binding *servicecatalog.Binding) error {
 	secretsCl := injector.client.Core().Secrets(binding.Namespace)
 	_, err := secretsCl.Get(binding.Name)
 	if err == nil {

--- a/pkg/controller/injector/k8s_binding_injector_test.go
+++ b/pkg/controller/injector/k8s_binding_injector_test.go
@@ -20,13 +20,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
+	"testing"
+
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/brokerapi"
 	"k8s.io/client-go/1.5/kubernetes/fake"
 	v1 "k8s.io/client-go/1.5/pkg/api/v1"
 	kapi "k8s.io/kubernetes/pkg/api"
-	"strconv"
-	"testing"
 )
 
 func TestInjectOne(t *testing.T) {

--- a/pkg/controller/injector/k8s_binding_injector_test.go
+++ b/pkg/controller/injector/k8s_binding_injector_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/1.5/kubernetes/fake"
 	v1 "k8s.io/client-go/1.5/pkg/api/v1"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"strconv"
 	"testing"
 )
 
@@ -158,8 +159,8 @@ func createFakeBindings(length int) []*servicecatalog.Binding {
 	for i := range ret {
 		ret[i] = &servicecatalog.Binding{
 			ObjectMeta: kapi.ObjectMeta{
-				Name:      "name" + string(i),
-				Namespace: "namespace" + string(i),
+				Name:      "name" + strconv.Itoa(i),
+				Namespace: "namespace" + strconv.Itoa(i),
 			},
 		}
 	}
@@ -170,10 +171,10 @@ func createCreds(length int) []*brokerapi.Credential {
 	ret := make([]*brokerapi.Credential, length, length)
 	for i := range ret {
 		ret[i] = &brokerapi.Credential{
-			Hostname: "host" + string(i),
-			Port:     "123" + string(i),
-			Username: "user" + string(i),
-			Password: "password!@#!@#!0)" + string(i),
+			Hostname: "host" + strconv.Itoa(i),
+			Port:     "123" + strconv.Itoa(i),
+			Username: "user" + strconv.Itoa(i),
+			Password: "password!@#!@#!0)" + strconv.Itoa(i),
 		}
 	}
 	return ret

--- a/pkg/controller/injector/k8s_binding_injector_test.go
+++ b/pkg/controller/injector/k8s_binding_injector_test.go
@@ -25,8 +25,8 @@ import (
 )
 
 func TestInjectOne(t *testing.T) {
-	binding,_ := getBindings()
-	cred,_ := getCreds()
+	binding, _ := getBindings()
+	cred, _ := getCreds()
 	injector := fakeK8sBindingInjector()
 	inject(t, injector, binding, cred)
 
@@ -62,8 +62,8 @@ func TestInjectTwo(t *testing.T) {
 }
 
 func TestUninjectOne(t *testing.T) {
-	binding,_ := getBindings()
-	cred,_ := getCreds()
+	binding, _ := getBindings()
+	cred, _ := getCreds()
 
 	injector := fakeK8sBindingInjector()
 	inject(t, injector, binding, cred)

--- a/pkg/controller/injector/k8s_binding_injector_test.go
+++ b/pkg/controller/injector/k8s_binding_injector_test.go
@@ -28,7 +28,7 @@ func TestInjectOne(t *testing.T) {
 	binding,_ := getBindings()
 	cred,_ := getCreds()
 	injector := fakeK8sBindingInjector()
-	injectAndTest(t, injector, binding, cred)
+	inject(t, injector, binding, cred)
 
 	secretsCl := injector.client.Core().Secrets(binding.Namespace)
 	secret, err := secretsCl.Get(binding.Name)
@@ -43,8 +43,8 @@ func TestInjectTwo(t *testing.T) {
 	cred0, cred1 := getCreds()
 
 	injector := fakeK8sBindingInjector()
-	injectAndTest(t, injector, binding0, cred0)
-	injectAndTest(t, injector, binding1, cred1)
+	inject(t, injector, binding0, cred0)
+	inject(t, injector, binding1, cred1)
 
 	secretsCl := injector.client.Core().Secrets(binding0.Namespace)
 	secret, err := secretsCl.Get(binding0.Name)
@@ -66,7 +66,7 @@ func TestUninjectOne(t *testing.T) {
 	cred,_ := getCreds()
 
 	injector := fakeK8sBindingInjector()
-	injectAndTest(t, injector, binding, cred)
+	inject(t, injector, binding, cred)
 	injector.Uninject(binding)
 
 	secretsCl := injector.client.Core().Secrets(binding.Namespace)
@@ -81,8 +81,8 @@ func TestUninjectTwo(t *testing.T) {
 	cred0, cred1 := getCreds()
 
 	injector := fakeK8sBindingInjector()
-	injectAndTest(t, injector, binding0, cred0)
-	injectAndTest(t, injector, binding1, cred1)
+	inject(t, injector, binding0, cred0)
+	inject(t, injector, binding1, cred1)
 
 	injector.Uninject(binding0)
 
@@ -102,10 +102,10 @@ func TestUninjectTwo(t *testing.T) {
 	testCredentialsInjected(t, secret.Data, cred1)
 
 	// test that binding1 is gone after uninject
-	// injector.Uninject(binding0)
+	injector.Uninject(binding1)
 
-	secretsCl = injector.client.Core().Secrets(binding0.Namespace)
-	secret, err = secretsCl.Get(binding0.Name)
+	secretsCl = injector.client.Core().Secrets(binding1.Namespace)
+	secret, err = secretsCl.Get(binding1.Name)
 	if err == nil {
 		testCredentialsUninjected(t, secret.Data)
 	}
@@ -149,7 +149,7 @@ func getCreds() (*brokerapi.Credential, *brokerapi.Credential) {
 	return cred0, cred1
 }
 
-func injectAndTest(t *testing.T, injector BindingInjector,
+func inject(t *testing.T, injector BindingInjector,
 	binding *servicecatalog.Binding, cred *brokerapi.Credential) {
 
 	err := injector.Inject(binding, cred)

--- a/pkg/controller/injector/k8s_binding_injector_test.go
+++ b/pkg/controller/injector/k8s_binding_injector_test.go
@@ -73,6 +73,21 @@ func TestInjectTwo(t *testing.T) {
 	}
 }
 
+func TestInjectOverride(t *testing.T) {
+	binding := createBindings(1)[0]
+	creds := createCreds(2)
+
+	injector := fakeK8sBindingInjector()
+	if err := inject(injector, binding, creds[0]); err != nil {
+		t.Fatal(err)
+	}
+
+	// note that we expect a failure here
+	if err := inject(injector, binding, creds[0]); err == nil {
+		t.Fatal("Injecting over the same binding succeeded even though it shouldn't")
+	}
+}
+
 func TestUninjectOne(t *testing.T) {
 	binding := createBindings(1)[0]
 	cred := createCreds(1)[0]

--- a/pkg/controller/injector/k8s_binding_injector_test.go
+++ b/pkg/controller/injector/k8s_binding_injector_test.go
@@ -17,11 +17,175 @@ limitations under the License.
 package injector
 
 import (
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/brokerapi"
+	"k8s.io/client-go/1.5/kubernetes/fake"
+	kapi "k8s.io/kubernetes/pkg/api"
 	"testing"
 )
 
-func TestInject(t *testing.T) {
+func TestInjectOne(t *testing.T) {
+	binding,_ := getBindings()
+	cred,_ := getCreds()
+	injector := fakeK8sBindingInjector()
+	injectAndTest(t, injector, binding, cred)
+
+	secretsCl := injector.client.Core().Secrets(binding.Namespace)
+	secret, err := secretsCl.Get(binding.Name)
+	if err != nil {
+		t.Fatalf("Error when getting secret: %s", err)
+	}
+	testCredentialsInjected(t, secret.Data, cred)
 }
 
-func TestUninject(t *testing.T) {
+func TestInjectTwo(t *testing.T) {
+	binding0, binding1 := getBindings()
+	cred0, cred1 := getCreds()
+
+	injector := fakeK8sBindingInjector()
+	injectAndTest(t, injector, binding0, cred0)
+	injectAndTest(t, injector, binding1, cred1)
+
+	secretsCl := injector.client.Core().Secrets(binding0.Namespace)
+	secret, err := secretsCl.Get(binding0.Name)
+	if err != nil {
+		t.Fatalf("Error when getting secret: %s", err)
+	}
+	testCredentialsInjected(t, secret.Data, cred0)
+
+	secretsCl = injector.client.Core().Secrets(binding1.Namespace)
+	secret, err = secretsCl.Get(binding1.Name)
+	if err != nil {
+		t.Fatalf("Error when getting secret: %s", err)
+	}
+	testCredentialsInjected(t, secret.Data, cred1)
+}
+
+func TestUninjectOne(t *testing.T) {
+	binding,_ := getBindings()
+	cred,_ := getCreds()
+
+	injector := fakeK8sBindingInjector()
+	injectAndTest(t, injector, binding, cred)
+	injector.Uninject(binding)
+
+	secretsCl := injector.client.Core().Secrets(binding.Namespace)
+	secret, err := secretsCl.Get(binding.Name)
+	if err == nil {
+		testCredentialsUninjected(t, secret.Data)
+	}
+}
+
+func TestUninjectTwo(t *testing.T) {
+	binding0, binding1 := getBindings()
+	cred0, cred1 := getCreds()
+
+	injector := fakeK8sBindingInjector()
+	injectAndTest(t, injector, binding0, cred0)
+	injectAndTest(t, injector, binding1, cred1)
+
+	injector.Uninject(binding0)
+
+	// test that binding0 is gone
+	secretsCl := injector.client.Core().Secrets(binding0.Namespace)
+	secret, err := secretsCl.Get(binding0.Name)
+	if err == nil {
+		testCredentialsUninjected(t, secret.Data)
+	}
+
+	//test that binding1 is still there
+	secretsCl = injector.client.Core().Secrets(binding1.Namespace)
+	secret, err = secretsCl.Get(binding1.Name)
+	if err != nil {
+		t.Fatalf("Error when getting secret: %s", err)
+	}
+	testCredentialsInjected(t, secret.Data, cred1)
+
+	// test that binding1 is gone after uninject
+	// injector.Uninject(binding0)
+
+	secretsCl = injector.client.Core().Secrets(binding0.Namespace)
+	secret, err = secretsCl.Get(binding0.Name)
+	if err == nil {
+		testCredentialsUninjected(t, secret.Data)
+	}
+}
+
+func fakeK8sBindingInjector() *k8sBindingInjector {
+	return &k8sBindingInjector{
+		client: fake.NewSimpleClientset(),
+	}
+}
+
+func getBindings() (*servicecatalog.Binding, *servicecatalog.Binding) {
+	binding0 := &servicecatalog.Binding{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "name0",
+			Namespace: "namespace0",
+		},
+	}
+	binding1 := &servicecatalog.Binding{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "name1",
+			Namespace: "namespace1",
+		},
+	}
+	return binding0, binding1
+}
+
+func getCreds() (*brokerapi.Credential, *brokerapi.Credential) {
+	cred0 := &brokerapi.Credential{
+		Hostname: "host0",
+		Port:     "123",
+		Username: "user0",
+		Password: "password!@#!@#!0)",
+	}
+	cred1 := &brokerapi.Credential{
+		Hostname: "host1",
+		Port:     "456",
+		Username: "user1",
+		Password: "password*(&*1)",
+	}
+	return cred0, cred1
+}
+
+func injectAndTest(t *testing.T, injector BindingInjector,
+	binding *servicecatalog.Binding, cred *brokerapi.Credential) {
+
+	err := injector.Inject(binding, cred)
+	if err != nil {
+		t.Fatalf("Error when injecting credentials: %s", err)
+	}
+}
+
+// tests all fields of credentials are there and also the same value
+func testCredentialsInjected(t *testing.T, data map[string][]byte, cred *brokerapi.Credential) {
+	testField := func(key string, expectedValue string) {
+		val, ok := data[key]
+		if !ok {
+			t.Errorf("%s not in secret after injecting", key)
+		} else if string(val) != expectedValue {
+			t.Errorf("%s does not match. Expected: %s; Actual: %s", key, expectedValue, val)
+		}
+	}
+
+	testField("hostname", cred.Hostname)
+	testField("port", cred.Port)
+	testField("username", cred.Username)
+	testField("password", cred.Password)
+}
+
+// test that fields from credential is no longer there
+func testCredentialsUninjected(t *testing.T, data map[string][]byte) {
+	testField := func(key string) {
+		_, ok := data[key]
+		if ok {
+			t.Errorf("%s found in map when it's expected to not be there", key)
+		}
+	}
+
+	testField("hostname")
+	testField("port")
+	testField("username")
+	testField("password")
 }

--- a/pkg/controller/injector/k8s_binding_injector_test.go
+++ b/pkg/controller/injector/k8s_binding_injector_test.go
@@ -25,8 +25,8 @@ import (
 )
 
 func TestInjectOne(t *testing.T) {
-	binding := createBindings()[0]
-	cred := createCreds()[0]
+	binding := createBindings(1)[0]
+	cred := createCreds(1)[0]
 	injector := fakeK8sBindingInjector()
 	inject(t, injector, binding, cred)
 
@@ -39,8 +39,8 @@ func TestInjectOne(t *testing.T) {
 }
 
 func TestInjectTwo(t *testing.T) {
-	bindings := createBindings()
-	creds := createCreds()
+	bindings := createBindings(2)
+	creds := createCreds(2)
 
 	injector := fakeK8sBindingInjector()
 	inject(t, injector, bindings[0], creds[0])
@@ -62,8 +62,8 @@ func TestInjectTwo(t *testing.T) {
 }
 
 func TestUninjectOne(t *testing.T) {
-	binding := createBindings()[0]
-	cred := createCreds()[0]
+	binding := createBindings(1)[0]
+	cred := createCreds(1)[0]
 
 	injector := fakeK8sBindingInjector()
 	inject(t, injector, binding, cred)
@@ -73,8 +73,8 @@ func TestUninjectOne(t *testing.T) {
 }
 
 func TestUninjectTwo(t *testing.T) {
-	bindings := createBindings()
-	creds := createCreds()
+	bindings := createBindings(2)
+	creds := createCreds(2)
 
 	injector := fakeK8sBindingInjector()
 	inject(t, injector, bindings[0], creds[0])
@@ -99,38 +99,30 @@ func TestUninjectTwo(t *testing.T) {
 	testCredentialsUninjected(t, injector, bindings[1])
 }
 
-func createBindings() []*servicecatalog.Binding {
-	return []*servicecatalog.Binding{
-		{
+func createBindings(length int) []*servicecatalog.Binding {
+	ret := make([]*servicecatalog.Binding, length, length)
+	for i := range ret {
+		ret[i] = &servicecatalog.Binding{
 			ObjectMeta: kapi.ObjectMeta{
-				Name:      "name0",
-				Namespace: "namespace0",
+				Name:      "name" + string(i),
+				Namespace: "namespace" + string(i),
 			},
-		},
-		&servicecatalog.Binding{
-			ObjectMeta: kapi.ObjectMeta{
-				Name:      "name1",
-				Namespace: "namespace1",
-			},
-		},
+		}
 	}
+	return ret
 }
 
-func createCreds() []*brokerapi.Credential {
-	return []*brokerapi.Credential{
-		{
-			Hostname: "host0",
-			Port:     "123",
-			Username: "user0",
-			Password: "password!@#!@#!0)",
-		},
-		{
-			Hostname: "host1",
-			Port:     "456",
-			Username: "user1",
-			Password: "password*(&*1)",
-		},
+func createCreds(length int) []*brokerapi.Credential {
+	ret := make([]*brokerapi.Credential, length, length)
+	for i := range ret {
+		ret[i] = &brokerapi.Credential{
+			Hostname: "host" + string(i),
+			Port:     "123" + string(i),
+			Username: "user" + string(i),
+			Password: "password!@#!@#!0)" + string(i),
+		}
 	}
+	return ret
 }
 
 func fakeK8sBindingInjector() *k8sBindingInjector {

--- a/pkg/controller/injector/k8s_binding_injector_test.go
+++ b/pkg/controller/injector/k8s_binding_injector_test.go
@@ -35,11 +35,7 @@ func TestInjectOne(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	secret, err := getSecret(injector, binding)
-	if err != nil {
-		t.Fatalf("Error when getting secret: %s", err)
-	}
-	if err := testCredentialsInjected(secret.Data, cred); err != nil {
+	if err := testCredentialsInjected(injector, binding, cred); err != nil {
 		t.Error(err)
 	}
 }
@@ -56,19 +52,11 @@ func TestInjectTwo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	secret, err := getSecret(injector, bindings[0])
-	if err != nil {
-		t.Fatalf("Error when getting secret: %s", err)
-	}
-	if err := testCredentialsInjected(secret.Data, creds[0]); err != nil {
+	if err := testCredentialsInjected(injector, bindings[0], creds[0]); err != nil {
 		t.Error(err)
 	}
 
-	secret, err = getSecret(injector, bindings[1])
-	if err != nil {
-		t.Fatalf("Error when getting secret: %s", err)
-	}
-	if err := testCredentialsInjected(secret.Data, creds[1]); err != nil {
+	if err := testCredentialsInjected(injector, bindings[1], creds[1]); err != nil {
 		t.Error(err)
 	}
 }
@@ -151,11 +139,7 @@ func TestUninjectTwo(t *testing.T) {
 	}
 
 	//test that bindings[1] is still there
-	secret, err := getSecret(injector, bindings[1])
-	if err != nil {
-		t.Fatalf("Error when getting secret: %s", err)
-	}
-	if err := testCredentialsInjected(secret.Data, creds[1]); err != nil {
+	if err := testCredentialsInjected(injector, bindings[1], creds[1]); err != nil {
 		t.Error(err)
 	}
 
@@ -207,7 +191,12 @@ func getSecret(injector *k8sBindingInjector, binding *servicecatalog.Binding) (*
 }
 
 // tests all fields of credentials are there and also the same value
-func testCredentialsInjected(data map[string][]byte, cred *brokerapi.Credential) error {
+func testCredentialsInjected(injector *k8sBindingInjector, binding *servicecatalog.Binding, cred *brokerapi.Credential) error {
+	secret, err := getSecret(injector, binding)
+	if err != nil {
+		return err
+	}
+	data := secret.Data
 	testField := func(key string, expectedValue string) error {
 		val, ok := data[key]
 		if !ok {
@@ -220,16 +209,16 @@ func testCredentialsInjected(data map[string][]byte, cred *brokerapi.Credential)
 	}
 
 	// TODO change so that it's not hard coded to Credential struct fields
-	if err := testField("hostname", cred.Hostname); err != nil {
+	if err = testField("hostname", cred.Hostname); err != nil {
 		return err
 	}
-	if err := testField("port", cred.Port); err != nil {
+	if err = testField("port", cred.Port); err != nil {
 		return err
 	}
-	if err := testField("username", cred.Username); err != nil {
+	if err = testField("username", cred.Username); err != nil {
 		return err
 	}
-	if err := testField("password", cred.Password); err != nil {
+	if err = testField("password", cred.Password); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/controller/injector/k8s_binding_injector_test.go
+++ b/pkg/controller/injector/k8s_binding_injector_test.go
@@ -104,7 +104,9 @@ func TestUninjectOne(t *testing.T) {
 	if err := injector.Inject(binding, cred); err != nil {
 		t.Fatal(err)
 	}
-	injector.Uninject(binding)
+	if err := injector.Uninject(binding); err != nil {
+		t.Fatal("Unexpected error when uninjecting")
+	}
 
 	if err := testCredentialsUninjected(injector, binding); err != nil {
 		t.Fatal(err)
@@ -139,7 +141,9 @@ func TestUninjectTwo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	injector.Uninject(bindings[0])
+	if err := injector.Uninject(bindings[0]); err != nil {
+		t.Fatal("Unexpected err when uninjecting")
+	}
 
 	// test that bindings[0] is gone
 	if err := testCredentialsUninjected(injector, bindings[0]); err != nil {
@@ -156,7 +160,9 @@ func TestUninjectTwo(t *testing.T) {
 	}
 
 	// test that bindings[1] is gone after uninject
-	injector.Uninject(bindings[1])
+	if err := injector.Uninject(bindings[1]); err != nil {
+		t.Fatal("Unexpected err when uninjecting")
+	}
 
 	if err := testCredentialsUninjected(injector, bindings[1]); err != nil {
 		t.Fatal(err)

--- a/pkg/controller/injector/k8s_binding_injector_test.go
+++ b/pkg/controller/injector/k8s_binding_injector_test.go
@@ -88,6 +88,14 @@ func TestInjectOverride(t *testing.T) {
 	}
 }
 
+func TestUninjectEmpty(t *testing.T) {
+	binding := createBindings(1)[0]
+	injector := fakeK8sBindingInjector()
+	if err := injector.Uninject(binding); err == nil {
+		t.Fatal("Uninject empty expected error but none returned!")
+	}
+}
+
 func TestUninjectOne(t *testing.T) {
 	binding := createBindings(1)[0]
 	cred := createCreds(1)[0]
@@ -100,6 +108,22 @@ func TestUninjectOne(t *testing.T) {
 
 	if err := testCredentialsUninjected(injector, binding); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestUninjectSame(t *testing.T) {
+	binding := createBindings(1)[0]
+	cred := createCreds(1)[0]
+
+	injector := fakeK8sBindingInjector()
+	if err := inject(injector, binding, cred); err != nil {
+		t.Fatal(err)
+	}
+	if err := injector.Uninject(binding); err != nil {
+		t.Fatal("Unexpected err when uninjecting:", err)
+	}
+	if err := injector.Uninject(binding); err == nil {
+		t.Fatal("Expected err when uninjecting twice but none found!")
 	}
 }
 


### PR DESCRIPTION
I don't really like how this hard codes the struct fields/strings of Credential since updates to Credential require updates to this file too, but seeing as there's a proposal to change it which would likely require changes to this either way, I figured it didn't warrant the additional complexity.