### PR TITLE
Make ServiceClasses non-namespaced in the client

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -34,7 +34,7 @@ type Broker struct {
 	metav1.TypeMeta
 	kapi.ObjectMeta
 
-	Spec   BrokerSpec `json:"spec"`
+	Spec   BrokerSpec
 	Status BrokerStatus
 }
 
@@ -114,6 +114,7 @@ type ServiceClassList struct {
 }
 
 // +genclient=true
+// +nonNamespaced=true
 
 // ServiceClass represents an offering in the service catalog.
 type ServiceClass struct {
@@ -185,7 +186,7 @@ type Instance struct {
 	metav1.TypeMeta
 	kapi.ObjectMeta
 
-	Spec   InstanceSpec `json:"spec"`
+	Spec   InstanceSpec
 	Status InstanceStatus
 }
 
@@ -193,9 +194,9 @@ type Instance struct {
 type InstanceSpec struct {
 	// ServiceClassName is the reference to the ServiceClass this is an
 	// instance of.  Immutable.
-	ServiceClassName string `json:"serviceClassName"`
+	ServiceClassName string
 	// ServicePlanName is the reference to the ServicePlan for this instance.
-	PlanName string `json:"planName"`
+	PlanName string
 
 	Parameters map[string]runtime.Object
 
@@ -265,7 +266,7 @@ type Binding struct {
 	metav1.TypeMeta
 	kapi.ObjectMeta
 
-	Spec   BindingSpec `json:"spec"`
+	Spec   BindingSpec
 	Status BindingStatus
 }
 
@@ -273,7 +274,7 @@ type Binding struct {
 type BindingSpec struct {
 	// InstanceRef is the reference to the Instance this binding is to.
 	// Immutable.
-	InstanceRef kapi.ObjectReference `json:"instanceRef"`
+	InstanceRef kapi.ObjectReference
 	// AppLabelSelector selects the pods in the Binding's namespace that
 	// should be injected with the results of the binding.  Immutable.
 	AppLabelSelector metav1.LabelSelector
@@ -282,7 +283,7 @@ type BindingSpec struct {
 
 	// Names of subordinate objects to create
 	SecretName    string
-	ServiceName   string `json:"serviceName"`
+	ServiceName   string
 	ConfigMapName string
 	// Placeholder for future SIP support
 	// ServiceInjectionPolicyName string

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -112,6 +112,7 @@ type ServiceClassList struct {
 }
 
 // +genclient=true
+// +nonNamespaced=true
 
 // ServiceClass represents an offering in the service catalog.
 type ServiceClass struct {

--- a/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1alpha1/fake/fake_servicecatalog_client.go
+++ b/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1alpha1/fake/fake_servicecatalog_client.go
@@ -38,8 +38,8 @@ func (c *FakeServicecatalogV1alpha1) Instances(namespace string) v1alpha1.Instan
 	return &FakeInstances{c, namespace}
 }
 
-func (c *FakeServicecatalogV1alpha1) ServiceClasses(namespace string) v1alpha1.ServiceClassInterface {
-	return &FakeServiceClasses{c, namespace}
+func (c *FakeServicecatalogV1alpha1) ServiceClasses() v1alpha1.ServiceClassInterface {
+	return &FakeServiceClasses{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1alpha1/fake/fake_serviceclass.go
+++ b/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1alpha1/fake/fake_serviceclass.go
@@ -29,15 +29,13 @@ import (
 // FakeServiceClasses implements ServiceClassInterface
 type FakeServiceClasses struct {
 	Fake *FakeServicecatalogV1alpha1
-	ns   string
 }
 
 var serviceclassesResource = schema.GroupVersionResource{Group: "servicecatalog.k8s.io", Version: "v1alpha1", Resource: "serviceclasses"}
 
 func (c *FakeServiceClasses) Create(serviceClass *v1alpha1.ServiceClass) (result *v1alpha1.ServiceClass, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewCreateAction(serviceclassesResource, c.ns, serviceClass), &v1alpha1.ServiceClass{})
-
+		Invokes(core.NewRootCreateAction(serviceclassesResource, serviceClass), &v1alpha1.ServiceClass{})
 	if obj == nil {
 		return nil, err
 	}
@@ -46,8 +44,7 @@ func (c *FakeServiceClasses) Create(serviceClass *v1alpha1.ServiceClass) (result
 
 func (c *FakeServiceClasses) Update(serviceClass *v1alpha1.ServiceClass) (result *v1alpha1.ServiceClass, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateAction(serviceclassesResource, c.ns, serviceClass), &v1alpha1.ServiceClass{})
-
+		Invokes(core.NewRootUpdateAction(serviceclassesResource, serviceClass), &v1alpha1.ServiceClass{})
 	if obj == nil {
 		return nil, err
 	}
@@ -56,13 +53,12 @@ func (c *FakeServiceClasses) Update(serviceClass *v1alpha1.ServiceClass) (result
 
 func (c *FakeServiceClasses) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewDeleteAction(serviceclassesResource, c.ns, name), &v1alpha1.ServiceClass{})
-
+		Invokes(core.NewRootDeleteAction(serviceclassesResource, name), &v1alpha1.ServiceClass{})
 	return err
 }
 
 func (c *FakeServiceClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := core.NewDeleteCollectionAction(serviceclassesResource, c.ns, listOptions)
+	action := core.NewRootDeleteCollectionAction(serviceclassesResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.ServiceClassList{})
 	return err
@@ -70,8 +66,7 @@ func (c *FakeServiceClasses) DeleteCollection(options *v1.DeleteOptions, listOpt
 
 func (c *FakeServiceClasses) Get(name string) (result *v1alpha1.ServiceClass, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewGetAction(serviceclassesResource, c.ns, name), &v1alpha1.ServiceClass{})
-
+		Invokes(core.NewRootGetAction(serviceclassesResource, name), &v1alpha1.ServiceClass{})
 	if obj == nil {
 		return nil, err
 	}
@@ -80,8 +75,7 @@ func (c *FakeServiceClasses) Get(name string) (result *v1alpha1.ServiceClass, er
 
 func (c *FakeServiceClasses) List(opts v1.ListOptions) (result *v1alpha1.ServiceClassList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewListAction(serviceclassesResource, c.ns, opts), &v1alpha1.ServiceClassList{})
-
+		Invokes(core.NewRootListAction(serviceclassesResource, opts), &v1alpha1.ServiceClassList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -102,15 +96,13 @@ func (c *FakeServiceClasses) List(opts v1.ListOptions) (result *v1alpha1.Service
 // Watch returns a watch.Interface that watches the requested serviceClasses.
 func (c *FakeServiceClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewWatchAction(serviceclassesResource, c.ns, opts))
-
+		InvokesWatch(core.NewRootWatchAction(serviceclassesResource, opts))
 }
 
 // Patch applies the patch and returns the patched serviceClass.
 func (c *FakeServiceClasses) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1alpha1.ServiceClass, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchSubresourceAction(serviceclassesResource, c.ns, name, data, subresources...), &v1alpha1.ServiceClass{})
-
+		Invokes(core.NewRootPatchSubresourceAction(serviceclassesResource, name, data, subresources...), &v1alpha1.ServiceClass{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1alpha1/servicecatalog_client.go
+++ b/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1alpha1/servicecatalog_client.go
@@ -50,8 +50,8 @@ func (c *ServicecatalogV1alpha1Client) Instances(namespace string) InstanceInter
 	return newInstances(c, namespace)
 }
 
-func (c *ServicecatalogV1alpha1Client) ServiceClasses(namespace string) ServiceClassInterface {
-	return newServiceClasses(c, namespace)
+func (c *ServicecatalogV1alpha1Client) ServiceClasses() ServiceClassInterface {
+	return newServiceClasses(c)
 }
 
 // NewForConfig creates a new ServicecatalogV1alpha1Client for the given config.

--- a/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1alpha1/serviceclass.go
+++ b/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1alpha1/serviceclass.go
@@ -27,7 +27,7 @@ import (
 // ServiceClassesGetter has a method to return a ServiceClassInterface.
 // A group's client should implement this interface.
 type ServiceClassesGetter interface {
-	ServiceClasses(namespace string) ServiceClassInterface
+	ServiceClasses() ServiceClassInterface
 }
 
 // ServiceClassInterface has methods to work with ServiceClass resources.
@@ -46,14 +46,12 @@ type ServiceClassInterface interface {
 // serviceClasses implements ServiceClassInterface
 type serviceClasses struct {
 	client restclient.Interface
-	ns     string
 }
 
 // newServiceClasses returns a ServiceClasses
-func newServiceClasses(c *ServicecatalogV1alpha1Client, namespace string) *serviceClasses {
+func newServiceClasses(c *ServicecatalogV1alpha1Client) *serviceClasses {
 	return &serviceClasses{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -61,7 +59,6 @@ func newServiceClasses(c *ServicecatalogV1alpha1Client, namespace string) *servi
 func (c *serviceClasses) Create(serviceClass *v1alpha1.ServiceClass) (result *v1alpha1.ServiceClass, err error) {
 	result = &v1alpha1.ServiceClass{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		Body(serviceClass).
 		Do().
@@ -73,7 +70,6 @@ func (c *serviceClasses) Create(serviceClass *v1alpha1.ServiceClass) (result *v1
 func (c *serviceClasses) Update(serviceClass *v1alpha1.ServiceClass) (result *v1alpha1.ServiceClass, err error) {
 	result = &v1alpha1.ServiceClass{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		Name(serviceClass.Name).
 		Body(serviceClass).
@@ -85,7 +81,6 @@ func (c *serviceClasses) Update(serviceClass *v1alpha1.ServiceClass) (result *v1
 // Delete takes name of the serviceClass and deletes it. Returns an error if one occurs.
 func (c *serviceClasses) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		Name(name).
 		Body(options).
@@ -96,7 +91,6 @@ func (c *serviceClasses) Delete(name string, options *v1.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *serviceClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		VersionedParams(&listOptions, api.ParameterCodec).
 		Body(options).
@@ -108,7 +102,6 @@ func (c *serviceClasses) DeleteCollection(options *v1.DeleteOptions, listOptions
 func (c *serviceClasses) Get(name string) (result *v1alpha1.ServiceClass, err error) {
 	result = &v1alpha1.ServiceClass{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		Name(name).
 		Do().
@@ -120,7 +113,6 @@ func (c *serviceClasses) Get(name string) (result *v1alpha1.ServiceClass, err er
 func (c *serviceClasses) List(opts v1.ListOptions) (result *v1alpha1.ServiceClassList, err error) {
 	result = &v1alpha1.ServiceClassList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		VersionedParams(&opts, api.ParameterCodec).
 		Do().
@@ -132,7 +124,6 @@ func (c *serviceClasses) List(opts v1.ListOptions) (result *v1alpha1.ServiceClas
 func (c *serviceClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
@@ -142,7 +133,6 @@ func (c *serviceClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 func (c *serviceClasses) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *v1alpha1.ServiceClass, err error) {
 	result = &v1alpha1.ServiceClass{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/fake/fake_servicecatalog_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/fake/fake_servicecatalog_client.go
@@ -38,8 +38,8 @@ func (c *FakeServicecatalog) Instances(namespace string) internalversion.Instanc
 	return &FakeInstances{c, namespace}
 }
 
-func (c *FakeServicecatalog) ServiceClasses(namespace string) internalversion.ServiceClassInterface {
-	return &FakeServiceClasses{c, namespace}
+func (c *FakeServicecatalog) ServiceClasses() internalversion.ServiceClassInterface {
+	return &FakeServiceClasses{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/fake/fake_serviceclass.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/fake/fake_serviceclass.go
@@ -28,15 +28,13 @@ import (
 // FakeServiceClasses implements ServiceClassInterface
 type FakeServiceClasses struct {
 	Fake *FakeServicecatalog
-	ns   string
 }
 
 var serviceclassesResource = schema.GroupVersionResource{Group: "", Version: "", Resource: "serviceclasses"}
 
 func (c *FakeServiceClasses) Create(serviceClass *servicecatalog.ServiceClass) (result *servicecatalog.ServiceClass, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewCreateAction(serviceclassesResource, c.ns, serviceClass), &servicecatalog.ServiceClass{})
-
+		Invokes(core.NewRootCreateAction(serviceclassesResource, serviceClass), &servicecatalog.ServiceClass{})
 	if obj == nil {
 		return nil, err
 	}
@@ -45,8 +43,7 @@ func (c *FakeServiceClasses) Create(serviceClass *servicecatalog.ServiceClass) (
 
 func (c *FakeServiceClasses) Update(serviceClass *servicecatalog.ServiceClass) (result *servicecatalog.ServiceClass, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewUpdateAction(serviceclassesResource, c.ns, serviceClass), &servicecatalog.ServiceClass{})
-
+		Invokes(core.NewRootUpdateAction(serviceclassesResource, serviceClass), &servicecatalog.ServiceClass{})
 	if obj == nil {
 		return nil, err
 	}
@@ -55,13 +52,12 @@ func (c *FakeServiceClasses) Update(serviceClass *servicecatalog.ServiceClass) (
 
 func (c *FakeServiceClasses) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(core.NewDeleteAction(serviceclassesResource, c.ns, name), &servicecatalog.ServiceClass{})
-
+		Invokes(core.NewRootDeleteAction(serviceclassesResource, name), &servicecatalog.ServiceClass{})
 	return err
 }
 
 func (c *FakeServiceClasses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := core.NewDeleteCollectionAction(serviceclassesResource, c.ns, listOptions)
+	action := core.NewRootDeleteCollectionAction(serviceclassesResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &servicecatalog.ServiceClassList{})
 	return err
@@ -69,8 +65,7 @@ func (c *FakeServiceClasses) DeleteCollection(options *api.DeleteOptions, listOp
 
 func (c *FakeServiceClasses) Get(name string) (result *servicecatalog.ServiceClass, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewGetAction(serviceclassesResource, c.ns, name), &servicecatalog.ServiceClass{})
-
+		Invokes(core.NewRootGetAction(serviceclassesResource, name), &servicecatalog.ServiceClass{})
 	if obj == nil {
 		return nil, err
 	}
@@ -79,8 +74,7 @@ func (c *FakeServiceClasses) Get(name string) (result *servicecatalog.ServiceCla
 
 func (c *FakeServiceClasses) List(opts api.ListOptions) (result *servicecatalog.ServiceClassList, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewListAction(serviceclassesResource, c.ns, opts), &servicecatalog.ServiceClassList{})
-
+		Invokes(core.NewRootListAction(serviceclassesResource, opts), &servicecatalog.ServiceClassList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -101,15 +95,13 @@ func (c *FakeServiceClasses) List(opts api.ListOptions) (result *servicecatalog.
 // Watch returns a watch.Interface that watches the requested serviceClasses.
 func (c *FakeServiceClasses) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(core.NewWatchAction(serviceclassesResource, c.ns, opts))
-
+		InvokesWatch(core.NewRootWatchAction(serviceclassesResource, opts))
 }
 
 // Patch applies the patch and returns the patched serviceClass.
 func (c *FakeServiceClasses) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *servicecatalog.ServiceClass, err error) {
 	obj, err := c.Fake.
-		Invokes(core.NewPatchSubresourceAction(serviceclassesResource, c.ns, name, data, subresources...), &servicecatalog.ServiceClass{})
-
+		Invokes(core.NewRootPatchSubresourceAction(serviceclassesResource, name, data, subresources...), &servicecatalog.ServiceClass{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/servicecatalog_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/servicecatalog_client.go
@@ -47,8 +47,8 @@ func (c *ServicecatalogClient) Instances(namespace string) InstanceInterface {
 	return newInstances(c, namespace)
 }
 
-func (c *ServicecatalogClient) ServiceClasses(namespace string) ServiceClassInterface {
-	return newServiceClasses(c, namespace)
+func (c *ServicecatalogClient) ServiceClasses() ServiceClassInterface {
+	return newServiceClasses(c)
 }
 
 // NewForConfig creates a new ServicecatalogClient for the given config.

--- a/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/serviceclass.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/serviceclass.go
@@ -26,7 +26,7 @@ import (
 // ServiceClassesGetter has a method to return a ServiceClassInterface.
 // A group's client should implement this interface.
 type ServiceClassesGetter interface {
-	ServiceClasses(namespace string) ServiceClassInterface
+	ServiceClasses() ServiceClassInterface
 }
 
 // ServiceClassInterface has methods to work with ServiceClass resources.
@@ -45,14 +45,12 @@ type ServiceClassInterface interface {
 // serviceClasses implements ServiceClassInterface
 type serviceClasses struct {
 	client restclient.Interface
-	ns     string
 }
 
 // newServiceClasses returns a ServiceClasses
-func newServiceClasses(c *ServicecatalogClient, namespace string) *serviceClasses {
+func newServiceClasses(c *ServicecatalogClient) *serviceClasses {
 	return &serviceClasses{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -60,7 +58,6 @@ func newServiceClasses(c *ServicecatalogClient, namespace string) *serviceClasse
 func (c *serviceClasses) Create(serviceClass *servicecatalog.ServiceClass) (result *servicecatalog.ServiceClass, err error) {
 	result = &servicecatalog.ServiceClass{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		Body(serviceClass).
 		Do().
@@ -72,7 +69,6 @@ func (c *serviceClasses) Create(serviceClass *servicecatalog.ServiceClass) (resu
 func (c *serviceClasses) Update(serviceClass *servicecatalog.ServiceClass) (result *servicecatalog.ServiceClass, err error) {
 	result = &servicecatalog.ServiceClass{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		Name(serviceClass.Name).
 		Body(serviceClass).
@@ -84,7 +80,6 @@ func (c *serviceClasses) Update(serviceClass *servicecatalog.ServiceClass) (resu
 // Delete takes name of the serviceClass and deletes it. Returns an error if one occurs.
 func (c *serviceClasses) Delete(name string, options *api.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		Name(name).
 		Body(options).
@@ -95,7 +90,6 @@ func (c *serviceClasses) Delete(name string, options *api.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *serviceClasses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		VersionedParams(&listOptions, api.ParameterCodec).
 		Body(options).
@@ -107,7 +101,6 @@ func (c *serviceClasses) DeleteCollection(options *api.DeleteOptions, listOption
 func (c *serviceClasses) Get(name string) (result *servicecatalog.ServiceClass, err error) {
 	result = &servicecatalog.ServiceClass{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		Name(name).
 		Do().
@@ -119,7 +112,6 @@ func (c *serviceClasses) Get(name string) (result *servicecatalog.ServiceClass, 
 func (c *serviceClasses) List(opts api.ListOptions) (result *servicecatalog.ServiceClassList, err error) {
 	result = &servicecatalog.ServiceClassList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		VersionedParams(&opts, api.ParameterCodec).
 		Do().
@@ -131,7 +123,6 @@ func (c *serviceClasses) List(opts api.ListOptions) (result *servicecatalog.Serv
 func (c *serviceClasses) Watch(opts api.ListOptions) (watch.Interface, error) {
 	return c.client.Get().
 		Prefix("watch").
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()
@@ -141,7 +132,6 @@ func (c *serviceClasses) Watch(opts api.ListOptions) (watch.Interface, error) {
 func (c *serviceClasses) Patch(name string, pt api.PatchType, data []byte, subresources ...string) (result *servicecatalog.ServiceClass, err error) {
 	result = &servicecatalog.ServiceClass{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("serviceclasses").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/client/informers/servicecatalog/internalversion/serviceclass.go
+++ b/pkg/client/informers/servicecatalog/internalversion/serviceclass.go
@@ -50,14 +50,14 @@ func newServiceClassInformer(client internalclientset.Interface, resyncPeriod ti
 				if err := api.Scheme.Convert(&options, &internalOptions, nil); err != nil {
 					return nil, err
 				}
-				return client.Servicecatalog().ServiceClasses(api.NamespaceAll).List(internalOptions)
+				return client.Servicecatalog().ServiceClasses().List(internalOptions)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				var internalOptions api.ListOptions
 				if err := api.Scheme.Convert(&options, &internalOptions, nil); err != nil {
 					return nil, err
 				}
-				return client.Servicecatalog().ServiceClasses(api.NamespaceAll).Watch(internalOptions)
+				return client.Servicecatalog().ServiceClasses().Watch(internalOptions)
 			},
 		},
 		&servicecatalog.ServiceClass{},

--- a/pkg/client/informers/servicecatalog/v1alpha1/serviceclass.go
+++ b/pkg/client/informers/servicecatalog/v1alpha1/serviceclass.go
@@ -45,10 +45,10 @@ func newServiceClassInformer(client clientset.Interface, resyncPeriod time.Durat
 	sharedIndexInformer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.ServicecatalogV1alpha1().ServiceClasses(v1.NamespaceAll).List(options)
+				return client.ServicecatalogV1alpha1().ServiceClasses().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.ServicecatalogV1alpha1().ServiceClasses(v1.NamespaceAll).Watch(options)
+				return client.ServicecatalogV1alpha1().ServiceClasses().Watch(options)
 			},
 		},
 		&servicecatalog_v1alpha1.ServiceClass{},

--- a/pkg/client/listers/servicecatalog/internalversion/expansion_generated.go
+++ b/pkg/client/listers/servicecatalog/internalversion/expansion_generated.go
@@ -41,7 +41,3 @@ type InstanceNamespaceListerExpansion interface{}
 // ServiceClassListerExpansion allows custom methods to be added to
 // ServiceClassLister.
 type ServiceClassListerExpansion interface{}
-
-// ServiceClassNamespaceListerExpansion allows custom methods to be added to
-// ServiceClassNamespaeLister.
-type ServiceClassNamespaceListerExpansion interface{}

--- a/pkg/client/listers/servicecatalog/internalversion/serviceclass.go
+++ b/pkg/client/listers/servicecatalog/internalversion/serviceclass.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	servicecatalog "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	api "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/labels"
@@ -29,8 +30,8 @@ import (
 type ServiceClassLister interface {
 	// List lists all ServiceClasses in the indexer.
 	List(selector labels.Selector) (ret []*servicecatalog.ServiceClass, err error)
-	// ServiceClasses returns an object that can list and get ServiceClasses.
-	ServiceClasses(namespace string) ServiceClassNamespaceLister
+	// Get retrieves the ServiceClass from the index for a given name.
+	Get(name string) (*servicecatalog.ServiceClass, error)
 	ServiceClassListerExpansion
 }
 
@@ -52,38 +53,10 @@ func (s *serviceClassLister) List(selector labels.Selector) (ret []*servicecatal
 	return ret, err
 }
 
-// ServiceClasses returns an object that can list and get ServiceClasses.
-func (s *serviceClassLister) ServiceClasses(namespace string) ServiceClassNamespaceLister {
-	return serviceClassNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// ServiceClassNamespaceLister helps list and get ServiceClasses.
-type ServiceClassNamespaceLister interface {
-	// List lists all ServiceClasses in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*servicecatalog.ServiceClass, err error)
-	// Get retrieves the ServiceClass from the indexer for a given namespace and name.
-	Get(name string) (*servicecatalog.ServiceClass, error)
-	ServiceClassNamespaceListerExpansion
-}
-
-// serviceClassNamespaceLister implements the ServiceClassNamespaceLister
-// interface.
-type serviceClassNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all ServiceClasses in the indexer for a given namespace.
-func (s serviceClassNamespaceLister) List(selector labels.Selector) (ret []*servicecatalog.ServiceClass, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*servicecatalog.ServiceClass))
-	})
-	return ret, err
-}
-
-// Get retrieves the ServiceClass from the indexer for a given namespace and name.
-func (s serviceClassNamespaceLister) Get(name string) (*servicecatalog.ServiceClass, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the ServiceClass from the index for a given name.
+func (s *serviceClassLister) Get(name string) (*servicecatalog.ServiceClass, error) {
+	key := &servicecatalog.ServiceClass{ObjectMeta: api.ObjectMeta{Name: name}}
+	obj, exists, err := s.indexer.Get(key)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/servicecatalog/v1alpha1/expansion_generated.go
+++ b/pkg/client/listers/servicecatalog/v1alpha1/expansion_generated.go
@@ -41,7 +41,3 @@ type InstanceNamespaceListerExpansion interface{}
 // ServiceClassListerExpansion allows custom methods to be added to
 // ServiceClassLister.
 type ServiceClassListerExpansion interface{}
-
-// ServiceClassNamespaceListerExpansion allows custom methods to be added to
-// ServiceClassNamespaeLister.
-type ServiceClassNamespaceListerExpansion interface{}

--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/client/restclient"
+	genericserveroptions "k8s.io/kubernetes/pkg/genericapiserver/options"
+
+	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
+	_ "k8s.io/kubernetes/pkg/api/install"
+
+	"github.com/kubernetes-incubator/service-catalog/cmd/apiserver/app/server"
+	servicecatalogclient "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
+)
+
+func getFreshApiserverAndClient(t *testing.T) (servicecatalogclient.Interface, func()) {
+	securePort := 65535
+	serverIP := fmt.Sprintf("https://localhost:%d", securePort)
+	stopCh := make(chan struct{})
+	serverFailed := make(chan struct{})
+	//defer close(stopCh)
+	shutdown := func() {
+		close(stopCh)
+	}
+
+	certDir, _ := ioutil.TempDir("", "service-catalog-integration")
+
+	secureServingOptions := genericserveroptions.NewSecureServingOptions()
+	go func() {
+		options := &server.ServiceCatalogServerOptions{
+			GenericServerRunOptions: genericserveroptions.NewServerRunOptions(),
+			SecureServingOptions:    secureServingOptions,
+			EtcdOptions:             genericserveroptions.NewEtcdOptions(),
+			AuthenticationOptions:   genericserveroptions.NewDelegatingAuthenticationOptions(),
+			AuthorizationOptions:    genericserveroptions.NewDelegatingAuthorizationOptions(),
+		}
+		options.SecureServingOptions.ServingOptions.BindPort = securePort
+		options.SecureServingOptions.ServerCert.CertDirectory = certDir
+		options.EtcdOptions.StorageConfig.ServerList = []string{"http://localhost:2379"}
+		if err := options.RunServer(stopCh); err != nil {
+			close(serverFailed)
+			t.Fatalf("Error in bringing up the server: %v", err)
+		}
+	}()
+
+	if err := waitForApiserverUp(serverIP, serverFailed); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	config := &restclient.Config{}
+	config.Host = serverIP
+	config.Insecure = true
+	clientset, err := servicecatalogclient.NewForConfig(config)
+	if nil != err {
+		t.Fatal("can't make the client from the config", err)
+	}
+	return clientset, shutdown
+}
+
+func waitForApiserverUp(serverIP string, stopCh <-chan struct{}) error {
+	minuteTimeout := time.After(time.Minute)
+	for {
+		select {
+		case <-stopCh:
+			return fmt.Errorf("apiserver failed")
+		case <-minuteTimeout:
+			return fmt.Errorf("waiting for apiserver timed out")
+		default:
+			glog.Infof("Waiting for : %#v", serverIP)
+			tr := &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}
+			client := &http.Client{Transport: tr}
+			_, err := client.Get(serverIP)
+			if err == nil {
+				return nil
+			}
+		}
+		// no success or overall timeout or stop due to failure
+		// wait and go around again
+		<-time.After(100 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
What it sounds like -- we were missing some comment-instructions for the generators.  Also adds a basic client integration tests for `ServiceClass` and cleans up a couple of json tags that snuck into the internal API.

cc @MHBauer @jpeeler 