### PR TITLE
Add back in the test-apiserver stuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,10 @@ test-unit: .init build
 	$(DOCKER_CMD) go test $(UNIT_TEST_FLAGS) \
 	  $(addprefix $(SC_PKG)/,$(TEST_DIRS))
 
-test-integration: .init build
+test-integration: .init $(scBuildImageTarget) build
+	# test kubectl
+	contrib/hack/setup-kubectl.sh
+	contrib/hack/test-apiserver.sh
 	# golang integration tests
 	$(DOCKER_CMD) test/integration.sh
 

--- a/contrib/examples/apiserver/binding.yaml
+++ b/contrib/examples/apiserver/binding.yaml
@@ -2,6 +2,7 @@ apiVersion: servicecatalog.k8s.io/v1alpha1
 kind: Binding
 metadata:
   name: test-binding
+  namespace: test-ns
 spec:
   instanceRef:
     name: test-instance

--- a/contrib/examples/apiserver/instance.yaml
+++ b/contrib/examples/apiserver/instance.yaml
@@ -2,6 +2,7 @@ apiVersion: servicecatalog.k8s.io/v1alpha1
 kind: Instance
 metadata:
   name: test-instance
+  namespace: test-ns
 spec:
   serviceClassName: test-serviceclass
   planName: example-plan-1

--- a/contrib/hack/kubectl
+++ b/contrib/hack/kubectl
@@ -25,9 +25,19 @@ mkdir -p ${ROOT}/.var/run/kubernetes-service-catalog ${ROOT}/.kube ${ROOT}/.run
 # Run kubectl in a container - make sure we cd into the correct dir
 # based on the current working dir. Yes, this assumes that you're running
 # this script from within our git repo source tree
+
+# Override the server port info based on current apiserver container's info.
+# If etcd-svc-cat isn't running then assume the caller already set up the
+# kubectl config info and we don't want to override it.
+PORT=$(docker port etcd-svc-cat 8081 | sed "s/.*://")
+if [ -n "${PORT}" ]; then
+	SERVER_INFO="--server localhost:${PORT}"
+fi
+
 docker run --rm -ti --net host \
 	-w /root/service-catalog${PWD#${ROOT}} \
 	-v ${ROOT}/.var/run/kubernetes-service-catalog:/var/run/kubernetes-service-catalog \
 	-v ${ROOT}/.kube:/.kube \
 	-v ${ROOT}:/root/service-catalog \
-	kubectl $*
+	--privileged \
+	kubectl ${SERVER_INFO} $*

--- a/contrib/hack/make-kubectl.sh
+++ b/contrib/hack/make-kubectl.sh
@@ -18,8 +18,9 @@ set -e
 # For now pull down a pre-built 'kubectl' image that has the latest
 # build. We need this version in order to pick-up some recent fixes.
 # Once we have an official image we can use then we can delete this section
-docker pull duglin/kubectl
-docker tag duglin/kubectl kubectl
+echo Downloading kubectl image...
+docker pull duglin/kubectl:latest
+docker tag duglin/kubectl:latest kubectl
 
 exit 0
 

--- a/contrib/hack/start-server.sh
+++ b/contrib/hack/start-server.sh
@@ -21,22 +21,45 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 export PATH=${ROOT}/contrib/hack:${PATH}
 
 # Clean up old containers if still around
-docker rm -f etcd apiserver > /dev/null 2>&1 || true
+docker rm -f etcd-svc-cat apiserver > /dev/null 2>&1 || true
 
-# Start etcd, our DB
+# Start etcd, our DB. Also, map 8081 (api server port) to some random
+# port on the host - then ask Docker for the port # as we'll need to use
+# that when we talk to it.
 echo Starting etcd
-docker run -ti --name etcd -d --net host quay.io/coreos/etcd > /dev/null
+docker run -ti --name etcd-svc-cat -d -p 8081 quay.io/coreos/etcd > /dev/null
+PORT=$(docker port etcd-svc-cat 8081 | sed "s/.*://")
 
 # And now our API Server
 echo Starting the API Server
-docker run -ti --name apiserver -d --net host \
+docker run -tid --name apiserver \
 	-v ${ROOT}:/go/src/github.com/kubernetes-incubator/service-catalog \
 	-v ${ROOT}/.var/run/kubernetes-service-catalog:/var/run/kubernetes-service-catalog \
 	-v ${ROOT}/.kube:/root/.kube \
+	-e KUBERNETES_SERVICE_HOST=localhost \
+	-e KUBERNETES_SERVICE_PORT=6443 \
+	--privileged \
+	--net container:etcd-svc-cat \
 	scbuildimage \
-	bin/apiserver -v 10 --etcd-servers http://localhost:2379 > /dev/null
+	bin/apiserver -v 10 --etcd-servers http://localhost:2379 \
+		--insecure-bind-address=0.0.0.0 --insecure-port=8081 \
+		--storage-type=etcd
 
 # Wait for apiserver to be up and running
-while ! curl -k http://localhost:6443 > /dev/null 2>&1 ; do
+echo Waiting for API Server to be available...
+count=0
+D_HOST=${DOCKER_HOST:-localhost}
+D_HOST=${D_HOST#*//}   # remove leading proto://
+D_HOST=${D_HOST%:*}    # remove trailing port #
+while ! curl http://${D_HOST}:${PORT} > /dev/null 2>&1 ; do
 	sleep 1
+	(( count++ )) || true
+	if [ "${count}" == "30" ]; then
+		echo "Timed-out waiting for API Server"
+		(set -x ; curl http://${D_HOST}:${PORT})
+		(set -x ; docker ps)
+		(set -x ; docker logs apiserver)
+		exit 1
+	fi
 done
+echo API Server is ready

--- a/contrib/hack/stop-server.sh
+++ b/contrib/hack/stop-server.sh
@@ -21,4 +21,4 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 export PATH=${ROOT}/contrib/hack:${PATH}
 
 # Clean up old containers if still around
-docker rm -f etcd apiserver || true
+docker rm -f etcd-svc-cat apiserver || true


### PR DESCRIPTION
Depends on #419 

The biggest change here is that we run etcd and apiserver in different containers but they share a network - this way they can talk to each other via "localhost" and we access it from outside the container via a port mapping that Docker sets up for us.  Thus avoiding any overlap with existing port usage.

Signed-off-by: Doug Davis <dug@us.ibm.com>