### PR TITLE
Add guid defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,9 +157,12 @@ verify: .init .generate_files
 	@rm .out
 	@#
 	@echo Running golint and go vet:
-	# Exclude the generated (zz) files for now
+	@# Exclude the generated (zz) files for now, as well as defaults.go (it
+	@# observes conventions from upstream that will not pass lint checks).
 	@$(DOCKER_CMD) sh -c \
-	  'for i in $$(find $(TOP_SRC_DIRS) -name *.go | grep -v generated); \
+	  'for i in $$(find $(TOP_SRC_DIRS) -name *.go \
+	    | grep -v generated \
+	    | grep -v v1alpha1/defaults.go); \
 	  do \
 	    golint --set_exit_status $$i; \
 	    go vet $$i; \

--- a/pkg/apis/servicecatalog/register.go
+++ b/pkg/apis/servicecatalog/register.go
@@ -17,8 +17,6 @@ limitations under the License.
 package servicecatalog
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/runtime/schema"
 )
@@ -49,12 +47,6 @@ var (
 
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
-		// TODO are all of these needed? What do they do?
-		&api.ListOptions{},
-		&api.DeleteOptions{},
-		&metav1.ExportOptions{},
-		&metav1.GetOptions{},
-
 		&Broker{},
 		&BrokerList{},
 		&ServiceClass{},

--- a/pkg/apis/servicecatalog/serialization_test.go
+++ b/pkg/apis/servicecatalog/serialization_test.go
@@ -28,10 +28,10 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	flag "github.com/spf13/pflag"
 
+	apitesting "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/testing"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/testapi"
-	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/runtime"

--- a/pkg/apis/servicecatalog/testing/fuzzer.go
+++ b/pkg/apis/servicecatalog/testing/fuzzer.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"math/rand"
+	"strconv"
+	"testing"
+
+	"github.com/google/gofuzz"
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	"github.com/satori/go.uuid"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/types"
+)
+
+// FuzzerFor can randomly populate api objects that are destined for version.
+func FuzzerFor(t *testing.T, version schema.GroupVersion, src rand.Source) *fuzz.Fuzzer {
+	f := fuzz.New().NilChance(.5).NumElements(0, 1)
+	if src != nil {
+		f.RandSource(src)
+	}
+	f.Funcs(
+		func(j *int, c fuzz.Continue) {
+			*j = int(c.Int31())
+		},
+		func(j **int, c fuzz.Continue) {
+			if c.RandBool() {
+				i := int(c.Int31())
+				*j = &i
+			} else {
+				*j = nil
+			}
+		},
+		func(j *runtime.TypeMeta, c fuzz.Continue) {
+			// We have to customize the randomization of TypeMetas because their
+			// APIVersion and Kind must remain blank in memory.
+			j.APIVersion = ""
+			j.Kind = ""
+		},
+		func(j *metav1.TypeMeta, c fuzz.Continue) {
+			// We have to customize the randomization of TypeMetas because their
+			// APIVersion and Kind must remain blank in memory.
+			j.APIVersion = ""
+			j.Kind = ""
+		},
+		func(j *api.ObjectMeta, c fuzz.Continue) {
+			j.Name = c.RandString()
+			j.ResourceVersion = strconv.FormatUint(c.RandUint64(), 10)
+			j.SelfLink = c.RandString()
+			j.UID = types.UID(c.RandString())
+			j.GenerateName = c.RandString()
+
+			var sec, nsec int64
+			c.Fuzz(&sec)
+			c.Fuzz(&nsec)
+			j.CreationTimestamp = metav1.Unix(sec, nsec).Rfc3339Copy()
+		},
+		func(j *api.ObjectReference, c fuzz.Continue) {
+			// We have to customize the randomization of TypeMetas because their
+			// APIVersion and Kind must remain blank in memory.
+			j.APIVersion = c.RandString()
+			j.Kind = c.RandString()
+			j.Namespace = c.RandString()
+			j.Name = c.RandString()
+			j.ResourceVersion = strconv.FormatUint(c.RandUint64(), 10)
+			j.FieldPath = c.RandString()
+		},
+		func(j *metav1.ListMeta, c fuzz.Continue) {
+			j.ResourceVersion = strconv.FormatUint(c.RandUint64(), 10)
+			j.SelfLink = c.RandString()
+		},
+		func(j *runtime.Object, c fuzz.Continue) {
+			// TODO: uncomment when round trip starts from a versioned object
+			if true { //c.RandBool() {
+				*j = &runtime.Unknown{
+					// We do not set TypeMeta here because it is not carried through a round trip
+					Raw:         []byte(`{"apiVersion":"unknown.group/unknown","kind":"Something","someKey":"someValue"}`),
+					ContentType: runtime.ContentTypeJSON,
+				}
+			} else {
+				types := []runtime.Object{&api.Pod{}, &api.ReplicationController{}}
+				t := types[c.Rand.Intn(len(types))]
+				c.Fuzz(t)
+				*j = t
+			}
+		},
+		func(r *runtime.RawExtension, c fuzz.Continue) {
+			// Pick an arbitrary type and fuzz it
+			types := []runtime.Object{&api.Pod{}, &extensions.Deployment{}, &api.Service{}}
+			obj := types[c.Rand.Intn(len(types))]
+			c.Fuzz(obj)
+
+			// Find a codec for converting the object to raw bytes.  This is necessary for the
+			// api version and kind to be correctly set be serialization.
+			var codec runtime.Codec
+			switch obj.(type) {
+			case *api.Pod:
+				codec = testapi.Default.Codec()
+			case *extensions.Deployment:
+				codec = testapi.Extensions.Codec()
+			case *api.Service:
+				codec = testapi.Default.Codec()
+			default:
+				t.Errorf("Failed to find codec for object type: %T", obj)
+				return
+			}
+
+			// Convert the object to raw bytes
+			bytes, err := runtime.Encode(codec, obj)
+			if err != nil {
+				t.Errorf("Failed to encode object: %v", err)
+				return
+			}
+
+			// Set the bytes field on the RawExtension
+			r.Raw = bytes
+		},
+		func(is *servicecatalog.InstanceSpec, c fuzz.Continue) {
+			c.FuzzNoCustom(is)
+			is.OSBGUID = uuid.NewV4().String()
+		},
+		func(bs *servicecatalog.BindingSpec, c fuzz.Continue) {
+			c.FuzzNoCustom(bs)
+			bs.OSBGUID = uuid.NewV4().String()
+		},
+	)
+	return f
+}

--- a/pkg/apis/servicecatalog/v1alpha1/defaults.go
+++ b/pkg/apis/servicecatalog/v1alpha1/defaults.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/satori/go.uuid"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func addDefaultingFuncs(scheme *runtime.Scheme) error {
+	RegisterDefaults(scheme)
+	return scheme.AddDefaultingFuncs(
+		SetDefaults_InstanceSpec,
+		SetDefaults_BindingSpec,
+	)
+}
+
+func SetDefaults_InstanceSpec(spec *InstanceSpec) {
+	if spec.OSBGUID == "" {
+		spec.OSBGUID = uuid.NewV4().String()
+	}
+}
+
+func SetDefaults_BindingSpec(spec *BindingSpec) {
+	if spec.OSBGUID == "" {
+		spec.OSBGUID = uuid.NewV4().String()
+	}
+}

--- a/pkg/apis/servicecatalog/v1alpha1/defaults_test.go
+++ b/pkg/apis/servicecatalog/v1alpha1/defaults_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
+	versioned "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/runtime/schema"
+)
+
+func init() {
+	groupVersion, err := schema.ParseGroupVersion("servicecatalog.k8s.io/v1alpha1")
+	if err != nil {
+		panic(fmt.Sprintf("Error parsing groupversion: %v", err))
+	}
+
+	externalGroupVersion := schema.GroupVersion{Group: servicecatalog.GroupName,
+		Version: registered.GroupOrDie(servicecatalog.GroupName).GroupVersion.Version}
+
+	testapi.Groups[servicecatalog.GroupName] = testapi.NewTestGroup(
+		groupVersion,
+		servicecatalog.SchemeGroupVersion,
+		api.Scheme.KnownTypes(servicecatalog.SchemeGroupVersion),
+		api.Scheme.KnownTypes(externalGroupVersion),
+	)
+}
+
+func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
+	codec, err := testapi.GetCodecForObject(obj)
+	if err != nil {
+		t.Fatalf("%v\n %#v", err, obj)
+	}
+	data, err := runtime.Encode(codec, obj)
+	if err != nil {
+		t.Fatalf("%v\n %#v", err, obj)
+	}
+	obj2, err := runtime.Decode(codec, data)
+	if err != nil {
+		t.Fatalf("%v\nData: %s\nSource: %#v", err, string(data), obj)
+	}
+	obj3 := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(runtime.Object)
+	err = api.Scheme.Convert(obj2, obj3, nil)
+	if err != nil {
+		t.Fatalf("%v\nSource: %#v", err, obj2)
+	}
+	return obj3
+}
+
+func TestSetDefaultInstance(t *testing.T) {
+	i := &versioned.Instance{}
+	obj2 := roundTrip(t, runtime.Object(i))
+	i2 := obj2.(*versioned.Instance)
+
+	if i2.Spec.OSBGUID == "" {
+		t.Error("Expected a default OSBGUID, but got none")
+	}
+}
+
+func TestSetDefaultBinding(t *testing.T) {
+	b := &versioned.Binding{}
+	obj2 := roundTrip(t, runtime.Object(b))
+	b2 := obj2.(*versioned.Binding)
+
+	if b2.Spec.OSBGUID == "" {
+		t.Error("Expected a default OSBGUID, but got none")
+	}
+}

--- a/pkg/apis/servicecatalog/v1alpha1/register.go
+++ b/pkg/apis/servicecatalog/v1alpha1/register.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/runtime/schema"
 	versionedwatch "k8s.io/kubernetes/pkg/watch/versioned"
@@ -43,19 +41,13 @@ func Resource(resource string) schema.GroupResource {
 var (
 	// SchemeBuilder needs to be exported as `SchemeBuilder` so
 	// the code-generation can find it.
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes, addDefaultingFuncs)
 	// AddToScheme is exposed for API installation
 	AddToScheme = SchemeBuilder.AddToScheme
 )
 
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
-		// TODO are all of these needed? What do they do?
-		&api.ListOptions{},
-		&api.DeleteOptions{},
-		&metav1.ExportOptions{},
-		&metav1.GetOptions{},
-
 		&Broker{},
 		&BrokerList{},
 		&ServiceClass{},

--- a/pkg/apis/servicecatalog/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/servicecatalog/v1alpha1/zz_generated.defaults.go
@@ -28,5 +28,31 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&Binding{}, func(obj interface{}) { SetObjectDefaults_Binding(obj.(*Binding)) })
+	scheme.AddTypeDefaultingFunc(&BindingList{}, func(obj interface{}) { SetObjectDefaults_BindingList(obj.(*BindingList)) })
+	scheme.AddTypeDefaultingFunc(&Instance{}, func(obj interface{}) { SetObjectDefaults_Instance(obj.(*Instance)) })
+	scheme.AddTypeDefaultingFunc(&InstanceList{}, func(obj interface{}) { SetObjectDefaults_InstanceList(obj.(*InstanceList)) })
 	return nil
+}
+
+func SetObjectDefaults_Binding(in *Binding) {
+	SetDefaults_BindingSpec(&in.Spec)
+}
+
+func SetObjectDefaults_BindingList(in *BindingList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_Binding(a)
+	}
+}
+
+func SetObjectDefaults_Instance(in *Instance) {
+	SetDefaults_InstanceSpec(&in.Spec)
+}
+
+func SetObjectDefaults_InstanceList(in *InstanceList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_Instance(a)
+	}
 }


### PR DESCRIPTION
Closes #324 

This allows the API to create default OSB GUIDs for instances and bindings _if_ they aren't specified directly by the operator. (It's too onerous to supply your own, so we don't expect anyone will.)

This mirrors functionality that is currently covered by the controller, but that will go away when the controller stops watching TPRs and starts watching API types instead.

To facilitate this, lots of API machinery was cribbed from upstream. This includes defaulters, registration of defaulters, etc. This new behavior also broke existing serialization tests, so custom fuzzers had to be introduced there.

Also note that for the convenience of reviewers, the changes to generated code have been split into a separate commit, which you can largely ignore when reviewing.

Lastly, thanks to @pmorie for pairing with me on parts of this.