### PR TITLE
Port business logic into new controller

### DIFF
--- a/cmd/controller-manager/app/controller_manager.go
+++ b/cmd/controller-manager/app/controller_manager.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/kubernetes-incubator/service-catalog/cmd/controller-manager/app/options"
 	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
+	"github.com/kubernetes-incubator/service-catalog/pkg/brokerapi/openservicebroker"
 	servicecataloginformers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers"
 	"github.com/kubernetes-incubator/service-catalog/pkg/controller"
 	"github.com/kubernetes-incubator/service-catalog/pkg/controller/wip"
@@ -283,11 +284,12 @@ func StartControllers(s *options.ControllerManagerServer,
 		glog.V(5).Info("Creating controller")
 		serviceCatalogController, err := wip.NewController(
 			coreClient,
-			serviceCatalogClientBuilder.ClientOrDie(controllerManagerAgentName),
-			serviceCatalogSharedInformers.Brokers().Informer(),
-			serviceCatalogSharedInformers.ServiceClasses().Informer(),
-			serviceCatalogSharedInformers.Instances().Informer(),
-			serviceCatalogSharedInformers.Bindings().Informer(),
+			serviceCatalogClientBuilder.ClientOrDie(controllerManagerAgentName).ServicecatalogV1alpha1(),
+			serviceCatalogSharedInformers.Brokers(),
+			serviceCatalogSharedInformers.ServiceClasses(),
+			serviceCatalogSharedInformers.Instances(),
+			serviceCatalogSharedInformers.Bindings(),
+			openservicebroker.NewClient,
 		)
 		if err != nil {
 			return err

--- a/pkg/controller/injector/k8s_binding_injector.go
+++ b/pkg/controller/injector/k8s_binding_injector.go
@@ -65,7 +65,7 @@ func (b *k8sBindingInjector) Inject(binding *servicecatalog.Binding, cred *broke
 
 	for k, v := range *cred {
 		var err error
-		secret.Data[k], err = serialize(v)
+		secret.Data[k], err = Serialize(v)
 		if err != nil {
 			return fmt.Errorf("Unable to serialize credential value %q: %v; %s",
 				k, v, err)

--- a/pkg/controller/injector/serializer.go
+++ b/pkg/controller/injector/serializer.go
@@ -20,26 +20,27 @@ import (
 	"encoding/json"
 )
 
-// serialize converts values of any type to a []byte, suitable for addition to a
-// k8s Secret's Data field (which is a map[string][]byte). Generally, this
-// serialization is performed using json.Unmarshal(), which easily handles most
-// primitives, but will also, conveniently, handle the scenario where the item
-// being serialized is a map[string]interface{} or []interface{}-- both of which
-// are possible since an OSB broker's response to a binding request might
-// contain credentials that are composed of arbitrarily complex JSON. These
-// would have been unmarshalled to map[string]interface{} or []interface{} when
-// they were received and need to be re-marshalled here before they can be added
-// to a Secret. (Note that the consumer would need to know what to do with those
-// bytes that contain arbitrarily complex JSON. The controller's only concern is
-// accurately passing along all credentials received from the OSB broker.) The
-// common case where this strategy doesn't work is that of string values. Using
-// json.Unmarshal() to serialize string values results in a []byte where the
-// leading and trailing bytes represent double quotes. Consequently, this would
-// lead to consumers receiving a credential like `"password"` where the
-// credential from the OSB broker was actually `password`. It's easy to see
-// that's bad, so an alternative strategy is used for serializing string values
-// to avoid introducing those errant quotes.
-func serialize(value interface{}) ([]byte, error) {
+// Serialize converts values of any type to a []byte, suitable for addition to
+// a k8s Secret's Data field (which is a map[string][]byte). Generally, this
+// serialization is performed using json.Unmarshal(), which easily handles
+// most primitives, but will also, conveniently, handle the scenario where the
+// item being serialized is a map[string]interface{} or []interface{}-- both
+// of which are possible since an OSB broker's response to a binding request
+// might contain credentials that are composed of arbitrarily complex JSON.
+// These would have been unmarshalled to map[string]interface{} or
+// []interface{} when they were received and need to be re-marshalled here
+// before they can be added to a Secret. (Note that the consumer would need to
+// know what to do with those bytes that contain arbitrarily complex JSON. The
+// controller's only concern is accurately passing along all credentials
+// received from the OSB broker.) The common case where this strategy doesn't
+// work is that of string values. Using json.Unmarshal() to serialize string
+// values results in a []byte where the leading and trailing bytes represent
+// double quotes. Consequently, this would lead to consumers receiving a
+// credential like `"password"` where the credential from the OSB broker was
+// actually `password`. It's easy to see that's bad, so an alternative
+// strategy is used for serializing string values to avoid introducing those
+// errant quotes.
+func Serialize(value interface{}) ([]byte, error) {
 	if strVal, ok := value.(string); ok {
 		return []byte(strVal), nil
 	}

--- a/pkg/controller/injector/serializer_test.go
+++ b/pkg/controller/injector/serializer_test.go
@@ -38,7 +38,7 @@ func TestSerializeInt(t *testing.T) {
 	for i := 0; i < fuzzIters; i++ {
 		var intVal int
 		fuzzer.Fuzz(&intVal)
-		bytes, err := serialize(intVal)
+		bytes, err := Serialize(intVal)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -57,7 +57,7 @@ func TestSerializeFloat(t *testing.T) {
 	for i := 0; i < fuzzIters; i++ {
 		var floatVal float64
 		fuzzer.Fuzz(&floatVal)
-		bytes, err := serialize(floatVal)
+		bytes, err := Serialize(floatVal)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -76,7 +76,7 @@ func TestSerializeString(t *testing.T) {
 	for i := 0; i < fuzzIters; i++ {
 		var strVal string
 		fuzzer.Fuzz(&strVal)
-		bytes, err := serialize(strVal)
+		bytes, err := Serialize(strVal)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -91,7 +91,7 @@ func TestSerializeMap(t *testing.T) {
 	var mapVal map[string]string
 	for i := 0; i < fuzzIters; i++ {
 		fuzzer.Fuzz(&mapVal)
-		bytes, err := serialize(mapVal)
+		bytes, err := Serialize(mapVal)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -110,7 +110,7 @@ func TestSerializeSlice(t *testing.T) {
 	var sliceVal []string
 	for i := 0; i < fuzzIters; i++ {
 		fuzzer.Fuzz(&sliceVal)
-		bytes, err := serialize(sliceVal)
+		bytes, err := Serialize(sliceVal)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}

--- a/pkg/controller/wip/controller.go
+++ b/pkg/controller/wip/controller.go
@@ -17,54 +17,69 @@ limitations under the License.
 package wip
 
 import (
+	"fmt"
+
 	"github.com/golang/glog"
 
 	"k8s.io/client-go/1.5/kubernetes"
+	"k8s.io/client-go/1.5/pkg/api"
+	"k8s.io/client-go/1.5/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/util/runtime"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
-	servicecatalogclientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
+	"github.com/kubernetes-incubator/service-catalog/pkg/brokerapi"
+	servicecatalogclientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1alpha1"
+	informers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers/servicecatalog/v1alpha1"
+	listers "github.com/kubernetes-incubator/service-catalog/pkg/client/listers/servicecatalog/v1alpha1"
+	"github.com/kubernetes-incubator/service-catalog/pkg/controller/injector"
 )
 
 // NewController returns a new Open Service Broker catalog
 // controller.
 func NewController(
 	kubeClient kubernetes.Interface,
-	serviceCatalogClient servicecatalogclientset.Interface,
-	brokerInformer cache.SharedInformer,
-	serviceClassInformer cache.SharedInformer,
-	instanceInformer cache.SharedInformer,
-	bindingInformer cache.SharedInformer,
+	serviceCatalogClient servicecatalogclientset.ServicecatalogV1alpha1Interface,
+	brokerInformer informers.BrokerInformer,
+	serviceClassInformer informers.ServiceClassInformer,
+	instanceInformer informers.InstanceInformer,
+	bindingInformer informers.BindingInformer,
+	brokerClientCreateFunc brokerapi.CreateFunc,
 ) (Controller, error) {
-	controller := &controller{
-		kubeClient:           kubeClient,
-		serviceCatalogClient: serviceCatalogClient,
-		brokerInformer:       brokerInformer,
-		serviceClassInformer: serviceClassInformer,
-		instanceInformer:     instanceInformer,
-		bindingInformer:      bindingInformer,
-	}
+	var (
+		brokerLister       = brokerInformer.Lister()
+		serviceClassLister = serviceClassInformer.Lister()
+		instanceLister     = instanceInformer.Lister()
 
-	brokerInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		controller = &controller{
+			kubeClient:             kubeClient,
+			serviceCatalogClient:   serviceCatalogClient,
+			brokerClientCreateFunc: brokerClientCreateFunc,
+			brokerLister:           brokerLister,
+			serviceClassLister:     serviceClassLister,
+			instanceLister:         instanceLister,
+		}
+	)
+
+	brokerInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.brokerAdd,
 		UpdateFunc: controller.brokerUpdate,
 		DeleteFunc: controller.brokerDelete,
 	})
 
-	serviceClassInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	serviceClassInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.serviceClassAdd,
 		UpdateFunc: controller.serviceClassUpdate,
 		DeleteFunc: controller.serviceClassDelete,
 	})
 
-	instanceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	instanceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.instanceAdd,
 		UpdateFunc: controller.instanceUpdate,
 		DeleteFunc: controller.instanceDelete,
 	})
 
-	bindingInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	bindingInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.bindingAdd,
 		UpdateFunc: controller.bindingUpdate,
 		DeleteFunc: controller.bindingDelete,
@@ -80,15 +95,17 @@ type Controller interface {
 	Run(stopCh <-chan struct{})
 }
 
+// controller is a concrete Controller.
 type controller struct {
-	kubeClient           kubernetes.Interface
-	serviceCatalogClient servicecatalogclientset.Interface
-	brokerInformer       cache.SharedInformer
-	serviceClassInformer cache.SharedInformer
-	instanceInformer     cache.SharedInformer
-	bindingInformer      cache.SharedInformer
+	kubeClient             kubernetes.Interface
+	serviceCatalogClient   servicecatalogclientset.ServicecatalogV1alpha1Interface
+	brokerClientCreateFunc brokerapi.CreateFunc
+	brokerLister           listers.BrokerLister
+	serviceClassLister     listers.ServiceClassLister
+	instanceLister         listers.InstanceLister
 }
 
+// Run runs the controller until the given stop channel can be read from.
 func (c *controller) Run(stopCh <-chan struct{}) {
 	defer runtime.HandleCrash()
 	glog.Info("Starting service-catalog controller")
@@ -96,6 +113,8 @@ func (c *controller) Run(stopCh <-chan struct{}) {
 	<-stopCh
 	glog.Info("Shutting down service-catalog controller")
 }
+
+// Broker handlers and control-loop
 
 func (c *controller) brokerAdd(obj interface{}) {
 	broker, ok := obj.(*v1alpha1.Broker)
@@ -119,9 +138,142 @@ func (c *controller) brokerDelete(obj interface{}) {
 	glog.V(4).Info("Received delete event for Broker %v", broker.Name)
 }
 
+const (
+	ErrorFetchingCatalogReason  string = "ErrorFetchingCatalog"
+	ErrorFetchingCatalogMessage string = "Error fetching catalog"
+	ErrorSyncingCatalogReason   string = "ErrorSyncingCatalog"
+	ErrorSyncingCatalogMessage  string = "Error syncing catalog from Broker"
+)
+
+// reconcileBroker is the control-loop that reconciles a Broker.
 func (c *controller) reconcileBroker(broker *v1alpha1.Broker) {
 	glog.V(4).Infof("Processing Broker %v", broker.Name)
+
+	username, password, err := GetAuthCredentialsFromBroker(c.kubeClient, broker)
+	if err != nil {
+		glog.Errorf("Error getting broker auth credentials for broker %v: %v", broker.Name, err)
+		c.updateBrokerReadyCondition(broker, v1alpha1.ConditionFalse, ErrorFetchingCatalogReason, ErrorFetchingCatalogMessage)
+		return
+	}
+
+	glog.V(4).Infof("Creating client for Broker %v, URL: %v", broker.Name, broker.Spec.URL)
+	brokerClient := c.brokerClientCreateFunc(broker.Name, broker.Spec.URL, username, password)
+	brokerCatalog, err := brokerClient.GetCatalog()
+	if err != nil {
+		glog.Errorf("Error getting broker catalog for broker %v: %v", broker.Name, err)
+		err := c.updateBrokerReadyCondition(broker, v1alpha1.ConditionFalse, ErrorFetchingCatalogReason, ErrorFetchingCatalogMessage)
+		if err != nil {
+			glog.Errorf("Error updating ready condition for Broker %v: %v", broker.Name, err)
+		}
+
+		return
+	} else {
+		glog.V(5).Infof("Successfully fetched %v catalog entries for Broker %v", len(brokerCatalog.Services), broker.Name)
+	}
+
+	glog.V(4).Infof("Converting catalog response for Broker %v into service-catalog API", broker.Name)
+	catalog, err := convertCatalog(brokerCatalog)
+	if err != nil {
+		glog.Errorf("Error converting catalog payload for broker %v to service-catalog API: %v", broker.Name, err)
+		c.updateBrokerReadyCondition(broker, v1alpha1.ConditionFalse, ErrorSyncingCatalogReason, ErrorSyncingCatalogMessage)
+		return
+	} else {
+		glog.V(5).Infof("Successfully converted catalog payload from Broker %v to service-catalog API", broker.Name)
+	}
+
+	for _, serviceClass := range catalog {
+		glog.V(4).Infof("Reconciling serviceClass %v (broker %v)", serviceClass.Name, broker.Name)
+		if err := c.reconcileServiceClassFromBrokerCatalog(broker, serviceClass); err != nil {
+			glog.Errorf("Error reconciling serviceClass %v (broker %v): %v", serviceClass.Name, broker.Name, err)
+			c.updateBrokerReadyCondition(broker, v1alpha1.ConditionFalse, ErrorSyncingCatalogReason, ErrorSyncingCatalogMessage)
+			return
+		} else {
+			glog.V(5).Infof("Reconciled serviceClass %v (broker %v)", serviceClass.Name, broker.Name)
+		}
+	}
+
+	c.updateBrokerReadyCondition(broker, v1alpha1.ConditionTrue, "FetchedCatalog", "Successfully fetched catalog from broker")
 }
+
+// reconcileServiceClassFromBrokerCatalog reconciles a ServiceClass after the
+// Broker's catalog has been re-listed.
+func (c *controller) reconcileServiceClassFromBrokerCatalog(broker *v1alpha1.Broker, serviceClass *v1alpha1.ServiceClass) error {
+	serviceClass.BrokerName = broker.Name
+
+	existingServiceClass, err := c.serviceClassLister.Get(serviceClass.Name)
+	if err != nil {
+		// An error returned from a lister Get call means that the object does
+		// not exist.  Create a new ServiceClass.
+		if _, err := c.serviceCatalogClient.ServiceClasses().Create(serviceClass); err != nil {
+			glog.Errorf("Error creating serviceClass %v from Broker %v: %v", serviceClass.Name, broker.Name, err)
+			return err
+		}
+
+		return nil
+	}
+
+	// There was an existing service class -- project the update onto it and
+	// update it.
+	clone, err := api.Scheme.DeepCopy(existingServiceClass)
+	if err != nil {
+		return err
+	}
+
+	toUpdate := clone.(*v1alpha1.ServiceClass)
+	toUpdate.Bindable = serviceClass.Bindable
+	toUpdate.Plans = serviceClass.Plans
+	toUpdate.PlanUpdatable = serviceClass.PlanUpdatable
+	toUpdate.OSBTags = serviceClass.OSBTags
+	toUpdate.OSBRequires = serviceClass.OSBRequires
+	toUpdate.OSBMaxDBPerNode = serviceClass.OSBMaxDBPerNode
+	toUpdate.OSBDashboardOAuth2ClientID = serviceClass.OSBDashboardOAuth2ClientID
+	toUpdate.OSBDashboardSecret = serviceClass.OSBDashboardSecret
+	toUpdate.OSBDashboardRedirectURI = serviceClass.OSBDashboardRedirectURI
+
+	toUpdate.Description = serviceClass.Description
+	toUpdate.DisplayName = serviceClass.DisplayName
+	toUpdate.ImageURL = serviceClass.ImageURL
+	toUpdate.LongDescription = serviceClass.LongDescription
+	toUpdate.ProviderDisplayName = serviceClass.ProviderDisplayName
+	toUpdate.DocumentationURL = serviceClass.DocumentationURL
+	toUpdate.SupportURL = serviceClass.SupportURL
+
+	if _, err := c.serviceCatalogClient.ServiceClasses().Update(toUpdate); err != nil {
+		glog.Errorf("Error updating serviceClass %v from Broker %v: %v", serviceClass.Name, broker.Name, err)
+		return err
+	}
+
+	return nil
+}
+
+// updateBrokerReadyCondition updates the ready condition for the given Broker
+// with the given status, reason, and message.
+func (c *controller) updateBrokerReadyCondition(broker *v1alpha1.Broker, status v1alpha1.ConditionStatus, reason, message string) error {
+
+	clone, err := api.Scheme.DeepCopy(broker)
+	if err != nil {
+		return err
+	}
+	toUpdate := clone.(*v1alpha1.Broker)
+	toUpdate.Status.Conditions = []v1alpha1.BrokerCondition{{
+		Type:    v1alpha1.BrokerConditionReady,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	}}
+
+	glog.V(4).Infof("Updating ready condition for Broker %v to %v", broker.Name, status)
+	_, err = c.serviceCatalogClient.Brokers().UpdateStatus(toUpdate)
+	if err != nil {
+		glog.Errorf("Error updating ready condition for Broker %v: %v", broker.Name, err)
+	} else {
+		glog.V(5).Infof("Updated ready condition for Broker %v to %v", broker.Name, status)
+	}
+
+	return err
+}
+
+// Service class handlers and control-loop
 
 func (c *controller) serviceClassAdd(obj interface{}) {
 	serviceClass, ok := obj.(*v1alpha1.ServiceClass)
@@ -132,12 +284,12 @@ func (c *controller) serviceClassAdd(obj interface{}) {
 	c.reconcileServiceClass(serviceClass)
 }
 
-func (c *controller) serviceClassUpdate(oldObj, newObj interface{}) {
-	c.serviceClassAdd(newObj)
+func (c *controller) reconcileServiceClass(serviceClass *v1alpha1.ServiceClass) {
+	glog.V(4).Infof("Processing Instance %v", serviceClass.Name)
 }
 
-func (c *controller) reconcileServiceClass(serviceClass *v1alpha1.ServiceClass) {
-	glog.V(4).Infof("Processing ServiceClass %v", serviceClass.Name)
+func (c *controller) serviceClassUpdate(oldObj, newObj interface{}) {
+	c.serviceClassAdd(newObj)
 }
 
 func (c *controller) serviceClassDelete(obj interface{}) {
@@ -148,6 +300,8 @@ func (c *controller) serviceClassDelete(obj interface{}) {
 
 	glog.V(4).Infof("Received delete event for ServiceClass %v", serviceClass.Name)
 }
+
+// Instance handlers and control-loop
 
 func (c *controller) instanceAdd(obj interface{}) {
 	instance, ok := obj.(*v1alpha1.Instance)
@@ -162,8 +316,145 @@ func (c *controller) instanceUpdate(oldObj, newObj interface{}) {
 	c.instanceAdd(newObj)
 }
 
+// const (
+// 	ErrorFetchingCatalogReason  string = "ErrorFetchingCatalog"
+// 	ErrorFetchingCatalogMessage string = "Error fetching catalog"
+// 	ErrorSyncingCatalogReason   string = "ErrorSyncingCatalog"
+// 	ErrorSyncingCatalogMessage  string = "Error syncing catalog from Broker"
+// )
+
+// reconcileInstance is the control-loop for reconciling Instances.
 func (c *controller) reconcileInstance(instance *v1alpha1.Instance) {
-	glog.V(4).Infof("Processing Instance %v", instance.Name)
+	glog.V(4).Infof("Processing Instance %v/%v", instance.Namespace, instance.Name)
+
+	serviceClass, err := c.serviceClassLister.Get(instance.Spec.ServiceClassName)
+	if err != nil {
+		glog.Errorf("Instance %v/%v references a non-existent ServiceClass %v", instance.Namespace, instance.Name, instance.Spec.ServiceClassName)
+		c.updateInstanceCondition(
+			instance,
+			v1alpha1.InstanceConditionReady,
+			v1alpha1.ConditionFalse,
+			"ReferencesNonexistentServiceClass",
+			"The instance references a ServiceClass that does not exist",
+		)
+		return
+	}
+
+	servicePlan := findServicePlan(instance.Spec.PlanName, serviceClass.Plans)
+	if servicePlan == nil {
+		glog.Errorf("Instance %v/%v references a non-existent ServicePlan %v on ServiceClass %v", instance.Namespace, instance.Name, servicePlan.Name, serviceClass.Name)
+		c.updateInstanceCondition(
+			instance,
+			v1alpha1.InstanceConditionReady,
+			v1alpha1.ConditionFalse,
+			"ReferencesNonexistentServicePlan",
+			"The instance references a ServicePlan that does not exist",
+		)
+		return
+	}
+
+	broker, err := c.brokerLister.Get(serviceClass.BrokerName)
+	if err != nil {
+		glog.Errorf("Instance %v/%v references a non-existent broker %v", instance.Namespace, instance.Name, serviceClass.BrokerName)
+		c.updateInstanceCondition(
+			instance,
+			v1alpha1.InstanceConditionReady,
+			v1alpha1.ConditionFalse,
+			"ReferencesNonexistentBroker",
+			"The instance references a Broker that does not exist",
+		)
+		return
+	}
+
+	username, password, err := GetAuthCredentialsFromBroker(c.kubeClient, broker)
+	if err != nil {
+		glog.Errorf("Error getting broker auth credentials for broker %v: %v", broker.Name, err)
+		c.updateInstanceCondition(
+			instance,
+			v1alpha1.InstanceConditionReady,
+			v1alpha1.ConditionFalse,
+			"ErrorGettingAuthCredentials",
+			"Error getting auth credentials",
+		)
+		return
+	}
+
+	glog.V(4).Infof("Creating client for Broker %v, URL: %v", broker.Name, broker.Spec.URL)
+	brokerClient := c.brokerClientCreateFunc(broker.Name, broker.Spec.URL, username, password)
+
+	// TODO: parameters
+
+	request := &brokerapi.CreateServiceInstanceRequest{
+		ServiceID: serviceClass.OSBGUID,
+		PlanID:    servicePlan.OSBGUID,
+	}
+
+	// TODO: handle async provisioning
+
+	glog.V(4).Infof("Provisioning a new Instance %v/%v of ServiceClass %v at Broker %v", instance.Namespace, instance.Name, serviceClass.Name, broker.Name)
+	response, err := brokerClient.CreateServiceInstance(instance.Spec.OSBGUID, request)
+	if err != nil {
+		glog.Errorf("Error provisioning Instance %v/%v of ServiceClass %v at Broker %v: %v", instance.Namespace, instance.Name, serviceClass.Name, broker.Name, err)
+		c.updateInstanceCondition(
+			instance,
+			v1alpha1.InstanceConditionReady,
+			v1alpha1.ConditionFalse,
+			"ProvisionCallFailed",
+			"Provision call failed")
+		return
+	} else {
+		glog.V(5).Infof("Successfully provisioned Instance %v/%v of ServiceClass %v at Broker %v: response: %v", instance.Namespace, instance.Name, serviceClass.Name, broker.Name, response)
+	}
+
+	// TODO: process response
+
+	c.updateInstanceCondition(
+		instance,
+		v1alpha1.InstanceConditionReady,
+		v1alpha1.ConditionTrue,
+		"ProvisionedSuccessfully",
+		"The instance was provisioned successfully",
+	)
+}
+
+func findServicePlan(name string, plans []v1alpha1.ServicePlan) *v1alpha1.ServicePlan {
+	for _, plan := range plans {
+		if name == plan.Name {
+			return &plan
+		}
+	}
+
+	return nil
+}
+
+// updateInstanceCondition updates the given condition for the given Instance
+// with the given status, reason, and message.
+func (c *controller) updateInstanceCondition(
+	instance *v1alpha1.Instance,
+	conditionType v1alpha1.InstanceConditionType,
+	status v1alpha1.ConditionStatus,
+	reason, message string) error {
+
+	clone, err := api.Scheme.DeepCopy(instance)
+	if err != nil {
+		return err
+	}
+	toUpdate := clone.(*v1alpha1.Instance)
+
+	toUpdate.Status.Conditions = []v1alpha1.InstanceCondition{{
+		Type:    conditionType,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	}}
+
+	glog.V(4).Infof("Updating %v condition for Instance %v/%v to %v", conditionType, instance.Namespace, instance.Name, status)
+	_, err = c.serviceCatalogClient.Instances(instance.Namespace).UpdateStatus(toUpdate)
+	if err != nil {
+		glog.Errorf("Failed to update condition %v for Instance %v/%v to true: %v", conditionType, instance.Namespace, instance.Name, err)
+	}
+
+	return err
 }
 
 func (c *controller) instanceDelete(obj interface{}) {
@@ -172,8 +463,10 @@ func (c *controller) instanceDelete(obj interface{}) {
 		return
 	}
 
-	glog.V(4).Infof("Received delete event for Instance %v", instance.Name)
+	glog.V(4).Infof("Received delete event for Instance %v/%v", instance.Namespace, instance.Name)
 }
+
+// Binding handlers and control-loop
 
 func (c *controller) bindingAdd(obj interface{}) {
 	binding, ok := obj.(*v1alpha1.Binding)
@@ -189,7 +482,171 @@ func (c *controller) bindingUpdate(oldObj, newObj interface{}) {
 }
 
 func (c *controller) reconcileBinding(binding *v1alpha1.Binding) {
-	glog.V(4).Infof("Processing Binding %v", binding.Name)
+	glog.V(4).Infof("Processing Binding %v/%v", binding.Namespace, binding.Name)
+
+	instance, err := c.instanceLister.Instances(binding.Namespace).Get(binding.Spec.InstanceRef.Name)
+	if err != nil {
+		glog.Errorf("Binding %v/%v references a non-existent Instance %v/%v", binding.Namespace, binding.Name, binding.Namespace, instance.Name)
+		c.updateBindingCondition(
+			binding,
+			v1alpha1.BindingConditionReady,
+			v1alpha1.ConditionFalse,
+			"ReferencesNonexistentServiceClass",
+			"The binding references an Instance that does not exist",
+		)
+		return
+	}
+
+	serviceClass, err := c.serviceClassLister.Get(instance.Spec.ServiceClassName)
+	if err != nil {
+		glog.Errorf("Binding %v/%v references a non-existent ServiceClass %v", binding.Namespace, binding.Name, instance.Spec.ServiceClassName)
+		c.updateBindingCondition(
+			binding,
+			v1alpha1.BindingConditionReady,
+			v1alpha1.ConditionFalse,
+			"ReferencesNonexistentServiceClass",
+			"The binding references a ServiceClass that does not exist",
+		)
+		return
+	}
+
+	broker, err := c.brokerLister.Get(serviceClass.BrokerName)
+	if err != nil {
+		glog.Errorf("Binding %v/%v references a non-existent Broker %v", binding.Namespace, binding.Name, serviceClass.BrokerName)
+		c.updateBindingCondition(
+			binding,
+			v1alpha1.BindingConditionReady,
+			v1alpha1.ConditionFalse,
+			"ReferencesNonexistentBroker",
+			"The binding references a Broker that does not exist",
+		)
+		return
+	}
+
+	servicePlan := findServicePlan(instance.Spec.PlanName, serviceClass.Plans)
+	if servicePlan == nil {
+		glog.Errorf("Instance %v/%v references a non-existent ServicePlan %v on ServiceClass %v", instance.Namespace, instance.Name, servicePlan.Name, serviceClass.Name)
+		c.updateBindingCondition(
+			binding,
+			v1alpha1.BindingConditionReady,
+			v1alpha1.ConditionFalse,
+			"ReferencesNonexistentServicePlan",
+			"The binding references a ServicePlan that does not exist",
+		)
+		return
+	}
+
+	username, password, err := GetAuthCredentialsFromBroker(c.kubeClient, broker)
+	if err != nil {
+		glog.Errorf("Error getting broker auth credentials for broker %v: %v", broker.Name, err)
+		c.updateBindingCondition(
+			binding,
+			v1alpha1.BindingConditionReady,
+			v1alpha1.ConditionFalse,
+			"ErrorGettingAuthCredentials",
+			"Error getting auth credentials",
+		)
+		return
+	}
+
+	glog.V(4).Infof("Creating client for Broker %v, URL: %v", broker.Name, broker.Spec.URL)
+	brokerClient := c.brokerClientCreateFunc(broker.Name, broker.Spec.URL, username, password)
+
+	// TODO: parameters
+
+	request := &brokerapi.BindingRequest{
+		ServiceID: serviceClass.OSBGUID,
+		PlanID:    servicePlan.OSBGUID,
+	}
+
+	response, err := brokerClient.CreateServiceBinding(instance.Spec.OSBGUID, binding.Spec.OSBGUID, request)
+
+	err = c.injectBinding(binding, &response.Credentials)
+	if err != nil {
+		glog.Errorf("Error injecting binding results for Binding %v/%v: %v", binding.Namespace, binding.Name, err)
+		c.updateBindingCondition(
+			binding,
+			v1alpha1.BindingConditionReady,
+			v1alpha1.ConditionFalse,
+			"ErrorInjectingBindResult",
+			"Error injecting bind result",
+		)
+		return
+	}
+
+	c.updateBindingCondition(
+		binding,
+		v1alpha1.BindingConditionReady,
+		v1alpha1.ConditionTrue,
+		"InjectedBindResult",
+		"Injected bind result",
+	)
+}
+
+func (c *controller) injectBinding(binding *v1alpha1.Binding, credentials *brokerapi.Credential) error {
+	secret := &v1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      binding.Spec.SecretName,
+			Namespace: binding.Namespace,
+		},
+		Data: make(map[string][]byte),
+	}
+
+	for k, v := range *credentials {
+		var err error
+		secret.Data[k], err = injector.Serialize(v)
+		if err != nil {
+			return fmt.Errorf("Unable to serialize credential value %q: %v; %s",
+				k, v, err)
+		}
+	}
+
+	found := false
+
+	_, err := c.kubeClient.Core().Secrets(binding.Namespace).Get(binding.Spec.SecretName)
+	if err == nil {
+		found = true
+	}
+
+	if found {
+		_, err = c.kubeClient.Core().Secrets(binding.Namespace).Update(secret)
+	} else {
+		_, err = c.kubeClient.Core().Secrets(binding.Namespace).Create(secret)
+	}
+
+	return err
+}
+
+// updateBindingCondition updates the given condition for the given Binding
+// with the given status, reason, and message.
+func (c *controller) updateBindingCondition(
+	binding *v1alpha1.Binding,
+	conditionType v1alpha1.BindingConditionType,
+	status v1alpha1.ConditionStatus,
+	reason, message string) error {
+
+	clone, err := api.Scheme.DeepCopy(binding)
+	if err != nil {
+		return err
+	}
+	toUpdate := clone.(*v1alpha1.Binding)
+
+	toUpdate.Status.Conditions = []v1alpha1.BindingCondition{{
+		Type:    conditionType,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	}}
+
+	logContext := fmt.Sprintf("%v condition for Binding %v/%v to %v (Reason: %q, Message: %q)",
+		conditionType, binding.Namespace, binding.Name, status, reason, message)
+
+	glog.V(4).Infof("Updating %v", logContext)
+	_, err = c.serviceCatalogClient.Bindings(binding.Namespace).UpdateStatus(toUpdate)
+	if err != nil {
+		glog.Errorf("Error updating %v: %v", logContext, err)
+	}
+	return err
 }
 
 func (c *controller) bindingDelete(obj interface{}) {
@@ -198,5 +655,66 @@ func (c *controller) bindingDelete(obj interface{}) {
 		return
 	}
 
-	glog.V(4).Infof("Received delete event for Binding %v", binding.Name)
+	glog.V(4).Infof("Received delete event for Binding %v/%v", binding.Namespace, binding.Name)
+}
+
+// Broker utility methods - move?
+
+// GetAuthCredentialsFromBroker returns the auth credentials, if any,
+// contained in the secret referenced in the Broker's AuthSecret field, or
+// returns an error. If the AuthSecret field is nil, empty values are
+// returned.
+func GetAuthCredentialsFromBroker(client kubernetes.Interface, broker *v1alpha1.Broker) (username, password string, err error) {
+	if broker.Spec.AuthSecret == nil {
+		return "", "", nil
+	}
+
+	authSecret, err := client.Core().Secrets(broker.Spec.AuthSecret.Namespace).Get(broker.Spec.AuthSecret.Name)
+	if err != nil {
+		return "", "", err
+	}
+
+	usernameBytes, ok := authSecret.Data["username"]
+	if !ok {
+		return "", "", fmt.Errorf("auth secret didn't contain username")
+	}
+
+	passwordBytes, ok := authSecret.Data["password"]
+	if !ok {
+		return "", "", fmt.Errorf("auth secret didn't contain password")
+	}
+
+	return string(usernameBytes), string(passwordBytes), nil
+}
+
+// convertCatalog converts a service broker catalog into an array of ServiceClasses
+func convertCatalog(in *brokerapi.Catalog) ([]*v1alpha1.ServiceClass, error) {
+	ret := make([]*v1alpha1.ServiceClass, len(in.Services))
+	for i, svc := range in.Services {
+		plans := convertServicePlans(svc.Plans)
+		ret[i] = &v1alpha1.ServiceClass{
+			Bindable:      svc.Bindable,
+			Plans:         plans,
+			PlanUpdatable: svc.PlanUpdateable,
+			OSBGUID:       svc.ID,
+			OSBTags:       svc.Tags,
+			OSBRequires:   svc.Requires,
+			// OSBMetadata:   svc.Metadata,
+		}
+		ret[i].SetName(svc.Name)
+	}
+	return ret, nil
+}
+
+func convertServicePlans(plans []brokerapi.ServicePlan) []v1alpha1.ServicePlan {
+	ret := make([]v1alpha1.ServicePlan, len(plans))
+	for i, plan := range plans {
+		ret[i] = v1alpha1.ServicePlan{
+			Name:    plan.Name,
+			OSBGUID: plan.ID,
+			// OSBMetadata: plan.Metadata,
+			OSBFree: plan.Free,
+		}
+	}
+	return ret
 }

--- a/pkg/controller/wip/controller_test.go
+++ b/pkg/controller/wip/controller_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wip
+
+import (
+	"testing"
+)
+
+func TestReconcileBroker(t *testing.T) {
+	// create a fake kube client
+	// create a fake sc client
+	// create a fake broker client
+	// create a test controller
+	// inject a broker resource into broker informer
+	// verify broker's catalog method is called
+	// verify sc client has service classes created
+	// verify no kube resources created
+}


### PR DESCRIPTION
Port biz logic from the prototype controller into the WIP informer-based controller.  Covers:

1.  Get catalog from broker
2.  Provision
3.  Bind

🏗 🏗 

Please review dependent PRs first:
- [x] #286 
- [x] #394 
- [x] #395

Changes for this PR are in final commit.