### PR TITLE
enable race detector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ test: .init build test-unit test-integration
 
 test-unit: .init build
 	@echo Running tests:
-	$(DOCKER_CMD) go test $(UNIT_TEST_FLAGS) \
+	$(DOCKER_CMD) go test -race $(UNIT_TEST_FLAGS) \
 	  $(addprefix $(SC_PKG)/,$(TEST_DIRS))
 
 test-integration: .init $(scBuildImageTarget) build

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -25,7 +25,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 runTests() {
   kube::etcd::start
 
-  go test -v github.com/kubernetes-incubator/service-catalog/test/integration/... --args -v 10 -logtostderr
+  go test -race -v github.com/kubernetes-incubator/service-catalog/test/integration/... --args -v 10 -logtostderr
 }
 
 # Run cleanup to stop etcd on interrupt or other kill signal.


### PR DESCRIPTION
I do not know of any arguments not to use this. It seems like it would have caught several previous flaky tests.

Make sure to turn it off when running coverage.