### PR TITLE
Removing the TPR installer

### DIFF
--- a/cmd/apiserver/app/server/run_server.go
+++ b/cmd/apiserver/app/server/run_server.go
@@ -47,8 +47,7 @@ func RunServer(opts *ServiceCatalogServerOptions) error {
 
 func installTPRsToCore(cl clientset.Interface) func() error {
 	return func() error {
-		installer := tpr.NewInstaller(cl.Extensions().ThirdPartyResources())
-		if err := installer.InstallTypes(); err != nil {
+		if err := tpr.InstallTypes(cl.Extensions().ThirdPartyResources()); err != nil {
 			glog.Errorf("Failed to install TPR types (%s)", err)
 			return err
 		}
@@ -60,6 +59,7 @@ func runTPRServer(opts *ServiceCatalogServerOptions) error {
 	tprOpts := opts.TPROptions
 	glog.Infoln("Installing TPR types to the cluster")
 	if err := tprOpts.InstallTPRsFunc(); err != nil {
+		glog.V(4).Infof("Installing TPR types failed, continuing anyway (%s)", err)
 		return err
 	}
 

--- a/pkg/storage/tpr/install_types_test.go
+++ b/pkg/storage/tpr/install_types_test.go
@@ -61,8 +61,9 @@ func TestInstallTypesAllResources(t *testing.T) {
 		},
 	)
 
-	installer := NewInstaller(fakeClientset.Extensions().ThirdPartyResources())
-	installer.InstallTypes()
+	if err := InstallTypes(fakeClientset.Extensions().ThirdPartyResources()); err != nil {
+		t.Fatalf("error installing types (%s)", err)
+	}
 
 	expectTotal := len(thirdPartyResources)
 	if createCallCount != expectTotal {
@@ -96,8 +97,9 @@ func TestInstallTypesResourceExisted(t *testing.T) {
 		},
 	)
 
-	installer := NewInstaller(fakeClientset.Extensions().ThirdPartyResources())
-	installer.InstallTypes()
+	if err := InstallTypes(fakeClientset.Extensions().ThirdPartyResources()); err != nil {
+		t.Fatalf("error installing (%s)", err)
+	}
 
 	if createCallCount != len(thirdPartyResources)-1 {
 		t.Errorf("Failed to skip 1 installed Third Party Resource")
@@ -135,8 +137,7 @@ func TestInstallTypesErrors(t *testing.T) {
 		},
 	)
 
-	installer := NewInstaller(fakeClientset.Extensions().ThirdPartyResources())
-	err := installer.InstallTypes()
+	err := InstallTypes(fakeClientset.Extensions().ThirdPartyResources())
 
 	errStr := err.Error()
 	if !strings.Contains(errStr, "Error 1") && !strings.Contains(errStr, "Error 2") {
@@ -170,8 +171,9 @@ func TestInstallTypesPolling(t *testing.T) {
 		},
 	)
 
-	installer := NewInstaller(fakeClientset.Extensions().ThirdPartyResources())
-	installer.InstallTypes()
+	if err := InstallTypes(fakeClientset.Extensions().ThirdPartyResources()); err == nil {
+		t.Fatal("InstallTypes was supposed to error but didn't")
+	}
 
 	for _, name := range getCallArgs {
 		if name == serviceBrokerTPR.Name || name == serviceInstanceTPR.Name {


### PR DESCRIPTION
It was an extra abstraction that wasn’t needed. This PR is purposefully not assigned to a milestone.

cc/ @simonleung8