### PR TITLE
Use name validations from our API instead of the k8s core

### DIFF
--- a/pkg/apis/servicecatalog/validation/binding.go
+++ b/pkg/apis/servicecatalog/validation/binding.go
@@ -23,13 +23,17 @@ import (
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 )
 
+// validateBindingName is the validation function for Binding names.
+var validateBindingName = apivalidation.NameIsDNSSubdomain
+
 // ValidateBinding checks the fields of a Binding.
 func ValidateBinding(binding *sc.Binding) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&binding.ObjectMeta, true, /*namespace*/
-		apivalidation.ValidateReplicationControllerName, // our custom name validator?
+		validateBindingName,
 		field.NewPath("metadata"))...)
 	allErrs = append(allErrs, validateBindingSpec(&binding.Spec, field.NewPath("Spec"))...)
+
 	// validate the status array
 	// allErrs = append(allErrs, validateBindingStatus(&binding.Spec, field.NewPath("Status"))...)
 	return allErrs

--- a/pkg/apis/servicecatalog/validation/broker.go
+++ b/pkg/apis/servicecatalog/validation/broker.go
@@ -29,15 +29,19 @@ import (
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 )
 
-// assuming a nil non-error is ok. not okay, should be empty struct `field.ErrorList{}`
+// ValidateBrokerName is the validation function for Broker names.
+var ValidateBrokerName = apivalidation.NameIsDNSSubdomain
 
-// ValidateBroker makes sure a broker object is okay?
+// ValidateBroker implements the validation rules for a BrokerResource.
 func ValidateBroker(broker *sc.Broker) field.ErrorList {
 	allErrs := field.ErrorList{}
-	// validate the name?
-	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&broker.ObjectMeta, false, /*namespace*/
-		apivalidation.ValidateReplicationControllerName, // our custom name validator?
-		field.NewPath("metadata"))...)
+
+	allErrs = append(allErrs,
+		apivalidation.ValidateObjectMeta(&broker.ObjectMeta,
+			false, /* namespace required */
+			ValidateBrokerName,
+			field.NewPath("metadata"))...)
+
 	allErrs = append(allErrs, validateBrokerSpec(&broker.Spec, field.NewPath("Spec"))...)
 	// Do we need to validate the status array?
 	// allErrs = append(allErrs, validateBrokerStatus(&broker.Spec, field.NewPath("Status"))...)

--- a/pkg/apis/servicecatalog/validation/instance.go
+++ b/pkg/apis/servicecatalog/validation/instance.go
@@ -23,11 +23,14 @@ import (
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 )
 
+// validateInstanceName is the validation function for Instance names.
+var validateInstanceName = apivalidation.NameIsDNSSubdomain
+
 // ValidateInstance checks the fields of a Instance.
 func ValidateInstance(instance *sc.Instance) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&instance.ObjectMeta, true, /*namespace*/
-		apivalidation.ValidateReplicationControllerName, // our custom name validator?
+		validateInstanceName,
 		field.NewPath("metadata"))...)
 	allErrs = append(allErrs, validateInstanceSpec(&instance.Spec, field.NewPath("Spec"))...)
 	// validate the status array

--- a/pkg/apis/servicecatalog/validation/serviceclass.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass.go
@@ -23,17 +23,25 @@ import (
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 )
 
+// validateServiceClassName is the validation function for ServiceClass names.
+var validateServiceClassName = apivalidation.NameIsDNSSubdomain
+
 // ValidateServiceclass makes sure a serviceclass object is okay.
 func ValidateServiceclass(serviceclass *sc.ServiceClass) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&serviceclass.ObjectMeta, false, /*namespace*/
-		apivalidation.ValidateReplicationControllerName, // our custom name validator?
-		field.NewPath("metadata"))...)
+
+	allErrs = append(allErrs,
+		apivalidation.ValidateObjectMeta(
+			&serviceclass.ObjectMeta,
+			false, /* namespace required */
+			validateServiceClassName,
+			field.NewPath("metadata"))...)
 
 	return allErrs
 }
 
-// ValidateServiceclassUpdate checks that when changing from an older serviceclass to a newer serviceclass is okay.
+// ValidateServiceclassUpdate checks that when changing from an older
+// serviceclass to a newer serviceclass is okay.
 func ValidateServiceclassUpdate(new *sc.ServiceClass, old *sc.ServiceClass) field.ErrorList {
 	allErrs := field.ErrorList{}
 	// should each individual serviceclass validate successfully before validating changes?


### PR DESCRIPTION
Written by Paul, slightly modified by me.
(Supercedes https://github.com/kubernetes-incubator/service-catalog/pull/330)