### PR TITLE
Add insecure mode for wip-catalog chart

### DIFF
--- a/cmd/apiserver/app/server/server.go
+++ b/cmd/apiserver/app/server/server.go
@@ -47,6 +47,8 @@ type ServiceCatalogServerOptions struct {
 	AuthenticationOptions *genericserveroptions.DelegatingAuthenticationOptions
 	// authz
 	AuthorizationOptions *genericserveroptions.DelegatingAuthorizationOptions
+	// InsecureOptions are options for serving insecurely.
+	InsecureServingOptions *genericserveroptions.ServingOptions
 }
 
 const (
@@ -72,6 +74,7 @@ func NewCommandServer(out io.Writer) *cobra.Command {
 		EtcdOptions:             genericserveroptions.NewEtcdOptions(),
 		AuthenticationOptions:   genericserveroptions.NewDelegatingAuthenticationOptions(),
 		AuthorizationOptions:    genericserveroptions.NewDelegatingAuthorizationOptions(),
+		InsecureServingOptions:  genericserveroptions.NewInsecureServingOptions(),
 	}
 
 	// Store resources in etcd under our special prefix
@@ -103,6 +106,7 @@ func NewCommandServer(out io.Writer) *cobra.Command {
 	options.EtcdOptions.AddFlags(flags)
 	options.AuthenticationOptions.AddFlags(flags)
 	options.AuthorizationOptions.AddFlags(flags)
+	options.InsecureServingOptions.AddFlags(flags)
 
 	return cmd
 }
@@ -139,6 +143,8 @@ func (serverOptions ServiceCatalogServerOptions) runServer() error {
 		glog.Errorln(err)
 		return err
 	}
+
+	genericconfig.ApplyInsecureServingOptions(serverOptions.InsecureServingOptions)
 
 	glog.V(4).Info("Setting up authn (disabled)")
 	// need to figure out what's throwing the `missing clientCA file` err

--- a/deploy/wip-catalog/templates/apiserver.yaml
+++ b/deploy/wip-catalog/templates/apiserver.yaml
@@ -13,13 +13,25 @@ spec:
       - name: apiserver
         image: {{ if .Values.registry }}{{ .Values.registry}}/{{ end }}apiserver:{{ if .Values.k8sApiServerVersion }}{{ .Values.k8sApiServerVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}
         imagePullPolicy: {{ default "Always" .Values.imagePullPolicy }}
-        args: 
+        args:
+        {{ if .Values.insecure }}
+        - --secure-port
+        - "0"
+        - --insecure-bind-address
+        - "0.0.0.0"
+        - --insecure-port
+        - {{ default 8081 .Values.insecurePort | quote }}
+        {{ end }}
         - --etcd-servers
         - http://localhost:2379
         - -v
         - "10"
         ports:
         - containerPort: 6443
+        {{ if .Values.insecure }}
+        - containerPort: {{ default 8081 .Values.insecurePort }}
+          hostPort: {{ default 8081 .Values.insecurePort }}
+        {{ end }}
         volumeMounts:
         - name: apiserver-ssl
           mountPath: /var/run/kubernetes-service-catalog


### PR DESCRIPTION
To help move things along until we have SSL stuff in place working with the aggregator.