### PR TITLE
Add dnsutils to apiserver-image

### DIFF
--- a/build/apiserver/Dockerfile
+++ b/build/apiserver/Dockerfile
@@ -14,6 +14,7 @@
 
 FROM debian
 
+RUN apt update && apt-get install -y dnsutils
 ADD tmp/apiserver /opt/services/
 
 ENTRYPOINT ["/opt/services/apiserver" ]


### PR DESCRIPTION
Useful for debugging service connectivity