### PR TITLE
deploy only from the main repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ deploy:
   provider: script
   script: scripts/deploy.sh
   on:
+    repo: kubernetes-incubator/service-catalog
     branch: master


### PR DESCRIPTION
This allows users to have a personal repository build
in travis without failing on the deploy step.