### PR TITLE
Implementing TPR storage in the API server

### DIFF
--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -24,11 +24,14 @@ import (
 
 	"github.com/golang/glog"
 	// set up logging the k8s way
+	"k8s.io/kubernetes/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/util/logs"
 
 	"github.com/kubernetes-incubator/service-catalog/cmd/apiserver/app/server"
 	// install our API groups
 	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	"k8s.io/kubernetes/pkg/client/restclient"
 )
 
 func main() {
@@ -36,9 +39,22 @@ func main() {
 	// make sure we print all the logs while shutting down.
 	defer logs.FlushLogs()
 
-	cmd := server.NewCommandServer(os.Stdout)
+	cfg, err := restclient.InClusterConfig()
+	if err != nil {
+		glog.Errorf("Failed to get kube client config (%s)", err)
+		os.Exit(1)
+	}
+	cfg.GroupVersion = &schema.GroupVersion{}
+
+	clIface, err := clientset.NewForConfig(cfg)
+	if err != nil {
+		glog.Errorf("Failed to create clientset Interface (%s)", err)
+		os.Exit(1)
+	}
+
+	cmd := server.NewCommandServer(os.Stdout, clIface)
 	if err := cmd.Execute(); err != nil {
-		glog.Errorln(err)
+		glog.Errorf("server exited unexpectedly (%s)", err)
 		logs.FlushLogs()
 		os.Exit(1)
 	}

--- a/cmd/apiserver/app/server/etcd_options.go
+++ b/cmd/apiserver/app/server/etcd_options.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"github.com/spf13/pflag"
+	// "k8s.io/kubernetes/pkg/client/typed/dynamic"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	genericserveroptions "k8s.io/kubernetes/pkg/genericapiserver/options"
+)
+
+// EtcdOptions contains the complete configuration for an API server that
+// communicates with an etcd. This struct is exported so that it can be used by integration
+// tests
+type EtcdOptions struct {
+	cl clientset.Interface
+	// storage with etcd
+	*genericserveroptions.EtcdOptions
+}
+
+// NewEtcdOptions creates a new, empty, EtcdOptions instance
+func NewEtcdOptions() *EtcdOptions {
+	return &EtcdOptions{
+		EtcdOptions: genericserveroptions.NewEtcdOptions(),
+	}
+}
+
+func (s *EtcdOptions) addFlags(flags *pflag.FlagSet) {
+	s.EtcdOptions.AddFlags(flags)
+}

--- a/cmd/apiserver/app/server/options.go
+++ b/cmd/apiserver/app/server/options.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	"github.com/spf13/pflag"
+	genericserveroptions "k8s.io/kubernetes/pkg/genericapiserver/options"
+)
+
+// ServiceCatalogServerOptions contains the aggregation of configuration structs for
+// the service-catalog server. It contains everything needed to configure a basic API server.
+// It is public so that integration tests can access it.
+type ServiceCatalogServerOptions struct {
+	StorageTypeString string
+	// the runtime configuration of our server
+	GenericServerRunOptions *genericserveroptions.ServerRunOptions
+	// the https configuration. certs, etc
+	SecureServingOptions *genericserveroptions.SecureServingOptions
+	// authn for the API
+	AuthenticationOptions *genericserveroptions.DelegatingAuthenticationOptions
+	// authz for the API
+	AuthorizationOptions *genericserveroptions.DelegatingAuthorizationOptions
+	// InsecureOptions are options for serving insecurely.
+	InsecureServingOptions *genericserveroptions.ServingOptions
+	// EtcdOptions are options for serving with etcd as the backing store
+	EtcdOptions *EtcdOptions
+	// TPROptions are options for serving with TPR as the backing store
+	TPROptions *TPROptions
+}
+
+func (s *ServiceCatalogServerOptions) addFlags(flags *pflag.FlagSet) {
+	flags.StringVar(
+		&s.StorageTypeString,
+		"storage-type",
+		"service-catalog",
+		"The type of backing storage this API server should use",
+	)
+
+	s.GenericServerRunOptions.AddUniversalFlags(flags)
+	s.SecureServingOptions.AddFlags(flags)
+	s.AuthenticationOptions.AddFlags(flags)
+	s.AuthorizationOptions.AddFlags(flags)
+	s.InsecureServingOptions.AddFlags(flags)
+	s.EtcdOptions.addFlags(flags)
+	s.TPROptions.addFlags(flags)
+}
+
+// StorageType returns the storage type configured on s, or a non-nil error if s holds an
+// invalid storage type
+func (s *ServiceCatalogServerOptions) StorageType() (server.StorageType, error) {
+	return server.StorageTypeFromString(s.StorageTypeString)
+}

--- a/cmd/apiserver/app/server/run_server.go
+++ b/cmd/apiserver/app/server/run_server.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/apiserver"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	"github.com/kubernetes-incubator/service-catalog/pkg/storage/tpr"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/genericapiserver"
+)
+
+// RunServer runs an API server with configuration according to opts
+func RunServer(opts *ServiceCatalogServerOptions) error {
+	storageType, err := opts.StorageType()
+	if err != nil {
+		return err
+	}
+	if storageType == server.StorageTypeTPR {
+		return runTPRServer(opts)
+	}
+	return runEtcdServer(opts)
+}
+
+func runTPRServer(opts *ServiceCatalogServerOptions) error {
+	tprOpts := opts.TPROptions
+	glog.Infoln("installing TPR types to the cluster")
+	if err := tpr.InstallTypes(tprOpts.clIface); err != nil {
+		glog.V(4).Infof("installing TPR types failed, continuing anyway (%s)", err)
+	}
+	glog.V(4).Infoln("Preparing to run API server")
+	genericConfig, err := setupBasicServer(opts)
+	if err != nil {
+		return err
+	}
+
+	config := apiserver.NewTPRConfig(
+		tprOpts.clIface,
+		genericConfig,
+		tprOpts.globalNamespace,
+		tprOpts.storageFactory(),
+	)
+	completed := config.Complete()
+	// make the server
+	glog.V(4).Infoln("Completing API server configuration")
+	server, err := completed.NewServer()
+	if err != nil {
+		return fmt.Errorf("error completing API server configuration: %v", err)
+	}
+
+	glog.Infoln("Running the API server")
+	stop := make(chan struct{})
+	server.GenericAPIServer.PrepareRun().Run(stop)
+
+	return nil
+}
+
+func runEtcdServer(opts *ServiceCatalogServerOptions) error {
+	etcdOpts := opts.EtcdOptions
+	glog.V(4).Infoln("Preparing to run API server")
+	genericConfig, err := setupBasicServer(opts)
+	if err != nil {
+		return err
+	}
+
+	// etcd options
+	if errs := etcdOpts.Validate(); len(errs) > 0 {
+		glog.Errorln("Error validating etcd options, do you have `--etcd-servers localhost` set?")
+		return errs[0]
+	}
+
+	glog.V(4).Infoln("Creating storage factory")
+	// The API server stores objects using a particular API version for each
+	// group, regardless of API version of the object when it was created.
+	//
+	// storageGroupsToEncodingVersion holds a map of API group to version that
+	// the API server uses to store that group.
+	storageGroupsToEncodingVersion, err := opts.GenericServerRunOptions.StorageGroupsToEncodingVersion()
+	if err != nil {
+		return fmt.Errorf("error generating storage version map: %s", err)
+	}
+
+	// Build the default storage factory.
+	//
+	// The default storage factory returns the storage interface for a
+	// particular GroupResource (an (api-group, resource) tuple).
+	storageFactory, err := genericapiserver.BuildDefaultStorageFactory(
+		etcdOpts.StorageConfig,
+		opts.GenericServerRunOptions.DefaultStorageMediaType,
+		api.Codecs,
+		genericapiserver.NewDefaultResourceEncodingConfig(),
+		storageGroupsToEncodingVersion,
+		nil, /* group storage version overrides */
+		apiserver.DefaultAPIResourceConfigSource(),
+		opts.GenericServerRunOptions.RuntimeConfig,
+	)
+	if err != nil {
+		glog.Errorf("error creating storage factory: %v", err)
+		return err
+	}
+
+	// Set the finalized generic and storage configs
+	config := apiserver.NewEtcdConfig(opts.EtcdOptions.cl, genericConfig, 0, storageFactory)
+
+	// Fill in defaults not already set in the config
+	completed := config.Complete()
+
+	// make the server
+	glog.V(4).Infoln("Completing API server configuration")
+	server, err := completed.NewServer()
+	if err != nil {
+		return fmt.Errorf("error completing API server configuration: %v", err)
+	}
+
+	// do we need to do any post api installation setup? We should have set up the api already?
+	glog.Infoln("Running the API server")
+	stop := make(chan struct{})
+	server.PrepareRun().Run(stop)
+
+	return nil
+}

--- a/cmd/apiserver/app/server/server.go
+++ b/cmd/apiserver/app/server/server.go
@@ -18,38 +18,15 @@ package server
 
 import (
 	"flag"
-	"fmt"
 	"io"
+	"os"
 
 	"github.com/golang/glog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
 	"github.com/spf13/cobra"
-
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/genericapiserver"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
 	genericserveroptions "k8s.io/kubernetes/pkg/genericapiserver/options"
-	"k8s.io/kubernetes/pkg/util/wait"
-
-	"github.com/kubernetes-incubator/service-catalog/pkg/apiserver"
 )
-
-// ServiceCatalogServerOptions contains the aggregation of configuration structs for
-// the service-catalog server. The theory here is that any future user
-// of this server will be able to use this options object as a sub
-// options of its own.
-type ServiceCatalogServerOptions struct {
-	// the runtime configuration of our server
-	GenericServerRunOptions *genericserveroptions.ServerRunOptions
-	// the https configuration. certs, etc
-	SecureServingOptions *genericserveroptions.SecureServingOptions
-	// storage with etcd
-	EtcdOptions *genericserveroptions.EtcdOptions
-	// authn
-	AuthenticationOptions *genericserveroptions.DelegatingAuthenticationOptions
-	// authz
-	AuthorizationOptions *genericserveroptions.DelegatingAuthorizationOptions
-	// InsecureOptions are options for serving insecurely.
-	InsecureServingOptions *genericserveroptions.ServingOptions
-}
 
 const (
 	// Store generated SSL certificates in a place that won't collide with the
@@ -63,157 +40,63 @@ const (
 
 	// GroupName I made this up. Maybe we'll need it.
 	GroupName = "service-catalog.k8s.io"
+
+	storageTypeFlagName    = "storageType"
+	tprGlobalNamespaceName = "tprGlobalNamespace"
 )
 
 // NewCommandServer creates a new cobra command to run our server.
-func NewCommandServer(out io.Writer) *cobra.Command {
-	// initalize our sub options.
-	options := &ServiceCatalogServerOptions{
-		GenericServerRunOptions: genericserveroptions.NewServerRunOptions(),
-		SecureServingOptions:    genericserveroptions.NewSecureServingOptions(),
-		EtcdOptions:             genericserveroptions.NewEtcdOptions(),
-		AuthenticationOptions:   genericserveroptions.NewDelegatingAuthenticationOptions(),
-		AuthorizationOptions:    genericserveroptions.NewDelegatingAuthorizationOptions(),
-		InsecureServingOptions:  genericserveroptions.NewInsecureServingOptions(),
-	}
-
-	// Store resources in etcd under our special prefix
-	options.EtcdOptions.StorageConfig.Prefix = etcdPathPrefix
-
-	// Set generated SSL cert path correctly
-	options.SecureServingOptions.ServerCert.CertDirectory = certDirectory
-
+func NewCommandServer(
+	out io.Writer,
+	clIface clientset.Interface,
+) *cobra.Command {
 	// Create the command that runs the API server
 	cmd := &cobra.Command{
 		Short: "run a service-catalog server",
-		Run: func(c *cobra.Command, args []string) {
-			options.RunServer(wait.NeverStop)
-		},
 	}
-
 	// We pass flags object to sub option structs to have them configure
 	// themselves. Each options adds its own command line flags
 	// in addition to the flags that are defined above.
 	flags := cmd.Flags()
-	// TODO consider an AddFlags() method on our options
-	// struct. Will need to import pflag.
-	//
-	// repeated pattern seems like it should be refactored if all
-	// options were of an interface type that specified AddFlags.
 	flags.AddGoFlagSet(flag.CommandLine)
-	options.GenericServerRunOptions.AddUniversalFlags(flags)
-	options.SecureServingOptions.AddFlags(flags)
-	options.EtcdOptions.AddFlags(flags)
-	options.AuthenticationOptions.AddFlags(flags)
-	options.AuthorizationOptions.AddFlags(flags)
-	options.InsecureServingOptions.AddFlags(flags)
+
+	opts := &ServiceCatalogServerOptions{
+		GenericServerRunOptions: genericserveroptions.NewServerRunOptions(),
+		SecureServingOptions:    genericserveroptions.NewSecureServingOptions(),
+		AuthenticationOptions:   genericserveroptions.NewDelegatingAuthenticationOptions(),
+		AuthorizationOptions:    genericserveroptions.NewDelegatingAuthorizationOptions(),
+		InsecureServingOptions:  genericserveroptions.NewInsecureServingOptions(),
+		EtcdOptions:             NewEtcdOptions(),
+		TPROptions:              NewTPROptions(),
+	}
+	opts.addFlags(flags)
+	// Set generated SSL cert path correctly
+	opts.SecureServingOptions.ServerCert.CertDirectory = certDirectory
+
+	flags.Parse(os.Args[1:])
+
+	storageType, err := opts.StorageType()
+	if err != nil {
+		glog.Fatalf("invalid storage type '%s' (%s)", storageType, err)
+		return nil
+	}
+	if storageType == server.StorageTypeEtcd {
+		glog.Infof("using etcd for storage")
+		opts.EtcdOptions.cl = clIface
+		// Store resources in etcd under our special prefix
+		opts.EtcdOptions.StorageConfig.Prefix = etcdPathPrefix
+	} else {
+		glog.Infof("using third party resources for storage")
+		opts.TPROptions.defaultGlobalNamespace = "servicecatalog"
+		opts.TPROptions.clIface = clIface
+	}
+
+	cmd.Run = func(c *cobra.Command, args []string) {
+		if err := RunServer(opts); err != nil {
+			glog.Fatalf("error running server (%s)", err)
+			return
+		}
+	}
 
 	return cmd
-}
-
-// RunServer is a method on the options for composition. Allows embedding in a
-// higher level options as we do the etcd and serving options.
-func (serverOptions ServiceCatalogServerOptions) RunServer(stopCh <-chan struct{}) error {
-	glog.V(4).Infoln("Preparing to run API server")
-	// options
-	// runtime options
-	if err := serverOptions.GenericServerRunOptions.DefaultExternalAddress(serverOptions.SecureServingOptions, nil); err != nil {
-		return err
-	}
-
-	// server configuration options
-	glog.V(4).Infoln("Setting up secure serving options")
-	if err := serverOptions.SecureServingOptions.MaybeDefaultWithSelfSignedCerts(serverOptions.GenericServerRunOptions.AdvertiseAddress.String()); err != nil {
-		glog.Errorf("Error creating self-signed certificates: %v", err)
-		return err
-	}
-
-	// etcd options
-	if errs := serverOptions.EtcdOptions.Validate(); len(errs) > 0 {
-		glog.Errorln("Error validating etcd options, do you have `--etcd-servers localhost` set?")
-		return errs[0]
-	}
-
-	// config
-	glog.V(4).Infoln("Configuring generic API server")
-	genericconfig := genericapiserver.NewConfig().ApplyOptions(serverOptions.GenericServerRunOptions)
-	// these are all mutators of each specific suboption in serverOptions object.
-	// this repeated pattern seems like we could refactor
-	if _, err := genericconfig.ApplySecureServingOptions(serverOptions.SecureServingOptions); err != nil {
-		glog.Errorln(err)
-		return err
-	}
-
-	genericconfig.ApplyInsecureServingOptions(serverOptions.InsecureServingOptions)
-
-	glog.V(4).Info("Setting up authn (disabled)")
-	// need to figure out what's throwing the `missing clientCA file` err
-	/*
-		if _, err := genericconfig.ApplyDelegatingAuthenticationOptions(serverOptions.AuthenticationOptions); err != nil {
-			glog.Infoln(err)
-			return err
-		}
-	*/
-
-	glog.V(4).Infoln("Setting up authz (disabled)")
-	// having this enabled causes the server to crash for any call
-	/*
-		if _, err := genericconfig.ApplyDelegatingAuthorizationOptions(serverOptions.AuthorizationOptions); err != nil {
-			glog.Infoln(err)
-			return err
-		}
-	*/
-
-	glog.V(4).Infoln("Creating storage factory")
-	// The API server stores objects using a particular API version for each
-	// group, regardless of API version of the object when it was created.
-	//
-	// storageGroupsToEncodingVersion holds a map of API group to version that
-	// the API server uses to store that group.
-	storageGroupsToEncodingVersion, err := serverOptions.GenericServerRunOptions.StorageGroupsToEncodingVersion()
-	if err != nil {
-		return fmt.Errorf("error generating storage version map: %s", err)
-	}
-
-	// Build the default storage factory.
-	//
-	// The default storage factory returns the storage interface for a
-	// particular GroupResource (an (api-group, resource) tuple).
-	storageFactory, err := genericapiserver.BuildDefaultStorageFactory(
-		serverOptions.EtcdOptions.StorageConfig,
-		serverOptions.GenericServerRunOptions.DefaultStorageMediaType,
-		api.Codecs,
-		genericapiserver.NewDefaultResourceEncodingConfig(),
-		storageGroupsToEncodingVersion,
-		nil, /* group storage version overrides */
-		apiserver.DefaultAPIResourceConfigSource(),
-		serverOptions.GenericServerRunOptions.RuntimeConfig)
-	if err != nil {
-		glog.Errorf("error creating storage factory: %v", err)
-		return err
-	}
-
-	// Set the finalized generic and storage configs
-	config := apiserver.Config{
-		GenericConfig:  genericconfig,
-		StorageFactory: storageFactory,
-	}
-
-	// Fill in defaults not already set in the config
-	completedconfig := config.Complete()
-
-	// make the server
-	glog.V(4).Infoln("Completing API server configuration")
-	server, err := completedconfig.New()
-	if err != nil {
-		return fmt.Errorf("error completing API server configuration: %v", err)
-	}
-
-	// I don't like this. We're reaching in too far to call things.
-	preparedserver := server.GenericAPIServer.PrepareRun() // post api installation setup? We should have set up the api already?
-
-	glog.Infoln("Running the API server")
-	preparedserver.Run(stopCh)
-
-	return nil
 }

--- a/cmd/apiserver/app/server/tpr_options.go
+++ b/cmd/apiserver/app/server/tpr_options.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"github.com/spf13/pflag"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	// "k8s.io/kubernetes/pkg/client/typed/dynamic"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/genericapiserver"
+	"k8s.io/kubernetes/pkg/storage/storagebackend"
+)
+
+// TPROptions contains the complete configuration for an API server that
+// communicates with the core Kubernetes API server to use third party resources (TPRs)
+// as a database. It is exported so that integration tests can use it
+type TPROptions struct {
+	defaultGlobalNamespace string
+	clIface                clientset.Interface
+	globalNamespace        string
+}
+
+// NewTPROptions creates a new, empty TPROptions struct
+func NewTPROptions() *TPROptions {
+	return &TPROptions{}
+}
+
+// NewStorageFactory returns a new StorageFactory from the config in opts
+func (s *TPROptions) storageFactory() genericapiserver.StorageFactory {
+	return genericapiserver.NewDefaultStorageFactory(
+		storagebackend.Config{},
+		"application/json",
+		api.Codecs,
+		genericapiserver.NewDefaultResourceEncodingConfig(),
+		genericapiserver.NewResourceConfig(),
+	)
+}
+
+func (s *TPROptions) addFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&s.globalNamespace, "global-namespace", s.defaultGlobalNamespace, ""+
+		"The namespace in which to store all TPRs that represent global service-catalog resources.")
+}

--- a/cmd/apiserver/app/server/util.go
+++ b/cmd/apiserver/app/server/util.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"k8s.io/kubernetes/pkg/genericapiserver"
+)
+
+func setupBasicServer(s *ServiceCatalogServerOptions) (*genericapiserver.Config, error) {
+	if err := s.GenericServerRunOptions.DefaultExternalAddress(
+		s.SecureServingOptions,
+		nil,
+	); err != nil {
+		return nil, err
+	}
+
+	// server configuration options
+	if err := s.SecureServingOptions.MaybeDefaultWithSelfSignedCerts(
+		s.GenericServerRunOptions.AdvertiseAddress.String(),
+	); err != nil {
+		return nil, err
+	}
+
+	genericConfig := genericapiserver.NewConfig().ApplyOptions(s.GenericServerRunOptions)
+	// these are all mutators of each specific suboption in serverOptions object.
+	// this repeated pattern seems like we could refactor
+	if _, err := genericConfig.ApplySecureServingOptions(s.SecureServingOptions); err != nil {
+		return nil, err
+	}
+
+	genericConfig.ApplyInsecureServingOptions(s.InsecureServingOptions)
+
+	// glog.V(4).Info("Setting up authn (disabled)")
+	// need to figure out what's throwing the `missing clientCA file` err
+	/*
+		if _, err := genericConfig.ApplyDelegatingAuthenticationOptions(serverOptions.AuthenticationOptions); err != nil {
+			glog.Infoln(err)
+			return err
+		}
+	*/
+
+	// glog.V(4).Infoln("Setting up authz (disabled)")
+	// having this enabled causes the server to crash for any call
+	/*
+		if _, err := genericConfig.ApplyDelegatingAuthorizationOptions(serverOptions.AuthorizationOptions); err != nil {
+			glog.Infoln(err)
+			return err
+		}
+	*/
+	return genericConfig, nil
+}

--- a/cmd/controller-manager/app/controller_manager.go
+++ b/cmd/controller-manager/app/controller_manager.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/wait"
 
 	"github.com/kubernetes-incubator/service-catalog/cmd/controller-manager/app/options"
+	// for installation of API groups
 	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
 	"github.com/kubernetes-incubator/service-catalog/pkg/brokerapi/openservicebroker"
 	servicecataloginformers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers"
@@ -84,7 +85,7 @@ func Run(controllerManagerOptions *options.ControllerManagerServer) error {
 
 	k8sKubeconfig, err := rest.InClusterConfig()
 	if err != nil {
-		glog.Fatal("Failed to get kube client config (%s)", err)
+		glog.Fatalf("Failed to get kube client config (%s)", err)
 	}
 	k8sKubeconfig.GroupVersion = &unversioned.GroupVersion{}
 

--- a/contrib/examples/apiserver/binding.yaml
+++ b/contrib/examples/apiserver/binding.yaml
@@ -2,7 +2,6 @@ apiVersion: servicecatalog.k8s.io/v1alpha1
 kind: Binding
 metadata:
   name: test-binding
-  namespace: test-ns
 spec:
   instanceRef:
     name: test-instance

--- a/contrib/examples/apiserver/instance.yaml
+++ b/contrib/examples/apiserver/instance.yaml
@@ -2,7 +2,6 @@ apiVersion: servicecatalog.k8s.io/v1alpha1
 kind: Instance
 metadata:
   name: test-instance
-  namespace: test-ns
 spec:
   serviceClassName: test-serviceclass
   planName: example-plan-1

--- a/deploy/catalog/README.md
+++ b/deploy/catalog/README.md
@@ -22,12 +22,13 @@ Supported template parameters (values):
 
   - `registry`  (required): Container registry with Service Catalog images.
   - `version`   (optional): Version of Service Catalog (container images) to deploy.
+  - `namespace` (optional): A Kubernetes namespace to use for Service Catalog deployment.
+  - `storageType` (optional): The type of storage for the API server to use.
+  - `verbosity` (optional): The verbosity of logs.
+  - `debug` (optional): create a load balancer for the api server service
 
-Example:
+Example `helm install` command:
 
-```
-$ export VERSION=$(git describe --tags --always --abbrev=7 --dirty)
-$ helm install \
-    --namespace catalog \
-    --set registry=${REGISTRY},version=${VERSION} .
+```console
+helm install --namespace ${NAMESPACE} --set registry=${REGISTRY},version=${VERSION},storageType=${STORAGE_TYPE},debug=${DEBUG} .
 ```

--- a/deploy/catalog/templates/apiserver.yaml
+++ b/deploy/catalog/templates/apiserver.yaml
@@ -11,21 +11,25 @@ spec:
     spec:
       containers:
       - name: apiserver
-        image: {{ .Values.registry }}/apiserver:{{ if .Values.k8sApiServerVersion }}{{ .Values.k8sApiServerVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}
+        image: "{{ .Values.registry }}/apiserver:{{ if .Values.k8sApiServerVersion }}{{.Values.k8sApiServerVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}"
         imagePullPolicy: Always
         args:
-        - --etcd-servers
-        - http://localhost:2379
+        - --storage-type
+        - {{ default "etcd" .Values.storageType }}
         - -v
-        - "10"
+        - {{ default "\"10\"" .Values.verbosity }}
+        {{ if eq .Values.storageType "etcd" }}- --etcd-servers {{ end }}
+        {{ if eq .Values.storageType "etcd" }}- http://localhost:2379 {{ end }}
         ports:
         - containerPort: 6443
         volumeMounts:
         - name: apiserver-ssl
           mountPath: /var/run/kubernetes-service-catalog
           readOnly: true
+      {{ if eq .Values.storageType "etcd" -}}
       - name: etcd
         image: {{ if .Values.etcdRepository }}{{ .Values.etcdRepository }}{{ else }}{{ "quay.io/coreos/etcd" }}{{ end }}:{{ if .Values.etcdVersion }}{{ .Values.etcdVersion }}{{ else }}{{ "latest" }}{{ end }}
+      {{- end }}
       volumes:
       - name: apiserver-ssl
         secret:

--- a/deploy/wip-catalog/templates/apiserver.yaml
+++ b/deploy/wip-catalog/templates/apiserver.yaml
@@ -11,33 +11,41 @@ spec:
     spec:
       containers:
       - name: apiserver
-        image: {{ if .Values.registry }}{{ .Values.registry}}/{{ end }}apiserver:{{ if .Values.k8sApiServerVersion }}{{ .Values.k8sApiServerVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}
+        image: {{ if .Values.registry }}{{ .Values.registry }}/{{ end }}apiserver:{{ if .Values.k8sApiServerVersion }}{{ .Values.k8sApiServerVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}
         imagePullPolicy: {{ default "Always" .Values.imagePullPolicy }}
         args:
-        {{ if .Values.insecure }}
+        - --global-namespace
+        - {{ default "servicecatalog" .Values.globalNamespace }}
+        - --storage-type
+        - {{ default "etcd" .Values.storageType }}
+        {{ if .Values.insecure -}}
         - --secure-port
         - "0"
         - --insecure-bind-address
         - "0.0.0.0"
         - --insecure-port
         - {{ default 8081 .Values.insecurePort | quote }}
-        {{ end }}
+        {{- end }}
+        {{ if eq .Values.storageType "etcd" -}}
         - --etcd-servers
         - http://localhost:2379
+        {{- end }}
         - -v
-        - "10"
+        - {{ default 10 .Values.verbosity | quote }}
         ports:
         - containerPort: 6443
-        {{ if .Values.insecure }}
+        {{ if .Values.insecure -}}
         - containerPort: {{ default 8081 .Values.insecurePort }}
           hostPort: {{ default 8081 .Values.insecurePort }}
-        {{ end }}
+        {{- end }}
         volumeMounts:
         - name: apiserver-ssl
           mountPath: /var/run/kubernetes-service-catalog
           readOnly: true
+      {{ if eq .Values.storageType "etcd" -}}
       - name: etcd
         image: {{ if .Values.etcdRepository }}{{ .Values.etcdRepository }}{{ else }}{{ "quay.io/coreos/etcd" }}{{ end }}:{{ if .Values.etcdVersion }}{{ .Values.etcdVersion }}{{ else }}{{ "latest" }}{{ end }}
+      {{- end }}
       volumes:
       - name: apiserver-ssl
         secret:
@@ -54,13 +62,13 @@ spec:
   selector:
     app: apiserver
   ports:
-{{ if .Values.insecure }}
+  {{ if .Values.insecure -}}
   - name: insecure
     protocol: TCP
     nodePort: {{ default 30001 .Values.insecureServicePort }}
-    port: {{ default 8081 .Values.insecurePort }}
+    port: 80
     targetPort: {{ default 8081 .Values.insecurePort }}
-{{ end }}
+  {{- end }}
   - name: secure
     protocol: TCP
     port: 6443

--- a/pkg/apis/servicecatalog/doc.go
+++ b/pkg/apis/servicecatalog/doc.go
@@ -18,4 +18,6 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 
 // +groupName=
+
+// Package servicecatalog contains API types for the service catalog controller and server
 package servicecatalog

--- a/pkg/apis/servicecatalog/doc.go
+++ b/pkg/apis/servicecatalog/doc.go
@@ -18,6 +18,4 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 
 // +groupName=
-
-// Package servicecatalog contains API types for the service catalog controller and server
 package servicecatalog

--- a/pkg/apis/servicecatalog/v1alpha1/doc.go
+++ b/pkg/apis/servicecatalog/v1alpha1/doc.go
@@ -20,7 +20,4 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=servicecatalog.k8s.io
-
-// Package v1alpha1 contains generated v1alpha1 types for the service catalog API server
-// and controller
 package v1alpha1

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -17,15 +17,8 @@ limitations under the License.
 package apiserver
 
 import (
-	"github.com/golang/glog"
-	"k8s.io/kubernetes/pkg/genericapiserver"
-	"k8s.io/kubernetes/pkg/registry"
-	"k8s.io/kubernetes/pkg/registry/generic"
-	"k8s.io/kubernetes/pkg/runtime/schema"
-	"k8s.io/kubernetes/pkg/version"
-
 	servicecatalogv1alpha1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
-	servicecatalogrest "github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/rest"
+	"k8s.io/kubernetes/pkg/genericapiserver"
 )
 
 // ServiceCatalogAPIServer contains the base GenericAPIServer along with other
@@ -34,127 +27,9 @@ type ServiceCatalogAPIServer struct {
 	GenericAPIServer *genericapiserver.GenericAPIServer
 }
 
-// Config contains a generic API server Config along with config specific to
-// the service catalog API server.
-type Config struct {
-	GenericConfig *genericapiserver.Config
-
-	// BABYNETES: cargo culted from master.go
-
-	APIResourceConfigSource genericapiserver.APIResourceConfigSource
-	DeleteCollectionWorkers int
-	StorageFactory          genericapiserver.StorageFactory
-}
-
-// CompletedConfig is an internal type to take advantage of typechecking in
-// the type system. mhb does not like it.
-type CompletedConfig struct {
-	*Config
-}
-
-// Complete fills in any fields not set that are required to have valid data
-// and can be derived from other fields.
-func (c *Config) Complete() CompletedConfig {
-	c.GenericConfig.Complete()
-
-	version := version.Get()
-	// Setting this var enables the version resource. We should populate the
-	// fields of the object from above if we wish to have our own output. Or
-	// establish our own version object somewhere else.
-	c.GenericConfig.Version = &version
-
-	return CompletedConfig{c}
-}
-
-// RESTStorageProvider is a local interface describing a REST storage factory.
-// It can report the name of the API group and create a new storage interface
-// for it.
-type RESTStorageProvider interface {
-	// GroupName returns the API group name
-	GroupName() string
-	// NewRESTStorage returns a new
-	NewRESTStorage(apiResourceConfigSource genericapiserver.APIResourceConfigSource, restOptionsGetter registry.RESTOptionsGetter) (genericapiserver.APIGroupInfo, bool)
-}
-
-// New creates the server to run.
-func (c CompletedConfig) New() (*ServiceCatalogAPIServer, error) {
-	// we need to call new on a "completed" config, which we
-	// should already have, as this is a 'CompletedConfig' and the
-	// only way to get here from there is by Complete()'ing. Thus
-	// we skip the complete on the underlying config and go
-	// straight to running it's New() method.
-	genericServer, err := c.Config.GenericConfig.SkipComplete().New()
-	if err != nil {
-		return nil, err
-	}
-
-	glog.V(4).Infoln("Creating API server")
-
-	s := &ServiceCatalogAPIServer{
-		GenericAPIServer: genericServer,
-	}
-
-	// Not every API group compiled in is necessarily enabled by the operator
-	// at runtime.
-	//
-	// Install the API resource config source, which describes versions of
-	// which API groups are enabled.
-	c.APIResourceConfigSource = DefaultAPIResourceConfigSource()
-
-	restStorageProviders := []RESTStorageProvider{
-		servicecatalogrest.StorageProvider{},
-	}
-
-	restOptionsFactory := restOptionsFactory{
-		deleteCollectionWorkers: c.DeleteCollectionWorkers,
-		enableGarbageCollection: c.GenericConfig.EnableGarbageCollection,
-		storageFactory:          c.StorageFactory,
-		storageDecorator:        generic.UndecoratedStorage,
-	}
-
-	glog.V(4).Infoln("Installing API groups")
-	for _, provider := range restStorageProviders {
-		groupInfo, enabled := provider.NewRESTStorage(c.Config.APIResourceConfigSource, restOptionsFactory.NewFor)
-		if !enabled {
-			glog.Warningf("Skipping API group %v because it is not enabled", provider.GroupName())
-		}
-
-		glog.V(4).Infof("Installing API group %v", provider.GroupName())
-		if err := s.GenericAPIServer.InstallAPIGroup(&groupInfo); err != nil {
-			glog.Fatalf("Error installing API group %v: %v", provider.GroupName(), err)
-		}
-	}
-
-	glog.Infoln("Finished installing API groups")
-
-	return s, nil
-}
-
-// BABYNETES: had to be lifted from pkg/master/master.go
-
-// restOptionsFactory is an object that provides a factory method for getting
-// the REST options for a particular GroupResource.
-type restOptionsFactory struct {
-	deleteCollectionWorkers int
-	enableGarbageCollection bool
-	storageFactory          genericapiserver.StorageFactory
-	storageDecorator        generic.StorageDecorator
-}
-
-// NewFor returns the RESTOptions for a particular GroupResource.
-func (f restOptionsFactory) NewFor(resource schema.GroupResource) generic.RESTOptions {
-	storageConfig, err := f.storageFactory.NewConfig(resource)
-	if err != nil {
-		glog.Fatalf("Unable to find storage destination for %v, due to %v", resource, err.Error())
-	}
-
-	return generic.RESTOptions{
-		StorageConfig:           storageConfig,
-		Decorator:               f.storageDecorator,
-		DeleteCollectionWorkers: f.deleteCollectionWorkers,
-		EnableGarbageCollection: f.enableGarbageCollection,
-		ResourcePrefix:          f.storageFactory.ResourcePrefix(resource),
-	}
+// PrepareRun prepares s to run. The returned value represents the runnable server
+func (s ServiceCatalogAPIServer) PrepareRun() RunnableServer {
+	return s.GenericAPIServer.PrepareRun()
 }
 
 // DefaultAPIResourceConfigSource returns a default API Resource config source

--- a/pkg/apiserver/config.go
+++ b/pkg/apiserver/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,13 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog
-// +k8s:openapi-gen=true
-// +k8s:defaulter-gen=TypeMeta
+package apiserver
 
-// +groupName=servicecatalog.k8s.io
+// Config is the raw configuration information for a server to fill in. After the config
+// information is entered, calling code should call Complete to prepare to start the server
+type Config interface {
+	Complete() CompletedConfig
+}
 
-// Package v1alpha1 contains generated v1alpha1 types for the service catalog API server
-// and controller
-package v1alpha1
+// CompletedConfig is the result of a Config being Complete()-ed. Calling code should call Start()
+// to start a server from its completed config
+type CompletedConfig interface {
+	NewServer() (*ServiceCatalogAPIServer, error)
+}

--- a/pkg/apiserver/etcd_config.go
+++ b/pkg/apiserver/etcd_config.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"github.com/golang/glog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	// "k8s.io/kubernetes/pkg/client/typed/dynamic"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	"k8s.io/kubernetes/pkg/genericapiserver"
+	"k8s.io/kubernetes/pkg/registry/generic"
+)
+
+// EtcdConfig contains a generic API server Config along with config specific to
+// the service catalog API server.
+type etcdConfig struct {
+	cl            clientset.Interface
+	genericConfig *genericapiserver.Config
+
+	// BABYNETES: cargo culted from master.go
+	deleteCollectionWorkers int
+	storageFactory          genericapiserver.StorageFactory
+}
+
+// NewEtcdConfig returns a new server config to describe an etcd-backed API server
+func NewEtcdConfig(
+	cl clientset.Interface,
+	genCfg *genericapiserver.Config,
+	deleteCollWorkers int,
+	factory genericapiserver.StorageFactory,
+) Config {
+	return &etcdConfig{
+		cl:                      cl,
+		genericConfig:           genCfg,
+		deleteCollectionWorkers: deleteCollWorkers,
+		storageFactory:          factory,
+	}
+}
+
+// Complete fills in any fields not set that are required to have valid data
+// and can be derived from other fields.
+func (c *etcdConfig) Complete() CompletedConfig {
+	completeGenericConfig(c.genericConfig)
+	return completedEtcdConfig{
+		cl:         c.cl,
+		etcdConfig: c,
+		// Not every API group compiled in is necessarily enabled by the operator
+		// at runtime.
+		//
+		// Install the API resource config source, which describes versions of
+		// which API groups are enabled.
+		apiResourceConfigSource: DefaultAPIResourceConfigSource(),
+	}
+}
+
+// CompletedEtcdConfig is an internal type to take advantage of typechecking in
+// the type system. mhb does not like it.
+type completedEtcdConfig struct {
+	cl clientset.Interface
+	*etcdConfig
+	apiResourceConfigSource genericapiserver.APIResourceConfigSource
+}
+
+// NewServer creates a new server that can be run. Returns a non-nil error if the server couldn't
+// be created
+func (c completedEtcdConfig) NewServer() (*ServiceCatalogAPIServer, error) {
+	s, err := createSkeletonServer(c.genericConfig)
+	if err != nil {
+		return nil, err
+	}
+	glog.V(4).Infoln("Created skeleton API server")
+
+	roFactory := etcdRESTOptionsFactory{
+		deleteCollectionWorkers: c.deleteCollectionWorkers,
+		enableGarbageCollection: c.genericConfig.EnableGarbageCollection,
+		storageFactory:          c.storageFactory,
+		storageDecorator:        generic.UndecoratedStorage,
+	}
+
+	glog.V(4).Infoln("Installing API groups")
+	// default namespace doesn't matter for etcd
+	providers := restStorageProviders("", server.StorageTypeEtcd, c.cl)
+	for _, provider := range providers {
+		groupInfo, err := provider.NewRESTStorage(c.apiResourceConfigSource, roFactory.NewFor)
+		if IsErrAPIGroupDisabled(err) {
+			glog.Warningf("Skipping API group %v because it is not enabled", provider.GroupName())
+			continue
+		} else if err != nil {
+			return nil, err
+		}
+
+		glog.V(4).Infof("Installing API group %v", provider.GroupName())
+		if err := s.GenericAPIServer.InstallAPIGroup(groupInfo); err != nil {
+			glog.Fatalf("Error installing API group %v: %v", provider.GroupName(), err)
+		}
+	}
+
+	glog.Infoln("Finished installing API groups")
+
+	return s, nil
+}

--- a/pkg/apiserver/etcd_rest_options_factory.go
+++ b/pkg/apiserver/etcd_rest_options_factory.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/genericapiserver"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	"k8s.io/kubernetes/pkg/runtime/schema"
+)
+
+// BABYNETES: had to be lifted from pkg/master/master.go
+
+// restOptionsFactory is an object that provides a factory method for getting
+// the REST options for a particular GroupResource.
+type etcdRESTOptionsFactory struct {
+	deleteCollectionWorkers int
+	enableGarbageCollection bool
+	storageFactory          genericapiserver.StorageFactory
+	storageDecorator        generic.StorageDecorator
+}
+
+// NewFor returns the RESTOptions for a particular GroupResource.
+func (f etcdRESTOptionsFactory) NewFor(resource schema.GroupResource) generic.RESTOptions {
+	storageConfig, err := f.storageFactory.NewConfig(resource)
+	if err != nil {
+		glog.Fatalf("Unable to find storage destination for %v, due to %v", resource, err.Error())
+	}
+
+	return generic.RESTOptions{
+		StorageConfig:           storageConfig,
+		Decorator:               f.storageDecorator,
+		DeleteCollectionWorkers: f.deleteCollectionWorkers,
+		EnableGarbageCollection: f.enableGarbageCollection,
+		ResourcePrefix:          f.storageFactory.ResourcePrefix(resource),
+	}
+}

--- a/pkg/apiserver/rest_storage_provider.go
+++ b/pkg/apiserver/rest_storage_provider.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/genericapiserver"
+	"k8s.io/kubernetes/pkg/registry"
+)
+
+// ErrAPIGroupDisabled is an error indicating that an API group should be disabled
+type ErrAPIGroupDisabled struct {
+	Name string
+}
+
+func (e ErrAPIGroupDisabled) Error() string {
+	return fmt.Sprintf("API group %s is disabled", e.Name)
+}
+
+// IsErrAPIGroupDisabled returns true if e is an error indicating that an API group is disabled
+func IsErrAPIGroupDisabled(e error) bool {
+	_, ok := e.(ErrAPIGroupDisabled)
+	return ok
+}
+
+// RESTStorageProvider is a local interface describing a REST storage factory.
+// It can report the name of the API group and create a new storage interface
+// for it.
+type RESTStorageProvider interface {
+	// GroupName returns the API group name that the storage manages
+	GroupName() string
+	// NewRESTStorage returns a new group info representing the storage this provider provides. If
+	// the API group should be disabled, a non-nil error will be returned, and
+	// IsErrAPIGroupDisabled(e) will return true for it. Otherwise, if the storage couldn't be
+	// created, a different non-nil error will be returned
+	// second parameter indicates whether the API group should be enabled. A non-nil error will
+	// be returned if a new group info couldn't be created
+	NewRESTStorage(
+		apiResourceConfigSource genericapiserver.APIResourceConfigSource,
+		restOptionsGetter registry.RESTOptionsGetter,
+	) (*genericapiserver.APIGroupInfo, error)
+}

--- a/pkg/apiserver/runnable_server.go
+++ b/pkg/apiserver/runnable_server.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,13 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog
-// +k8s:openapi-gen=true
-// +k8s:defaulter-gen=TypeMeta
+package apiserver
 
-// +groupName=servicecatalog.k8s.io
-
-// Package v1alpha1 contains generated v1alpha1 types for the service catalog API server
-// and controller
-package v1alpha1
+// RunnableServer is an interface to represent a server that is completely ready to start
+type RunnableServer interface {
+	// Run starts the server, and blocks until the given channel is closed, after which point
+	// it returns and the server has stopped
+	Run(<-chan struct{})
+}

--- a/pkg/apiserver/tpr_config.go
+++ b/pkg/apiserver/tpr_config.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/genericapiserver"
+	// "k8s.io/kubernetes/pkg/registry/generic"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+)
+
+// tprConfig is the configuration needed to run the API server in TPR storage mode
+type tprConfig struct {
+	cl              clientset.Interface
+	genericConfig   *genericapiserver.Config
+	globalNamespace string
+	storageFactory  genericapiserver.StorageFactory
+}
+
+// NewTPRConfig returns a new Config for a server that is backed by TPR storage
+func NewTPRConfig(
+	cl clientset.Interface,
+	genericCfg *genericapiserver.Config,
+	globalNS string,
+	factory genericapiserver.StorageFactory,
+) Config {
+	return &tprConfig{
+		cl:              cl,
+		genericConfig:   genericCfg,
+		globalNamespace: globalNS,
+		storageFactory:  factory,
+	}
+}
+
+// Complete fills in the remaining fields of t and returns a completed config
+func (t *tprConfig) Complete() CompletedConfig {
+	completeGenericConfig(t.genericConfig)
+	return &completedTPRConfig{
+		cl:        t.cl,
+		tprConfig: t,
+		// Not every API group compiled in is necessarily enabled by the operator
+		// at runtime.
+		//
+		// Install the API resource config source, which describes versions of
+		// which API groups are enabled.
+		apiResourceConfigSource: DefaultAPIResourceConfigSource(),
+		factory:                 t.storageFactory,
+	}
+}
+
+// CompletedTPRConfig is the completed version of the TPR config. It can be used to create a
+// new server, ready to be run
+type completedTPRConfig struct {
+	cl clientset.Interface
+	*tprConfig
+	apiResourceConfigSource genericapiserver.APIResourceConfigSource
+	factory                 genericapiserver.StorageFactory
+}
+
+// NewServer returns a new service catalog server, that is ready for execution
+func (c *completedTPRConfig) NewServer() (*ServiceCatalogAPIServer, error) {
+	s, err := createSkeletonServer(c.tprConfig.genericConfig)
+	if err != nil {
+		return nil, err
+	}
+	glog.V(4).Infoln("Created skeleton API server. Installing API groups")
+
+	roFactory := tprRESTOptionsFactory{
+		storageFactory: c.factory,
+	}
+	providers := restStorageProviders(c.globalNamespace, server.StorageTypeTPR, c.cl)
+	for _, provider := range providers {
+		groupInfo, err := provider.NewRESTStorage(
+			c.apiResourceConfigSource, // genericapiserver.APIResourceConfigSource
+			roFactory.NewFor,          // registry.RESTOptionsGetter
+		)
+		if IsErrAPIGroupDisabled(err) {
+			glog.Warningf("Skipping API group %v because it is not enabled", provider.GroupName())
+			continue
+		} else if err != nil {
+			return nil, err
+		}
+		glog.V(4).Infof("Installing API group %v", provider.GroupName())
+		if err := s.GenericAPIServer.InstallAPIGroup(groupInfo); err != nil {
+			glog.Fatalf("Error installing API group %v: %v", provider.GroupName(), err)
+		}
+	}
+	glog.Infoln("Finished installing API groups")
+	return s, nil
+}

--- a/pkg/apiserver/tpr_rest_options_factory.go
+++ b/pkg/apiserver/tpr_rest_options_factory.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/genericapiserver"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	"k8s.io/kubernetes/pkg/runtime/schema"
+)
+
+type tprRESTOptionsFactory struct {
+	storageFactory genericapiserver.StorageFactory
+}
+
+func (t tprRESTOptionsFactory) NewFor(resource schema.GroupResource) generic.RESTOptions {
+	storageConfig, err := t.storageFactory.NewConfig(resource)
+	if err != nil {
+		glog.Fatalf("Unable to find storage destination for %v, due to %v", resource, err.Error())
+	}
+	// this function should create a RESTOptions that contains a Decorator function to create
+	// a TPR based storage config. This should be done in a follow up to
+	// https://github.com/kubernetes-incubator/service-catalog/pull/338. When this decorator
+	// function is implemented, the 'NewStorage' functions in
+	// ./pkg/registry/servicecatalog/{binding,broker,instance,serviceclass} no longer will need
+	// to have the switching logic to choose between TPR and etcd
+	return generic.RESTOptions{
+		StorageConfig: storageConfig,
+	}
+}

--- a/pkg/apiserver/util.go
+++ b/pkg/apiserver/util.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	servicecatalogrest "github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/rest"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	"k8s.io/kubernetes/pkg/genericapiserver"
+	"k8s.io/kubernetes/pkg/version"
+)
+
+func restStorageProviders(
+	defaultNamespace string,
+	storageType server.StorageType,
+	client clientset.Interface,
+) []RESTStorageProvider {
+	return []RESTStorageProvider{
+		servicecatalogrest.StorageProvider{
+			DefaultNamespace: defaultNamespace,
+			StorageType:      storageType,
+			Client:           client,
+		},
+	}
+}
+
+func completeGenericConfig(cfg *genericapiserver.Config) {
+	cfg.Complete()
+
+	version := version.Get()
+	// Setting this var enables the version resource. We should populate the
+	// fields of the object from above if we wish to have our own output. Or
+	// establish our own version object somewhere else.
+	cfg.Version = &version
+}
+
+func createSkeletonServer(genericCfg *genericapiserver.Config) (*ServiceCatalogAPIServer, error) {
+	// we need to call new on a "completed" config, which we
+	// should already have, as this is a 'CompletedConfig' and the
+	// only way to get here from there is by Complete()'ing. Thus
+	// we skip the complete on the underlying config and go
+	// straight to running it's New() method.
+	genericServer, err := genericCfg.SkipComplete().New()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ServiceCatalogAPIServer{
+		GenericAPIServer: genericServer,
+	}, nil
+}

--- a/pkg/registry/servicecatalog/binding/storage.go
+++ b/pkg/registry/servicecatalog/binding/storage.go
@@ -17,19 +17,63 @@ limitations under the License.
 package binding
 
 import (
+	"errors"
 	"fmt"
 
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	"github.com/kubernetes-incubator/service-catalog/pkg/storage/tpr"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/rest"
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/storage"
-
-	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 )
+
+var (
+	errNotABinding = errors.New("not a binding")
+)
+
+// NewSingular returns a new shell of a service binding, according to the given namespace and
+// name
+func NewSingular(ns, name string) runtime.Object {
+	return &servicecatalog.Binding{
+		TypeMeta: metav1.TypeMeta{
+			Kind: tpr.ServiceBindingKind.String(),
+		},
+		ObjectMeta: api.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+	}
+}
+
+// EmptyObject returns an empty binding
+func EmptyObject() runtime.Object {
+	return &servicecatalog.Binding{}
+}
+
+// NewList returns a new shell of a binding list
+func NewList() runtime.Object {
+	return &servicecatalog.BindingList{
+		TypeMeta: metav1.TypeMeta{
+			Kind: tpr.ServiceBindingListKind.String(),
+		},
+	}
+}
+
+// CheckObject returns a non-nil error if obj is not a binding object
+func CheckObject(obj runtime.Object) error {
+	_, ok := obj.(*servicecatalog.Binding)
+	if !ok {
+		return errNotABinding
+	}
+	return nil
+}
 
 // Match determines whether an Instance matches a field and label
 // selector.
@@ -41,8 +85,8 @@ func Match(label labels.Selector, field fields.Selector) storage.SelectionPredic
 	}
 }
 
-// ToSelectableFields returns a field set that represents the object for matching purposes.
-func ToSelectableFields(binding *servicecatalog.Binding) fields.Set {
+// toSelectableFields returns a field set that represents the object for matching purposes.
+func toSelectableFields(binding *servicecatalog.Binding) fields.Set {
 	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(&binding.ObjectMeta, true)
 	return generic.MergeFieldsSets(objectMetaFieldsSet, nil)
 }
@@ -53,46 +97,33 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 	if !ok {
 		return nil, nil, fmt.Errorf("given object is not a Binding")
 	}
-	return labels.Set(binding.ObjectMeta.Labels), ToSelectableFields(binding), nil
+	return labels.Set(binding.ObjectMeta.Labels), toSelectableFields(binding), nil
 }
 
-// NewStorage creates a new rest.Storage for each of Bindings and
-// Status of Bindings
-func NewStorage(opts generic.RESTOptions) (rest.Storage, rest.Storage) {
-	prefix := "/" + opts.ResourcePrefix
+// NewStorage creates a new rest.Storage responsible for accessing Instance
+// resources
+func NewStorage(opts server.Options) (rest.Storage, rest.Storage, error) {
+	prefix := "/" + opts.ResourcePrefix()
 
-	newListFunc := func() runtime.Object { return &servicecatalog.BindingList{} }
-	storageInterface, dFunc := opts.Decorator(
-		opts.StorageConfig,
+	storageInterface, dFunc := opts.GetStorage(
 		1000,
 		&servicecatalog.Binding{},
 		prefix,
 		bindingRESTStrategies,
-		newListFunc,
+		NewList,
 		nil,
 		storage.NoTriggerPublisher,
 	)
 
 	store := registry.Store{
-		NewFunc: func() runtime.Object {
-			return &servicecatalog.Binding{}
-		},
+		NewFunc: EmptyObject,
 		// NewListFunc returns an object capable of storing results of an etcd list.
-		NewListFunc: newListFunc,
-
-		// Produces a path that etcd understands, to the root of the resource
-		// by combining the namespace in the context with the given prefix
-		KeyRootFunc: func(ctx api.Context) string {
-			return registry.NamespaceKeyRootFunc(ctx, prefix)
-		},
-		// Produces a path that etcd understands, to the resource by combining
-		// the namespace in the context with the given prefix
-		KeyFunc: func(ctx api.Context, name string) (string, error) {
-			return registry.NamespaceKeyFunc(ctx, prefix, name)
-		},
+		NewListFunc: NewList,
+		KeyRootFunc: opts.KeyRootFunc(),
+		KeyFunc:     opts.KeyFunc(),
 		// Retrieve the name field of the resource.
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*servicecatalog.Binding).Name, nil
+			return tpr.GetAccessor().Name(obj)
 		},
 		// Used to match objects based on labels/fields for list.
 		PredicateFunc: Match,
@@ -110,5 +141,5 @@ func NewStorage(opts generic.RESTOptions) (rest.Storage, rest.Storage) {
 	statusStore := store
 	statusStore.UpdateStrategy = bindingStatusUpdateStrategy
 
-	return &store, &statusStore
+	return &store, &statusStore, nil
 }

--- a/pkg/registry/servicecatalog/binding/storage.go
+++ b/pkg/registry/servicecatalog/binding/storage.go
@@ -120,7 +120,7 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage, error) {
 		// NewListFunc returns an object capable of storing results of an etcd list.
 		NewListFunc: NewList,
 		KeyRootFunc: opts.KeyRootFunc(),
-		KeyFunc:     opts.KeyFunc(),
+		KeyFunc:     opts.KeyFunc(true),
 		// Retrieve the name field of the resource.
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return tpr.GetAccessor().Name(obj)

--- a/pkg/registry/servicecatalog/binding/strategy.go
+++ b/pkg/registry/servicecatalog/binding/strategy.go
@@ -29,7 +29,13 @@ import (
 	scv "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation"
 )
 
-// implements interfaces RESTCreateStrategy, RESTUpdateStrategy, RESTDeleteStrategy
+// NewScopeStrategy returns a new NamespaceScopedStrategy for bindings
+func NewScopeStrategy() rest.NamespaceScopedStrategy {
+	return bindingRESTStrategies
+}
+
+// implements interfaces RESTCreateStrategy, RESTUpdateStrategy, RESTDeleteStrategy,
+// NamespaceScopedStrategy
 type bindingRESTStrategy struct {
 	runtime.ObjectTyper // inherit ObjectKinds method
 	kapi.NameGenerator  // GenerateName method for CreateStrategy

--- a/pkg/registry/servicecatalog/broker/storage.go
+++ b/pkg/registry/servicecatalog/broker/storage.go
@@ -119,7 +119,7 @@ func NewStorage(opts server.Options) (brokers, brokersStatus rest.Storage) {
 		NewFunc:     EmptyObject,
 		NewListFunc: NewList,
 		KeyRootFunc: opts.KeyRootFunc(),
-		KeyFunc:     opts.KeyFunc(),
+		KeyFunc:     opts.KeyFunc(false),
 		// Retrieve the name field of the resource.
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return tpr.GetAccessor().Name(obj)

--- a/pkg/registry/servicecatalog/broker/storage.go
+++ b/pkg/registry/servicecatalog/broker/storage.go
@@ -17,19 +17,63 @@ limitations under the License.
 package broker
 
 import (
+	"errors"
 	"fmt"
 
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	"github.com/kubernetes-incubator/service-catalog/pkg/storage/tpr"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/rest"
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/storage"
-
-	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 )
+
+var (
+	errNotABroker = errors.New("not a broker")
+)
+
+// NewSingular returns a new shell of a service broker, according to the given namespace and
+// name
+func NewSingular(ns, name string) runtime.Object {
+	return &servicecatalog.Broker{
+		TypeMeta: metav1.TypeMeta{
+			Kind: tpr.ServiceBrokerKind.TPRName(),
+		},
+		ObjectMeta: api.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+	}
+}
+
+// EmptyObject returns an empty broker
+func EmptyObject() runtime.Object {
+	return &servicecatalog.Broker{}
+}
+
+// NewList returns a new shell of a broker list
+func NewList() runtime.Object {
+	return &servicecatalog.BrokerList{
+		TypeMeta: metav1.TypeMeta{
+			Kind: tpr.ServiceBrokerKind.TPRName(),
+		},
+	}
+}
+
+// CheckObject returns a non-nil error if obj is not a broker object
+func CheckObject(obj runtime.Object) error {
+	_, ok := obj.(*servicecatalog.Broker)
+	if !ok {
+		return errNotABroker
+	}
+	return nil
+}
 
 // Match determines whether an Instance matches a field and label
 // selector.
@@ -41,8 +85,8 @@ func Match(label labels.Selector, field fields.Selector) storage.SelectionPredic
 	}
 }
 
-// ToSelectableFields returns a field set that represents the object for matching purposes.
-func ToSelectableFields(broker *servicecatalog.Broker) fields.Set {
+// toSelectableFields returns a field set that represents the object for matching purposes.
+func toSelectableFields(broker *servicecatalog.Broker) fields.Set {
 	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(&broker.ObjectMeta, true)
 	return generic.MergeFieldsSets(objectMetaFieldsSet, nil)
 }
@@ -53,45 +97,32 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 	if !ok {
 		return nil, nil, fmt.Errorf("given object is not a Broker")
 	}
-	return labels.Set(broker.ObjectMeta.Labels), ToSelectableFields(broker), nil
+	return labels.Set(broker.ObjectMeta.Labels), toSelectableFields(broker), nil
 }
 
 // NewStorage creates a new rest.Storage responsible for accessing Instance
 // resources
-func NewStorage(opts generic.RESTOptions) (brokers, brokersStatus rest.Storage) {
-	prefix := "/" + opts.ResourcePrefix
+func NewStorage(opts server.Options) (brokers, brokersStatus rest.Storage) {
+	prefix := "/" + opts.ResourcePrefix()
 
-	newListFunc := func() runtime.Object { return &servicecatalog.BrokerList{} }
-	storageInterface, dFunc := opts.Decorator(
-		opts.StorageConfig,
+	storageInterface, dFunc := opts.GetStorage(
 		1000,
 		&servicecatalog.Broker{},
 		prefix,
 		brokerRESTStrategies,
-		newListFunc,
+		NewList,
 		nil,
 		storage.NoTriggerPublisher,
 	)
 
 	store := registry.Store{
-		NewFunc: func() runtime.Object {
-			return &servicecatalog.Broker{}
-		},
-		// NewListFunc returns an object capable of storing results of an etcd list.
-		NewListFunc: newListFunc,
-		// KeyRootFunc places this resource at the prefix for this resource;
-		// not namespaced.
-		KeyRootFunc: func(ctx api.Context) string {
-			return prefix
-		},
-		// Produces a path that etcd understands by combining the object's
-		// name with the prefix.
-		KeyFunc: func(ctx api.Context, name string) (string, error) {
-			return registry.NoNamespaceKeyFunc(ctx, prefix, name)
-		},
+		NewFunc:     EmptyObject,
+		NewListFunc: NewList,
+		KeyRootFunc: opts.KeyRootFunc(),
+		KeyFunc:     opts.KeyFunc(),
 		// Retrieve the name field of the resource.
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*servicecatalog.Broker).Name, nil
+			return tpr.GetAccessor().Name(obj)
 		},
 		// Used to match objects based on labels/fields for list.
 		PredicateFunc: Match,

--- a/pkg/registry/servicecatalog/broker/strategy.go
+++ b/pkg/registry/servicecatalog/broker/strategy.go
@@ -29,7 +29,13 @@ import (
 	scv "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation"
 )
 
-// implements interfaces RESTCreateStrategy, RESTUpdateStrategy, RESTDeleteStrategy
+// NewScopeStrategy returns a new NamespaceScopedStrategy for brokers
+func NewScopeStrategy() rest.NamespaceScopedStrategy {
+	return brokerRESTStrategies
+}
+
+// implements interfaces RESTCreateStrategy, RESTUpdateStrategy, RESTDeleteStrategy,
+// NamespaceScopedStrategy
 type brokerRESTStrategy struct {
 	runtime.ObjectTyper // inherit ObjectKinds method
 	kapi.NameGenerator  // GenerateName method for CreateStrategy

--- a/pkg/registry/servicecatalog/instance/storage.go
+++ b/pkg/registry/servicecatalog/instance/storage.go
@@ -119,7 +119,7 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 		NewFunc:     EmptyObject,
 		NewListFunc: NewList,
 		KeyRootFunc: opts.KeyRootFunc(),
-		KeyFunc:     opts.KeyFunc(),
+		KeyFunc:     opts.KeyFunc(true),
 		// Retrieve the name field of the resource.
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return tpr.GetAccessor().Name(obj)

--- a/pkg/registry/servicecatalog/instance/strategy.go
+++ b/pkg/registry/servicecatalog/instance/strategy.go
@@ -29,7 +29,13 @@ import (
 	scv "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation"
 )
 
-// implements interfaces RESTCreateStrategy, RESTUpdateStrategy, RESTDeleteStrategy
+// NewScopeStrategy returns a new NamespaceScopedStrategy for instances
+func NewScopeStrategy() rest.NamespaceScopedStrategy {
+	return instanceRESTStrategies
+}
+
+// implements interfaces RESTCreateStrategy, RESTUpdateStrategy, RESTDeleteStrategy,
+// NamespaceScopedStrategy
 type instanceRESTStrategy struct {
 	runtime.ObjectTyper // inherit ObjectKinds method
 	kapi.NameGenerator  // GenerateName method for CreateStrategy

--- a/pkg/registry/servicecatalog/rest/storage_servicecatalog.go
+++ b/pkg/registry/servicecatalog/rest/storage_servicecatalog.go
@@ -17,47 +17,188 @@ limitations under the License.
 package rest
 
 import (
-	"k8s.io/kubernetes/pkg/api/rest"
-	"k8s.io/kubernetes/pkg/genericapiserver"
-	"k8s.io/kubernetes/pkg/registry"
-
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	servicecatalogv1alpha1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/binding"
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/broker"
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/instance"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/serviceclass"
+	"github.com/kubernetes-incubator/service-catalog/pkg/storage/etcd"
+	"github.com/kubernetes-incubator/service-catalog/pkg/storage/tpr"
+	"k8s.io/kubernetes/pkg/api/rest"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	"k8s.io/kubernetes/pkg/genericapiserver"
+	"k8s.io/kubernetes/pkg/registry"
+	"k8s.io/kubernetes/pkg/storage"
 )
 
 // StorageProvider provides a factory method to create a new APIGroupInfo for
-// the servicecatalog API group.
-type StorageProvider struct{}
+// the servicecatalog API group. It implements (./pkg/apiserver).RESTStorageProvider
+type StorageProvider struct {
+	DefaultNamespace string
+	StorageType      server.StorageType
+	Client           clientset.Interface
+}
 
 // NewRESTStorage is a factory method to make a new APIGroupInfo for the
 // servicecatalog API group.
-func (p StorageProvider) NewRESTStorage(apiResourceConfigSource genericapiserver.APIResourceConfigSource, restOptionsGetter registry.RESTOptionsGetter) (genericapiserver.APIGroupInfo, bool) {
+func (p StorageProvider) NewRESTStorage(
+	apiResourceConfigSource genericapiserver.APIResourceConfigSource,
+	restOptionsGetter registry.RESTOptionsGetter,
+) (*genericapiserver.APIGroupInfo, error) {
+
+	storage, err := p.v1alpha1Storage(apiResourceConfigSource, restOptionsGetter)
+	if err != nil {
+		return nil, err
+	}
+
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(servicecatalog.GroupName)
 	apiGroupInfo.GroupMeta.GroupVersion = servicecatalogv1alpha1.SchemeGroupVersion
+
 	apiGroupInfo.VersionedResourcesStorageMap = map[string]map[string]rest.Storage{
-		servicecatalogv1alpha1.SchemeGroupVersion.Version: p.v1alpha1Storage(apiResourceConfigSource, restOptionsGetter),
+		servicecatalogv1alpha1.SchemeGroupVersion.Version: storage,
 	}
 
-	return apiGroupInfo, true
+	return &apiGroupInfo, nil
 }
 
-func (p StorageProvider) v1alpha1Storage(apiResourceConfigSource genericapiserver.APIResourceConfigSource, restOptionsGetter registry.RESTOptionsGetter) map[string]rest.Storage {
-	brokers, brokersStatus := broker.NewStorage(restOptionsGetter(servicecatalog.Resource("brokers")))
-	instances, instancesStatus := instance.NewStorage(restOptionsGetter(servicecatalog.Resource("instances")))
-	bindings, bindingsStatus := binding.NewStorage(restOptionsGetter(servicecatalog.Resource("bindings")))
-	return map[string]rest.Storage{
-		"brokers":          brokers,
-		"brokers/status":   brokersStatus,
-		"serviceclasses":   serviceclass.NewStorage(restOptionsGetter(servicecatalog.Resource("serviceclasses"))),
-		"instances":        instances,
-		"instances/status": instancesStatus,
-		"bindings":         bindings,
-		"bindings/status":  bindingsStatus,
+func (p StorageProvider) v1alpha1Storage(
+	apiResourceConfigSource genericapiserver.APIResourceConfigSource,
+	restOptionsGetter registry.RESTOptionsGetter,
+) (map[string]rest.Storage, error) {
+	brokerOpts := server.NewOptions(
+		etcd.Options{
+			RESTOptions:   restOptionsGetter(servicecatalog.Resource("brokers")),
+			Capacity:      1000,
+			ObjectType:    broker.EmptyObject(),
+			ScopeStrategy: broker.NewScopeStrategy(),
+			NewListFunc:   broker.NewList,
+			GetAttrsFunc:  broker.GetAttrs,
+			Trigger:       storage.NoTriggerPublisher,
+		},
+		tpr.Options{
+			RESTOptions:      restOptionsGetter(servicecatalog.Resource("brokers")),
+			DefaultNamespace: p.DefaultNamespace,
+			Client:           p.Client,
+			SingularKind:     tpr.ServiceBrokerKind,
+			NewSingularFunc:  broker.NewSingular,
+			ListKind:         tpr.ServiceBrokerListKind,
+			NewListFunc:      broker.NewList,
+			CheckObjectFunc:  broker.CheckObject,
+			DestroyFunc:      func() {},
+			Keyer: tpr.Keyer{
+				DefaultNamespace: p.DefaultNamespace,
+				ResourceName:     tpr.ServiceBrokerKind.String(),
+				Separator:        "/",
+			},
+		},
+		p.StorageType,
+	)
+
+	serviceClassOpts := server.NewOptions(
+		etcd.Options{
+			RESTOptions:   restOptionsGetter(servicecatalog.Resource("serviceclasses")),
+			Capacity:      1000,
+			ObjectType:    serviceclass.EmptyObject(),
+			ScopeStrategy: serviceclass.NewScopeStrategy(),
+			NewListFunc:   serviceclass.NewList,
+			GetAttrsFunc:  serviceclass.GetAttrs,
+			Trigger:       storage.NoTriggerPublisher,
+		},
+		tpr.Options{
+			RESTOptions:      restOptionsGetter(servicecatalog.Resource("serviceclasses")),
+			DefaultNamespace: p.DefaultNamespace,
+			Client:           p.Client,
+			SingularKind:     tpr.ServiceClassKind,
+			NewSingularFunc:  serviceclass.NewSingular,
+			ListKind:         tpr.ServiceClassListKind,
+			NewListFunc:      serviceclass.NewList,
+			CheckObjectFunc:  serviceclass.CheckObject,
+			DestroyFunc:      func() {},
+			Keyer: tpr.Keyer{
+				DefaultNamespace: p.DefaultNamespace,
+				ResourceName:     tpr.ServiceClassKind.String(),
+				Separator:        "/",
+			},
+		},
+		p.StorageType,
+	)
+
+	instanceOpts := server.NewOptions(
+		etcd.Options{
+			RESTOptions:   restOptionsGetter(servicecatalog.Resource("instances")),
+			Capacity:      1000,
+			ObjectType:    instance.EmptyObject(),
+			ScopeStrategy: instance.NewScopeStrategy(),
+			NewListFunc:   instance.NewList,
+			GetAttrsFunc:  instance.GetAttrs,
+			Trigger:       storage.NoTriggerPublisher,
+		},
+		tpr.Options{
+			RESTOptions:      restOptionsGetter(servicecatalog.Resource("instances")),
+			DefaultNamespace: p.DefaultNamespace,
+			Client:           p.Client,
+			SingularKind:     tpr.ServiceInstanceKind,
+			NewSingularFunc:  instance.NewSingular,
+			ListKind:         tpr.ServiceInstanceListKind,
+			NewListFunc:      instance.NewList,
+			CheckObjectFunc:  instance.CheckObject,
+			DestroyFunc:      func() {},
+			Keyer: tpr.Keyer{
+				DefaultNamespace: p.DefaultNamespace,
+				ResourceName:     tpr.ServiceInstanceKind.String(),
+				Separator:        "/",
+			},
+		},
+		p.StorageType,
+	)
+
+	bindingsOpts := server.NewOptions(
+		etcd.Options{
+			RESTOptions:   restOptionsGetter(servicecatalog.Resource("bindings")),
+			Capacity:      1000,
+			ObjectType:    binding.EmptyObject(),
+			ScopeStrategy: binding.NewScopeStrategy(),
+			NewListFunc:   binding.NewList,
+			GetAttrsFunc:  binding.GetAttrs,
+			Trigger:       storage.NoTriggerPublisher,
+		},
+		tpr.Options{
+			RESTOptions:      restOptionsGetter(servicecatalog.Resource("bindings")),
+			DefaultNamespace: p.DefaultNamespace,
+			Client:           p.Client,
+			SingularKind:     tpr.ServiceBindingKind,
+			NewSingularFunc:  binding.NewSingular,
+			ListKind:         tpr.ServiceBindingListKind,
+			NewListFunc:      binding.NewList,
+			CheckObjectFunc:  binding.CheckObject,
+			DestroyFunc:      func() {},
+			Keyer: tpr.Keyer{
+				DefaultNamespace: p.DefaultNamespace,
+				ResourceName:     tpr.ServiceBindingKind.String(),
+				Separator:        "/",
+			},
+		},
+		p.StorageType,
+	)
+
+	brokerStorage, brokerStatusStorage := broker.NewStorage(*brokerOpts)
+	serviceClassStorage := serviceclass.NewStorage(*serviceClassOpts)
+	instanceStorage, instanceStatusStorage := instance.NewStorage(*instanceOpts)
+	bindingStorage, bindingStatusStorage, err := binding.NewStorage(*bindingsOpts)
+	if err != nil {
+		return nil, err
 	}
+	return map[string]rest.Storage{
+		"brokers":          brokerStorage,
+		"brokers/status":   brokerStatusStorage,
+		"serviceclasses":   serviceClassStorage,
+		"instances":        instanceStorage,
+		"instances/status": instanceStatusStorage,
+		"bindings":         bindingStorage,
+		"bindings/status":  bindingStatusStorage,
+	}, nil
 }
 
 // GroupName returns the API group name.

--- a/pkg/registry/servicecatalog/rest/storage_servicecatalog_test.go
+++ b/pkg/registry/servicecatalog/rest/storage_servicecatalog_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"testing"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	"k8s.io/kubernetes/pkg/api/rest"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/genericapiserver"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/registry"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/storage"
+	"k8s.io/kubernetes/pkg/storage/storagebackend"
+	"k8s.io/kubernetes/pkg/storage/storagebackend/factory"
+)
+
+func testRESTOptionsGetter(
+	retStorageInterface storage.Interface,
+	retDestroyFunc func(),
+) registry.RESTOptionsGetter {
+	return func(resource schema.GroupResource) generic.RESTOptions {
+		return generic.RESTOptions{
+			StorageConfig: &storagebackend.Config{},
+			Decorator: generic.StorageDecorator(func(
+				config *storagebackend.Config,
+				capacity int,
+				objectType runtime.Object,
+				resourcePrefix string,
+				scopeStrategy rest.NamespaceScopedStrategy,
+				newListFunc func() runtime.Object,
+				getAttrsFunc func(
+					runtime.Object,
+				) (labels.Set, fields.Set, error),
+				trigger storage.TriggerPublisherFunc,
+			) (storage.Interface, factory.DestroyFunc) {
+				return retStorageInterface, retDestroyFunc
+			}),
+		}
+	}
+}
+
+func TestV1Alpha1Storage(t *testing.T) {
+	provider := StorageProvider{
+		DefaultNamespace: "test-default",
+		StorageType:      server.StorageTypeTPR,
+		Client:           nil,
+	}
+	configSource := genericapiserver.NewResourceConfig()
+	roGetter := testRESTOptionsGetter(nil, func() {})
+	storageMap, err := provider.v1alpha1Storage(configSource, roGetter)
+	if err != nil {
+		t.Fatalf("error getting v1alpha1 storage (%s)", err)
+	}
+	_, brokerStorageExists := storageMap["brokers"]
+	if !brokerStorageExists {
+		t.Fatalf("no broker storage found")
+	}
+	// TODO: do stuff with broker storage
+	_, brokerStatusStorageExists := storageMap["brokers/status"]
+	if !brokerStatusStorageExists {
+		t.Fatalf("no broker status storage found")
+	}
+	// TODO: do stuff with broker status storage
+
+	_, serviceClassStorageExists := storageMap["serviceclasses"]
+	if !serviceClassStorageExists {
+		t.Fatalf("no service class storage found")
+	}
+	// TODO: do stuff with service class storage
+
+	_, instanceStorageExists := storageMap["instances"]
+	if !instanceStorageExists {
+		t.Fatalf("no instance storage found")
+	}
+	// TODO: do stuff with instance storage
+
+	_, bindingStorageExists := storageMap["bindings"]
+	if !bindingStorageExists {
+		t.Fatalf("no binding storage found")
+	}
+	// TODO: do stuff with binding storage
+
+}

--- a/pkg/registry/servicecatalog/server/options.go
+++ b/pkg/registry/servicecatalog/server/options.go
@@ -124,7 +124,7 @@ func (o Options) KeyRootFunc() func(api.Context) string {
 // KeyFunc returns the appropriate key function for the storage type in o.
 // This function should produce a path that etcd or TPR storage understands, to the resource
 // by combining the namespace in the context with the given prefix
-func (o Options) KeyFunc() func(api.Context, string) (string, error) {
+func (o Options) KeyFunc(namespaced bool) func(api.Context, string) (string, error) {
 	prefix := o.ResourcePrefix()
 	sType, err := o.StorageType()
 	if err != nil {
@@ -132,7 +132,10 @@ func (o Options) KeyFunc() func(api.Context, string) (string, error) {
 	}
 	if sType == StorageTypeEtcd {
 		return func(ctx api.Context, name string) (string, error) {
-			return registry.NamespaceKeyFunc(ctx, prefix, name)
+			if namespaced {
+				return registry.NamespaceKeyFunc(ctx, prefix, name)
+			}
+			return registry.NoNamespaceKeyFunc(ctx, prefix, name)
 		}
 	}
 	return o.TPROptions.Keyer.Key

--- a/pkg/registry/servicecatalog/server/options.go
+++ b/pkg/registry/servicecatalog/server/options.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/storage/etcd"
+	"github.com/kubernetes-incubator/service-catalog/pkg/storage/tpr"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/rest"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/registry/generic/registry"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
+	"k8s.io/kubernetes/pkg/storage/storagebackend/factory"
+)
+
+type errUnsupportedStorageType struct {
+	t StorageType
+}
+
+func (e errUnsupportedStorageType) Error() string {
+	return fmt.Sprintf("unsupported storage type %s", e.t)
+}
+
+// StorageType represents the type of storage a storage interface should use
+type StorageType string
+
+// StorageTypeFromString converts s to a valid StorageType. Returns StorageType("") and a non-nil
+// error if s names an invalid or unsupported storage type
+func StorageTypeFromString(s string) (StorageType, error) {
+	switch s {
+	case StorageTypeTPR.String():
+		return StorageTypeTPR, nil
+	case StorageTypeEtcd.String():
+		return StorageTypeEtcd, nil
+	default:
+		return StorageType(""), errUnsupportedStorageType{t: StorageType(s)}
+	}
+}
+
+func (s StorageType) String() string {
+	return string(s)
+}
+
+const (
+	// StorageTypeTPR indicates a storage interface should use TPRs
+	// TPRs
+	StorageTypeTPR StorageType = "tpr"
+	// StorageTypeEtcd indicates a storage interface should use etcd
+	StorageTypeEtcd StorageType = "etcd"
+)
+
+// Options is the extension of a generic.RESTOptions struct, complete with service-catalog
+// specific things
+type Options struct {
+	EtcdOptions etcd.Options
+	TPROptions  tpr.Options
+	storageType StorageType
+}
+
+// NewOptions returns a new Options with the given parameters
+func NewOptions(
+	etcdOpts etcd.Options,
+	tprOpts tpr.Options,
+	sType StorageType,
+) *Options {
+	return &Options{
+		EtcdOptions: etcdOpts,
+		TPROptions:  tprOpts,
+		storageType: sType,
+	}
+}
+
+// StorageType returns the storage type the rest server should use, or an error if an unsupported
+// storage type is indicated
+func (o Options) StorageType() (StorageType, error) {
+	switch o.storageType {
+	case StorageTypeTPR, StorageTypeEtcd:
+		return o.storageType, nil
+	default:
+		return StorageType(""), errUnsupportedStorageType{t: o.storageType}
+	}
+}
+
+// ResourcePrefix gets the resource prefix of all etcd keys
+func (o Options) ResourcePrefix() string {
+	return o.EtcdOptions.RESTOptions.ResourcePrefix
+}
+
+// KeyRootFunc returns the appropriate key root function for the storage type in o.
+// This function produces a path that etcd or TPR storage understands, to the root of the resource
+// by combining the namespace in the context with the given prefix
+func (o Options) KeyRootFunc() func(api.Context) string {
+	prefix := o.ResourcePrefix()
+	sType, err := o.StorageType()
+	if err != nil {
+		return nil
+	}
+	if sType == StorageTypeEtcd {
+		return func(ctx api.Context) string {
+			return registry.NamespaceKeyRootFunc(ctx, prefix)
+		}
+	}
+	return o.TPROptions.Keyer.KeyRoot
+}
+
+// KeyFunc returns the appropriate key function for the storage type in o.
+// This function should produce a path that etcd or TPR storage understands, to the resource
+// by combining the namespace in the context with the given prefix
+func (o Options) KeyFunc() func(api.Context, string) (string, error) {
+	prefix := o.ResourcePrefix()
+	sType, err := o.StorageType()
+	if err != nil {
+		return nil
+	}
+	if sType == StorageTypeEtcd {
+		return func(ctx api.Context, name string) (string, error) {
+			return registry.NamespaceKeyFunc(ctx, prefix, name)
+		}
+	}
+	return o.TPROptions.Keyer.Key
+}
+
+// GetStorage returns the storage from the given parameters
+func (o Options) GetStorage(
+	capacity int,
+	objectType runtime.Object,
+	resourcePrefix string,
+	scopeStrategy rest.NamespaceScopedStrategy,
+	newListFunc func() runtime.Object,
+	getAttrsFunc func(runtime.Object) (labels.Set, fields.Set, error),
+	trigger storage.TriggerPublisherFunc,
+) (storage.Interface, factory.DestroyFunc) {
+	if o.storageType == StorageTypeEtcd {
+		etcdRESTOpts := o.EtcdOptions.RESTOptions
+		return etcdRESTOpts.Decorator(
+			etcdRESTOpts.StorageConfig,
+			capacity,
+			objectType,
+			resourcePrefix,
+			scopeStrategy,
+			newListFunc,
+			getAttrsFunc,
+			trigger,
+		)
+	}
+	return tpr.NewStorageInterface(o.TPROptions)
+}

--- a/pkg/registry/servicecatalog/server/options_test.go
+++ b/pkg/registry/servicecatalog/server/options_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/storage/etcd"
+	"github.com/kubernetes-incubator/service-catalog/pkg/storage/tpr"
+)
+
+func TestNewOptions(t *testing.T) {
+	origStorageType := StorageTypeEtcd
+	opts := NewOptions(etcd.Options{}, tpr.Options{}, origStorageType)
+	retStorageType, err := opts.StorageType()
+	if err != nil {
+		t.Fatalf("getting storage type (%s)", err)
+	}
+	if origStorageType != retStorageType {
+		t.Fatalf("expected storage type %s, got %s",
+			origStorageType,
+			retStorageType,
+		)
+	}
+
+}

--- a/pkg/registry/servicecatalog/serviceclass/storage.go
+++ b/pkg/registry/servicecatalog/serviceclass/storage.go
@@ -120,7 +120,7 @@ func NewStorage(opts server.Options) rest.Storage {
 		// NewListFunc returns an object capable of storing results of an etcd list.
 		NewListFunc: NewList,
 		KeyRootFunc: opts.KeyRootFunc(),
-		KeyFunc:     opts.KeyFunc(),
+		KeyFunc:     opts.KeyFunc(false),
 		// Retrieve the name field of the resource.
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return tpr.GetAccessor().Name(obj)

--- a/pkg/registry/servicecatalog/serviceclass/storage.go
+++ b/pkg/registry/servicecatalog/serviceclass/storage.go
@@ -17,19 +17,63 @@ limitations under the License.
 package serviceclass
 
 import (
+	"errors"
 	"fmt"
 
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	"github.com/kubernetes-incubator/service-catalog/pkg/storage/tpr"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/rest"
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/storage"
-
-	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 )
+
+var (
+	errNotAServiceClass = errors.New("not a service class")
+)
+
+// NewSingular returns a new shell of a service class, according to the given namespace and
+// name
+func NewSingular(ns, name string) runtime.Object {
+	return &servicecatalog.ServiceClass{
+		TypeMeta: metav1.TypeMeta{
+			Kind: tpr.ServiceClassKind.String(),
+		},
+		ObjectMeta: api.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+	}
+}
+
+// EmptyObject returns an empty service class
+func EmptyObject() runtime.Object {
+	return &servicecatalog.ServiceClass{}
+}
+
+// NewList returns a new shell of a service class list
+func NewList() runtime.Object {
+	return &servicecatalog.ServiceClassList{
+		TypeMeta: metav1.TypeMeta{
+			Kind: tpr.ServiceClassListKind.String(),
+		},
+	}
+}
+
+// CheckObject returns a non-nil error if obj is not a service class object
+func CheckObject(obj runtime.Object) error {
+	_, ok := obj.(*servicecatalog.ServiceClass)
+	if !ok {
+		return errNotAServiceClass
+	}
+	return nil
+}
 
 // Match determines whether an Instance matches a field and label
 // selector.
@@ -41,8 +85,8 @@ func Match(label labels.Selector, field fields.Selector) storage.SelectionPredic
 	}
 }
 
-// ToSelectableFields returns a field set that represents the object for matching purposes.
-func ToSelectableFields(serviceClass *servicecatalog.ServiceClass) fields.Set {
+// toSelectableFields returns a field set that represents the object for matching purposes.
+func toSelectableFields(serviceClass *servicecatalog.ServiceClass) fields.Set {
 	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(&serviceClass.ObjectMeta, true)
 	return generic.MergeFieldsSets(objectMetaFieldsSet, nil)
 }
@@ -53,45 +97,33 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 	if !ok {
 		return nil, nil, fmt.Errorf("given object is not a ServiceClass")
 	}
-	return labels.Set(serviceclass.ObjectMeta.Labels), ToSelectableFields(serviceclass), nil
+	return labels.Set(serviceclass.ObjectMeta.Labels), toSelectableFields(serviceclass), nil
 }
 
 // NewStorage creates a new rest.Storage responsible for accessing ServiceClass
 // resources
-func NewStorage(opts generic.RESTOptions) rest.Storage {
-	prefix := "/" + opts.ResourcePrefix
+func NewStorage(opts server.Options) rest.Storage {
+	prefix := "/" + opts.ResourcePrefix()
 
-	newListFunc := func() runtime.Object { return &servicecatalog.ServiceClassList{} }
-	storageInterface, dFunc := opts.Decorator(
-		opts.StorageConfig,
+	storageInterface, dFunc := opts.GetStorage(
 		1000,
 		&servicecatalog.ServiceClass{},
 		prefix,
 		serviceclassRESTStrategies,
-		newListFunc,
+		NewList,
 		nil,
 		storage.NoTriggerPublisher,
 	)
 
 	store := registry.Store{
-		NewFunc: func() runtime.Object {
-			return &servicecatalog.ServiceClass{}
-		},
+		NewFunc: EmptyObject,
 		// NewListFunc returns an object capable of storing results of an etcd list.
-		NewListFunc: newListFunc,
-		// KeyRootFunc places this resource at the prefix for this resource;
-		// not namespaced.
-		KeyRootFunc: func(ctx api.Context) string {
-			return prefix
-		},
-		// Produces a path that etcd understands by combining the object's
-		// name with the prefix.
-		KeyFunc: func(ctx api.Context, name string) (string, error) {
-			return registry.NoNamespaceKeyFunc(ctx, prefix, name)
-		},
+		NewListFunc: NewList,
+		KeyRootFunc: opts.KeyRootFunc(),
+		KeyFunc:     opts.KeyFunc(),
 		// Retrieve the name field of the resource.
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*servicecatalog.ServiceClass).Name, nil
+			return tpr.GetAccessor().Name(obj)
 		},
 		// Used to match objects based on labels/fields for list.
 		PredicateFunc: Match,

--- a/pkg/registry/servicecatalog/serviceclass/strategy.go
+++ b/pkg/registry/servicecatalog/serviceclass/strategy.go
@@ -29,7 +29,13 @@ import (
 	scv "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation"
 )
 
-// implements interfaces RESTCreateStrategy, RESTUpdateStrategy, RESTDeleteStrategy
+// NewScopeStrategy returns a new NamespaceScopedStrategy for service classes
+func NewScopeStrategy() rest.NamespaceScopedStrategy {
+	return serviceclassRESTStrategies
+}
+
+// implements interfaces RESTCreateStrategy, RESTUpdateStrategy, RESTDeleteStrategy,
+// NamespaceScopedStrategy
 type serviceclassRESTStrategy struct {
 	runtime.ObjectTyper // inherit ObjectKinds method
 	kapi.NameGenerator  // GenerateName method for CreateStrategy

--- a/pkg/storage/etcd/options.go
+++ b/pkg/storage/etcd/options.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"k8s.io/kubernetes/pkg/api/rest"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
+)
+
+// Options is the set of options necessary for creating etcd-backed storage
+type Options struct {
+	RESTOptions   generic.RESTOptions
+	Capacity      int
+	ObjectType    runtime.Object
+	ScopeStrategy rest.NamespaceScopedStrategy
+	NewListFunc   func() runtime.Object
+	GetAttrsFunc  func(runtime.Object) (labels.Set, fields.Set, error)
+	Trigger       storage.TriggerPublisherFunc
+}

--- a/pkg/storage/tpr/client.go
+++ b/pkg/storage/tpr/client.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tpr
+
+import (
+	"fmt"
+	"k8s.io/kubernetes/pkg/client/typed/dynamic"
+)
+
+type errUnsupportedResource struct {
+	kind Kind
+}
+
+func (e errUnsupportedResource) Error() string {
+	return fmt.Sprintf("unsupported resource %s", e.kind)
+}
+
+// GetResourceClient returns the *dynamic.ResourceClient for a given resource type
+func GetResourceClient(cl *dynamic.Client, kind Kind, namespace string) (*dynamic.ResourceClient, error) {
+	switch kind {
+	case ServiceInstanceKind, ServiceInstanceListKind:
+		return cl.Resource(&ServiceInstanceResource, namespace), nil
+	case ServiceBindingKind, ServiceBindingListKind:
+		return cl.Resource(&ServiceBindingResource, namespace), nil
+	case ServiceBrokerKind, ServiceBrokerListKind:
+		return cl.Resource(&ServiceBrokerResource, namespace), nil
+	case ServiceClassKind, ServiceClassListKind:
+		return cl.Resource(&ServiceClassResource, namespace), nil
+	default:
+		return nil, errUnsupportedResource{kind: kind}
+	}
+}

--- a/pkg/storage/tpr/install_types.go
+++ b/pkg/storage/tpr/install_types.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tpr
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+)
+
+// this is the set of third party resources to be installed. each key is the name of the TPR to
+// install, and each value is the resource to install
+//
+var thirdPartyResources = []v1beta1.ThirdPartyResource{
+	serviceBrokerTPR,
+	serviceClassTPR,
+	serviceInstanceTPR,
+	serviceBindingTPR,
+}
+
+// InstallTypes installs all third party resource types to the cluster
+func InstallTypes(cs clientset.Interface) error {
+	tprs := cs.Extensions().ThirdPartyResources()
+	for _, tpr := range thirdPartyResources {
+		glog.Infof("Checking for existence of %s", tpr.Name)
+		if _, err := tprs.Get(tpr.Name); err == nil {
+			glog.Infof("Found existing TPR %s", tpr.Name)
+			continue
+		}
+
+		glog.Infof("Creating Third Party Resource Type: %s", tpr.Name)
+		if _, err := tprs.Create(&tpr); err != nil {
+			glog.Errorf("Failed to create Third Party Resource Type: %s (%s))", tpr.Name, err)
+			return err
+		}
+		glog.Infof("Created TPR '%s'", tpr.Name)
+		// There can be a delay, so poll until it's ready to go...
+		for i := 0; i < 30; i++ {
+			if _, err := tprs.Get(tpr.Name); err != nil {
+				glog.Infof("TPR %s is ready", tpr.Name)
+				break
+			}
+			glog.Infof("TPR %s is not ready yet... waiting...", tpr.Name)
+			time.Sleep(1 * time.Second)
+		}
+	}
+	return nil
+}

--- a/pkg/storage/tpr/keyer.go
+++ b/pkg/storage/tpr/keyer.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tpr
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+var (
+	errEmptyKey = errors.New("empty key")
+)
+
+type errInvalidKey struct {
+	k string
+}
+
+func (e errInvalidKey) Error() string {
+	return fmt.Sprintf("invalid key '%s'", e.k)
+}
+
+// Keyer is a containing struct for
+type Keyer struct {
+	DefaultNamespace string
+	ResourceName     string
+	Separator        string
+}
+
+// KeyRoot is a (k8s.io/kubernetes/pkg/registry/generic/registry).Store compatible function to
+// get the key root to be passed to a third party resource based storage Interface.
+//
+// It is meant to be passed to a Store's KeyRootFunc field, so that a TPR based storage interface
+// can parse the namespace and name from fields that it is later given.
+//
+// The returned string will never be empty is k.DefaultNamespace is not empty
+func (k Keyer) KeyRoot(ctx api.Context) string {
+	ns, ok := api.NamespaceFrom(ctx)
+	if ok && len(ns) > 0 {
+		return ns
+	}
+	return k.DefaultNamespace
+}
+
+// Key is a (k8s.io/kubernetes/pkg/registry/generic/registry).Store compatible function to
+// get the key to be passed to a third party resource based storage Interface.
+//
+// It is meant to be passed to a Store's KeyRoot field, so that a TPR based storage interface
+// can parse the namespace and name from fields that it is later given
+func (k Keyer) Key(ctx api.Context, name string) (string, error) {
+	root := k.KeyRoot(ctx)
+	return strings.Join([]string{root, name}, k.Separator), nil
+}
+
+// NamespaceAndNameFromKey returns the namespace (or an empty string if there wasn't one) and
+// name for a given etcd-style key. This function is intended to be used in a TPR based
+// storage.Interface that uses k.KeyRoot and k.Key to construct its etcd keys.
+//
+// The first return value is the namespace, and may be empty if the key represents a
+// namespace-less resource. The second return value is the name and will not be empty if the
+// error is nil. The error will be non-nil if the key was malformed, in which case all other
+// return values will be empty strings.
+func (k Keyer) NamespaceAndNameFromKey(key string) (string, string, error) {
+	spl := strings.Split(key, k.Separator)
+	splLen := len(spl)
+	if splLen == 1 {
+		// single slice entry is namespace-less, so use the default
+		return k.DefaultNamespace, key, nil
+	} else if splLen == 2 {
+		// two slice entries has a namespace
+		return spl[0], spl[1], nil
+	}
+
+	return "", "", errInvalidKey{k: key}
+}

--- a/pkg/storage/tpr/keyer_test.go
+++ b/pkg/storage/tpr/keyer_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,13 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog
-// +k8s:openapi-gen=true
-// +k8s:defaulter-gen=TypeMeta
+package tpr
 
-// +groupName=servicecatalog.k8s.io
+import (
+	"testing"
+)
 
-// Package v1alpha1 contains generated v1alpha1 types for the service catalog API server
-// and controller
-package v1alpha1
+func TestKeyRoot(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestKey(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestNamespaceAndNameFromKey(t *testing.T) {
+	t.Skip("TODO")
+}

--- a/pkg/storage/tpr/kinds.go
+++ b/pkg/storage/tpr/kinds.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tpr
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	groupName = "servicecatalog.k8s.io"
+)
+
+func withGroupName(name string) string {
+	return fmt.Sprintf("%s.%s", name, groupName)
+}
+
+// Kind represents the kind of a third party resource. This type implements fmt.Stringer
+type Kind string
+
+// String is the fmt.Stringer interface implementation
+func (k Kind) String() string {
+	return string(k)
+}
+
+// TPRName returns the lowercase name, suitable for fetching resources of this kind
+func (k Kind) TPRName() string {
+	return strings.ToLower(k.String())
+}
+
+const (
+	// ServiceBrokerKind is the name of a Service Broker resource, a Kubernetes third party resource.
+	ServiceBrokerKind Kind = "Broker"
+
+	// ServiceBrokerListKind is the name of a list of Service Broker resources
+	ServiceBrokerListKind Kind = "BrokerList"
+
+	// ServiceBindingKind is the name of a Service Binding resource, a Kubernetes third party resource.
+	ServiceBindingKind Kind = "Binding"
+
+	// ServiceBindingListKind is the name for lists of Service Bindings
+	ServiceBindingListKind Kind = "BindingList"
+
+	// ServiceClassKind is the name of a Service Class resource, a Kubernetes third party resource.
+	ServiceClassKind Kind = "ServiceClass"
+
+	// ServiceClassListKind is the name of a list of service class resources
+	ServiceClassListKind Kind = "ServiceClassList"
+
+	// ServiceInstanceKind is the name of a Service Instance resource, a Kubernetes third party resource.
+	ServiceInstanceKind Kind = "Instance"
+
+	// ServiceInstanceListKind is the name of a list of service instance resources
+	ServiceInstanceListKind Kind = "InstanceList"
+)

--- a/pkg/storage/tpr/metadata_access.go
+++ b/pkg/storage/tpr/metadata_access.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tpr
+
+import (
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+var (
+	accessor   = meta.NewAccessor()
+	selfLinker = runtime.SelfLinker(accessor)
+)
+
+// GetAccessor returns a MetadataAccessor to fetch general information on metadata of
+// runtime.Object types
+func GetAccessor() meta.MetadataAccessor {
+	return accessor
+}
+
+// GetNamespace returns the namespace for the given object, if there is one. If not, returns
+// the empty string and a non-nil error
+func GetNamespace(obj runtime.Object) (string, error) {
+	return selfLinker.Namespace(obj)
+}

--- a/pkg/storage/tpr/options.go
+++ b/pkg/storage/tpr/options.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tpr
+
+import (
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// Options is the set of options to create a new TPR storage interface
+type Options struct {
+	RESTOptions      generic.RESTOptions
+	DefaultNamespace string
+	Client           clientset.Interface
+	SingularKind     Kind
+	NewSingularFunc  func(string, string) runtime.Object
+	ListKind         Kind
+	NewListFunc      func() runtime.Object
+	CheckObjectFunc  func(runtime.Object) error
+	DestroyFunc      func()
+	Keyer            Keyer
+}

--- a/pkg/storage/tpr/resources.go
+++ b/pkg/storage/tpr/resources.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tpr
+
+import (
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
+)
+
+const (
+	tprKind    = "ThirdPartyResource"
+	tprVersion = "v1alpha1"
+)
+
+// ServiceInstanceResource represents the API resource for the service instance third
+// party resource
+var ServiceInstanceResource = metav1.APIResource{
+	Name:       ServiceInstanceKind.TPRName(),
+	Namespaced: true,
+}
+
+// ServiceBindingResource represents the API resource for the service binding third
+// party resource
+var ServiceBindingResource = metav1.APIResource{
+	Name:       ServiceBindingKind.TPRName(),
+	Namespaced: true,
+}
+
+// ServiceBrokerResource represents the API resource for the service broker third
+// party resource
+var ServiceBrokerResource = metav1.APIResource{
+	Name:       ServiceBrokerKind.TPRName(),
+	Namespaced: true,
+}
+
+// ServiceClassResource represents the API resource for the service class third
+// party resource
+var ServiceClassResource = metav1.APIResource{
+	// ServiceClass is the kind, but TPRName converts it to 'serviceclass'. For now, just hard-code
+	// it here
+	Name:       "service-class",
+	Namespaced: true,
+}
+
+// ServiceInstanceResource represents the API resource for the service instance third
+// party resource
+var serviceInstanceTPR = v1beta1.ThirdPartyResource{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       tprKind,
+		APIVersion: tprVersion,
+	},
+	ObjectMeta: v1.ObjectMeta{
+		Name: withGroupName(ServiceInstanceKind.TPRName()),
+	},
+	Versions: []v1beta1.APIVersion{
+		{Name: tprVersion},
+	},
+}
+
+// ServiceBindingResource represents the API resource for the service binding third
+// party resource
+var serviceBindingTPR = v1beta1.ThirdPartyResource{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       tprKind,
+		APIVersion: tprVersion,
+	},
+	ObjectMeta: v1.ObjectMeta{
+		Name: withGroupName(ServiceBindingKind.TPRName()),
+	},
+	Versions: []v1beta1.APIVersion{
+		{Name: tprVersion},
+	},
+}
+
+// ServiceBrokerResource represents the API resource for the service broker third
+// party resource
+var serviceBrokerTPR = v1beta1.ThirdPartyResource{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       tprKind,
+		APIVersion: tprVersion,
+	},
+	ObjectMeta: v1.ObjectMeta{
+		Name: withGroupName(ServiceBrokerKind.TPRName()),
+	},
+	Versions: []v1beta1.APIVersion{
+		{Name: tprVersion},
+	},
+}
+
+// ServiceClassResource represents the API resource for the service class third
+// party resource
+var serviceClassTPR = v1beta1.ThirdPartyResource{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       tprKind,
+		APIVersion: tprVersion,
+	},
+	// ServiceClass is the kind, but TPRName converts it to 'serviceclass'. For now, just hard-code
+	// it here
+	ObjectMeta: v1.ObjectMeta{
+		Name: withGroupName("ServiceClass"),
+	},
+	Versions: []v1beta1.APIVersion{
+		{Name: tprVersion},
+	},
+}

--- a/pkg/storage/tpr/storage_interface.go
+++ b/pkg/storage/tpr/storage_interface.go
@@ -144,7 +144,7 @@ func (t *storageInterface) Delete(
 		name,
 	)
 	if err := req.Do().Error(); err != nil {
-		glog.Errorf("error deleting", err)
+		glog.Errorf("error deleting (%s)", err)
 		return err
 	}
 
@@ -195,7 +195,7 @@ func watchFilterer(t *storageInterface, ns string) func(watch.Event) (watch.Even
 			return in, false
 		}
 		if err := FromUnstructured(unstruc, out); err != nil {
-			glog.Errorf("%s object wasn't a %s (%s)", t.singularKind, err)
+			glog.Errorf("object wasn't a %s (%s)", t.singularKind, err)
 			return in, false
 		}
 		return watch.Event{

--- a/pkg/storage/tpr/storage_interface.go
+++ b/pkg/storage/tpr/storage_interface.go
@@ -1,0 +1,391 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tpr
+
+import (
+	"errors"
+
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	"k8s.io/kubernetes/pkg/conversion"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
+	"k8s.io/kubernetes/pkg/storage/storagebackend/factory"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+var (
+	errNotImplemented = errors.New("not implemented for third party resources")
+)
+
+type storageInterface struct {
+	codec            runtime.Codec
+	defaultNamespace string
+	cl               clientset.Interface
+	singularKind     Kind
+	singularShell    func(string, string) runtime.Object
+	listKind         Kind
+	listShell        func() runtime.Object
+	checkObject      func(runtime.Object) error
+	decodeKey        func(string) (string, string, error)
+}
+
+// NewStorageInterface creates a new TPR-based storage.Interface implementation
+func NewStorageInterface(opts Options) (storage.Interface, factory.DestroyFunc) {
+	return &storageInterface{
+		codec:            opts.RESTOptions.StorageConfig.Codec,
+		defaultNamespace: opts.DefaultNamespace,
+		cl:               opts.Client,
+		singularKind:     opts.SingularKind,
+		singularShell:    opts.NewSingularFunc,
+		listKind:         opts.ListKind,
+		listShell:        opts.NewListFunc,
+		checkObject:      opts.CheckObjectFunc,
+		decodeKey:        opts.Keyer.NamespaceAndNameFromKey,
+	}, opts.DestroyFunc
+}
+
+// Versioned returns the versioned associated with this interface
+func (t *storageInterface) Versioner() storage.Versioner {
+	return &storageVersioner{
+		singularKind: t.singularKind,
+		listKind:     t.listKind,
+		checkObject:  t.checkObject,
+
+		cl: t.cl,
+	}
+}
+
+// Create adds a new object at a key unless it already exists. 'ttl' is time-to-live
+// in seconds (0 means forever). If no error is returned and out is not nil, out will be
+// set to the read value from database.
+func (t *storageInterface) Create(
+	ctx context.Context,
+	key string,
+	obj,
+	out runtime.Object,
+	ttl uint64,
+) error {
+
+	ns, _, err := t.decodeKey(key)
+	if err != nil {
+		glog.Errorf("decoding key %s (%s)", key, err)
+		return err
+	}
+
+	data, err := runtime.Encode(t.codec, obj)
+	if err != nil {
+		return err
+	}
+
+	req := t.cl.Core().RESTClient().Post().AbsPath(
+		"apis",
+		groupName,
+		tprVersion,
+		"namespaces",
+		ns,
+		t.singularKind.TPRName()+"s",
+	).Body(data)
+
+	var unknown runtime.Unknown
+	if err := req.Do().Into(&unknown); err != nil {
+		glog.Errorf("decoding response (%s)", err)
+		return err
+	}
+
+	if err := decode(t.codec, nil, unknown.Raw, out); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete removes the specified key and returns the value that existed at that spot.
+// If key didn't exist, it will return NotFound storage error.
+//
+// In this implementation, Delete will not write the deleted object back to out
+func (t *storageInterface) Delete(
+	ctx context.Context,
+	key string,
+	out runtime.Object,
+	preconditions *storage.Preconditions,
+) error {
+	ns, name, err := t.decodeKey(key)
+	if err != nil {
+		glog.Errorf("decoding key %s (%s)", key, err)
+		return err
+	}
+	// if ns == "" {
+	// 	glog.Infof("no namespace, defaulting to %s", t.defaultNamespace)
+	// 	ns = t.defaultNamespace
+	// }
+
+	req := t.cl.Core().RESTClient().Delete().AbsPath(
+		"apis",
+		groupName,
+		tprVersion,
+		"namespaces",
+		ns,
+		t.singularKind.TPRName()+"s",
+		name,
+	)
+	if err := req.Do().Error(); err != nil {
+		glog.Errorf("error deleting", err)
+		return err
+	}
+
+	return nil
+}
+
+// Watch begins watching the specified key. Events are decoded into API objects,
+// and any items selected by 'p' are sent down to returned watch.Interface.
+// resourceVersion may be used to specify what version to begin watching,
+// which should be the current resourceVersion, and no longer rv+1
+// (e.g. reconnecting without missing any updates).
+// If resource version is "0", this interface will get current object at given key
+// and send it in an "ADDED" event, before watch starts.
+func (t *storageInterface) Watch(
+	ctx context.Context,
+	key string,
+	resourceVersion string,
+	p storage.SelectionPredicate,
+) (watch.Interface, error) {
+	ns, name, err := t.decodeKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	req := t.cl.Core().RESTClient().Get().AbsPath(
+		"apis",
+		groupName,
+		tprVersion,
+		"namespaces",
+		ns,
+		t.singularKind.TPRName()+"s",
+		name,
+	).Param("watch", "true")
+	watchIface, err := req.Watch()
+	if err != nil {
+		return nil, err
+	}
+	filteredIFace := watch.Filter(watchIface, watchFilterer(t, ns))
+	return filteredIFace, nil
+}
+
+func watchFilterer(t *storageInterface, ns string) func(watch.Event) (watch.Event, bool) {
+	return func(in watch.Event) (watch.Event, bool) {
+		out := t.singularShell(ns, "")
+		unstruc, err := ToUnstructured(in.Object)
+		if err != nil {
+			glog.Errorf("%s object wasn't unstructured (%s)", in.Type, err)
+			return in, false
+		}
+		if err := FromUnstructured(unstruc, out); err != nil {
+			glog.Errorf("%s object wasn't a %s (%s)", t.singularKind, err)
+			return in, false
+		}
+		return watch.Event{
+			Type:   in.Type,
+			Object: out,
+		}, true
+	}
+}
+
+// WatchList begins watching the specified key's items. Items are decoded into API
+// objects and any item selected by 'p' are sent down to returned watch.Interface.
+// resourceVersion may be used to specify what version to begin watching,
+// which should be the current resourceVersion, and no longer rv+1
+// (e.g. reconnecting without missing any updates).
+// If resource version is "0", this interface will list current objects directory defined by key
+// and send them in "ADDED" events, before watch starts.
+func (t *storageInterface) WatchList(
+	ctx context.Context,
+	key string,
+	resourceVersion string,
+	p storage.SelectionPredicate,
+) (watch.Interface, error) {
+	// ns, _, err := t.decodeKey(key)
+	_, _, err := t.decodeKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// cl, err := GetResourceClient(t.cl, t.listKind, ns)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// list := t.listShell()
+	// // servicecatalog.BindingList{
+	// // 	TypeMeta: metav1.TypeMeta{
+	// // 		Kind: ServiceBindingListKind.String(),
+	// // 	},
+	// // }
+	// return cl.Watch(list)
+	return nil, nil
+}
+
+// Get unmarshals json found at key into objPtr. On a not found error, will either
+// return a zero object of the requested type, or an error, depending on ignoreNotFound.
+// Treats empty responses and nil response nodes exactly like a not found error.
+// The returned contents may be delayed, but it is guaranteed that they will
+// be have at least 'resourceVersion'.
+func (t *storageInterface) Get(
+	ctx context.Context,
+	key string,
+	resourceVersion string,
+	objPtr runtime.Object,
+	ignoreNotFound bool,
+) error {
+	ns, name, err := t.decodeKey(key)
+	if err != nil {
+		glog.Errorf("decoding key %s (%s)", key, err)
+		return err
+	}
+	req := t.cl.Core().RESTClient().Get().AbsPath(
+		"apis",
+		groupName,
+		tprVersion,
+		"namespaces",
+		ns,
+		t.singularKind.TPRName()+"s",
+		name,
+	)
+
+	var unknown runtime.Unknown
+	if err := req.Do().Into(&unknown); err != nil {
+		glog.Errorf("decoding response (%s)", err)
+		return err
+	}
+
+	if err := decode(t.codec, nil, unknown.Raw, objPtr); err != nil {
+		return nil
+	}
+	return nil
+}
+
+// GetToList unmarshals json found at key and opaque it into *List api object
+// (an object that satisfies the runtime.IsList definition).
+// The returned contents may be delayed, but it is guaranteed that they will
+// be have at least 'resourceVersion'.
+func (t *storageInterface) GetToList(
+	ctx context.Context,
+	key string,
+	resourceVersion string,
+	p storage.SelectionPredicate,
+	listObj runtime.Object,
+) error {
+	return t.List(ctx, key, resourceVersion, p, listObj)
+}
+
+// List unmarshalls jsons found at directory defined by key and opaque them
+// into *List api object (an object that satisfies runtime.IsList definition).
+// The returned contents may be delayed, but it is guaranteed that they will
+// be have at least 'resourceVersion'.
+func (t *storageInterface) List(
+	ctx context.Context,
+	key string,
+	resourceVersion string,
+	p storage.SelectionPredicate,
+	listObj runtime.Object,
+) error {
+	ns, _, err := t.decodeKey(key)
+	if err != nil {
+		glog.Errorf("decoding %s (%s)", key, err)
+		return err
+	}
+
+	req := t.cl.Core().RESTClient().Get().AbsPath(
+		"apis",
+		groupName,
+		tprVersion,
+		"namespaces",
+		ns,
+		t.singularKind.TPRName()+"s",
+	)
+
+	var unknown runtime.Unknown
+	if err := req.Do().Into(&unknown); err != nil {
+		glog.Errorf("doing request (%s)", err)
+		return err
+	}
+
+	if err := decode(t.codec, nil, unknown.Raw, listObj); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GuaranteedUpdate keeps calling 'tryUpdate()' to update key 'key' (of type 'ptrToType')
+// retrying the update until success if there is index conflict.
+// Note that object passed to tryUpdate may change across invocations of tryUpdate() if
+// other writers are simultaneously updating it, so tryUpdate() needs to take into account
+// the current contents of the object when deciding how the update object should look.
+// If the key doesn't exist, it will return NotFound storage error if ignoreNotFound=false
+// or zero value in 'ptrToType' parameter otherwise.
+// If the object to update has the same value as previous, it won't do any update
+// but will return the object in 'ptrToType' parameter.
+// If 'suggestion' can contain zero or one element - in such case this can be used as
+// a suggestion about the current version of the object to avoid read operation from
+// storage to get it.
+//
+// Example:
+//
+// s := /* implementation of Interface */
+// err := s.GuaranteedUpdate(
+//     "myKey", &MyType{}, true,
+//     func(input runtime.Object, res ResponseMeta) (runtime.Object, *uint64, error) {
+//       // Before each incovation of the user defined function, "input" is reset to
+//       // current contents for "myKey" in database.
+//       curr := input.(*MyType)  // Guaranteed to succeed.
+//
+//       // Make the modification
+//       curr.Counter++
+//
+//       // Return the modified object - return an error to stop iterating. Return
+//       // a uint64 to alter the TTL on the object, or nil to keep it the same value.
+//       return cur, nil, nil
+//    }
+// })
+func (t *storageInterface) GuaranteedUpdate(
+	ctx context.Context,
+	key string,
+	ptrToType runtime.Object,
+	ignoreNotFound bool,
+	precondtions *storage.Preconditions,
+	tryUpdate storage.UpdateFunc,
+	suggestion ...runtime.Object,
+) error {
+	// TODO: implement
+	return errNotImplemented
+}
+
+func decode(
+	codec runtime.Codec,
+	versioner storage.Versioner,
+	value []byte,
+	objPtr runtime.Object,
+) error {
+	if _, err := conversion.EnforcePtr(objPtr); err != nil {
+		panic("unable to convert output object to pointer")
+	}
+	_, _, err := codec.Decode(value, nil, objPtr)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/storage/tpr/storage_versioner.go
+++ b/pkg/storage/tpr/storage_versioner.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tpr
+
+import (
+	"strconv"
+
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+type storageVersioner struct {
+	singularKind Kind
+	listKind     Kind
+	checkObject  func(runtime.Object) error
+	cl           clientset.Interface
+}
+
+// UpdateObject sets storage metadata into an API object. Returns an error if the object
+// cannot be updated correctly. May return nil if the requested object does not need metadata
+// from database.
+func (t *storageVersioner) UpdateObject(obj runtime.Object, resourceVersion uint64) error {
+	// if err := t.checkObject(obj); err != nil {
+	// 	return err
+	// }
+	// namespace, err := accessor.Namespace(obj)
+	// if err != nil {
+	// 	return err
+	// }
+	// accessor.SetResourceVersion(obj, fmt.Sprintf("%d", resourceVersion))
+	// unstruc, err := ToUnstructured(obj)
+	// if err != nil {
+	// 	return err
+	// }
+	// cl, err := GetResourceClient(t.cl, t.singularKind, namespace)
+	// if err != nil {
+	// 	return err
+	// }
+	// if _, err := cl.Update(unstruc); err != nil {
+	// 	return err
+	// }
+	return nil
+}
+
+// UpdateList sets the resource version into an API list object. Returns an error if the object
+// cannot be updated correctly. May return nil if the requested object does not need metadata
+// from database.
+func (t *storageVersioner) UpdateList(obj runtime.Object, resourceVersion uint64) error {
+	// ns, err := GetNamespace(obj)
+	// if err != nil {
+	// 	return err
+	// }
+	// if rvErr := GetAccessor().SetResourceVersion(
+	// 	obj,
+	// 	strconv.Itoa(int(resourceVersion)),
+	// ); rvErr != nil {
+	// 	return rvErr
+	// }
+	// unstruc, err := ToUnstructured(obj)
+	// if err != nil {
+	// 	return err
+	// }
+	// cl, err := GetResourceClient(t.cl, t.listKind, ns)
+	// if err != nil {
+	// 	return err
+	// }
+	// if _, err := cl.Update(unstruc); err != nil {
+	// 	return err
+	// }
+	return nil
+}
+
+// ObjectResourceVersion returns the resource version (for persistence) of the specified object.
+// Should return an error if the specified object does not have a persistable version.
+func (t *storageVersioner) ObjectResourceVersion(obj runtime.Object) (uint64, error) {
+	vsnStr, err := GetAccessor().ResourceVersion(obj)
+	if err != nil {
+		return 0, err
+	}
+	ret, err := strconv.ParseUint(vsnStr, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return ret, nil
+}

--- a/pkg/storage/tpr/tpr_converter.go
+++ b/pkg/storage/tpr/tpr_converter.go
@@ -22,13 +22,6 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
-func JSONBytesToObj(in []byte, out runtime.Object) error {
-	if err := json.Unmarshal(in, out); err != nil {
-		return err
-	}
-	return nil
-}
-
 // FromUnstructured converts o, a Kubernetes Third Party Resource type, into a
 // *runtime.Unstructured and writes it to object. Returns a non-nil error is there were any issues
 // with the conversion
@@ -38,18 +31,6 @@ func FromUnstructured(in *runtime.Unstructured, out runtime.Object) error {
 		return err
 	}
 
-	if err := json.Unmarshal(b, out); err != nil {
-		return err
-	}
-	return nil
-}
-
-// FromUnstructuredList converts a list of *runtime.Unstructured into a runtime.Object
-func FromUnstructuredList(in *runtime.UnstructuredList, out runtime.Object) error {
-	b, err := json.Marshal(in)
-	if err != nil {
-		return err
-	}
 	if err := json.Unmarshal(b, out); err != nil {
 		return err
 	}

--- a/pkg/storage/tpr/tpr_converter.go
+++ b/pkg/storage/tpr/tpr_converter.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tpr
+
+import (
+	"encoding/json"
+
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func JSONBytesToObj(in []byte, out runtime.Object) error {
+	if err := json.Unmarshal(in, out); err != nil {
+		return err
+	}
+	return nil
+}
+
+// FromUnstructured converts o, a Kubernetes Third Party Resource type, into a
+// *runtime.Unstructured and writes it to object. Returns a non-nil error is there were any issues
+// with the conversion
+func FromUnstructured(in *runtime.Unstructured, out runtime.Object) error {
+	b, err := json.Marshal(in.Object)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(b, out); err != nil {
+		return err
+	}
+	return nil
+}
+
+// FromUnstructuredList converts a list of *runtime.Unstructured into a runtime.Object
+func FromUnstructuredList(in *runtime.UnstructuredList, out runtime.Object) error {
+	b, err := json.Marshal(in)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(b, out); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ToUnstructured converts in (which should be a Service Catalog third party object type) into a
+// runtime.Unstructured for use in writing to Kubernetes
+func ToUnstructured(in runtime.Object) (*runtime.Unstructured, error) {
+	m, err := json.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+	var ret runtime.Unstructured
+	err = json.Unmarshal(m, &ret)
+	if err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}

--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -119,24 +119,33 @@ func TestBrokerClient(t *testing.T) {
 
 	// start from scratch
 	brokers, err := brokerClient.List(v1.ListOptions{})
+	if err != nil {
+		t.Fatalf("error listing brokers (%s)", err)
+	}
 	if len(brokers.Items) > 0 {
 		t.Fatalf("brokers should not exist on start, had %v brokers", len(brokers.Items))
 	}
 
 	brokerServer, err := brokerClient.Create(broker)
 	if nil != err {
-		t.Fatal("error creating the broker", broker)
+		t.Fatalf("error creating the broker '%s' (%s)", broker, err)
 	}
 	if broker.Name != brokerServer.Name {
 		t.Fatalf("didn't get the same broker back from the server \n%+v\n%+v", broker, brokerServer)
 	}
 
 	brokers, err = brokerClient.List(v1.ListOptions{})
+	if err != nil {
+		t.Fatalf("error listing brokers (%s)", err)
+	}
 	if 1 != len(brokers.Items) {
 		t.Fatalf("should have exactly one broker, had %v brokers", len(brokers.Items))
 	}
 
 	brokerServer, err = brokerClient.Get(broker.Name)
+	if err != nil {
+		t.Fatalf("error getting broker %s (%s)", broker.Name, err)
+	}
 	if broker.Name != brokerServer.Name &&
 		broker.ResourceVersion == brokerServer.ResourceVersion {
 		t.Fatalf("didn't get the same broker back from the server \n%+v\n%+v", broker, brokerServer)
@@ -233,6 +242,9 @@ func TestServiceClassClient(t *testing.T) {
 
 	// start from scratch
 	serviceClasses, err := serviceClassClient.List(v1.ListOptions{})
+	if err != nil {
+		t.Fatalf("error listing service classes (%s)", err)
+	}
 	if len(serviceClasses.Items) > 0 {
 		t.Fatalf("serviceClasses should not exist on start, had %v serviceClasses", len(serviceClasses.Items))
 	}
@@ -246,11 +258,17 @@ func TestServiceClassClient(t *testing.T) {
 	}
 
 	serviceClasses, err = serviceClassClient.List(v1.ListOptions{})
+	if err != nil {
+		t.Fatalf("error listing service classes (%s)", err)
+	}
 	if 1 != len(serviceClasses.Items) {
 		t.Fatalf("should have exactly one ServiceClass, had %v ServiceClasses", len(serviceClasses.Items))
 	}
 
 	serviceClassAtServer, err = serviceClassClient.Get(serviceClass.Name)
+	if err != nil {
+		t.Fatalf("error listing service classes (%s)", err)
+	}
 	if serviceClassAtServer.Name != serviceClass.Name &&
 		serviceClass.ResourceVersion == serviceClassAtServer.ResourceVersion {
 		t.Fatalf("didn't get the same ServiceClass back from the server \n%+v\n%+v", serviceClass, serviceClassAtServer)
@@ -294,6 +312,9 @@ func TestInstanceClient(t *testing.T) {
 	}
 
 	instances, err := instanceClient.List(v1.ListOptions{})
+	if err != nil {
+		t.Fatalf("error listing instances (%s)", err)
+	}
 	if len(instances.Items) > 0 {
 		t.Fatalf("instances should not exist on start, had %v instances", len(instances.Items))
 	}
@@ -307,11 +328,17 @@ func TestInstanceClient(t *testing.T) {
 	}
 
 	instances, err = instanceClient.List(v1.ListOptions{})
+	if err != nil {
+		t.Fatalf("error listing instances (%s)", err)
+	}
 	if 1 != len(instances.Items) {
 		t.Fatalf("should have exactly one instance, had %v instances", len(instances.Items))
 	}
 
 	instanceServer, err = instanceClient.Get(instance.Name)
+	if err != nil {
+		t.Fatalf("error getting instance (%s)", err)
+	}
 	if instanceServer.Name != instance.Name &&
 		instanceServer.ResourceVersion == instance.ResourceVersion {
 		t.Fatalf("didn't get the same instance back from the server \n%+v\n%+v", instance, instanceServer)
@@ -382,6 +409,9 @@ func TestBindingClient(t *testing.T) {
 	}
 
 	bindings, err := bindingClient.List(v1.ListOptions{})
+	if err != nil {
+		t.Fatalf("error listing bindings (%s)", err)
+	}
 	if len(bindings.Items) > 0 {
 		t.Fatalf("bindings should not exist on start, had %v bindings", len(bindings.Items))
 	}
@@ -395,11 +425,17 @@ func TestBindingClient(t *testing.T) {
 	}
 
 	bindings, err = bindingClient.List(v1.ListOptions{})
+	if err != nil {
+		t.Fatalf("error listing bindings (%s)", err)
+	}
 	if 1 != len(bindings.Items) {
 		t.Fatalf("should have exactly one binding, had %v bindings", len(bindings.Items))
 	}
 
 	bindingServer, err = bindingClient.Get(binding.Name)
+	if err != nil {
+		t.Fatalf("error getting binding (%s)", err)
+	}
 	if bindingServer.Name != binding.Name &&
 		bindingServer.ResourceVersion == binding.ResourceVersion {
 		t.Fatalf("didn't get the same binding back from the server \n%+v\n%+v", binding, bindingServer)

--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"testing"
 	"time"
@@ -36,8 +37,12 @@ import (
 	servicecatalogclient "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
 )
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
 func getFreshApiserverAndClient(t *testing.T) (servicecatalogclient.Interface, func()) {
-	securePort := 65535
+	securePort := rand.Intn(35534) + 3000
 	serverIP := fmt.Sprintf("https://localhost:%d", securePort)
 	stopCh := make(chan struct{})
 	serverFailed := make(chan struct{})

--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -50,17 +50,22 @@ func getFreshApiserverAndClient(t *testing.T) (servicecatalogclient.Interface, f
 
 	secureServingOptions := genericserveroptions.NewSecureServingOptions()
 	go func() {
+
 		options := &server.ServiceCatalogServerOptions{
+			StorageTypeString:       "etcd",
 			GenericServerRunOptions: genericserveroptions.NewServerRunOptions(),
 			SecureServingOptions:    secureServingOptions,
-			EtcdOptions:             genericserveroptions.NewEtcdOptions(),
-			AuthenticationOptions:   genericserveroptions.NewDelegatingAuthenticationOptions(),
-			AuthorizationOptions:    genericserveroptions.NewDelegatingAuthorizationOptions(),
+			EtcdOptions: &server.EtcdOptions{
+				EtcdOptions: genericserveroptions.NewEtcdOptions(),
+			},
+			TPROptions:            server.NewTPROptions(),
+			AuthenticationOptions: genericserveroptions.NewDelegatingAuthenticationOptions(),
+			AuthorizationOptions:  genericserveroptions.NewDelegatingAuthorizationOptions(),
 		}
 		options.SecureServingOptions.ServingOptions.BindPort = securePort
 		options.SecureServingOptions.ServerCert.CertDirectory = certDir
 		options.EtcdOptions.StorageConfig.ServerList = []string{"http://localhost:2379"}
-		if err := options.RunServer(stopCh); err != nil {
+		if err := server.RunServer(options); err != nil {
 			close(serverFailed)
 			t.Fatalf("Error in bringing up the server: %v", err)
 		}


### PR DESCRIPTION
This PR does two major things:

- Refactors multiple layers of the API server to account for both etcd and third party resource (TPR) based backend storage configuration
- Implements a `storage.Interface` for storing `Binding` resource data in TPRs

After this PR is merged, a follow-up should be opened to add support for storing `Broker`s, `ServiceClass`es and `Instances` in TPRs as well. The purpose of this PR is to do the necessary refactors to illustrate TPR support for one API resource type.

Follow-up PRs will add full TPR support for the other 3 resources (`Broker`, `ServiceClass`, and `Instance`)

## TODO

- [x] implementations for all funcs in `./pkg/registry/servicecatalog/binding/{tpr_storage_interface.go,tpr_storage_versioner.go}`
    - [x] copy code from the TPR-based `(./pkg/apiclient).APIClient` implementation (including tests) into `./pkg/storage/tpr`
        - This TODO is to insulate from the large refactoring changes that @pmorie and others will be doing to the controller
- [x] Add filter to returned `watch.Interface` in the returned `storage.Interface`s (https://github.com/kubernetes-incubator/service-catalog/pull/338/files#r100164716)
- [x] Install the TPRs at the top level of the server (inside the `./cmd` pkg)
    - May want to check TPR existence before installing
- [x] The Switching logic in `./pkg/registry/servicecatalog/binding/storage.go`'s `NewStorage` function should be made generic, so that all 4 object `NewStorage` funcs can reuse it. Additional notes:
- [x] Each `NewStorage` func should call `opts.Decorator` and get back the proper `storage.Interface` and destroy function
- [x] Get create working
- [ ] fix tests

## Follow-up Work

- Complete unit tests for `Keyer` type.
- Implement watch, watchList, storage versioner and guaranteed update    
- Consolidate all functionality that creates empty lists and single objects
    - Includes removing `singularShell` and `listShell` from the TPR storage interface impl
- Accommodate the camel-casing of `ServiceClass`
- Consolidate creation of registry.Store inside of the NewStorage funcs
- Add TPR storage to the integration tests
