### PR TITLE
Adding INFO logs for when API server validations fail

### DIFF
--- a/pkg/apis/servicecatalog/validation/binding.go
+++ b/pkg/apis/servicecatalog/validation/binding.go
@@ -17,10 +17,9 @@ limitations under the License.
 package validation
 
 import (
+	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	apivalidation "k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/util/validation/field"
-
-	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 )
 
 // validateBindingName is the validation function for Binding names.
@@ -29,10 +28,19 @@ var validateBindingName = apivalidation.NameIsDNSSubdomain
 // ValidateBinding validates a Binding and returns a list of errors.
 func ValidateBinding(binding *sc.Binding) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&binding.ObjectMeta, true, /*namespace*/
-		validateBindingName,
-		field.NewPath("metadata"))...)
-	allErrs = append(allErrs, validateBindingSpec(&binding.Spec, field.NewPath("Spec"))...)
+	allErrs = appendToErrListAndLog(
+		allErrs,
+		apivalidation.ValidateObjectMeta(
+			&binding.ObjectMeta,
+			true, /*namespace*/
+			validateBindingName,
+			field.NewPath("metadata"),
+		)...,
+	)
+	allErrs = appendToErrListAndLog(
+		allErrs,
+		validateBindingSpec(&binding.Spec, field.NewPath("Spec"))...,
+	)
 
 	return allErrs
 }

--- a/pkg/apis/servicecatalog/validation/broker.go
+++ b/pkg/apis/servicecatalog/validation/broker.go
@@ -32,13 +32,20 @@ var ValidateBrokerName = apivalidation.NameIsDNSSubdomain
 func ValidateBroker(broker *sc.Broker) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs,
-		apivalidation.ValidateObjectMeta(&broker.ObjectMeta,
+	allErrs = appendToErrListAndLog(
+		allErrs,
+		apivalidation.ValidateObjectMeta(
+			&broker.ObjectMeta,
 			false, /* namespace required */
 			ValidateBrokerName,
-			field.NewPath("metadata"))...)
+			field.NewPath("metadata"),
+		)...,
+	)
 
-	allErrs = append(allErrs, validateBrokerSpec(&broker.Spec, field.NewPath("spec"))...)
+	allErrs = appendToErrListAndLog(
+		allErrs,
+		validateBrokerSpec(&broker.Spec, field.NewPath("spec"))...,
+	)
 	return allErrs
 }
 

--- a/pkg/apis/servicecatalog/validation/err_list.go
+++ b/pkg/apis/servicecatalog/validation/err_list.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package validation
 
 import (

--- a/pkg/apis/servicecatalog/validation/err_list.go
+++ b/pkg/apis/servicecatalog/validation/err_list.go
@@ -31,6 +31,6 @@ func appendToErrListAndLog(list field.ErrorList, toAppend ...*field.Error) field
 
 func logErrList(list ...*field.Error) {
 	for i, err := range list {
-		glog.Errorf("%d: %#v", i, *err)
+		glog.Infof("%d: %#v", i, *err)
 	}
 }

--- a/pkg/apis/servicecatalog/validation/err_list.go
+++ b/pkg/apis/servicecatalog/validation/err_list.go
@@ -31,6 +31,6 @@ func appendToErrListAndLog(list field.ErrorList, toAppend ...*field.Error) field
 
 func logErrList(list ...*field.Error) {
 	for i, err := range list {
-		glog.Infof("%d: %#v", i, *err)
+		glog.Infof("API Validation Error %d: %#v", i, *err)
 	}
 }

--- a/pkg/apis/servicecatalog/validation/err_list.go
+++ b/pkg/apis/servicecatalog/validation/err_list.go
@@ -1,0 +1,20 @@
+package validation
+
+import (
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/util/validation/field"
+)
+
+func appendToErrListAndLog(list field.ErrorList, toAppend ...*field.Error) field.ErrorList {
+	if len(toAppend) > 0 {
+		logErrList(toAppend...)
+		list = append(list, toAppend...)
+	}
+	return list
+}
+
+func logErrList(list ...*field.Error) {
+	for i, err := range list {
+		glog.Errorf("%d: %#v", i, *err)
+	}
+}

--- a/pkg/apis/servicecatalog/validation/instance.go
+++ b/pkg/apis/servicecatalog/validation/instance.go
@@ -29,10 +29,16 @@ var validateInstanceName = apivalidation.NameIsDNSSubdomain
 // ValidateInstance validates an Instance and returns a list of errors.
 func ValidateInstance(instance *sc.Instance) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&instance.ObjectMeta, true, /*namespace*/
+	allErrs = appendToErrListAndLog(allErrs, apivalidation.ValidateObjectMeta(
+		&instance.ObjectMeta,
+		true, /*namespace*/
 		validateInstanceName,
-		field.NewPath("metadata"))...)
-	allErrs = append(allErrs, validateInstanceSpec(&instance.Spec, field.NewPath("Spec"))...)
+		field.NewPath("metadata"),
+	)...)
+	allErrs = appendToErrListAndLog(
+		allErrs,
+		validateInstanceSpec(&instance.Spec, field.NewPath("Spec"))...,
+	)
 	return allErrs
 }
 
@@ -40,7 +46,10 @@ func validateInstanceSpec(spec *sc.InstanceSpec, fldPath *field.Path) field.Erro
 	allErrs := field.ErrorList{}
 
 	if "" == spec.ServiceClassName {
-		allErrs = append(allErrs, field.Required(fldPath.Child("serviceClassName"), "serviceClassName is required"))
+		allErrs = append(allErrs, field.Required(
+			fldPath.Child("serviceClassName"),
+			"serviceClassName is required",
+		))
 	}
 
 	for _, msg := range validateServiceClassName(spec.ServiceClassName, false /* prefix */) {


### PR DESCRIPTION
@vaikas-google, @MHBauer and I met earlier today (3/14/2017) to investigate https://github.com/kubernetes-incubator/service-catalog/issues/541, and found the following:

- The ups-broker was sending a catalog with UUIDs with upper-case letters in it
- The API server disallows upper case letters (it uses `NameIsDNS1035Label` to validate UUIDs)
- The API server received the POST for the new service class, and fails the validation
- The API server sends the failure back to the core API machinery, which appears to send error details back to the client
- The client’s `Create` function for service classes returns an error that doesn’t contain any descriptive detail

This PR is a stop-gap measure to increase the amount of descriptive error reporting we have. Ultimately, we’ll have to determine where the error detail is being lost (my money is on the generated client, fwiw) and fix it.

cc/ @vaikas-google @krancour @pmorie @MHBauer