### PR TITLE
Containerize the last two verification checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,9 +174,9 @@ verify: .init .generate_files
 	@rm .out
 	@#
 	@echo Running href checker:
-	@build/verify-links.sh
+	@$(DOCKER_CMD) build/verify-links.sh
 	@echo Running errexit checker:
-	@build/verify-errexit.sh
+	@$(DOCKER_CMD) build/verify-errexit.sh
 
 format: .init
 	$(DOCKER_CMD) gofmt -w -s $(TOP_SRC_DIRS)


### PR DESCRIPTION
As currently written, these checks fail on a Mac because of differences between GNU sed (Linux) and BSD sed (Mac). Rather than dive deep into resolving those issues, I've prefixed two lines here with `$(DOCKER_CMD)` so that they run in-container, where GNU sed is guaranteed.

No... this won't help anyone wanting to run verification steps out-of-container on Mac, but we've agreed out-of-container build isn't _officially_ supported anyway. This is a step in the right direction at least, because now these can at least be run in-container on Mac. They didn't work at all on Mac prior.