### PR TITLE
Fix issue building ctrl-mgr image name in wip chart

### DIFF
--- a/deploy/wip-catalog/templates/controller-manager.yaml
+++ b/deploy/wip-catalog/templates/controller-manager.yaml
@@ -11,9 +11,9 @@ spec:
     spec:
       containers:
       - name: controller-manager
-        image: {{ if .Values.registry }}{{ cat .Values.registry "/"}}{{ end }}controller-manager:{{ if .Values.k8sApiServerVersion }}{{ .Values.k8sApiServerVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}
+        image: {{ if .Values.registry }}{{ .Values.registry }}/{{ end }}controller-manager:{{ if .Values.k8sApiServerVersion }}{{ .Values.k8sApiServerVersion }}{{ else }}{{ default "latest" .Values.version }}{{ end }}
         imagePullPolicy: {{ default "Always" .Values.imagePullPolicy }}
-        args: 
+        args:
         - -v
         - "5"
         - --service-catalog-api-server-url


### PR DESCRIPTION
`cat` adds a space and makes this an invalid image name / URL.