### PR TITLE
Remove dead watcher code

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -66,25 +66,13 @@ func (c *controller) Run() error {
 	}
 
 	glog.Infoln("Starting to watch for new Service Brokers")
-	err := c.watcher.Watch(watch.ServiceBroker, "default", c.serviceBrokerCallback)
-	if err != nil {
-		glog.Errorf("Failed to start a watcher for Service Brokers: %v\n", err)
-		return err
-	}
+	c.watcher.Watch(watch.ServiceBroker, "default", c.serviceBrokerCallback)
 
 	glog.Infoln("Starting to watch for new Service Instances")
-	err = c.watcher.Watch(watch.ServiceInstance, "default", c.serviceInstanceCallback)
-	if err != nil {
-		glog.Errorf("Failed to start a watcher for Service Instances: %v\n", err)
-		return err
-	}
+	c.watcher.Watch(watch.ServiceInstance, "default", c.serviceInstanceCallback)
 
 	glog.Infoln("Starting to watch for new Service Bindings")
-	err = c.watcher.Watch(watch.ServiceBinding, "default", c.serviceBindingCallback)
-	if err != nil {
-		glog.Errorf("Failed to start a watcher for Service Bindings: %v\n", err)
-		return err
-	}
+	c.watcher.Watch(watch.ServiceBinding, "default", c.serviceBindingCallback)
 
 	return nil
 }

--- a/pkg/controller/watch/README.md
+++ b/pkg/controller/watch/README.md
@@ -5,7 +5,6 @@ creates these resources under it:
 
 * ServiceBroker
 * ServiceClass
-* ManagedService
 * ServiceInstance
 * ServiceBinding
 
@@ -41,4 +40,3 @@ This is SUPER early work, so the list is long
 
 * watch times out
 * error handling is minimal at best
-

--- a/pkg/controller/watch/watcher.go
+++ b/pkg/controller/watch/watcher.go
@@ -36,8 +36,7 @@ type resourceType int
 
 // These define the Third Party Resources that we can handle or operate on.
 const (
-	ManagedService = iota
-	ServiceInstance
+	ServiceInstance = iota
 	ServiceBinding
 	ServiceBroker
 	ServiceClass
@@ -49,15 +48,13 @@ func (rt *resourceType) name() string {
 }
 
 var resourceTypeNames = []string{
-	"ManagedService",
 	"ServiceInstance",
 	"ServiceBinding",
 	"ServiceBroker",
 	"ServiceClass",
 	"Deployment"}
 
-// These resources _must_ exist in the cluster before proceeding. ManagedService is not
-// used yet.
+// These resources _must_ exist in the cluster before proceeding.
 var resourceTypes = []resourceType{ServiceInstance, ServiceBinding, ServiceBroker, ServiceClass}
 
 const (
@@ -104,12 +101,6 @@ var thirdPartyResourceTypes = map[string]v1beta1.ThirdPartyResource{
 		Description: "A Service Binding representation, creates a Service Binding",
 		Versions:    []v1beta1.APIVersion{{Name: "v1alpha1"}},
 	},
-}
-
-var managedServiceResource = unversioned.APIResource{
-	Name:       "managedservices",
-	Kind:       "ManagedService",
-	Namespaced: true,
 }
 
 var serviceInstanceResource = unversioned.APIResource{
@@ -350,8 +341,6 @@ func (w *Watcher) GetResourceClient(t resourceType, namespace string) *dynamic.R
 
 func getResourceClient(client *dynamic.Client, t resourceType, namespace string) *dynamic.ResourceClient {
 	switch t {
-	case ManagedService:
-		return client.Resource(&managedServiceResource, namespace)
 	case ServiceInstance:
 		return client.Resource(&serviceInstanceResource, namespace)
 	case ServiceBinding:

--- a/pkg/controller/watch/watcher_test.go
+++ b/pkg/controller/watch/watcher_test.go
@@ -21,89 +21,10 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/client-go/1.5/pkg/api/unversioned"
 	"k8s.io/client-go/1.5/pkg/api/v1"
 	extv1beta1 "k8s.io/client-go/1.5/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/1.5/pkg/watch"
 )
-
-func TestDeploymentWatcher(t *testing.T) {
-	const (
-		evtChTimeout = 100 * time.Millisecond
-	)
-	fakeWatcher := watch.NewFake()
-	deplIface := &fakeDeploymentInterface{
-		listRet: &extv1beta1.DeploymentList{
-			TypeMeta: unversioned.TypeMeta{},
-			ListMeta: unversioned.ListMeta{},
-			Items: []extv1beta1.Deployment{
-				{ObjectMeta: v1.ObjectMeta{Name: "listdepl1"}},
-				{ObjectMeta: v1.ObjectMeta{Name: "listdepl2"}},
-			},
-		},
-		watchRet: fakeWatcher,
-	}
-	evtCh := make(chan watch.Event)
-	wcb := func(evt watch.Event) error {
-		evtCh <- evt
-		return nil
-	}
-	go deploymentWatcher(deplIface, wcb)
-
-	numRecv := 0
-	numItems := len(deplIface.listRet.Items)
-	done := false
-	// ensure exactly the list of deployments is processed first
-	for {
-		select {
-		case evt := <-evtCh:
-			if numRecv >= numItems {
-				t.Fatal("received more events than the number of listed items")
-			}
-			item := deplIface.listRet.Items[numRecv]
-			if evt.Type != watch.Added {
-				t.Fatalf("listed event %d wasn't ADDED, it was %s", numRecv, evt.Type)
-			}
-			retDepl, ok := evt.Object.(*extv1beta1.Deployment)
-			if !ok {
-				t.Fatalf("event %d wasn't a deployment (%s)", numRecv, evt.Object)
-			}
-			if reflect.DeepEqual(retDepl, item) {
-				t.Fatalf("deployment %d (%v) wasn't expected (%v)", numRecv, retDepl, item)
-			}
-			numRecv++
-		case <-time.After(evtChTimeout):
-			// if we haven't yet received all the expected items in the list, fail
-			// expected items in the list, so fail
-			if numRecv < numItems {
-				t.Fatalf("no event %d within %s", numRecv, evtChTimeout)
-			}
-			done = true
-			break
-		}
-		if done {
-			break
-		}
-	}
-
-	// now add some events to the list
-	addedDepl := &extv1beta1.Deployment{
-		ObjectMeta: v1.ObjectMeta{Name: "adddepl1"},
-	}
-	fakeWatcher.Add(addedDepl)
-	select {
-	case evt := <-evtCh:
-		retDepl, ok := evt.Object.(*extv1beta1.Deployment)
-		if !ok {
-			t.Fatalf("watch event wasn't a deployment (%s)", evt.Object)
-		}
-		if retDepl.Name != addedDepl.Name {
-			t.Fatalf("watch event object (%s) != received event object (%s)", retDepl.Name, addedDepl.Name)
-		}
-	case <-time.After(evtChTimeout):
-		t.Fatalf("no watch event within %s", evtChTimeout)
-	}
-}
 
 func TestThirdPartyWatcher(t *testing.T) {
 	const evtChTimeout = 100 * time.Millisecond


### PR DESCRIPTION
This removes dead code from the watcher. It's split into two commits. The first removes dead code related to a `ManagedService` that the SIG hasn't discussed. This seems to be leftover from an early prototype. `Deployment` resources also do not need to be watched. The second commit removes code for watching those.