### PR TITLE
Empty storageType should be treated as "etcd" value

### DIFF
--- a/deploy/catalog/templates/apiserver.yaml
+++ b/deploy/catalog/templates/apiserver.yaml
@@ -18,15 +18,17 @@ spec:
         - {{ default "etcd" .Values.storageType }}
         - -v
         - {{ default "\"10\"" .Values.verbosity }}
-        {{ if eq .Values.storageType "etcd" }}- --etcd-servers {{ end }}
-        {{ if eq .Values.storageType "etcd" }}- http://localhost:2379 {{ end }}
+        {{ if eq (default .Values.storageType "etcd") "etcd" -}}
+        - --etcd-servers
+        - http://localhost:2379
+        {{ end }}
         ports:
         - containerPort: 6443
         volumeMounts:
         - name: apiserver-ssl
           mountPath: /var/run/kubernetes-service-catalog
           readOnly: true
-      {{ if eq .Values.storageType "etcd" -}}
+      {{ if eq (default .Values.storageType "etcd") "etcd" -}}
       - name: etcd
         image: {{ if .Values.etcdRepository }}{{ .Values.etcdRepository }}{{ else }}{{ "quay.io/coreos/etcd" }}{{ end }}:{{ if .Values.etcdVersion }}{{ .Values.etcdVersion }}{{ else }}{{ "latest" }}{{ end }}
       {{- end }}

--- a/deploy/wip-catalog/templates/apiserver.yaml
+++ b/deploy/wip-catalog/templates/apiserver.yaml
@@ -26,7 +26,7 @@ spec:
         - --insecure-port
         - {{ default 8081 .Values.insecurePort | quote }}
         {{- end }}
-        {{ if eq .Values.storageType "etcd" -}}
+        {{ if eq (default .Values.storageType "etcd") "etcd" -}}
         - --etcd-servers
         - http://localhost:2379
         {{- end }}
@@ -42,7 +42,7 @@ spec:
         - name: apiserver-ssl
           mountPath: /var/run/kubernetes-service-catalog
           readOnly: true
-      {{ if eq .Values.storageType "etcd" -}}
+      {{ if eq (default .Values.storageType "etcd") "etcd" -}}
       - name: etcd
         image: {{ default .Values.etcdImage "quay.io/coreos/etcd" }}:{{ if .Values.etcdVersion }}{{ .Values.etcdVersion }}{{ else }}{{ "latest" }}{{ end }}
       {{- end }}


### PR DESCRIPTION
The helm chart is expecting a value `storageType`, if it isn't set to anything
at all helm will fail to do the equal comparison. Adding it as an input value
even when it's empty if could do the check between string and empty string and
everything will work as expected.

This should be changed as well in the `WIP` version of the catalog chart. However, I am not still sure if this is the best solution but I couldn't find a better way to do this with helm/templates/sprig.