### PR TITLE
Make 'verify' target run first in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ cache:
   directories:
   - .glide
 script:
-- make build test verify images
+- make verify build test images


### PR DESCRIPTION
We should fail fast in CI if there's a verify error to decrease time waiting for results.  A lot of CI failures are due to this and this will help cut the wall of text effect - I _think_.  