### PR TITLE
Fix bug in injector.Inject where secret.Data is not initialized

### DIFF
--- a/pkg/controller/injector/k8s_binding_injector.go
+++ b/pkg/controller/injector/k8s_binding_injector.go
@@ -61,6 +61,7 @@ func (b *k8sBindingInjector) Inject(binding *servicecatalog.Binding, cred *broke
 			Name:      binding.Name,
 			Namespace: binding.Spec.InstanceRef.Namespace,
 		},
+		Data: make(map[string][]byte),
 	}
 
 	// For each item in the cred just serialize its value into JSON and


### PR DESCRIPTION
Credential was changed in #280 so this map was nil causing a panic