### PR TITLE
Enhance unit testing for cred serialization

### DIFF
--- a/pkg/controller/injector/k8s_binding_injector.go
+++ b/pkg/controller/injector/k8s_binding_injector.go
@@ -54,7 +54,7 @@ func CreateK8sBindingInjector() (BindingInjector, error) {
 	}, nil
 }
 
-func (b *k8sBindingInjector) Inject(binding *servicecatalog.Binding, cred *brokerapi.Credential) error {
+func createSerializedSecret(binding *servicecatalog.Binding, cred *brokerapi.Credential) (*v1.Secret, error) {
 	secret := &v1.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      binding.Name,
@@ -67,12 +67,22 @@ func (b *k8sBindingInjector) Inject(binding *servicecatalog.Binding, cred *broke
 		var err error
 		secret.Data[k], err = serialize(v)
 		if err != nil {
-			return fmt.Errorf("Unable to serialize credential value %q: %v; %s",
+			return nil, fmt.Errorf("Unable to serialize credential value %q: %v; %s",
 				k, v, err)
 		}
 	}
+
+	return secret, nil
+}
+
+func (b *k8sBindingInjector) Inject(binding *servicecatalog.Binding, cred *brokerapi.Credential) error {
+	secret, err := createSerializedSecret(binding, cred)
+	if err != nil {
+		return err
+	}
+
 	secretsCl := b.client.Core().Secrets(binding.Spec.InstanceRef.Namespace)
-	_, err := secretsCl.Create(secret)
+	_, err = secretsCl.Create(secret)
 	return err
 }
 


### PR DESCRIPTION
Similar to the fuzz testing done in serializer_test, this tests the
serialize function at a higher level from the Inject prospective. The
other difference is that serialization is compared in one direction
only, so no unmarshalling is required to verify the result. Ints,
floats, strings, slices, and maps are data types tested to be correct so
far.