### PR TITLE
Add some additional fields to example resource yamls

### DIFF
--- a/contrib/examples/apiserver/README.md
+++ b/contrib/examples/apiserver/README.md
@@ -1,0 +1,5 @@
+### Example API resources
+
+These resource descriptors are intended to be examples for people attempting
+to integrate with the service-catalog API.  They are subject to change and do
+not necessarily reflect how ordinary users would create them.

--- a/contrib/examples/apiserver/binding.yaml
+++ b/contrib/examples/apiserver/binding.yaml
@@ -2,5 +2,10 @@ apiVersion: servicecatalog.k8s.io/v1alpha1
 kind: Binding
 metadata:
   name: test-binding
+  namespace: test-ns
 spec:
+  instanceRef:
+    name: test-instance
   secretName: my-secret
+  configMapName: my-configmap
+  serviceName: my-service

--- a/contrib/examples/apiserver/instance.yaml
+++ b/contrib/examples/apiserver/instance.yaml
@@ -2,5 +2,7 @@ apiVersion: servicecatalog.k8s.io/v1alpha1
 kind: Instance
 metadata:
   name: test-instance
+  namespace: test-ns
 spec:
-  serviceClassName: dugs awesome service instance
+  serviceClassName: test-serviceclass
+  planName: example-plan-1

--- a/contrib/examples/apiserver/serviceclass.yaml
+++ b/contrib/examples/apiserver/serviceclass.yaml
@@ -3,3 +3,12 @@ kind: ServiceClass
 metadata:
   name: test-serviceclass
 brokerName: test-broker
+bindable: true
+osbGuid: d35b55b2-b1fd-4123-8045-5b9c619cb629
+plans:
+  - name: example-plan-1
+    osbGuid: 10e03cb7-b2cf-40dd-a954-16a382b92446
+    osbFree: true
+  - name: example-plan-2
+    osbGuid: b8269ab4-7d2d-456d-8c8b-5aab63b321d1
+    osbFree: false

--- a/contrib/hack/test-apiserver.sh
+++ b/contrib/hack/test-apiserver.sh
@@ -30,8 +30,8 @@ kubectl create -f contrib/examples/apiserver/binding.yaml
 
 kubectl get broker test-broker -o yaml
 kubectl get serviceclass test-serviceclass -o yaml
-kubectl get instance test-instance -o yaml
-kubectl get binding test-binding -o yaml
+kubectl get instance test-instance --namespace test-ns -o yaml
+kubectl get binding test-binding --namespace test-ns -o yaml
 
 kubectl delete -f contrib/examples/apiserver/broker.yaml
 kubectl delete -f contrib/examples/apiserver/serviceclass.yaml


### PR DESCRIPTION
Add a couple fields to example yamls, and make them internally consistent (ie, binding points to instance points to service class points to broker).