### PR TITLE
Add focused clean targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,12 +257,25 @@ test-integration: .init build
 	contrib/hack/setup-kubectl.sh
 	contrib/hack/test-apiserver.sh
 
-clean:
+clean: clean-bin clean-deps clean-build-image clean-generated clean-coverage
+
+clean-bin:
 	rm -rf $(BINDIR)
-	rm -f .init .scBuildImage .generate_files .generate_exes
-	rm -f $(COVERAGE)
-	find $(TOP_SRC_DIRS) -name zz_generated* -exec rm {} \;
+	rm -f .generate_exes
+
+clean-deps:
+	rm -f .init
+
+clean-build-image:
+	rm -f .scBuildImage
 	docker rmi -f scbuildimage > /dev/null 2>&1 || true
+
+clean-generated:
+	rm -f .generate_files
+	find $(TOP_SRC_DIRS) -name zz_generated* -exec rm {} \;
+
+clean-coverage:
+	rm -f $(COVERAGE)
 
 # Building Docker Images for our executables
 ############################################


### PR DESCRIPTION
This is an alternative to #375

The `clean` target blows away a _lot_ of stuff. Each time you `make clean`, you're ensuring whatever you do next is going to take a long time. 😦 

It would be nice if we had the _option_ to clean bits and pieces more selectively through a series of `clean-<something>` targets, each of which the the classic `clean` target would depend on so familiar `make clean` behavior remains unchanged.

See https://github.com/kubernetes-incubator/service-catalog/pull/375#issuecomment-280231603 for an example of a case where this would be a big benefit. (It's a case where I want to selectively blow away generated files and nothing else.)