### PR TITLE
Install TPRs concurrently

### DIFF
--- a/cmd/apiserver/app/server/run_server.go
+++ b/cmd/apiserver/app/server/run_server.go
@@ -42,7 +42,8 @@ func RunServer(opts *ServiceCatalogServerOptions) error {
 func runTPRServer(opts *ServiceCatalogServerOptions) error {
 	tprOpts := opts.TPROptions
 	glog.Infoln("Installing TPR types to the cluster")
-	if err := tpr.InstallTypes(tprOpts.clIface); err != nil {
+	tprInstaller := tpr.NewInstaller(tprOpts.clIface.Extensions().ThirdPartyResources())
+	if err := tprInstaller.InstallTypes(); err != nil {
 		glog.V(4).Infof("Installing TPR types failed, continuing anyway (%s)", err)
 	}
 	glog.V(4).Infoln("Preparing to run API server")

--- a/pkg/storage/tpr/install_types.go
+++ b/pkg/storage/tpr/install_types.go
@@ -17,11 +17,14 @@ limitations under the License.
 package tpr
 
 import (
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
-	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	extensionsv1beta "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/util/wait"
 )
 
 // this is the set of third party resources to be installed. each key is the name of the TPR to
@@ -34,31 +37,71 @@ var thirdPartyResources = []v1beta1.ThirdPartyResource{
 	serviceBindingTPR,
 }
 
+//Installer takes in a client and exposes method for installing third party resources
+type Installer struct {
+	tprs extensionsv1beta.ThirdPartyResourceInterface
+}
+
+//NewInstaller is used to install third party resources
+func NewInstaller(tprs extensionsv1beta.ThirdPartyResourceInterface) *Installer {
+	return &Installer{
+		tprs: tprs,
+	}
+}
+
 // InstallTypes installs all third party resource types to the cluster
-func InstallTypes(cs clientset.Interface) error {
-	tprs := cs.Extensions().ThirdPartyResources()
+func (i *Installer) InstallTypes() error {
+	var wg sync.WaitGroup
+	errMsg := make(chan string, len(thirdPartyResources))
+
 	for _, tpr := range thirdPartyResources {
 		glog.Infof("Checking for existence of %s", tpr.Name)
-		if _, err := tprs.Get(tpr.Name); err == nil {
+		if _, err := i.tprs.Get(tpr.Name); err == nil {
 			glog.Infof("Found existing TPR %s", tpr.Name)
 			continue
 		}
 
 		glog.Infof("Creating Third Party Resource Type: %s", tpr.Name)
-		if _, err := tprs.Create(&tpr); err != nil {
-			glog.Errorf("Failed to create Third Party Resource Type: %s (%s))", tpr.Name, err)
-			return err
-		}
-		glog.Infof("Created TPR '%s'", tpr.Name)
-		// There can be a delay, so poll until it's ready to go...
-		for i := 0; i < 30; i++ {
-			if _, err := tprs.Get(tpr.Name); err == nil {
-				glog.Infof("TPR %s is ready", tpr.Name)
-				break
+
+		wg.Add(1)
+		go func(tpr v1beta1.ThirdPartyResource, tprInfce extensionsv1beta.ThirdPartyResourceInterface) {
+			defer wg.Done()
+			if _, err := i.tprs.Create(&tpr); err != nil {
+				errMsg <- fmt.Sprintf("%s: %s", tpr.Name, err)
+			} else {
+				glog.Infof("Created TPR '%s'", tpr.Name)
+
+				// There can be a delay, so poll until it's ready to go...
+				err := wait.PollImmediate(1*time.Second, 1*time.Second, func() (bool, error) {
+					if _, err := tprInfce.Get(tpr.Name); err == nil {
+						glog.Infof("TPR %s is ready", tpr.Name)
+						return true, nil
+					}
+
+					glog.Infof("TPR %s is not ready yet... waiting...", tpr.Name)
+					return false, nil
+				})
+				if err != nil {
+					glog.Infof("Error polling for TPR status:", err)
+				}
 			}
-			glog.Infof("TPR %s is not ready yet... waiting...", tpr.Name)
-			time.Sleep(1 * time.Second)
+		}(tpr, i.tprs)
+	}
+
+	wg.Wait()
+	close(errMsg)
+
+	var allErrMsg string
+	for msg := range errMsg {
+		if msg != "" {
+			allErrMsg = fmt.Sprintf("%s\n%s", allErrMsg, msg)
 		}
 	}
+
+	if allErrMsg != "" {
+		glog.Errorf("Failed to create Third Party Resource:\n%s)", allErrMsg)
+		return fmt.Errorf("Failed to create Third Party Resource:\n%s)", allErrMsg)
+	}
+
 	return nil
 }

--- a/pkg/storage/tpr/install_types.go
+++ b/pkg/storage/tpr/install_types.go
@@ -52,7 +52,7 @@ func InstallTypes(cs clientset.Interface) error {
 		glog.Infof("Created TPR '%s'", tpr.Name)
 		// There can be a delay, so poll until it's ready to go...
 		for i := 0; i < 30; i++ {
-			if _, err := tprs.Get(tpr.Name); err != nil {
+			if _, err := tprs.Get(tpr.Name); err == nil {
 				glog.Infof("TPR %s is ready", tpr.Name)
 				break
 			}

--- a/pkg/storage/tpr/install_types_test.go
+++ b/pkg/storage/tpr/install_types_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tpr
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+
+	kubeclientfake "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5/fake"
+	"k8s.io/kubernetes/pkg/client/testing/core"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+var (
+	fakeClientset   *kubeclientfake.Clientset
+	getCallCount    int
+	createCallCount int
+	createCallArgs  []string
+	getCallArgs     []string
+)
+
+func setup(getFn, createFn func(core.Action) (bool, runtime.Object, error)) {
+	getCallCount = 0
+	createCallCount = 0
+	getCallArgs = []string{}
+	createCallArgs = []string{}
+
+	fakeClientset = &kubeclientfake.Clientset{}
+
+	fakeClientset.AddReactor("get", "thirdpartyresources", getFn)
+
+	fakeClientset.AddReactor("create", "thirdpartyresources", createFn)
+}
+
+//make sure all resources types are installed
+func TestInstallTypesAllResources(t *testing.T) {
+	setup(
+		func(core.Action) (bool, runtime.Object, error) {
+			getCallCount++
+			if getCallCount > len(thirdPartyResources) {
+				return true, &v1beta1.ThirdPartyResource{}, nil
+			}
+
+			return true, nil, errors.New("Resource not found")
+		},
+		func(core.Action) (bool, runtime.Object, error) {
+			createCallCount++
+			return true, nil, nil
+		},
+	)
+
+	installer := NewInstaller(fakeClientset.Extensions().ThirdPartyResources())
+	installer.InstallTypes()
+
+	if createCallCount != len(thirdPartyResources) {
+		t.Errorf("Error: The number of Third Party Resources installed is not 4")
+	}
+}
+
+//make sure to skip resource that is already installed
+func TestInstallTypesResourceExisted(t *testing.T) {
+	setup(
+		func(core.Action) (bool, runtime.Object, error) {
+			getCallCount++
+			if getCallCount == 1 {
+				return true, &serviceBrokerTPR, nil
+			} else if getCallCount > len(thirdPartyResources) {
+				return true, &v1beta1.ThirdPartyResource{}, nil
+			}
+
+			return true, nil, errors.New("Resource not found")
+		},
+		func(action core.Action) (bool, runtime.Object, error) {
+			createCallCount++
+			createCallArgs = append(createCallArgs, action.(core.CreateAction).GetObject().(*v1beta1.ThirdPartyResource).Name)
+			return true, nil, nil
+		},
+	)
+
+	installer := NewInstaller(fakeClientset.Extensions().ThirdPartyResources())
+	installer.InstallTypes()
+
+	if createCallCount != len(thirdPartyResources)-1 {
+		t.Errorf("Failed to skip 1 installed Third Party Resource")
+	}
+
+	for _, name := range createCallArgs {
+		if name == serviceBrokerTPR.Name {
+			t.Errorf("Failed to skip installing 'broker' as Third Party Resource as it already existed")
+		}
+	}
+}
+
+//make sure all errors are received for all failed install
+func TestInstallTypesErrors(t *testing.T) {
+	setup(
+		func(core.Action) (bool, runtime.Object, error) {
+			getCallCount++
+			if getCallCount > len(thirdPartyResources) {
+				return true, &v1beta1.ThirdPartyResource{}, nil
+			}
+
+			return true, nil, errors.New("Resource not found")
+		},
+		func(core.Action) (bool, runtime.Object, error) {
+			createCallCount++
+			if createCallCount <= 2 {
+				return true, nil, errors.New("Error " + strconv.Itoa(createCallCount))
+			}
+			return true, nil, nil
+		},
+	)
+
+	installer := NewInstaller(fakeClientset.Extensions().ThirdPartyResources())
+	err := installer.InstallTypes()
+
+	errStr := err.Error()
+	if !strings.Contains(errStr, "Error 1") && !strings.Contains(errStr, "Error 2") {
+		t.Errorf("Failed to receive correct errors during installation of Third Party Resource concurrently, error received: %s", errStr)
+	}
+}
+
+//make sure we don't poll on resource that was failed on install
+func TestInstallTypesPolling(t *testing.T) {
+	setup(
+		func(action core.Action) (bool, runtime.Object, error) {
+			getCallCount++
+			if getCallCount > len(thirdPartyResources) {
+				getCallArgs = append(getCallArgs, action.(core.GetAction).GetName())
+				return true, &v1beta1.ThirdPartyResource{}, nil
+			}
+
+			return true, nil, errors.New("Resource not found")
+		},
+		func(action core.Action) (bool, runtime.Object, error) {
+			createCallCount++
+			name := action.(core.CreateAction).GetObject().(*v1beta1.ThirdPartyResource).Name
+			if name == serviceBrokerTPR.Name || name == serviceInstanceTPR.Name {
+				return true, nil, errors.New("Error creating TPR")
+			}
+			return true, nil, nil
+		},
+	)
+
+	installer := NewInstaller(fakeClientset.Extensions().ThirdPartyResources())
+	installer.InstallTypes()
+
+	for _, name := range getCallArgs {
+		if name == serviceBrokerTPR.Name || name == serviceInstanceTPR.Name {
+			t.Errorf("Failed to skip polling for resource that failed to install")
+		}
+	}
+}


### PR DESCRIPTION
Closes: #435 
This resolves the issue in #435

TPR creating and status polling is running parallelly in a goroutine.

k8s client fakes are used

- yet to be tested
  Timeout of our polling for result (needs fake timer to reduce testing time)