### PR TITLE
add PLATFORM env var support to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,11 @@ NEWEST_GO_FILE = $(shell find $(SRC_DIRS) -name \*.go -exec $(STAT) {} \; \
                    | sort -r | head -n 1 | sed "s/.* //")
 TYPES_FILES    = $(shell find pkg/apis -name types.go)
 GO_VERSION     = 1.7.3
-GO_BUILD       = env GOOS=linux GOARCH=amd64 go build -i $(GOFLAGS) \
+
+PLATFORM?=linux
+ARCH?=amd64
+
+GO_BUILD       = env GOOS=$(PLATFORM) GOARCH=$(ARCH) go build -i $(GOFLAGS) \
                    -ldflags "-X $(SC_PKG)/pkg.VERSION=$(VERSION)"
 BASE_PATH      = $(ROOT:/src/github.com/kubernetes-incubator/service-catalog/=)
 export GOPATH  = $(BASE_PATH):$(ROOT)/vendor


### PR DESCRIPTION
Allow a `PLATFORM` env var to be set in order to allow building for different platforms.

Usage: 
```
$ PLATFORM=darwin make apiserver
docker run --rm -ti -v /home/jvallejo/go/src/github.com/kubernetes-incubator/service-catalog:/go/src/github.com/kubernetes-incubator/service-catalog -v /home/jvallejo/go/src/github.com/kubernetes-incubator/service-catalog/.pkg:/go/pkg scbuildimage env GOOS=darwin GOARCH=amd64 go build -i  -ldflags "-X github.com/kubernetes-incubator/service-catalog/pkg.VERSION=e40e7c0-dirty" -o bin/apiserver github.com/kubernetes-incubator/service-catalog/cmd/apiserver
```

TODO: update docs to mention this

cc @pwittrock 