### PR TITLE
Initial version of apiserver pod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,3 +302,5 @@ apiserver-push: apiserver-image
 	[ ! -z "$(REGISTRY)" ] || (echo Set your REGISTRY env var first ; exit 1)
 	docker tag apiserver:$(VERSION) $(REGISTRY)/apiserver:$(VERSION)
 	docker push $(REGISTRY)/apiserver:$(VERSION)
+	docker tag apiserver:$(VERSION) $(REGISTRY)/apiserver:latest
+	docker push $(REGISTRY)/apiserver:latest

--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,7 @@ apiserver-image: build/apiserver/Dockerfile $(BINDIR)/apiserver
 	mkdir -p build/apiserver/tmp
 	cp $(BINDIR)/apiserver build/apiserver/tmp
 	docker build -t apiserver:$(VERSION) build/apiserver
+	docker tag apiserver:$(VERSION) apiserver:latest
 	rm -rf build/apiserver/tmp
 
 # Push our Docker Images to a registry

--- a/contrib/examples/apiserver/apiserver.yaml
+++ b/contrib/examples/apiserver/apiserver.yaml
@@ -8,6 +8,7 @@ spec:
   containers:
   - name: apiserver
     image: apiserver
+    imagePullPolicy: IfNotPresent
     args: 
     - --etcd-servers
     - http://localhost:2379

--- a/contrib/examples/apiserver/apiserver.yaml
+++ b/contrib/examples/apiserver/apiserver.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: service-catalog-apiserver
+  labels:
+    app: apiserver
+spec:
+  containers:
+  - name: apiserver
+    image: apiserver
+    args: 
+    - --etcd-servers
+    - http://localhost:2379
+    - -v
+    - "10"
+    ports:
+    - name: https
+      containerPort: 6443
+  - name: etcd
+    image: gcr.io/google_containers/etcd:3.0.14
+    command: ["etcd"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-catalog-apiserver
+spec:
+  selector:
+    app: apiserver
+  ports:
+  - protocol: TCP
+    port: 6443
+    targetPort: https
+

--- a/contrib/examples/apiserver/apiserver.yaml
+++ b/contrib/examples/apiserver/apiserver.yaml
@@ -18,8 +18,7 @@ spec:
     - name: https
       containerPort: 6443
   - name: etcd
-    image: gcr.io/google_containers/etcd:3.0.14
-    command: ["etcd"]
+    image: quay.io/coreos/etcd:v3.0.17
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/catalog/templates/apiserver.yaml
+++ b/deploy/catalog/templates/apiserver.yaml
@@ -1,0 +1,39 @@
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: apiserver
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: apiserver
+    spec:
+      containers:
+      - name: apiserver
+        image: {{ .Values.registry }}/apiserver:{{ if .Values.k8sApiServerVersion }}{{ .Values.k8sApiServerVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}
+        imagePullPolicy: Always
+        args:
+        - --etcd-servers
+        - http://localhost:2379
+        - -v
+        - "10"
+        ports:
+        - containerPort: 6443
+      - name: etcd
+        image: {{ if .Values.etcdRepository }}{{ .Values.etcdRepository }}{{ else }}{{ "quay.io/coreos/etcd" }}{{ end }}:{{ if .Values.etcdVersion }}{{ .Values.etcdVersion }}{{ else }}{{ "latest" }}{{ end }}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: apiserver
+spec:
+{{ if .Values.debug }}
+  type: LoadBalancer
+{{ end }}
+  selector:
+    app: apiserver
+  ports:
+  - protocol: TCP
+    port: 6443
+    targetPort: 6443

--- a/docs/api-server-walkthrough.md
+++ b/docs/api-server-walkthrough.md
@@ -23,13 +23,23 @@ $ bash -c 'if [ -w /var/run/kubernetes-service-catalog/ ] ; then echo "OK" ; els
 If it fails, create the directory with the user that will run the apiserver.
 
 
-Start with:
+To run it locally, start with:
 
 ```
 # run etcd locally on the default port
 $ etcd 
 # switch to another shell and run
 $ ./bin/apiserver -v 10 --etcd-servers http://localhost:2379
+```
+
+Alternatively, you can run the apiserver and etcd as a pod:
+```
+# run the apiserver & etcd as a pod
+$ kubectl create -f contrib/examples/apiserver/apiserver.yaml
+# enable port forwarding from localhost:6443 to the apiserver
+$ kubectl port-forward service-catalog-apiserver 6443:6443
+# get apiserver certificate from the pod
+$ kubectl cp service-catalog-apiserver:/var/run/kubernetes/apiserver.crt /var/run/kubernetes/apiserver.crt
 ```
 
 In another term check for response from curl.

--- a/docs/api-server-walkthrough.md
+++ b/docs/api-server-walkthrough.md
@@ -39,7 +39,7 @@ $ kubectl create -f contrib/examples/apiserver/apiserver.yaml
 # enable port forwarding from localhost:6443 to the apiserver
 $ kubectl port-forward service-catalog-apiserver 6443:6443
 # get apiserver certificate from the pod
-$ kubectl cp service-catalog-apiserver:/var/run/kubernetes/apiserver.crt /var/run/kubernetes/apiserver.crt
+$ kubectl cp service-catalog-apiserver:/var/run/kubernetes-service-catalog/apiserver.crt /var/run/kubernetes-service-catalog/apiserver.crt
 ```
 
 In another term check for response from curl.


### PR DESCRIPTION
You may need to modify the name of the apiserver image in the pod YAML if you're not actually pushing the image to the registry used by k8s. 