### PR TITLE
Checking the storage type properly

### DIFF
--- a/deploy/catalog/templates/apiserver.yaml
+++ b/deploy/catalog/templates/apiserver.yaml
@@ -42,7 +42,7 @@ spec:
         - name: apiserver-ssl
           mountPath: /var/run/kubernetes-service-catalog
           readOnly: true
-      {{ if eq (default .Values.storageType "etcd") "etcd" -}}
+      {{ if eq (.Values.storageType | default "etcd") "etcd" -}}
       - name: etcd
         image: {{ default .Values.etcdImage "quay.io/coreos/etcd" }}:{{ if .Values.etcdVersion }}{{ .Values.etcdVersion }}{{ else }}{{ "latest" }}{{ end }}
         env:


### PR DESCRIPTION
If the storage type is not given, it should be defaulted to “etcd”. Previously, we were not applying the default properly, so the storageType was always being set to etcd.

Fixes https://github.com/kubernetes-incubator/service-catalog/issues/539

I ran two `helm install` command locally to ensure that this works. The first command was to install in `tpr` mode:

```console
helm install \
  --namespace=steward \
  --set version=${VERSION},storageType=tpr,debug=true,insecure=true,imagePullPolicy=Never,globalNamespace=steward \
  deploy/catalog
```

This produced an apiserver pod that contains only 1 container (because etcd is not needed in TPR mode):

```console
ENG000656:service-catalog aaronschlesinger$ ks get po
NAME                                  READY     STATUS    RESTARTS   AGE
apiserver-3369828308-xkwwk            1/1       Running   0          46s
controller-manager-2879509801-zkwnl   1/1       Running   1          46s
```

The second command was to install in etcd mode:

```console
helm install \
  --namespace=steward \
  --set version=${VERSION},debug=true,insecure=true,imagePullPolicy=Never,globalNamespace=steward \
  deploy/catalog
```

This resulted in an apiserver pod that has 2 containers, one for the server and the other for etcd itself:

```console
ENG000656:service-catalog aaronschlesinger$ ks get po
NAME                                  READY     STATUS    RESTARTS   AGE
apiserver-2617155571-rrzs3            2/2       Running   0          3s
controller-manager-2879509801-6lc1j   1/1       Running   0          3s
```