### PR TITLE
Simplify the verify target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,15 +158,12 @@ verify: .init .generate_files
 	@#
 	@echo Running golint and go vet:
 	# Exclude the generated (zz) files for now
-	@# The following command echo's the "for" loop to stdout so that it can
-	@# be piped to the "sh" cmd running in the container. This allows the
-	@# "for" to be executed in the container and not on the host. Which means
-	@# we have just one container for everything and not one container per
-	@# file.  The $(subst) removes the "-t" flag from the Docker cmd.
-	@echo for i in \`find $(TOP_SRC_DIRS) -name \*.go \| grep -v generated\`\; do \
-	  golint --set_exit_status \$$i \; \
-	  go vet \$$i \; \
-	done | $(subst -ti,-i,$(DOCKER_CMD)) sh -e
+	@$(DOCKER_CMD) sh -c \
+	  'for i in $$(find $(TOP_SRC_DIRS) -name *.go | grep -v generated); \
+	  do \
+	    golint --set_exit_status $$i; \
+	    go vet $$i; \
+	  done'
 	@#
 	@echo Running repo-infra verify scripts
 	@$(DOCKER_CMD) vendor/github.com/kubernetes/repo-infra/verify/verify-boilerplate.sh --rootdir=. | grep -v generated > .out 2>&1 || true


### PR DESCRIPTION
`make verify` wouldn't run on my machine because gnu text functions like `substr` aren't installed by default on a Mac. (And after a bit of trying, I actually couldn't get those to work via homebrew installation either.)

So, I started looking at that target to see how we could stop using `substr` and actually found that the whole `gofmt` / `golint` process could be dramatically simplified. What was there before gave me a headache when I tried to mentally parse what was going on.

This should be functionally equivalent to what we had before, more readable, and should work in-container or out-of-container on Mac now, as well as Linux.