### PR TITLE
Return lowercase service GUIDs from the ups-broker

### DIFF
--- a/contrib/pkg/broker/user_provided/controller/controller.go
+++ b/contrib/pkg/broker/user_provided/controller/controller.go
@@ -47,7 +47,7 @@ func (c *userProvidedController) Catalog() (*brokerapi.Catalog, error) {
 		Services: []*brokerapi.Service{
 			{
 				Name:        "user-provided-service",
-				ID:          "4F6E6CF6-FFDD-425F-A2C7-3C9258AD2468",
+				ID:          "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468",
 				Description: "User Provided Service",
 				Plans: []brokerapi.ServicePlan{{
 					Name:        "default",


### PR DESCRIPTION
This PR partially addresses https://github.com/kubernetes-incubator/service-catalog/issues/541 because it returns UUIDs with lower-case letters that will satisfy the `NameIsDNS1035Label` validation on the service-catalog API server