### PR TITLE
Make REGISTRY env var optionally include a prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ GO_BUILD       = env GOOS=$(PLATFORM) GOARCH=$(ARCH) go build -i $(GOFLAGS) \
 BASE_PATH      = $(ROOT:/src/github.com/kubernetes-incubator/service-catalog/=)
 export GOPATH  = $(BASE_PATH):$(ROOT)/vendor
 
+REGISTRY      ?= quay.io/kubernetes-service-catalog/
+
 # precheck to avoid kubernetes-incubator/service-catalog#361
 $(if $(realpath vendor/k8s.io/kubernetes/vendor), \
 	$(error the vendor directory exists in the kubernetes \
@@ -296,29 +298,25 @@ controller-manager-image: build/controller-manager/Dockerfile $(BINDIR)/controll
 push: k8s-broker-push user-broker-push controller-manager-push apiserver-push
 
 k8s-broker-push: k8s-broker-image
-	[ ! -z "$(REGISTRY)" ] || (echo Set your REGISTRY env var first ; exit 1)
-	docker tag k8s-broker:$(VERSION) $(REGISTRY)/k8s-broker:$(VERSION)
-	docker push $(REGISTRY)/k8s-broker:$(VERSION)
-	docker tag k8s-broker:$(VERSION) $(REGISTRY)/k8s-broker:canary
-	docker push $(REGISTRY)/k8s-broker:canary
+	docker tag k8s-broker:$(VERSION) $(REGISTRY)k8s-broker:$(VERSION)
+	docker push $(REGISTRY)k8s-broker:$(VERSION)
+	docker tag k8s-broker:$(VERSION) $(REGISTRY)k8s-broker:canary
+	docker push $(REGISTRY)k8s-broker:canary
 
 user-broker-push: user-broker-image
-	[ ! -z "$(REGISTRY)" ] || (echo Set your REGISTRY env var first ; exit 1)
-	docker tag user-broker:$(VERSION) $(REGISTRY)/user-broker:$(VERSION)
-	docker push $(REGISTRY)/user-broker:$(VERSION)
-	docker tag user-broker:$(VERSION) $(REGISTRY)/user-broker:canary
-	docker push $(REGISTRY)/user-broker:canary
+	docker tag user-broker:$(VERSION) $(REGISTRY)user-broker:$(VERSION)
+	docker push $(REGISTRY)user-broker:$(VERSION)
+	docker tag user-broker:$(VERSION) $(REGISTRY)user-broker:canary
+	docker push $(REGISTRY)user-broker:canary
 
 controller-manager-push: controller-manager-image
-	[ ! -z "$(REGISTRY)" ] || (echo Set your REGISTRY env var first ; exit 1)
-	docker tag controller-manager:$(VERSION) $(REGISTRY)/controller-manager:$(VERSION)
-	docker push $(REGISTRY)/controller-manager:$(VERSION)
-	docker tag controller-manager:$(VERSION) $(REGISTRY)/controller-manager:canary
-	docker push $(REGISTRY)/controller-manager:canary
+	docker tag controller-manager:$(VERSION) $(REGISTRY)controller-manager:$(VERSION)
+	docker push $(REGISTRY)controller-manager:$(VERSION)
+	docker tag controller-manager:$(VERSION) $(REGISTRY)controller-manager:canary
+	docker push $(REGISTRY)controller-manager:canary
 
 apiserver-push: apiserver-image
-	[ ! -z "$(REGISTRY)" ] || (echo Set your REGISTRY env var first ; exit 1)
-	docker tag apiserver:$(VERSION) $(REGISTRY)/apiserver:$(VERSION)
-	docker push $(REGISTRY)/apiserver:$(VERSION)
-	docker tag apiserver:$(VERSION) $(REGISTRY)/apiserver:canary
-	docker push $(REGISTRY)/apiserver:canary
+	docker tag apiserver:$(VERSION) $(REGISTRY)apiserver:$(VERSION)
+	docker push $(REGISTRY)apiserver:$(VERSION)
+	docker tag apiserver:$(VERSION) $(REGISTRY)apiserver:canary
+	docker push $(REGISTRY)apiserver:canary

--- a/contrib/jenkins/build.sh
+++ b/contrib/jenkins/build.sh
@@ -73,7 +73,7 @@ if [[ "$(uname -s)" == "Linux" ]]; then
   gcloud docker --authorize-only --server=gcr.io \
     || error_exit 'gcloud docker authorization failed'
 
-  make "${MAKE_VARS[@]}" REGISTRY=gcr.io/${PROJECT}/catalog push \
+  make "${MAKE_VARS[@]}" REGISTRY=gcr.io/${PROJECT}/catalog/ push \
     || error_exit 'make push failed.'
 
   docker images \

--- a/docs/DEVGUIDE.md
+++ b/docs/DEVGUIDE.md
@@ -158,19 +158,28 @@ cover all code paths. The results are put into a file called:
 
 ## Advanced Build Steps
 
-You can build the service catalog executables into Docker images and push
-them to a Docker Registry so they can be accessed by your Kubernetes clusters:
+You can build the service catalog executables into Docker images yourself. By
+default, image names are `quay.io/kubernetes-service-catalog/<component>`. Since
+most contributors who hack on service catalog components will wish to produce
+custom-built images, but will be unable to push to this location, it can be
+overridden through use of the `REGISTRY` environment variable.
 
-    # Registry URL is the portion up to, but excluding the image name and its
-    # preceding slash, e.g., "gcr.io/my-repo", "my-docker-id"
-    $ export REGISTRY=<registry URL>
+Examples of apiserver image names:
+
+| `REGISTRY` | Fully Qualified Image Name | Notes |
+|----------|----------------------------|-------|
+| Unset; default | `quay.io/kubernetes-service-catalog/apiserver` | You probably don't have permissions to push to here |
+| Dockerhub username + trailing slash, e.g. `krancour/` | `krancour/apiserver` | Missing hostname == Dockerhub |
+| Dockerhub username + slash + some prefix, e.g. `krancour/sc-` | `krancour/sc-apiserver` | The prefix is useful for disambiguating similarly names images within a single namespace. |
+| 192.168.99.102:5000/ | `192.168.99.102:5000/apiserver` | A local registry |
+
+With `REGISTRY` set appropriately:
 
     $ make images push
 
-This will build Docker images for the service controller, Kubernetes service
-broker, and service classes registry. The images are also pushed to the
-registry specified by the `REGISTRY` environment variable, so they
-can be accessed by your Kubernetes cluster.
+This will build Docker images for all service catalog components. The images are
+also pushed to the registry specified by the `REGISTRY` environment variable, so
+they can be accessed by your Kubernetes cluster.
 
 The images are tagged with the current Git commit SHA:
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,8 +18,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export REGISTRY=quay.io/kubernetes-service-catalog
-
 docker login -e="${QUAY_EMAIL}" -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
 
 if [[ -n "${TRAVIS_TAG}" ]]; then


### PR DESCRIPTION
Follows up on #529 and presents an alternative to #525-- cc @agonzalezro 

This alters our use of the `REGISTRY` environment variable slightly to make it more flexible-- including the ability to end this string (optionally) with an image "prefix" (as originally proposed by #525) to help users disambiguate similarly named images within their own namespace in a public registry.

cc @arschles this should implement the strategy we discussed offline earlier.