### PR TITLE
Make build container privileged to avoid changing filesystem SELinux context on host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ ifdef NO_DOCKER
 	scBuildImageTarget =
 else
 	# Mount .pkg as pkg so that we save our cached "go build" output files
-	DOCKER_CMD = docker run --rm -ti -v $(PWD):/go/src/$(SC_PKG) \
+	DOCKER_CMD = docker run --privileged --rm -ti -v $(PWD):/go/src/$(SC_PKG) \
 	  -v $(PWD)/.pkg:/go/pkg scbuildimage
 	scBuildImageTarget = .scBuildImage
 endif


### PR DESCRIPTION
This is the least disruptive way to enable containerized builds with SELinux that doesn't trash the labels on my home directory.  Privileged containers get `spc_t` which is an unconfined type.  Normal containers get SELinux contexts that make them unable to to use files in normal user home directories.  It's possible to just get the SELinux type by setting `security-opt`, but docker recently had a breaking API change that makes it impossible to write a security opt setting that will work on all dockers.  So, for now, privileged container is the way to go without hacking up the makefile to check for docker version (which I would be willing to do if poeple have objections to privileged containers).