### PR TITLE
Do not create a client in the API server when storage type == etcd

### DIFF
--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -24,14 +24,11 @@ import (
 
 	"github.com/golang/glog"
 	// set up logging the k8s way
-	"k8s.io/kubernetes/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/util/logs"
 
 	"github.com/kubernetes-incubator/service-catalog/cmd/apiserver/app/server"
 	// install our API groups
 	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
-	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
-	"k8s.io/kubernetes/pkg/client/restclient"
 )
 
 func main() {
@@ -39,20 +36,13 @@ func main() {
 	// make sure we print all the logs while shutting down.
 	defer logs.FlushLogs()
 
-	cfg, err := restclient.InClusterConfig()
+	cmd, err := server.NewCommandServer(os.Stdout)
 	if err != nil {
-		glog.Errorf("Failed to get kube client config (%s)", err)
-		os.Exit(1)
-	}
-	cfg.GroupVersion = &schema.GroupVersion{}
-
-	clIface, err := clientset.NewForConfig(cfg)
-	if err != nil {
-		glog.Errorf("Failed to create clientset Interface (%s)", err)
+		glog.Errorf("Error creating server: %v", err)
+		logs.FlushLogs()
 		os.Exit(1)
 	}
 
-	cmd := server.NewCommandServer(os.Stdout, clIface)
 	if err := cmd.Execute(); err != nil {
 		glog.Errorf("server exited unexpectedly (%s)", err)
 		logs.FlushLogs()

--- a/cmd/apiserver/app/server/etcd_options.go
+++ b/cmd/apiserver/app/server/etcd_options.go
@@ -19,7 +19,6 @@ package server
 import (
 	"github.com/spf13/pflag"
 	// "k8s.io/kubernetes/pkg/client/typed/dynamic"
-	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
 	genericserveroptions "k8s.io/kubernetes/pkg/genericapiserver/options"
 )
 
@@ -27,7 +26,6 @@ import (
 // communicates with an etcd. This struct is exported so that it can be used by integration
 // tests
 type EtcdOptions struct {
-	cl clientset.Interface
 	// storage with etcd
 	*genericserveroptions.EtcdOptions
 }

--- a/cmd/apiserver/app/server/options.go
+++ b/cmd/apiserver/app/server/options.go
@@ -47,7 +47,7 @@ func (s *ServiceCatalogServerOptions) addFlags(flags *pflag.FlagSet) {
 	flags.StringVar(
 		&s.StorageTypeString,
 		"storage-type",
-		"service-catalog",
+		"etcd",
 		"The type of backing storage this API server should use",
 	)
 

--- a/cmd/apiserver/app/server/run_server.go
+++ b/cmd/apiserver/app/server/run_server.go
@@ -41,9 +41,9 @@ func RunServer(opts *ServiceCatalogServerOptions) error {
 
 func runTPRServer(opts *ServiceCatalogServerOptions) error {
 	tprOpts := opts.TPROptions
-	glog.Infoln("installing TPR types to the cluster")
+	glog.Infoln("Installing TPR types to the cluster")
 	if err := tpr.InstallTypes(tprOpts.clIface); err != nil {
-		glog.V(4).Infof("installing TPR types failed, continuing anyway (%s)", err)
+		glog.V(4).Infof("Installing TPR types failed, continuing anyway (%s)", err)
 	}
 	glog.V(4).Infoln("Preparing to run API server")
 	genericConfig, err := setupBasicServer(opts)
@@ -117,7 +117,7 @@ func runEtcdServer(opts *ServiceCatalogServerOptions) error {
 	}
 
 	// Set the finalized generic and storage configs
-	config := apiserver.NewEtcdConfig(opts.EtcdOptions.cl, genericConfig, 0, storageFactory)
+	config := apiserver.NewEtcdConfig(genericConfig, 0 /* deleteCollectionWorkers */, storageFactory)
 
 	// Fill in defaults not already set in the config
 	completed := config.Complete()


### PR DESCRIPTION
Currently the apiserver binary assumes an in-cluster config is available regardless of storage type, which causes problems running with etcd storage outside a cluster.