### PR TITLE
Correct client error messages as interpretted in the controller

### DIFF
--- a/cmd/controller-manager/app/controller_manager.go
+++ b/cmd/controller-manager/app/controller_manager.go
@@ -43,6 +43,9 @@ import (
 	// is the point at which we handle this for the controller-manager
 	// process.  Please do not remove.
 	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
+	// The core API has to be installed in order for the client to understand
+	// error messages from the API server.  Please do not remove.
+	_ "k8s.io/kubernetes/pkg/api/install"
 
 	"github.com/kubernetes-incubator/service-catalog/cmd/controller-manager/app/options"
 	"github.com/kubernetes-incubator/service-catalog/pkg/brokerapi/openservicebroker"


### PR DESCRIPTION
The controller currently doesn't register the core k8s api group, which means that it cannot correctly interpret error messages from the service catalog client.  Example:

```
I0315 19:24:07.670935       1 request.go:1152] body was not decodable (unable to check for Status): no kind "Status" is registered for version "v1"
E0315 19:24:07.670981       1 controller.go:268] Error creating serviceClass user-provided-service from Broker ups-broker: the server rejected our request due to an error in
 our request (post serviceclasses.servicecatalog.k8s.io)
E0315 19:24:07.671007       1 controller.go:269] Error: &errors.StatusError{ErrStatus:v1.Status{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ListMeta:v1.ListMeta{SelfLink:"
", ResourceVersion:""}, Status:"Failure", Message:"the server rejected our request due to an error in our request (post serviceclasses.servicecatalog.k8s.io)", Reason:"Inval
id", Details:(*v1.StatusDetails)(0xc420062be0), Code:422}}
```

This PR installs the group, which allows the client used by the controller to correctly interpret error messages:

```
E0315 19:40:11.470025       1 controller.go:268] Error creating serviceClass user-provided-service from Broker ups-broker: ServiceClass.servicecatalog.k8s.io "user-provided-service" is invalid: osbGuid: Invalid value: "4F6E6CF6-FFDD-425F-A2C7-3C9258AD2468": must match the regex [a-z0-9]([-a-z0-9]*[a-z0-9])? (e.g. 'my-name' or '123-abc')
```