### PR TITLE
e2e start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,12 +247,16 @@ verify: .init .generate_files
 	@echo Running errexit checker:
 	@$(DOCKER_CMD) build/verify-errexit.sh
 
+.PHONY: format coverage
+
 format: .init
 	$(DOCKER_CMD) gofmt -w -s $(TOP_SRC_DIRS)
 
 coverage: .init
 	$(DOCKER_CMD) contrib/hack/coverage.sh --html "$(COVERAGE)" \
 	  $(addprefix ./,$(TEST_DIRS))
+
+.PHONY: test test-unit test-integration
 
 test: .init build test-unit test-integration
 
@@ -268,6 +272,8 @@ test-integration: .init build
 	# golang integration tests
 	$(DOCKER_CMD) test/integration.sh
 
+test-e2e:
+	$(DOCKER_CMD) test/e2e.sh
 
 clean:
 	rm -rf $(BINDIR)

--- a/test/e2e/e2e-setup.yaml
+++ b/test/e2e/e2e-setup.yaml
@@ -16,13 +16,14 @@ spec:
     - -v
     - "10"
     ports:
-    - name: https
-      containerPort: 6443
+    - containerPort: 6443
   # bring our own etcd until we can attach to core
   - name: etcd
     image: quay.io/coreos/etcd:v3.0.17
 ---
-# this exposes the apiserver
+# this exposes the apiserver on a specific port
+#
+# not sure why I have to repeat myself so many times
 apiVersion: v1
 kind: Service
 metadata:
@@ -30,8 +31,10 @@ metadata:
 spec:
   selector:
     app: apiserver
+  type: NodePort
   ports:
   - protocol: TCP
-    port: 6443
-    targetPort: https
+    port: 30000
+    nodePort: 30000
+    targetPort: 6443
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1,0 +1,1 @@
+package e2e

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	kv1 "k8s.io/client-go/1.5/pkg/api/v1"
-
-	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	"k8s.io/kubernetes/test/e2e/framework"
 
@@ -15,6 +12,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/restclient"
 
 	// avoid error `servicecatalog/v1alpha1 is not enabled`
+	k8sclient "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
 
 	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
 	// avoid error `no kind is registered for the type v1.ListOptions`
@@ -48,21 +46,33 @@ func init() {
 //
 // It will call the apiserver to
 func TestBrokerInstall(t *testing.T) {
-	// framework config
-	c, err := framework.LoadConfig()
+	var err error
+
+	_ = clientcmd.NewDefaultClientConfig(*clientcmdapi.NewConfig(), &clientcmd.ConfigOverrides{})
+	t.Log(po)
+	_, err = po.GetStartingConfig()
+	t.Log(po)
+	t.Log(po.LoadingRules.ExplicitPath)
+	//kubeconfigPath, err := filepath.Abs(po.kubeconfigPath)
+	//kclient := util.NewFactory(kconfig)
+	//kgv := kclient.Core().RESTClient().APIVersion()
+	//t.Log(kgv)
 	if nil != err {
-		t.Fatalf("Failed to create a kube config, could not figure out the path\n:%v\n", err)
+		t.Fatalf("Failed to read a kube config, could not figure out the path\n:%v\n", err)
 	}
 	t.Logf(">>> kubeConfig: %s\n", framework.TestContext.KubeConfig)
 	t.Logf(">>> kubeConfig: %s\n", framework.TestContext.KubeConfig)
 	if TestContext.KubeConfig == "" {
 		return nil, fmt.Errorf("KubeConfig must be specified to load client config")
 	}
-	kclient, err := clientset.NewForConfig(config)
+	//kconfig := &rest.Config{}
+	//kconfig.Host = "https://localhost:6443"
+	//kconfig.Insecure = true
+	kclient, err := k8sclient.NewForConfig(kconfig)
 	if nil != err {
 		t.Fatalf("Failed to load config and make client\n:%v\n", err)
 	}
-	kgv = kclient.Core().GetRESTClient().APIVersion()
+	kgv := kclient.Core().RESTClient().APIVersion()
 	t.Log(kgv)
 
 	// k8s client
@@ -73,7 +83,7 @@ func TestBrokerInstall(t *testing.T) {
 	// kgv = kclient.Core().GetRESTClient().APIVersion()
 	// t.Log(kgv)
 
-	pod := &kv1.Pod{}
+	pod := &v1.Pod{}
 	pod, err = kclient.Core().Pods("default").Create(pod)
 	if nil != err {
 		t.Fatal("error creating pod\n", err)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,138 @@
+package e2e_test
+
+import (
+	"flag"
+	"testing"
+
+	"k8s.io/client-go/1.5/kubernetes"
+
+	kv1 "k8s.io/client-go/1.5/pkg/api/v1"
+
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/client/restclient"
+
+	// avoid error `servicecatalog/v1alpha1 is not enabled`
+
+	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
+	// avoid error `no kind is registered for the type v1.ListOptions`
+
+	_ "k8s.io/kubernetes/pkg/api/install"
+
+	// client-go has got to come from somewhere, and this is part of it, cause we need the tools
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	servicecatalogclient "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
+)
+
+var kubeconfigPath string
+var po *clientcmd.PathOptions
+
+func init() {
+	po = clientcmd.NewDefaultPathOptions()
+	flag.StringVar(&po.LoadingRules.ExplicitPath, po.ExplicitFileFlag, po.LoadingRules.ExplicitPath, "what do you think this is?")
+}
+
+// TestBrokerInstall relies on:
+// - a running k8s
+// - running apiserver
+// - running broker (maybe? if we don't actually contact it, this shouldn't matter)
+// - controller (to do the watch on the brokers and contact it to change it's status)
+//
+// It will call the apiserver to
+func TestBrokerInstall(t *testing.T) {
+	_ = clientcmd.NewDefaultClientConfig(*clientcmdapi.NewConfig(), &clientcmd.ConfigOverrides{})
+
+	config2, err := po.GetStartingConfig()
+	//kubeconfigPath, err := filepath.Abs(po.kubeconfigPath)
+	//kclient := util.NewFactory(kconfig)
+	//kgv := kclient.Core().RESTClient().APIVersion()
+	//t.Log(kgv)
+	if nil != err {
+		t.Fatalf("Failed to create a kube config, could not figure out the path\n:%v\n", err)
+	}
+	// k8s client
+	kconfig, err := clientcmd.BuildConfigFromFlags("", po.LoadingRules.ExplicitPath)
+	if err != nil {
+		t.Fatalf("Failed to create a kube config\n:%v\n", err)
+	}
+	//kconfig := &rest.Config{}
+	//kconfig.Host = "https://localhost:6443"
+	//kconfig.Insecure = true
+	kclient, err := kubernetes.NewForConfig(kconfig)
+	if nil != err {
+		t.Fatal("can't make the client from the config", err)
+	}
+	kgv = kclient.Core().GetRESTClient().APIVersion()
+	t.Log(kgv)
+
+	pod := &kv1.Pod{}
+	pod, err = kclient.Core().Pods("default").Create(pod)
+	if nil != err {
+		t.Fatal("error creating pod\n", err)
+	}
+
+	// sc client
+	config := &restclient.Config{}
+	config.Host = "https://localhost:30000"
+	config.Insecure = true
+	client, err := servicecatalogclient.NewForConfig(config)
+	if nil != err {
+		t.Fatal("can't make the client from the config", err)
+	}
+	gv := client.Servicecatalog().RESTClient().APIVersion()
+	t.Log(gv)
+
+	brokerClient := client.Servicecatalog().Brokers()
+	_ = brokerClient.Delete("test-broker", &v1.DeleteOptions{})
+
+	brokers, err := brokerClient.List(v1.ListOptions{})
+	if nil != err {
+		t.Fatal("error listing the broker\n", err)
+	}
+	if len(brokers.Items) > 0 {
+		t.Fatalf("brokers should not exist on start, had %v brokers", len(brokers.Items))
+	}
+	t.Log(brokers)
+
+	broker := &v1alpha1.Broker{
+		ObjectMeta: v1.ObjectMeta{Name: "test-broker"},
+		Spec: v1alpha1.BrokerSpec{
+			URL:          "https://example.com",
+			AuthUsername: "auth username field value",
+			AuthPassword: "auth password field value",
+			OSBGUID:      "OSBGUID field",
+		},
+	}
+
+	brokerServer, err := brokerClient.Create(broker)
+	if nil != err {
+		t.Fatal("error creating the broker\n", err, "\nbroker ", broker)
+	}
+	if broker.Name != brokerServer.Name {
+		t.Fatalf("didn't get the same broker back from the server \n%+v\n%+v", broker, brokerServer)
+	}
+
+	brokers, err = brokerClient.List(v1.ListOptions{})
+	if 1 != len(brokers.Items) {
+		t.Fatalf("should have exactly one broker, had %v brokers", len(brokers.Items))
+	}
+
+	brokerServer, err = brokerClient.Get(broker.Name)
+	if broker.Name != brokerServer.Name &&
+		broker.ResourceVersion == brokerServer.ResourceVersion {
+		t.Fatalf("didn't get the same broker back from the server \n%+v\n%+v", broker, brokerServer)
+	}
+	err = brokerClient.Delete("test-broker", &v1.DeleteOptions{})
+	if nil != err {
+		t.Fatal("broker should be deleted", err)
+	}
+
+	brokerDeleted, err := brokerClient.Get("test-broker")
+	if nil == err {
+		t.Fatal("broker should be deleted", brokerDeleted)
+	}
+
+}


### PR DESCRIPTION
It's really the same exact test as the integration test, but with a differently configured client and no starting of a server internally. 

We need to be able to tell the test, "go and talk to this server". 

I'm waiting for the controller to settle down before I tackle adding that.

Need to also figure out running a broker and add it to the same pod (for testing for now) until we can run this on a cluster where everything runs elsewhere.

I don't know the best-practices on exposing pods, so I copied the example yaml and modified it till it works. 

Process to work is:
 - run kubernetes with dns (I actually don't think this is needed anymore)
 - `kubectl create -f e2e-setup.yaml`
 - `go test e2e_test.go' which looks at localhost for the exposed port 30000 and talks to it using our standard client