### PR TITLE
Fix caching of "go build" output files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,9 @@ ifeq ("$(NO_DOCKER)", "1")
 	DOCKER_CMD =
 	scBuildImageTarget =
 else
-	DOCKER_CMD = docker run --rm -ti -v $(PWD):/go/src/$(SC_PKG) scbuildimage
+	# Mount .pkg as pkg so that we save our cached "go build" output files
+	DOCKER_CMD = docker run --rm -ti -v $(PWD):/go/src/$(SC_PKG) \
+	  -v $(PWD)/.pkg:/go/pkg scbuildimage
 	scBuildImageTarget = .scBuildImage
 endif
 


### PR DESCRIPTION
Mount our cache of the "go build" output files into the container

Signed-off-by: Doug Davis <dug@us.ibm.com>