### PR TITLE
Add validations for Bindings

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -260,7 +260,7 @@ type Binding struct {
 type BindingSpec struct {
 	// InstanceRef is the reference to the Instance this binding is to.
 	// Immutable.
-	InstanceRef kapi.ObjectReference
+	InstanceRef v1.LocalObjectReference
 
 	// Parameters is a YAML representation of the properties to be
 	// passed to the underlying broker.

--- a/pkg/apis/servicecatalog/v1alpha1/types.generated.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.generated.go
@@ -6242,7 +6242,7 @@ func (x *BindingSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		switch yys581 {
 		case "instanceRef":
 			if r.TryDecodeAsNil() {
-				x.InstanceRef = pkg2_v1.ObjectReference{}
+				x.InstanceRef = pkg2_v1.LocalObjectReference{}
 			} else {
 				yyv582 := &x.InstanceRef
 				yyv582.CodecDecodeSelf(d)
@@ -6304,7 +6304,7 @@ func (x *BindingSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.InstanceRef = pkg2_v1.ObjectReference{}
+		x.InstanceRef = pkg2_v1.LocalObjectReference{}
 	} else {
 		yyv588 := &x.InstanceRef
 		yyv588.CodecDecodeSelf(d)
@@ -7591,7 +7591,7 @@ func (x codecSelfer1234) decSliceBinding(v *[]Binding, d *codec1978.Decoder) {
 
 			yyrg668 := len(yyv668) > 0
 			yyv2668 := yyv668
-			yyrl668, yyrt668 = z.DecInferLen(yyl668, z.DecBasicHandle().MaxInitLen, 432)
+			yyrl668, yyrt668 = z.DecInferLen(yyl668, z.DecBasicHandle().MaxInitLen, 336)
 			if yyrt668 {
 				if yyrl668 <= cap(yyv668) {
 					yyv668 = yyv668[:yyrl668]

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -255,7 +255,7 @@ type Binding struct {
 type BindingSpec struct {
 	// InstanceRef is the reference to the Instance this binding is to.
 	// Immutable.
-	InstanceRef v1.ObjectReference `json:"instanceRef"`
+	InstanceRef v1.LocalObjectReference `json:"instanceRef"`
 
 	// Parameters is a YAML representation of the properties to be
 	// passed to the underlying broker.

--- a/pkg/apis/servicecatalog/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1alpha1/zz_generated.conversion.go
@@ -156,10 +156,7 @@ func Convert_servicecatalog_BindingList_To_v1alpha1_BindingList(in *servicecatal
 }
 
 func autoConvert_v1alpha1_BindingSpec_To_servicecatalog_BindingSpec(in *BindingSpec, out *servicecatalog.BindingSpec, s conversion.Scope) error {
-	// TODO: Inefficient conversion - can we improve it?
-	if err := s.Convert(&in.InstanceRef, &out.InstanceRef, 0); err != nil {
-		return err
-	}
+	out.InstanceRef = in.InstanceRef
 	out.Parameters = (*runtime.RawExtension)(unsafe.Pointer(in.Parameters))
 	out.SecretName = in.SecretName
 	out.OSBGUID = in.OSBGUID
@@ -171,10 +168,7 @@ func Convert_v1alpha1_BindingSpec_To_servicecatalog_BindingSpec(in *BindingSpec,
 }
 
 func autoConvert_servicecatalog_BindingSpec_To_v1alpha1_BindingSpec(in *servicecatalog.BindingSpec, out *BindingSpec, s conversion.Scope) error {
-	// TODO: Inefficient conversion - can we improve it?
-	if err := s.Convert(&in.InstanceRef, &out.InstanceRef, 0); err != nil {
-		return err
-	}
+	out.InstanceRef = in.InstanceRef
 	out.Parameters = (*runtime.RawExtension)(unsafe.Pointer(in.Parameters))
 	out.SecretName = in.SecretName
 	out.OSBGUID = in.OSBGUID

--- a/pkg/apis/servicecatalog/validation/binding.go
+++ b/pkg/apis/servicecatalog/validation/binding.go
@@ -26,7 +26,7 @@ import (
 // validateBindingName is the validation function for Binding names.
 var validateBindingName = apivalidation.NameIsDNSSubdomain
 
-// ValidateBinding checks the fields of a Binding.
+// ValidateBinding validates a Binding and returns a list of errors.
 func ValidateBinding(binding *sc.Binding) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&binding.ObjectMeta, true, /*namespace*/
@@ -39,6 +39,14 @@ func ValidateBinding(binding *sc.Binding) field.ErrorList {
 
 func validateBindingSpec(spec *sc.BindingSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+
+	for _, msg := range validateInstanceName(spec.InstanceRef.Name, false /* prefix */) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("instanceRef", "name"), spec.InstanceRef.Name, msg))
+	}
+
+	for _, msg := range apivalidation.ValidateSecretName(spec.SecretName, false /* prefix */) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("secretName"), spec.SecretName, msg))
+	}
 
 	return allErrs
 }

--- a/pkg/apis/servicecatalog/validation/binding_test.go
+++ b/pkg/apis/servicecatalog/validation/binding_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+)
+
+func TestValidateBinding(t *testing.T) {
+	cases := []struct {
+		name    string
+		binding *servicecatalog.Binding
+		valid   bool
+	}{
+		{
+			name: "valid",
+			binding: &servicecatalog.Binding{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "test-binding",
+					Namespace: "test-ns",
+				},
+				Spec: servicecatalog.BindingSpec{
+					InstanceRef: v1.LocalObjectReference{
+						Name: "test-instance",
+					},
+					SecretName: "test-secret",
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "missing namespace",
+			binding: &servicecatalog.Binding{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "test-binding",
+				},
+				Spec: servicecatalog.BindingSpec{
+					InstanceRef: v1.LocalObjectReference{
+						Name: "test-instance",
+					},
+					SecretName: "test-secret",
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "missing instance name",
+			binding: &servicecatalog.Binding{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "test-binding",
+					Namespace: "test-ns",
+				},
+				Spec: servicecatalog.BindingSpec{
+					SecretName: "test-secret",
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid instance name",
+			binding: &servicecatalog.Binding{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "test-binding",
+					Namespace: "test-ns",
+				},
+				Spec: servicecatalog.BindingSpec{
+					InstanceRef: v1.LocalObjectReference{
+						Name: "test-instance-)*!",
+					},
+					SecretName: "test-secret",
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "missing secretName",
+			binding: &servicecatalog.Binding{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "test-binding",
+					Namespace: "test-ns",
+				},
+				Spec: servicecatalog.BindingSpec{
+					InstanceRef: v1.LocalObjectReference{
+						Name: "test-instance",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid secretName",
+			binding: &servicecatalog.Binding{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "test-binding",
+					Namespace: "test-ns",
+				},
+				Spec: servicecatalog.BindingSpec{
+					InstanceRef: v1.LocalObjectReference{
+						Name: "test-instance",
+					},
+					SecretName: "T_T",
+				},
+			},
+			valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := ValidateBinding(tc.binding)
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}

--- a/pkg/apis/servicecatalog/validation/broker.go
+++ b/pkg/apis/servicecatalog/validation/broker.go
@@ -38,7 +38,7 @@ func ValidateBroker(broker *sc.Broker) field.ErrorList {
 			ValidateBrokerName,
 			field.NewPath("metadata"))...)
 
-	allErrs = append(allErrs, validateBrokerSpec(&broker.Spec, field.NewPath("Spec"))...)
+	allErrs = append(allErrs, validateBrokerSpec(&broker.Spec, field.NewPath("spec"))...)
 	return allErrs
 }
 
@@ -47,7 +47,7 @@ func validateBrokerSpec(spec *sc.BrokerSpec, fldPath *field.Path) field.ErrorLis
 
 	if "" == spec.URL {
 		allErrs = append(allErrs,
-			field.Required(fldPath.Child("URL"),
+			field.Required(fldPath.Child("url"),
 				"brokers must have a remote url to contact"))
 	}
 

--- a/pkg/apis/servicecatalog/validation/instance_test.go
+++ b/pkg/apis/servicecatalog/validation/instance_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+)
+
+func TestValidateInstance(t *testing.T) {
+	cases := []struct {
+		name     string
+		instance *servicecatalog.Instance
+		valid    bool
+	}{
+		{
+			name: "valid",
+			instance: &servicecatalog.Instance{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "test-instance",
+					Namespace: "test-ns",
+				},
+				Spec: servicecatalog.InstanceSpec{
+					ServiceClassName: "test-serviceclass",
+					PlanName:         "test-plan",
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "missing namespace",
+			instance: &servicecatalog.Instance{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "test-instance",
+				},
+				Spec: servicecatalog.InstanceSpec{
+					ServiceClassName: "test-serviceclass",
+					PlanName:         "test-plan",
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "missing serviceClassName",
+			instance: &servicecatalog.Instance{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "test-instance",
+					Namespace: "test-ns",
+				},
+				Spec: servicecatalog.InstanceSpec{
+					PlanName: "test-plan",
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid serviceClassName",
+			instance: &servicecatalog.Instance{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "test-instance",
+					Namespace: "test-ns",
+				},
+				Spec: servicecatalog.InstanceSpec{
+					ServiceClassName: "oing20&)*^&",
+					PlanName:         "test-plan",
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "missing planName",
+			instance: &servicecatalog.Instance{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "test-instance",
+					Namespace: "test-ns",
+				},
+				Spec: servicecatalog.InstanceSpec{
+					ServiceClassName: "test-serviceclass",
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid planName",
+			instance: &servicecatalog.Instance{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "test-instance",
+					Namespace: "test-ns",
+				},
+				Spec: servicecatalog.InstanceSpec{
+					ServiceClassName: "test-serviceclass",
+					PlanName:         "9651JVHbebe",
+				},
+			},
+			valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := ValidateInstance(tc.instance)
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}

--- a/pkg/apis/servicecatalog/validation/serviceclass.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	apivalidation "k8s.io/kubernetes/pkg/api/validation"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/validation/field"
 
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
@@ -26,8 +27,20 @@ import (
 // validateServiceClassName is the validation function for ServiceClass names.
 var validateServiceClassName = apivalidation.NameIsDNSSubdomain
 
-// ValidateServiceclass makes sure a serviceclass object is okay.
-func ValidateServiceclass(serviceclass *sc.ServiceClass) field.ErrorList {
+// validateServicePlanName is the validation function for ServicePlan names.
+var validateServicePlanName = apivalidation.NameIsDNSLabel
+
+// validateOSBGuid is the validation function for OSB GUIDs.  We generate
+// GUIDs for Instances and Bindings, but for ServiceClass and ServicePlan,
+// they are part of the payload returned from the Broker.
+//
+// TODO: This might be looser than it should be, but it seems like a
+// reasonable approximation for now.  The OSB spec does not provide specifics
+// about the format of ID fields in the API.
+var validateOSBGuid = apivalidation.NameIsDNSLabel
+
+// ValidateServiceClass validates a ServiceClass and returns a list of errors.
+func ValidateServiceClass(serviceclass *sc.ServiceClass) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs,
@@ -37,15 +50,57 @@ func ValidateServiceclass(serviceclass *sc.ServiceClass) field.ErrorList {
 			validateServiceClassName,
 			field.NewPath("metadata"))...)
 
+	if "" == serviceclass.BrokerName {
+		allErrs = append(allErrs, field.Required(field.NewPath("brokerName"), "brokerName is required"))
+	}
+
+	if "" == serviceclass.OSBGUID {
+		allErrs = append(allErrs, field.Required(field.NewPath("osbGuid"), "osbGuid is required"))
+	}
+
+	for _, msg := range validateOSBGuid(serviceclass.OSBGUID, false /* prefix */) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("osbGuid"), serviceclass.OSBGUID, msg))
+	}
+
+	planNames := sets.NewString()
+	for i, plan := range serviceclass.Plans {
+		planPath := field.NewPath("plans").Index(i)
+		allErrs = append(allErrs, validateServicePlan(plan, planPath)...)
+
+		if planNames.Has(plan.Name) {
+			allErrs = append(allErrs, field.Invalid(planPath.Child("name"), plan.Name, "each plan must have a unique name"))
+		}
+	}
+
 	return allErrs
 }
 
-// ValidateServiceclassUpdate checks that when changing from an older
-// serviceclass to a newer serviceclass is okay.
-func ValidateServiceclassUpdate(new *sc.ServiceClass, old *sc.ServiceClass) field.ErrorList {
+// validateServicePlan validates the fields of a single ServicePlan and
+// returns a list of errors.
+func validateServicePlan(plan sc.ServicePlan, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, ValidateServiceclass(new)...)
-	allErrs = append(allErrs, ValidateServiceclass(old)...)
+
+	for _, msg := range validateServicePlanName(plan.Name, false /* prefix */) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), plan.Name, msg))
+	}
+
+	if "" == plan.OSBGUID {
+		allErrs = append(allErrs, field.Required(fldPath.Child("osbGuid"), "osbGuid is required"))
+	}
+
+	for _, msg := range validateOSBGuid(plan.OSBGUID, false /* prefix */) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("osbGuid"), plan.OSBGUID, msg))
+	}
+
+	return allErrs
+}
+
+// ValidateServiceClassUpdate checks that when changing from an older
+// ServiceClass to a newer ServiceClass is okay.
+func ValidateServiceClassUpdate(new *sc.ServiceClass, old *sc.ServiceClass) field.ErrorList {
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, ValidateServiceClass(new)...)
+	allErrs = append(allErrs, ValidateServiceClass(old)...)
 
 	return allErrs
 }

--- a/pkg/apis/servicecatalog/validation/serviceclass_test.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+)
+
+func TestValidateServiceClass(t *testing.T) {
+	cases := []struct {
+		name         string
+		serviceClass *servicecatalog.ServiceClass
+		valid        bool
+	}{
+		{
+			name: "valid serviceClass",
+			serviceClass: &servicecatalog.ServiceClass{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "test-serviceclass",
+				},
+				Bindable:   true,
+				BrokerName: "test-broker",
+				OSBGUID:    "1234-4354a-49b",
+				Plans: []servicecatalog.ServicePlan{
+					{
+						Name:    "test-plan",
+						OSBGUID: "40d-0983-1b89",
+					},
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "invalid serviceClass - has namespace",
+			serviceClass: &servicecatalog.ServiceClass{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "test-serviceclass",
+					Namespace: "test-ns",
+				},
+				Bindable:   true,
+				BrokerName: "test-broker",
+				OSBGUID:    "1234-4354a-49b",
+				Plans: []servicecatalog.ServicePlan{
+					{
+						Name:    "test-plan",
+						OSBGUID: "40d-0983-1b89",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid serviceClass - missing guid",
+			serviceClass: &servicecatalog.ServiceClass{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "test-serviceclass",
+				},
+				Bindable:   true,
+				BrokerName: "test-broker",
+				Plans: []servicecatalog.ServicePlan{
+					{
+						Name:    "test-plan",
+						OSBGUID: "40d-0983-1b89",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid serviceClass - invalid guid",
+			serviceClass: &servicecatalog.ServiceClass{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "test-serviceclass",
+				},
+				Bindable:   true,
+				BrokerName: "test-broker",
+				OSBGUID:    "1234-4354a\\%-49b",
+				Plans: []servicecatalog.ServicePlan{
+					{
+						Name:    "test-plan",
+						OSBGUID: "40d-0983-1b89",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid serviceClass - invalid plan name",
+			serviceClass: &servicecatalog.ServiceClass{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "test-serviceclass",
+				},
+				Bindable:   true,
+				BrokerName: "test-broker",
+				OSBGUID:    "1234-4354a-49b",
+				Plans: []servicecatalog.ServicePlan{
+					{
+						Name:    "test-plan.oops",
+						OSBGUID: "40d-0983-1b89",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid serviceClass - invalid plan guid",
+			serviceClass: &servicecatalog.ServiceClass{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "test-serviceclass",
+				},
+				Bindable:   true,
+				BrokerName: "test-broker",
+				OSBGUID:    "1234-4354a-49b",
+				Plans: []servicecatalog.ServicePlan{
+					{
+						Name:    "test-plan",
+						OSBGUID: "40d-0983-1b89-★",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid serviceClass - missing plan guid",
+			serviceClass: &servicecatalog.ServiceClass{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "test-serviceclass",
+				},
+				Bindable:   true,
+				BrokerName: "test-broker",
+				OSBGUID:    "1234-4354a-49b",
+				Plans: []servicecatalog.ServicePlan{
+					{
+						Name: "test-plan",
+					},
+				},
+			},
+			valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := ValidateServiceClass(tc.serviceClass)
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -892,7 +892,7 @@ func TestReconcileBindingNonExistingInstance(t *testing.T) {
 	binding := &v1alpha1.Binding{
 		ObjectMeta: v1.ObjectMeta{Name: "test-binding"},
 		Spec: v1alpha1.BindingSpec{
-			InstanceRef: v1.ObjectReference{Name: "nothere"},
+			InstanceRef: v1.LocalObjectReference{Name: "nothere"},
 			OSBGUID:     bindingGUID,
 		},
 	}
@@ -941,7 +941,7 @@ func TestReconcileBindingNonExistingServiceClass(t *testing.T) {
 	binding := &v1alpha1.Binding{
 		ObjectMeta: v1.ObjectMeta{Name: "test-binding", Namespace: "test-ns"},
 		Spec: v1alpha1.BindingSpec{
-			InstanceRef: v1.ObjectReference{Name: "test-instance", Namespace: "test-ns"},
+			InstanceRef: v1.LocalObjectReference{Name: "test-instance"},
 			OSBGUID:     bindingGUID,
 		},
 	}
@@ -990,7 +990,7 @@ func TestReconcileBindingWithParameters(t *testing.T) {
 	binding := &v1alpha1.Binding{
 		ObjectMeta: v1.ObjectMeta{Name: "test-binding", Namespace: "test-ns"},
 		Spec: v1alpha1.BindingSpec{
-			InstanceRef: v1.ObjectReference{Name: "test-instance", Namespace: "test-ns"},
+			InstanceRef: v1.LocalObjectReference{Name: "test-instance"},
 			OSBGUID:     bindingGUID,
 		},
 	}
@@ -1071,7 +1071,7 @@ func TestReconcileBindingDelete(t *testing.T) {
 			Finalizers:        []string{"kubernetes"},
 		},
 		Spec: v1alpha1.BindingSpec{
-			InstanceRef: v1.ObjectReference{Name: "test-instance", Namespace: "test-ns"},
+			InstanceRef: v1.LocalObjectReference{Name: "test-instance"},
 			OSBGUID:     bindingGUID,
 			SecretName:  "test-secret",
 		},

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -7037,7 +7037,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"instanceRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "InstanceRef is the reference to the Instance this binding is to. Immutable.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectReference"),
+							Ref:         spec.MustCreateRef("#/definitions/v1.LocalObjectReference"),
 						},
 					},
 					"parameters": {
@@ -7065,7 +7065,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 			},
 		},
 		Dependencies: []string{
-			"runtime.RawExtension", "v1.ObjectReference"},
+			"runtime.RawExtension", "v1.LocalObjectReference"},
 	},
 	"v1alpha1.BindingStatus": {
 		Schema: spec.Schema{

--- a/pkg/registry/servicecatalog/serviceclass/strategy.go
+++ b/pkg/registry/servicecatalog/serviceclass/strategy.go
@@ -78,7 +78,7 @@ func (serviceclassRESTStrategy) PrepareForCreate(ctx kapi.Context, obj runtime.O
 }
 
 func (serviceclassRESTStrategy) Validate(ctx kapi.Context, obj runtime.Object) field.ErrorList {
-	return scv.ValidateServiceclass(obj.(*sc.ServiceClass))
+	return scv.ValidateServiceClass(obj.(*sc.ServiceClass))
 }
 
 func (serviceclassRESTStrategy) AllowCreateOnUpdate() bool {
@@ -112,5 +112,5 @@ func (serviceclassRESTStrategy) ValidateUpdate(ctx kapi.Context, new, old runtim
 		glog.Fatal("received a non-serviceclass object to validate from")
 	}
 
-	return scv.ValidateServiceclassUpdate(newServiceclass, oldServiceclass)
+	return scv.ValidateServiceClassUpdate(newServiceclass, oldServiceclass)
 }

--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -584,9 +584,8 @@ func testBindingClient(client servicecatalogclient.Interface, name string) error
 	binding := &v1alpha1.Binding{
 		ObjectMeta: v1.ObjectMeta{Name: "test-binding"},
 		Spec: v1alpha1.BindingSpec{
-			InstanceRef: v1.ObjectReference{
-				Name:      "bar",
-				Namespace: "test-namespace",
+			InstanceRef: v1.LocalObjectReference{
+				Name: "bar",
 			},
 			Parameters: &runtime.RawExtension{Raw: []byte(bindingParameter)},
 			SecretName: "secret-name",
@@ -607,7 +606,7 @@ func testBindingClient(client servicecatalogclient.Interface, name string) error
 
 	bindingServer, err := bindingClient.Create(binding)
 	if nil != err {
-		return fmt.Errorf("error creating the binding, %v", binding)
+		return fmt.Errorf("error creating the binding: %v\n\n%#v", err, binding)
 	}
 	if name != bindingServer.Name {
 		return fmt.Errorf(

--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -330,6 +330,7 @@ func testServiceClassClient(client servicecatalogclient.Interface, name string) 
 		ObjectMeta: v1.ObjectMeta{Name: name},
 		BrokerName: "test-broker",
 		Bindable:   true,
+		OSBGUID:    "b8269ab4-7d2d-456d-8c8b-5aab63b321d1",
 	}
 
 	// start from scratch


### PR DESCRIPTION
Part of #268; depends on:

- #507 
- #509 

I have changed `Binding.Spec.InstanceRef` into a `LocalObjectReference` because we do not support cross-namespace references currently, and it is not something we will have at MVP.