### PR TITLE
Add support for running just certain unit tests

### DIFF
--- a/docs/DEVGUIDE.md
+++ b/docs/DEVGUIDE.md
@@ -104,7 +104,16 @@ The `test` Makefile target will run both the unit and integration tests, e.g.:
 
     make test
 
-To see how well the unit tests cover the source code, you can use:
+If you want to run just a subset of the unit testcases then you can
+specify the source directories of the tests:
+
+    TEST_DIRS="path1 path2" make test
+
+or you can specify a regexp expression for the test name:
+
+    UNIT_TESTS=TestBar* make test
+
+To see how well these tests cover the source code, you can use:
 
     make coverage
 


### PR DESCRIPTION
new env vars for "make":
TEST_DIRS=...   list of dirs to run 'make test' in
UNIT_TESTS=...  regexp of unit test names to run

they can be combined on the same "make test".

Created a dedicated "test-unit" Makefile target in prep for some
e2e tests later

While we tell people to set NO_DOCKER to "1", I made it so that we're
actually more lax on this and allow it to be set to anything.

Signed-off-by: Doug Davis <dug@us.ibm.com>