### PR TITLE
Stop creating broker that's already created

### DIFF
--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -222,11 +222,6 @@ func (h *handler) CreateServiceBroker(in *servicecatalog.Broker) (*servicecatalo
 	}
 
 	glog.Infof("Adding a broker %s catalog:\n%v\n", in.Name, catalog)
-	_, err = h.apiClient.Brokers().Create(in)
-	if err != nil {
-		return nil, err
-	}
-
 	for _, sc := range catalog {
 		sc.BrokerName = in.Name
 		if _, err := h.apiClient.ServiceClasses().Create(sc); err != nil {


### PR DESCRIPTION
This strikes me as a bug. In the handler that is fired in response to a create broker event, we _create a broker_. That's not only unnecessary, but it _will_ fail. Looking at other handlers, they do not generally follow this same pattern, which makes me even more certain this is unintentional.

cc @arschles @pmorie 