### PR TITLE
Removing trailing slashes from broker server URLs

### DIFF
--- a/pkg/brokerapi/openservicebroker/open_service_broker_client.go
+++ b/pkg/brokerapi/openservicebroker/open_service_broker_client.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -90,7 +91,7 @@ type openServiceBrokerClient struct {
 func NewClient(name, url, username, password string) brokerapi.BrokerClient {
 	return &openServiceBrokerClient{
 		name:     name,
-		url:      url,
+		url:      strings.TrimRight(url, "/"), // remove trailing slashes from broker server URLs
 		username: username,
 		password: password,
 		client: &http.Client{

--- a/pkg/brokerapi/openservicebroker/open_service_broker_client_test.go
+++ b/pkg/brokerapi/openservicebroker/open_service_broker_client_test.go
@@ -47,6 +47,21 @@ func setup() (*util.FakeBrokerServer, *servicecatalog.Broker) {
 	return fbs, fakeBroker
 }
 
+func TestTrailingSlash(t *testing.T) {
+	const (
+		input    = "http://a/b/c/"
+		expected = "http://a/b/c"
+	)
+	cl := NewClient("testBroker", input, "test-user", "test-pass")
+	osbCl, ok := cl.(*openServiceBrokerClient)
+	if !ok {
+		t.Fatalf("NewClient didn't return an openServiceBrokerClient")
+	}
+	if osbCl.url != expected {
+		t.Fatalf("URL was %s, expected %s", osbCl.url, expected)
+	}
+}
+
 // Provision
 
 func TestProvisionInstanceCreated(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/service-catalog/issues/567