### PR TITLE
import has no effect on api behavior

### DIFF
--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -27,8 +27,6 @@ import (
 	"k8s.io/kubernetes/pkg/util/logs"
 
 	"github.com/kubernetes-incubator/service-catalog/cmd/apiserver/app/server"
-	// TODO: may be necessary
-	_ "k8s.io/kubernetes/pkg/api/install"
 	// install our API groups
 	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
 )


### PR DESCRIPTION
While documenting I wanted to know if this did anything before recommending others to do it. The api server works without it. Did a CRD check. Worked fine, so let's take it out.

Follow up questions:
How do I use kubectl to do an update?
Is the install import for our API in the correct place? Is there a better place for it? @pmorie