### PR TITLE
build with registry/"prefix" from the get go

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,6 +18,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+export REGISTRY=quay.io/kubernetes-service-catalog/
+
 docker login -e="${QUAY_EMAIL}" -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
 
 if [[ -n "${TRAVIS_TAG}" ]]; then


### PR DESCRIPTION
Closes #550 

This is cleaner. Docker images are built and tagged correctly right up front instead of being tagged last-minute if / before they are pushed to a registry.

cc @arschles as you requested