### PR TITLE
Use correct etcd storage path for Broker and ServiceClass

### DIFF
--- a/pkg/apis/servicecatalog/install/install.go
+++ b/pkg/apis/servicecatalog/install/install.go
@@ -19,6 +19,7 @@ package install
 
 import (
 	"k8s.io/kubernetes/pkg/apimachinery/announced"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
@@ -30,8 +31,7 @@ func init() {
 			GroupName:              servicecatalog.GroupName,
 			VersionPreferenceOrder: []string{v1alpha1.SchemeGroupVersion.Version},
 			ImportPrefix:           "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog",
-			// TODO: what does this do?
-			RootScopedKinds: nil, // nil is allowed
+			RootScopedKinds:        sets.NewString("Broker", "ServiceClass"),
 			// TODO: Do we have 'internal objects'? What is an 'internal object'?
 			// mhb: ? broker/catalog/service/instance are our 'internal objects' ?
 			AddInternalObjectsToScheme: servicecatalog.AddToScheme, // nil if there are no 'internal objects'

--- a/pkg/registry/servicecatalog/broker/storage.go
+++ b/pkg/registry/servicecatalog/broker/storage.go
@@ -79,16 +79,15 @@ func NewStorage(opts generic.RESTOptions) rest.Storage {
 		},
 		// NewListFunc returns an object capable of storing results of an etcd list.
 		NewListFunc: newListFunc,
-
-		// Produces a path that etcd understands, to the root of the resource
-		// by combining the namespace in the context with the given prefix
+		// KeyRootFunc places this resource at the prefix for this resource;
+		// not namespaced.
 		KeyRootFunc: func(ctx api.Context) string {
-			return registry.NamespaceKeyRootFunc(ctx, prefix)
+			return prefix
 		},
-		// Produces a path that etcd understands, to the resource by combining
-		// the namespace in the context with the given prefix
+		// Produces a path that etcd understands by combining the object's
+		// name with the prefix.
 		KeyFunc: func(ctx api.Context, name string) (string, error) {
-			return registry.NamespaceKeyFunc(ctx, prefix, name)
+			return registry.NoNamespaceKeyFunc(ctx, prefix, name)
 		},
 		// Retrieve the name field of the resource.
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {

--- a/pkg/registry/servicecatalog/serviceclass/storage.go
+++ b/pkg/registry/servicecatalog/serviceclass/storage.go
@@ -78,18 +78,16 @@ func NewStorage(opts generic.RESTOptions) rest.Storage {
 			return &servicecatalog.ServiceClass{}
 		},
 		// NewListFunc returns an object capable of storing results of an etcd list.
-		NewListFunc: func() runtime.Object {
-			return &servicecatalog.ServiceClassList{}
-		},
-		// Produces a path that etcd understands, to the root of the resource
-		// by combining the namespace in the context with the given prefix
+		NewListFunc: newListFunc,
+		// KeyRootFunc places this resource at the prefix for this resource;
+		// not namespaced.
 		KeyRootFunc: func(ctx api.Context) string {
-			return registry.NamespaceKeyRootFunc(ctx, prefix)
+			return prefix
 		},
-		// Produces a path that etcd understands, to the resource by combining
-		// the namespace in the context with the given prefix
+		// Produces a path that etcd understands by combining the object's
+		// name with the prefix.
 		KeyFunc: func(ctx api.Context, name string) (string, error) {
-			return registry.NamespaceKeyFunc(ctx, prefix, name)
+			return registry.NoNamespaceKeyFunc(ctx, prefix, name)
 		},
 		// Retrieve the name field of the resource.
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {


### PR DESCRIPTION
Fixes the storage path within etcd for these non-namespaced resources