### PR TITLE
Making TPRName() return the proper name for the TPR

### DIFF
--- a/pkg/storage/tpr/kinds.go
+++ b/pkg/storage/tpr/kinds.go
@@ -18,6 +18,7 @@ package tpr
 
 import (
 	"fmt"
+	"strings"
 	"unicode"
 )
 
@@ -37,7 +38,7 @@ func (k Kind) String() string {
 	return string(k)
 }
 
-// TPRName returns the lowercase name, suitable for fetching resources of this kind
+// TPRName returns the lowercase name, suitable for creating third party resources of this kind
 func (k Kind) TPRName() string {
 	// this code taken from code under
 	// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/extending-api.md#expectations-about-third-party-objects
@@ -50,6 +51,23 @@ func (k Kind) TPRName() string {
 		result = result + string(unicode.ToLower(current))
 	}
 	return result
+}
+
+// URLName returns the URL-worthy name this TPR kind. Examples:
+//
+//	Kind("ServiceClass").URLName() == "serviceclasses"
+//	Kind("Broker").URLName() == "brokers"
+func (k Kind) URLName() string {
+	str := k.String()
+	strLen := len(str)
+	lastChar := str[strLen-1]
+	var ret string
+	if lastChar == 's' {
+		ret = str + "es"
+	} else {
+		ret = str + "s"
+	}
+	return strings.ToLower(ret)
 }
 
 const (

--- a/pkg/storage/tpr/kinds.go
+++ b/pkg/storage/tpr/kinds.go
@@ -57,6 +57,9 @@ func (k Kind) TPRName() string {
 //
 //	Kind("ServiceClass").URLName() == "serviceclasses"
 //	Kind("Broker").URLName() == "brokers"
+//
+// Note that this function is incomplete - it is only guaranteed to properly pluralize our 4
+// resource types ("Broker", "ServiceClass", "Instance", "Binding")
 func (k Kind) URLName() string {
 	str := k.String()
 	strLen := len(str)

--- a/pkg/storage/tpr/kinds.go
+++ b/pkg/storage/tpr/kinds.go
@@ -18,7 +18,7 @@ package tpr
 
 import (
 	"fmt"
-	"strings"
+	"unicode"
 )
 
 const (
@@ -39,7 +39,17 @@ func (k Kind) String() string {
 
 // TPRName returns the lowercase name, suitable for fetching resources of this kind
 func (k Kind) TPRName() string {
-	return strings.ToLower(k.String())
+	// this code taken from code under
+	// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/extending-api.md#expectations-about-third-party-objects
+	var result string
+	for ix := range k.String() {
+		current := rune(k.String()[ix])
+		if unicode.IsUpper(current) && ix > 0 {
+			result = result + "-"
+		}
+		result = result + string(unicode.ToLower(current))
+	}
+	return result
 }
 
 const (

--- a/pkg/storage/tpr/kinds_test.go
+++ b/pkg/storage/tpr/kinds_test.go
@@ -13,11 +13,31 @@ func TestTPRName(t *testing.T) {
 		{before: "ThisIsAThing", after: "this-is-a-thing"},
 		{before: "thisIsAThing", after: "this-is-a-thing"},
 		{before: "Binding", after: "binding"},
+		{before: "ThisIsAAThing", after: "this-is-a-a-thing"},
 	}
 	for _, testCase := range testCases {
 		kind := Kind(testCase.before)
 		if kind.TPRName() != testCase.after {
 			t.Errorf("expected %s, got %s", testCase.after, kind.TPRName())
+		}
+	}
+}
+
+func TestURLName(t *testing.T) {
+	testCases := []struct {
+		before string
+		after  string
+	}{
+		{before: "ServiceClass", after: "serviceclasses"},
+		{before: "ThisIsAThing", after: "thisisathings"},
+		{before: "thisIsAThing", after: "thisisathings"},
+		{before: "Binding", after: "bindings"},
+	}
+
+	for _, testCase := range testCases {
+		kind := Kind(testCase.before)
+		if kind.URLName() != testCase.after {
+			t.Errorf("expected %s, got %s", testCase.after, kind.URLName())
 		}
 	}
 }

--- a/pkg/storage/tpr/kinds_test.go
+++ b/pkg/storage/tpr/kinds_test.go
@@ -1,0 +1,23 @@
+package tpr
+
+import (
+	"testing"
+)
+
+func TestTPRName(t *testing.T) {
+	testCases := []struct {
+		before string
+		after  string
+	}{
+		{before: "ServiceClass", after: "service-class"},
+		{before: "ThisIsAThing", after: "this-is-a-thing"},
+		{before: "thisIsAThing", after: "this-is-a-thing"},
+		{before: "Binding", after: "binding"},
+	}
+	for _, testCase := range testCases {
+		kind := Kind(testCase.before)
+		if kind.TPRName() != testCase.after {
+			t.Errorf("expected %s, got %s", testCase.after, kind.TPRName())
+		}
+	}
+}

--- a/pkg/storage/tpr/storage_interface.go
+++ b/pkg/storage/tpr/storage_interface.go
@@ -102,8 +102,6 @@ func (t *storageInterface) Create(
 		t.singularKind.URLName(),
 	).Body(data)
 
-	glog.Infof("POSTing to URL %s", req.URL().String())
-
 	var unknown runtime.Unknown
 	if err := req.Do().Into(&unknown); err != nil {
 		glog.Errorf("decoding response (%s)", err)

--- a/pkg/storage/tpr/storage_interface.go
+++ b/pkg/storage/tpr/storage_interface.go
@@ -99,7 +99,7 @@ func (t *storageInterface) Create(
 		tprVersion,
 		"namespaces",
 		ns,
-		t.singularKind.TPRName()+"s",
+		t.singularKind.TPRName(),
 	).Body(data)
 
 	var unknown runtime.Unknown
@@ -140,7 +140,7 @@ func (t *storageInterface) Delete(
 		tprVersion,
 		"namespaces",
 		ns,
-		t.singularKind.TPRName()+"s",
+		t.singularKind.TPRName(),
 		name,
 	)
 	if err := req.Do().Error(); err != nil {
@@ -175,7 +175,7 @@ func (t *storageInterface) Watch(
 		tprVersion,
 		"namespaces",
 		ns,
-		t.singularKind.TPRName()+"s",
+		t.singularKind.TPRName(),
 		name,
 	).Param("watch", "true")
 	watchIface, err := req.Watch()
@@ -261,7 +261,7 @@ func (t *storageInterface) Get(
 		tprVersion,
 		"namespaces",
 		ns,
-		t.singularKind.TPRName()+"s",
+		t.singularKind.TPRName(),
 		name,
 	)
 
@@ -314,7 +314,7 @@ func (t *storageInterface) List(
 		tprVersion,
 		"namespaces",
 		ns,
-		t.singularKind.TPRName()+"s",
+		t.singularKind.TPRName(),
 	)
 
 	var unknown runtime.Unknown

--- a/pkg/storage/tpr/storage_interface.go
+++ b/pkg/storage/tpr/storage_interface.go
@@ -99,8 +99,10 @@ func (t *storageInterface) Create(
 		tprVersion,
 		"namespaces",
 		ns,
-		t.singularKind.TPRName(),
+		t.singularKind.URLName(),
 	).Body(data)
+
+	glog.Infof("POSTing to URL %s", req.URL().String())
 
 	var unknown runtime.Unknown
 	if err := req.Do().Into(&unknown); err != nil {
@@ -140,7 +142,7 @@ func (t *storageInterface) Delete(
 		tprVersion,
 		"namespaces",
 		ns,
-		t.singularKind.TPRName(),
+		t.singularKind.URLName(),
 		name,
 	)
 	if err := req.Do().Error(); err != nil {
@@ -175,7 +177,7 @@ func (t *storageInterface) Watch(
 		tprVersion,
 		"namespaces",
 		ns,
-		t.singularKind.TPRName(),
+		t.singularKind.URLName(),
 		name,
 	).Param("watch", "true")
 	watchIface, err := req.Watch()
@@ -261,7 +263,7 @@ func (t *storageInterface) Get(
 		tprVersion,
 		"namespaces",
 		ns,
-		t.singularKind.TPRName(),
+		t.singularKind.URLName(),
 		name,
 	)
 
@@ -314,7 +316,7 @@ func (t *storageInterface) List(
 		tprVersion,
 		"namespaces",
 		ns,
-		t.singularKind.TPRName(),
+		t.singularKind.URLName(),
 	)
 
 	var unknown runtime.Unknown


### PR DESCRIPTION
cc/ @simonleung8

Also implements a `URLName()` on kind that the storage interface uses

Ref #428