### PR TITLE
Add new guid to new binding only if not already specified

### DIFF
--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -163,7 +163,9 @@ func (h *handler) CreateServiceBinding(in *servicecatalog.Binding) (*servicecata
 	client := h.newClientFunc(broker)
 
 	// Assign UUID to binding.
-	in.Spec.OSBGUID = uuid.NewV4().String()
+	if in.Spec.OSBGUID == "" {
+		in.Spec.OSBGUID = uuid.NewV4().String()
+	}
 
 	// TODO: uncomment parameters line once parameters types are refactored.
 	// Make the request to bind.


### PR DESCRIPTION
This addresses an inconsistency in how we add OSB guids to instances and bindings. For instances, we were adding the guid only if it wasn't already specified. That guard was lacking for bindings.

After some offline discussion, @pmorie and I agree that the api should be defaulting this field (if unset) to a new guid (PR for that to follow shortly), _however_, to maintain the possibility that the controller can continue to be used with tprs and _without_ the apiserver in the near time, we're going to leave this guid generation code here in the controller as well, but having this guard in place is essential so that any guid that might have been generated by the api gets left alone.