### PR TITLE
Fix getFreshApiserverAndClient server shutdown

### DIFF
--- a/cmd/apiserver/app/server/options.go
+++ b/cmd/apiserver/app/server/options.go
@@ -41,6 +41,7 @@ type ServiceCatalogServerOptions struct {
 	EtcdOptions *EtcdOptions
 	// TPROptions are options for serving with TPR as the backing store
 	TPROptions *TPROptions
+	StopCh     <-chan struct{}
 }
 
 func (s *ServiceCatalogServerOptions) addFlags(flags *pflag.FlagSet) {

--- a/cmd/apiserver/app/server/run_server.go
+++ b/cmd/apiserver/app/server/run_server.go
@@ -33,6 +33,11 @@ func RunServer(opts *ServiceCatalogServerOptions) error {
 	if err != nil {
 		return err
 	}
+	if opts.StopCh == nil {
+		/* the caller of RunServer should generate the stop channel
+		if there is a need to stop the API server */
+		opts.StopCh = make(chan struct{})
+	}
 	if storageType == server.StorageTypeTPR {
 		return runTPRServer(opts)
 	}
@@ -66,8 +71,7 @@ func runTPRServer(opts *ServiceCatalogServerOptions) error {
 	}
 
 	glog.Infoln("Running the API server")
-	stop := make(chan struct{})
-	server.GenericAPIServer.PrepareRun().Run(stop)
+	server.GenericAPIServer.PrepareRun().Run(opts.StopCh)
 
 	return nil
 }
@@ -131,8 +135,7 @@ func runEtcdServer(opts *ServiceCatalogServerOptions) error {
 
 	// do we need to do any post api installation setup? We should have set up the api already?
 	glog.Infoln("Running the API server")
-	stop := make(chan struct{})
-	server.PrepareRun().Run(stop)
+	server.PrepareRun().Run(opts.StopCh)
 
 	return nil
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1165,7 +1165,6 @@ func TestReconcileBindingDelete(t *testing.T) {
 // - a fake broker binding client
 // - a test controller
 // - the shared informers for the service catalog v1alpha1 api
-// - a stop channel hooked to the informer factory that was created
 //
 // If there is an error, newTestController calls 'Fatal' on the injected
 // testing.T.

--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -46,8 +46,8 @@ func getFreshApiserverAndClient(t *testing.T, storageTypeStr string) (servicecat
 	serverIP := fmt.Sprintf("https://localhost:%d", securePort)
 	stopCh := make(chan struct{})
 	serverFailed := make(chan struct{})
-	//defer close(stopCh)
 	shutdown := func() {
+		t.Logf("Shutting down server on port: %d", securePort)
 		close(stopCh)
 	}
 
@@ -66,6 +66,7 @@ func getFreshApiserverAndClient(t *testing.T, storageTypeStr string) (servicecat
 			TPROptions:            &server.TPROptions{},
 			AuthenticationOptions: genericserveroptions.NewDelegatingAuthenticationOptions(),
 			AuthorizationOptions:  genericserveroptions.NewDelegatingAuthorizationOptions(),
+			StopCh:                stopCh,
 		}
 		options.SecureServingOptions.ServingOptions.BindPort = securePort
 		options.SecureServingOptions.ServerCert.CertDirectory = certDir


### PR DESCRIPTION
I believe this fix solves the problem, but there are some new errors produced such as this one:
`Error serving 0.0.0.0:8728 (accept tcp [::]:8728: use of closed network connection); will try again.`

I assume it's because it's not doing a graceful shutdown, which might be beyond our control.