### PR TITLE
Remove build-before-test logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,14 +246,14 @@ coverage: .init
 	$(DOCKER_CMD) contrib/hack/coverage.sh --html "$(COVERAGE)" \
 	  $(addprefix ./,$(TEST_DIRS))
 
-test: .init build test-unit test-integration
+test: .init test-unit test-integration
 
-test-unit: .init build
+test-unit: .init
 	@echo Running tests:
 	$(DOCKER_CMD) go test $(UNIT_TEST_FLAGS) \
 	  $(addprefix $(SC_PKG)/,$(TEST_DIRS))
 
-test-integration: .init build
+test-integration: .init
 	contrib/hack/setup-kubectl.sh
 	contrib/hack/test-apiserver.sh
 


### PR DESCRIPTION
I LGTM-ed the original PR to add this logic (https://github.com/kubernetes-incubator/service-catalog/pull/326), but that was a mistake.

The current implementation of `make test` builds all executables and then tests all packages. That means that every `make test` invocation requires, in the best case, that we re-scan all files and re-walk the dependency graph. These are expensive operations, especially given our large dependency tree, and need to be done even if there are no misses on the build cache.

In brief, our current `make test` implementation is _always_ slower than it needs to be, regardless of whether the build cache is cold or hot. We are negating the value of the build cache.

Instead of forcing a build before each test, I recommend that everyone just runs `make build` or `make test` periodically to keep the build cache warm. Alternatively, running `go test $(glide nv)` on your host is significantly faster in wall clock time regardless of the state of the build cache. Go as a language and build toolchain was made in part for builds significantly faster than other lanuages.