### PR TITLE
Add provision and binding to controller integration tests

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -143,7 +143,7 @@ func (c *controller) brokerDelete(obj interface{}) {
 		return
 	}
 
-	glog.V(4).Info("Received delete event for Broker %v", broker.Name)
+	glog.V(4).Infof("Received delete event for Broker %v", broker.Name)
 }
 
 const (
@@ -620,6 +620,14 @@ func (c *controller) updateInstanceFinalizers(
 	instance *v1alpha1.Instance,
 	finalizers []string) error {
 
+	// Get the latest version of the instance so that we can avoid conflicts
+	// (since we have probably just updated the status of the instance and are
+	// now removing the last finalizer).
+	instance, err := c.serviceCatalogClient.Instances(instance.Namespace).Get(instance.Name)
+	if err != nil {
+		glog.Errorf("Error getting Instance %v/%v to finalize: %v", instance.Namespace, instance.Name, err)
+	}
+
 	clone, err := api.Scheme.DeepCopy(instance)
 	if err != nil {
 		return err
@@ -944,6 +952,14 @@ func (c *controller) updateBindingCondition(
 func (c *controller) updateBindingFinalizers(
 	binding *v1alpha1.Binding,
 	finalizers []string) error {
+
+	// Get the latest version of the binding so that we can avoid conflicts
+	// (since we have probably just updated the status of the binding and are
+	// now removing the last finalizer).
+	binding, err := c.serviceCatalogClient.Bindings(binding.Namespace).Get(binding.Name)
+	if err != nil {
+		glog.Errorf("Error getting Binding %v/%v to finalize: %v", binding.Namespace, binding.Name, err)
+	}
 
 	clone, err := api.Scheme.DeepCopy(binding)
 	if err != nil {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -953,6 +953,10 @@ func TestReconcileInstanceDelete(t *testing.T) {
 		},
 	}
 
+	fakeCatalogClient.AddReactor("get", "instances", func(action core.Action) (bool, runtime.Object, error) {
+		return true, instance, nil
+	})
+
 	testController.reconcileInstance(instance)
 
 	// Verify no core kube actions occurred
@@ -965,7 +969,7 @@ func TestReconcileInstanceDelete(t *testing.T) {
 	// The two actions should be:
 	// 0. Updating the ready condition
 	// 1. Removing the finalizer
-	if e, a := 2, len(actions); e != a {
+	if e, a := 3, len(actions); e != a {
 		t.Logf("%+v\n", actions)
 		t.Fatalf("Unexpected number of actions: expected %v, got %v", e, a)
 	}
@@ -996,7 +1000,15 @@ func TestReconcileInstanceDelete(t *testing.T) {
 		t.Fatalf("Found the deleted Instance in fakeInstanceClient after deletion")
 	}
 
-	updateAction = actions[1].(core.UpdateAction)
+	getAction := actions[1].(core.GetAction)
+	if e, a := "get", getAction.GetVerb(); e != a {
+		t.Fatalf("Unexpected verb on actions[1]; expected %v, got %v", e, a)
+	}
+	if e, a := testInstanceName, getAction.GetName(); e != a {
+		t.Fatalf("Unexpected name of object to get; expected %v; got %v", e, a)
+	}
+
+	updateAction = actions[2].(core.UpdateAction)
 	if e, a := "update", updateAction.GetVerb(); e != a {
 		t.Fatalf("Unexpected verb on actions[1]; expected %v, got %v", e, a)
 	}
@@ -1227,6 +1239,10 @@ func TestReconcileBindingDelete(t *testing.T) {
 		},
 	}
 
+	fakeCatalogClient.AddReactor("get", "bindings", func(action core.Action) (bool, runtime.Object, error) {
+		return true, binding, nil
+	})
+
 	testController.reconcileBinding(binding)
 
 	kubeActions := fakeKubeClient.Actions()
@@ -1259,7 +1275,7 @@ func TestReconcileBindingDelete(t *testing.T) {
 	// The two actions should be:
 	// 0. Updating the ready condition
 	// 1. Removing the finalizer
-	if e, a := 2, len(actions); e != a {
+	if e, a := 3, len(actions); e != a {
 		t.Logf("%+v\n", actions)
 		t.Fatalf("Unexpected number of actions: expected %v, got %v", e, a)
 	}
@@ -1290,7 +1306,15 @@ func TestReconcileBindingDelete(t *testing.T) {
 		t.Fatalf("Found the deleted Binding in fakeBindingClient after deletion")
 	}
 
-	updateAction = actions[1].(core.UpdateAction)
+	getAction2 := actions[1].(core.GetAction)
+	if e, a := "get", getAction2.GetVerb(); e != a {
+		t.Fatalf("Unexpected verb on actions[1]; expected %v, got %v", e, a)
+	}
+	if e, a := testBindingName, getAction2.GetName(); e != a {
+		t.Fatalf("Unexpected name of object to get; expected %v; got %v", e, a)
+	}
+
+	updateAction = actions[2].(core.UpdateAction)
 	if e, a := "update", updateAction.GetVerb(); e != a {
 		t.Fatalf("Unexpected verb on actions[1]; expected %v, got %v", e, a)
 	}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/glog"
+
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/util/wait"
 
@@ -32,6 +34,7 @@ import (
 func WaitForBrokerCondition(client v1alpha1servicecatalog.ServicecatalogV1alpha1Interface, name string, condition v1alpha1.BrokerCondition) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
+			glog.V(5).Infof("Waiting for broker %v condition %#v", name, condition)
 			broker, err := client.Brokers().Get(name)
 			if nil != err {
 				return false, fmt.Errorf("error getting Broker %v: %v", name, err)
@@ -57,6 +60,7 @@ func WaitForBrokerCondition(client v1alpha1servicecatalog.ServicecatalogV1alpha1
 func WaitForBrokerToNotExist(client v1alpha1servicecatalog.ServicecatalogV1alpha1Interface, name string) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
+			glog.V(5).Infof("Waiting for broker %v to not exist", name)
 			_, err := client.Brokers().Get(name)
 			if nil == err {
 				return false, nil
@@ -76,6 +80,7 @@ func WaitForBrokerToNotExist(client v1alpha1servicecatalog.ServicecatalogV1alpha
 func WaitForServiceClassToExist(client v1alpha1servicecatalog.ServicecatalogV1alpha1Interface, name string) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
+			glog.V(5).Infof("Waiting for serviceClass %v to exist", name)
 			_, err := client.ServiceClasses().Get(name)
 			if nil == err {
 				return true, nil
@@ -91,6 +96,7 @@ func WaitForServiceClassToExist(client v1alpha1servicecatalog.ServicecatalogV1al
 func WaitForServiceClassToNotExist(client v1alpha1servicecatalog.ServicecatalogV1alpha1Interface, name string) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
+			glog.V(5).Infof("Waiting for serviceClass %v to not exist", name)
 			_, err := client.ServiceClasses().Get(name)
 			if nil == err {
 				return false, nil
@@ -110,6 +116,7 @@ func WaitForServiceClassToNotExist(client v1alpha1servicecatalog.ServicecatalogV
 func WaitForInstanceCondition(client v1alpha1servicecatalog.ServicecatalogV1alpha1Interface, namespace, name string, condition v1alpha1.InstanceCondition) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
+			glog.V(5).Infof("Waiting for instance %v/%v condition %#v", namespace, name, condition)
 			instance, err := client.Instances(namespace).Get(name)
 			if nil != err {
 				return false, fmt.Errorf("error getting Instance %v/%v: %v", namespace, name, err)
@@ -130,11 +137,34 @@ func WaitForInstanceCondition(client v1alpha1servicecatalog.ServicecatalogV1alph
 	)
 }
 
+// WaitForInstanceToNotExist waits for the Instance with the given name to no
+// longer exist.
+func WaitForInstanceToNotExist(client v1alpha1servicecatalog.ServicecatalogV1alpha1Interface, namespace, name string) error {
+	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
+		func() (bool, error) {
+			glog.V(5).Infof("Waiting for instance %v/%v to not exist", namespace, name)
+
+			_, err := client.Instances(namespace).Get(name)
+			if nil == err {
+				return false, nil
+			}
+
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+
+			return false, nil
+		},
+	)
+}
+
 // WaitForBindingCondition waits for the status of the named binding to
 // contain a condition whose type and status matches the supplied one.
 func WaitForBindingCondition(client v1alpha1servicecatalog.ServicecatalogV1alpha1Interface, namespace, name string, condition v1alpha1.BindingCondition) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
+			glog.V(5).Infof("Waiting for binding %v/%v condition %#v", namespace, name, condition)
+
 			binding, err := client.Bindings(namespace).Get(name)
 			if nil != err {
 				return false, fmt.Errorf("error getting Binding %v/%v: %v", namespace, name, err)
@@ -148,6 +178,27 @@ func WaitForBindingCondition(client v1alpha1servicecatalog.ServicecatalogV1alpha
 				if condition.Type == cond.Type && condition.Status == cond.Status {
 					return true, nil
 				}
+			}
+
+			return false, nil
+		},
+	)
+}
+
+// WaitForBindingToNotExist waits for the Binding with the given name to no
+// longer exist.
+func WaitForBindingToNotExist(client v1alpha1servicecatalog.ServicecatalogV1alpha1Interface, namespace, name string) error {
+	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
+		func() (bool, error) {
+			glog.V(5).Infof("Waiting for binding %v/%v to not exist", namespace, name)
+
+			_, err := client.Bindings(namespace).Get(name)
+			if nil == err {
+				return false, nil
+			}
+
+			if errors.IsNotFound(err) {
+				return true, nil
 			}
 
 			return false, nil


### PR DESCRIPTION
Add coverage for provision, bind, unbind, and deprovision to the controller integration test.  Next up, I will refactor this to support testing error conditions, etc.

Note: I found that the fake broker does not correctly implement the OSB API semantics.  I made a couple changes here to get the test working, but as a follow-up, I will probably take a pass through the brokerapi and fake broker implementations and refactor / make correct.