### PR TITLE
Do not start API Server when TPR install fails

### DIFF
--- a/cmd/apiserver/app/server/run_server_test.go
+++ b/cmd/apiserver/app/server/run_server_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/storage/tpr"
+
+	kubeclientfake "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5/fake"
+	"k8s.io/kubernetes/pkg/client/testing/core"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// make sure RunServer returns with an error when TPR fails to install
+func TestRunServerInstallTPRFails(t *testing.T) {
+	options := &ServiceCatalogServerOptions{}
+
+	fakeClientset := &kubeclientfake.Clientset{}
+	fakeClientset.AddReactor("get", "thirdpartyresources", func(core.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("TPR not found")
+	})
+	fakeClientset.AddReactor("create", "thirdpartyresources", func(core.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("Failed to create TPR")
+	})
+
+	options.StorageTypeString = "tpr"
+	options.TPROptions = &TPROptions{
+		"default-name-space",
+		fakeClientset.Core().RESTClient(),
+		installTPRsToCore(fakeClientset),
+		"name-space",
+	}
+
+	err := RunServer(options)
+	if _, ok := err.(tpr.ErrTPRInstall); !ok {
+		t.Errorf("API Server did not report failure after failing to install Third Party Resources")
+	}
+
+	// make sure no more action after tpr failed to install
+	actions := fakeClientset.Actions()
+	for _, action := range actions {
+		if action.GetResource().Resource != "thirdpartyresources" {
+			t.Errorf("Unexpected action performed after failing to install third party resource")
+		}
+	}
+}

--- a/cmd/apiserver/app/server/run_server_test.go
+++ b/cmd/apiserver/app/server/run_server_test.go
@@ -53,10 +53,29 @@ func TestRunServerInstallTPRFails(t *testing.T) {
 	}
 
 	// make sure no more action after tpr failed to install
+	getAction := 0
+	createAction := 0
 	actions := fakeClientset.Actions()
 	for _, action := range actions {
+		switch verb := action.GetVerb(); verb {
+		case "get":
+			getAction++
+		case "create":
+			createAction++
+		default:
+			t.Errorf("Unexpected action only 'get' and 'create' should be performed, got action: %s", verb)
+		}
+
 		if action.GetResource().Resource != "thirdpartyresources" {
 			t.Errorf("Unexpected action performed after failing to install third party resource")
 		}
+	}
+
+	if getAction != 4 {
+		t.Errorf("Expected 4 'get' action, got %d", getAction)
+	}
+
+	if createAction != 4 {
+		t.Errorf("Expected 4 'create' action, got %d", createAction)
 	}
 }

--- a/cmd/apiserver/app/server/tpr_options.go
+++ b/cmd/apiserver/app/server/tpr_options.go
@@ -31,7 +31,7 @@ import (
 type TPROptions struct {
 	DefaultGlobalNamespace string
 	RESTClient             restclient.Interface
-	InstallTPRsFunc        func()
+	InstallTPRsFunc        func() error
 	GlobalNamespace        string
 }
 

--- a/pkg/storage/tpr/install_types.go
+++ b/pkg/storage/tpr/install_types.go
@@ -37,6 +37,11 @@ var thirdPartyResources = []v1beta1.ThirdPartyResource{
 	serviceBindingTPR,
 }
 
+// ErrTPRInstall is returned when we fail to install TPR
+type ErrTPRInstall struct {
+	errMsg string
+}
+
 // Installer takes in a client and exposes method for installing third party resources
 type Installer struct {
 	tprs extensionsv1beta.ThirdPartyResourceInterface
@@ -100,8 +105,12 @@ func (i *Installer) InstallTypes() error {
 
 	if allErrMsg != "" {
 		glog.Errorf("Failed to create Third Party Resource:\n%s)", allErrMsg)
-		return fmt.Errorf("Failed to create Third Party Resource:\n%s)", allErrMsg)
+		return ErrTPRInstall{fmt.Sprintf("Failed to create Third Party Resource:%s)", allErrMsg)}
 	}
 
 	return nil
+}
+
+func (e ErrTPRInstall) Error() string {
+	return e.errMsg
 }


### PR DESCRIPTION
This is the first part of PRs that addresses #464

We don't want the API Server to start if any third party resource fails to install.