### PR TITLE
Remove unused description annotation

### DIFF
--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -44,12 +44,6 @@ type BrokerList struct {
 	Items []Broker `json:"items"`
 }
 
-const (
-	// DescriptionKey is the key of an annotation that holds the brief
-	// description of an API resource
-	DescriptionKey = "alpha.service-catalog.kubernetes.io/description"
-)
-
 // BrokerSpec represents a description of a Broker.
 type BrokerSpec struct {
 	// The URL to communicate with the Broker via..


### PR DESCRIPTION
Not used; the convention is to just use `description` for the annotation key upstream, but for now we just have fields, which is fine and good.