### PR TITLE
Publishing docker images from master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,8 @@ cache:
   - .glide
 script:
 - make verify build test images
+deploy:
+  provider: script
+  script: scripts/deploy.sh
+  on:
+    branch: master

--- a/Makefile
+++ b/Makefile
@@ -314,5 +314,3 @@ apiserver-push: apiserver-image
 	[ ! -z "$(REGISTRY)" ] || (echo Set your REGISTRY env var first ; exit 1)
 	docker tag apiserver:$(VERSION) $(REGISTRY)/apiserver:$(VERSION)
 	docker push $(REGISTRY)/apiserver:$(VERSION)
-	docker tag apiserver:$(VERSION) $(REGISTRY)/apiserver:latest
-	docker push $(REGISTRY)/apiserver:latest

--- a/Makefile
+++ b/Makefile
@@ -299,18 +299,26 @@ k8s-broker-push: k8s-broker-image
 	[ ! -z "$(REGISTRY)" ] || (echo Set your REGISTRY env var first ; exit 1)
 	docker tag k8s-broker:$(VERSION) $(REGISTRY)/k8s-broker:$(VERSION)
 	docker push $(REGISTRY)/k8s-broker:$(VERSION)
+	docker tag k8s-broker:$(VERSION) $(REGISTRY)/k8s-broker:canary
+	docker push $(REGISTRY)/k8s-broker:canary
 
 user-broker-push: user-broker-image
 	[ ! -z "$(REGISTRY)" ] || (echo Set your REGISTRY env var first ; exit 1)
 	docker tag user-broker:$(VERSION) $(REGISTRY)/user-broker:$(VERSION)
 	docker push $(REGISTRY)/user-broker:$(VERSION)
+	docker tag user-broker:$(VERSION) $(REGISTRY)/user-broker:canary
+	docker push $(REGISTRY)/user-broker:canary
 
 controller-manager-push: controller-manager-image
 	[ ! -z "$(REGISTRY)" ] || (echo Set your REGISTRY env var first ; exit 1)
 	docker tag controller-manager:$(VERSION) $(REGISTRY)/controller-manager:$(VERSION)
 	docker push $(REGISTRY)/controller-manager:$(VERSION)
+	docker tag controller-manager:$(VERSION) $(REGISTRY)/controller-manager:canary
+	docker push $(REGISTRY)/controller-manager:canary
 
 apiserver-push: apiserver-image
 	[ ! -z "$(REGISTRY)" ] || (echo Set your REGISTRY env var first ; exit 1)
 	docker tag apiserver:$(VERSION) $(REGISTRY)/apiserver:$(VERSION)
 	docker push $(REGISTRY)/apiserver:$(VERSION)
+	docker tag apiserver:$(VERSION) $(REGISTRY)/apiserver:canary
+	docker push $(REGISTRY)/apiserver:canary

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright 2017 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export REGISTRY=quay.io/kubernetes-service-catalog
+
+if [[ -n "${TRAVIS_TAG:-}" ]]; then
+    echo "Pushing images with tag ${TRAVIS_TAG}."
+    VERSION="${TRAVIS_TAG}" make push
+else
+    echo "Pushing images with sha tag."
+    make push
+fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-# Copyright 2017 The Kubernetes Authors All rights reserved.
+# Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -20,6 +20,8 @@ set -o pipefail
 
 export REGISTRY=quay.io/kubernetes-service-catalog
 
+docker login -e="${QUAY_EMAIL}" -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}"
+
 if [[ -n "${TRAVIS_TAG}" ]]; then
     echo "Pushing images with tag ${TRAVIS_TAG}."
     VERSION="${TRAVIS_TAG}" make push

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,7 +16,7 @@
 
 export REGISTRY=quay.io/kubernetes-service-catalog
 
-if [[ -n "${TRAVIS_TAG:-}" ]]; then
+if [[ -n "${TRAVIS_TAG}" ]]; then
     echo "Pushing images with tag ${TRAVIS_TAG}."
     VERSION="${TRAVIS_TAG}" make push
 else

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 export REGISTRY=quay.io/kubernetes-service-catalog
 
 if [[ -n "${TRAVIS_TAG}" ]]; then


### PR DESCRIPTION
Images are published on each commit to master. In the publishing step, docker images will be tagged with the git tag if there is one (as reported by travis) or otherwise will be tagged with the commit sha. Thus, images will never be pushed to an existing tag and will be immutable. See https://github.com/kubernetes-incubator/service-catalog/issues/504#issuecomment-286204441 for more detail on the tagging strategy.

Fixes #504
Fixes #488 

I believe we should use this tagging strategy instead of that in #520. I also believe that we can close #525 (and hence, #331) with this PR. See https://github.com/kubernetes-incubator/service-catalog/pull/529#discussion_r105745994 for more details. Official `Closes #1234` clauses are below so that when this PR is merged, those issues/PRs automatically close.

Closes #520 
Closes #525 
Closes #331 