### PR TITLE
removing old scripts from the integration test make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,9 +262,6 @@ test-unit: .init build
 	  $(addprefix $(SC_PKG)/,$(TEST_DIRS))
 
 test-integration: .init build
-	# test kubectl
-	contrib/hack/setup-kubectl.sh
-	contrib/hack/test-apiserver.sh
 	# golang integration tests
 	$(DOCKER_CMD) test/integration.sh
 


### PR DESCRIPTION
These scripts were previously making integration tests hang forever, causing travis to abort builds