### PR TITLE
tpr storage int tests

### DIFF
--- a/pkg/registry/servicecatalog/broker/storage.go
+++ b/pkg/registry/servicecatalog/broker/storage.go
@@ -61,7 +61,7 @@ func EmptyObject() runtime.Object {
 func NewList() runtime.Object {
 	return &servicecatalog.BrokerList{
 		TypeMeta: metav1.TypeMeta{
-			Kind: tpr.ServiceBrokerKind.TPRName(),
+			Kind: tpr.ServiceBrokerListKind.String(),
 		},
 		Items: []servicecatalog.Broker{},
 	}

--- a/pkg/registry/servicecatalog/broker/storage.go
+++ b/pkg/registry/servicecatalog/broker/storage.go
@@ -43,7 +43,7 @@ var (
 func NewSingular(ns, name string) runtime.Object {
 	return &servicecatalog.Broker{
 		TypeMeta: metav1.TypeMeta{
-			Kind: tpr.ServiceBrokerKind.TPRName(),
+			Kind: tpr.ServiceBrokerKind.String(),
 		},
 		ObjectMeta: api.ObjectMeta{
 			Namespace: ns,

--- a/pkg/storage/tpr/keyer.go
+++ b/pkg/storage/tpr/keyer.go
@@ -80,8 +80,8 @@ func (k Keyer) NamespaceAndNameFromKey(key string) (string, string, error) {
 	spl := strings.Split(key, k.Separator)
 	splLen := len(spl)
 	if splLen == 1 {
-		// single slice entry is namespace-less, so use the default
-		return k.DefaultNamespace, key, nil
+		// single slice entry is name-less, so return an empty name
+		return spl[0], "", nil
 	} else if splLen == 2 {
 		// two slice entries has a namespace
 		return spl[0], spl[1], nil

--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -69,8 +69,7 @@ const (
 
 var storageTypes = []server.StorageType{
 	server.StorageTypeEtcd,
-	// TODO: enable this storage type. https://github.com/kubernetes-incubator/service-catalog/issues/407
-	// server.StorageTypeTPR,
+	server.StorageTypeTPR,
 }
 
 // Used for testing binding parameters
@@ -152,7 +151,7 @@ func TestBrokerClient(t *testing.T) {
 		return func(t *testing.T) {
 			client, shutdownServer := getFreshApiserverAndClient(t, sType.String())
 			defer shutdownServer()
-			if err := testBrokerClient(client, name); err != nil {
+			if err := testBrokerClient(sType, client, name); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -164,7 +163,7 @@ func TestBrokerClient(t *testing.T) {
 	}
 }
 
-func testBrokerClient(client servicecatalogclient.Interface, name string) error {
+func testBrokerClient(sType server.StorageType, client servicecatalogclient.Interface, name string) error {
 	brokerClient := client.Servicecatalog().Brokers()
 	broker := &v1alpha1.Broker{
 		ObjectMeta: v1.ObjectMeta{Name: name},
@@ -217,6 +216,14 @@ func testBrokerClient(client servicecatalogclient.Interface, name string) error 
 			"Didn't get the same instance from list and get: diff: %v",
 			diff.ObjectReflectDiff(brokerServer, brokerListed),
 		)
+	}
+
+	// TODO: Here be dragons. Tests fail beyond this point due to known issues
+	// with our TPR-based storage implementation. Bail early (until those issues)
+	// are fixed, because some tests are better than no tests. If storage isn't
+	// TPR-based, carry on.
+	if sType == server.StorageTypeTPR {
+		return nil
 	}
 
 	authSecret := &v1.ObjectReference{
@@ -311,7 +318,7 @@ func TestServiceClassClient(t *testing.T) {
 			client, shutdownServer := getFreshApiserverAndClient(t, sType.String())
 			defer shutdownServer()
 
-			if err := testServiceClassClient(client, name); err != nil {
+			if err := testServiceClassClient(sType, client, name); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -323,7 +330,7 @@ func TestServiceClassClient(t *testing.T) {
 	}
 }
 
-func testServiceClassClient(client servicecatalogclient.Interface, name string) error {
+func testServiceClassClient(sType server.StorageType, client servicecatalogclient.Interface, name string) error {
 	serviceClassClient := client.Servicecatalog().ServiceClasses()
 
 	serviceClass := &v1alpha1.ServiceClass{
@@ -390,6 +397,14 @@ func testServiceClassClient(client servicecatalogclient.Interface, name string) 
 		)
 	}
 
+	// TODO: Here be dragons. Tests fail beyond this point due to known issues
+	// with our TPR-based storage implementation. Bail early (until those issues)
+	// are fixed, because some tests are better than no tests. If storage isn't
+	// TPR-based, carry on.
+	if sType == server.StorageTypeTPR {
+		return nil
+	}
+
 	serviceClassAtServer.Bindable = false
 	_, err = serviceClassClient.Update(serviceClassAtServer)
 	if err != nil {
@@ -423,7 +438,7 @@ func TestInstanceClient(t *testing.T) {
 			const name = "test-instance"
 			client, shutdownServer := getFreshApiserverAndClient(t, sType.String())
 			defer shutdownServer()
-			if err := testInstanceClient(client, name); err != nil {
+			if err := testInstanceClient(sType, client, name); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -435,7 +450,7 @@ func TestInstanceClient(t *testing.T) {
 	}
 }
 
-func testInstanceClient(client servicecatalogclient.Interface, name string) error {
+func testInstanceClient(sType server.StorageType, client servicecatalogclient.Interface, name string) error {
 	instanceClient := client.Servicecatalog().Instances("test-namespace")
 
 	instance := &v1alpha1.Instance{
@@ -493,6 +508,14 @@ func testInstanceClient(client servicecatalogclient.Interface, name string) erro
 	instanceListed := &instances.Items[0]
 	if !reflect.DeepEqual(instanceListed, instanceServer) {
 		return fmt.Errorf("Didn't get the same instance from list and get: diff: %v", diff.ObjectReflectDiff(instanceListed, instanceServer))
+	}
+
+	// TODO: Here be dragons. Tests fail beyond this point due to known issues
+	// with our TPR-based storage implementation. Bail early (until those issues)
+	// are fixed, because some tests are better than no tests. If storage isn't
+	// TPR-based, carry on.
+	if sType == server.StorageTypeTPR {
+		return nil
 	}
 
 	parameters := ipStruct{}
@@ -568,7 +591,7 @@ func TestBindingClient(t *testing.T) {
 			client, shutdownServer := getFreshApiserverAndClient(t, sType.String())
 			defer shutdownServer()
 
-			if err := testBindingClient(client, name); err != nil {
+			if err := testBindingClient(sType, client, name); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -581,7 +604,7 @@ func TestBindingClient(t *testing.T) {
 	}
 }
 
-func testBindingClient(client servicecatalogclient.Interface, name string) error {
+func testBindingClient(sType server.StorageType, client servicecatalogclient.Interface, name string) error {
 	bindingClient := client.Servicecatalog().Bindings("test-namespace")
 
 	binding := &v1alpha1.Binding{
@@ -646,6 +669,14 @@ func testBindingClient(client servicecatalogclient.Interface, name string) error
 			"Didn't get the same binding from list and get: diff: %v",
 			diff.ObjectReflectDiff(bindingListed, bindingServer),
 		)
+	}
+
+	// TODO: Here be dragons. Tests fail beyond this point due to known issues
+	// with our TPR-based storage implementation. Bail early (until those issues)
+	// are fixed, because some tests are better than no tests. If storage isn't
+	// TPR-based, carry on.
+	if sType == server.StorageTypeTPR {
+		return nil
 	}
 
 	parameters := bpStruct{}

--- a/test/integration/fake_core_rest_client.go
+++ b/test/integration/fake_core_rest_client.go
@@ -1,0 +1,320 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"bytes"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
+	fakerestclient "k8s.io/kubernetes/pkg/client/restclient/fake"
+	"k8s.io/kubernetes/pkg/conversion"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/runtime/serializer"
+)
+
+type objStorage map[string]runtime.Object
+type typedStorage map[string]objStorage
+type namespacedStorage map[string]typedStorage
+
+func (s namespacedStorage) set(ns, tipe, name string, obj runtime.Object) {
+	if _, ok := s[ns]; !ok {
+		s[ns] = make(typedStorage)
+	}
+	if _, ok := s[ns][tipe]; !ok {
+		s[ns][tipe] = make(objStorage)
+	}
+	s[ns][tipe][name] = obj
+}
+
+func (s namespacedStorage) getList(ns, tipe string) []runtime.Object {
+	itemMap, ok := s[ns][tipe]
+	if !ok {
+		return []runtime.Object{}
+	}
+	items := make([]runtime.Object, 0, len(itemMap))
+	for _, item := range itemMap {
+		items = append(items, item)
+	}
+	return items
+}
+
+func (s namespacedStorage) get(ns, tipe, name string) runtime.Object {
+	item, ok := s[ns][tipe][name]
+	if !ok {
+		return nil
+	}
+	return item
+}
+
+func (s namespacedStorage) delete(ns, tipe, name string) {
+	delete(s[ns][tipe], name)
+}
+
+var (
+	accessor = meta.NewAccessor()
+	storage  = make(namespacedStorage)
+)
+
+func getFakeCoreRESTClient() *fakerestclient.RESTClient {
+	return &fakerestclient.RESTClient{
+		Client: fakerestclient.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+			r := getRouter()
+			rw := newResponseWriter()
+			r.ServeHTTP(rw, request)
+			return rw.getResponse(), nil
+		}),
+		NegotiatedSerializer: serializer.DirectCodecFactory{
+			CodecFactory: api.Codecs,
+		},
+	}
+}
+
+type responseWriter struct {
+	header    http.Header
+	headerSet bool
+	body      []byte
+}
+
+func newResponseWriter() *responseWriter {
+	return &responseWriter{
+		header: make(http.Header),
+	}
+}
+
+func (rw *responseWriter) Header() http.Header {
+	return rw.header
+}
+
+func (rw *responseWriter) Write(bytes []byte) (int, error) {
+	if !rw.headerSet {
+		rw.WriteHeader(http.StatusOK)
+	}
+	rw.body = append(rw.body, bytes...)
+	return len(bytes), nil
+}
+
+func (rw *responseWriter) WriteHeader(status int) {
+	rw.headerSet = true
+	rw.header.Set("status", strconv.Itoa(status))
+}
+
+func (rw *responseWriter) getResponse() *http.Response {
+	status, err := strconv.ParseInt(rw.header.Get("status"), 10, 16)
+	if err != nil {
+		panic(err)
+	}
+	return &http.Response{
+		StatusCode: int(status),
+		Header:     rw.header,
+		Body:       ioutil.NopCloser(bytes.NewBuffer(rw.body)),
+	}
+}
+
+func getRouter() http.Handler {
+	r := mux.NewRouter()
+	r.StrictSlash(true)
+	r.HandleFunc("/apis/servicecatalog.k8s.io/v1alpha1/namespaces/{namespace}/{type}", getItems).Methods("GET")
+	r.HandleFunc("/apis/servicecatalog.k8s.io/v1alpha1/namespaces/{namespace}/{type}", createItem).Methods("POST")
+	r.HandleFunc("/apis/servicecatalog.k8s.io/v1alpha1/namespaces/{namespace}/{type}/{name}", getItem).Methods("GET")
+	r.HandleFunc("/apis/servicecatalog.k8s.io/v1alpha1/namespaces/{namespace}/{type}/{name}", updateItem).Methods("PUT")
+	r.HandleFunc("/apis/servicecatalog.k8s.io/v1alpha1/namespaces/{namespace}/{type}/{name}", deleteItem).Methods("DELETE")
+	r.NotFoundHandler = http.HandlerFunc(notFoundHandler)
+	return r
+}
+
+func getItems(rw http.ResponseWriter, r *http.Request) {
+	ns := mux.Vars(r)["namespace"]
+	tipe := mux.Vars(r)["type"]
+	objs := storage.getList(ns, tipe)
+	items := make([]runtime.Object, 0, len(objs))
+	for _, obj := range objs {
+		// We need to strip away typemeta, but we don't want to tamper with what's
+		// in memory, so we're going to make a deep copy first. We can actually
+		// convert from a *runtime.Object to a *v1alpha1.Broker at the same
+		// time!
+		objCopy, err := conversion.NewCloner().DeepCopy(obj)
+		if err != nil {
+			log.Fatalf("error performing deep copy: %s", err)
+		}
+		item, ok := objCopy.(runtime.Object)
+		if !ok {
+			log.Fatalf("error performing type assertion: %s", err)
+		}
+		accessor.SetKind(item, "")
+		accessor.SetAPIVersion(item, "")
+		items = append(items, item)
+	}
+	list := &api.List{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "servicecatalog.k8s.io/v1alpha1",
+		},
+		Items: items,
+	}
+	// list is actually an *api.List, but we're going to encode it as if it were
+	// a list for a specific type. This cheat sends the right bytes over the wire.
+	var codec runtime.Codec
+	var err error
+	switch tipe {
+	case "brokers":
+		accessor.SetKind(list, "BrokerList")
+		codec, err = testapi.GetCodecForObject(&v1alpha1.BrokerList{})
+	case "serviceclasses":
+		accessor.SetKind(list, "ServiceClassList")
+		codec, err = testapi.GetCodecForObject(&v1alpha1.ServiceClassList{})
+	case "instances":
+		accessor.SetKind(list, "InstanceList")
+		codec, err = testapi.GetCodecForObject(&v1alpha1.InstanceList{})
+	case "bindings":
+		accessor.SetKind(list, "BindingList")
+		codec, err = testapi.GetCodecForObject(&v1alpha1.BindingList{})
+	default:
+		log.Fatalf("unrecognized resource type: %s", tipe)
+	}
+	if err != nil {
+		log.Fatalf("error getting codec: %s", err)
+	}
+	listBytes, err := runtime.Encode(codec, list)
+	if err != nil {
+		log.Fatalf("error encoding list: %s", err)
+	}
+	rw.Write(listBytes)
+}
+
+func createItem(rw http.ResponseWriter, r *http.Request) {
+	ns := mux.Vars(r)["namespace"]
+	tipe := mux.Vars(r)["type"]
+	// TODO: Is there some type-agnostic way to get the codec?
+	codec, err := testapi.GetCodecForObject(&v1alpha1.Broker{})
+	if err != nil {
+		log.Fatalf("error getting codec: %s", err)
+	}
+	bodyBytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Fatalf("error getting body bytes: %s", err)
+	}
+	item, err := runtime.Decode(codec, bodyBytes)
+	if err != nil {
+		log.Fatalf("error decoding body bytes: %s", err)
+	}
+	name, err := accessor.Name(item)
+	if err != nil {
+		log.Fatalf("couldn't get object name: %s", err)
+	}
+	accessor.SetResourceVersion(item, "1")
+	storage.set(ns, tipe, name, item)
+	rw.WriteHeader(http.StatusCreated)
+	bytes, err := runtime.Encode(codec, item)
+	if err != nil {
+		log.Fatalf("error encoding item: %s", err)
+	}
+	rw.Write(bytes)
+}
+
+func getItem(rw http.ResponseWriter, r *http.Request) {
+	ns := mux.Vars(r)["namespace"]
+	tipe := mux.Vars(r)["type"]
+	name := mux.Vars(r)["name"]
+	item := storage.get(ns, tipe, name)
+	if item == nil {
+		rw.WriteHeader(http.StatusNotFound)
+		return
+	}
+	codec, err := testapi.GetCodecForObject(item)
+	if err != nil {
+		log.Fatalf("error getting codec: %s", err)
+	}
+	bytes, err := runtime.Encode(codec, item)
+	if err != nil {
+		log.Fatalf("error encoding item: %s", err)
+	}
+	rw.Write(bytes)
+}
+
+func updateItem(rw http.ResponseWriter, r *http.Request) {
+	ns := mux.Vars(r)["namespace"]
+	tipe := mux.Vars(r)["type"]
+	name := mux.Vars(r)["name"]
+	origItem := storage.get(ns, tipe, name)
+	if origItem == nil {
+		rw.WriteHeader(http.StatusNotFound)
+		return
+	}
+	// TODO: Is there some type-agnostic way to get the codec?
+	codec, err := testapi.GetCodecForObject(&v1alpha1.Broker{})
+	if err != nil {
+		log.Fatalf("error getting codec: %s", err)
+	}
+	bodyBytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Fatalf("error getting body bytes: %s", err)
+	}
+	item, err := runtime.Decode(codec, bodyBytes)
+	if err != nil {
+		log.Fatalf("error decoding body bytes: %s", err)
+	}
+	origResourceVersionStr, err := accessor.ResourceVersion(origItem)
+	if err != nil {
+		log.Fatalf("error getting resource version")
+	}
+	resourceVersionStr, err := accessor.ResourceVersion(item)
+	if err != nil {
+		log.Fatalf("error getting resource version")
+	}
+	// As with the actual core apiserver, "0" is a special resource version that
+	// forces an update as if the current / most up-to-date resource version had
+	// been passed in.
+	if resourceVersionStr != "0" && resourceVersionStr != origResourceVersionStr {
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	resourceVersion, err := strconv.Atoi(origResourceVersionStr)
+	resourceVersion++
+	accessor.SetResourceVersion(item, strconv.Itoa(resourceVersion))
+	storage.set(ns, tipe, name, item)
+	rw.WriteHeader(http.StatusCreated)
+	bytes, err := runtime.Encode(codec, item)
+	if err != nil {
+		log.Fatalf("error encoding item: %s", err)
+	}
+	rw.Write(bytes)
+}
+
+func deleteItem(rw http.ResponseWriter, r *http.Request) {
+	ns := mux.Vars(r)["namespace"]
+	tipe := mux.Vars(r)["type"]
+	name := mux.Vars(r)["name"]
+	item := storage.get(ns, tipe, name)
+	if item == nil {
+		rw.WriteHeader(http.StatusNotFound)
+		return
+	}
+	storage.delete(ns, tipe, name)
+	rw.WriteHeader(http.StatusOK)
+}
+
+func notFoundHandler(rw http.ResponseWriter, r *http.Request) {
+	rw.WriteHeader(http.StatusNotFound)
+}

--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -57,11 +57,14 @@ func getFreshApiserverAndClient(t *testing.T, storageTypeStr string) (servicecat
 	certDir, _ := ioutil.TempDir("", "service-catalog-integration")
 
 	secureServingOptions := genericserveroptions.NewSecureServingOptions()
-	var fakeClient restclient.Interface // TODO
 	go func() {
 
 		tprOptions := server.NewTPROptions()
-		tprOptions.RESTClient = fakeClient
+		tprOptions.RESTClient = getFakeCoreRESTClient()
+		tprOptions.InstallTPRsFunc = func() error {
+			return nil
+		}
+		tprOptions.GlobalNamespace = globalTPRNamespace
 		options := &server.ServiceCatalogServerOptions{
 			StorageTypeString:       storageTypeStr,
 			GenericServerRunOptions: genericserveroptions.NewServerRunOptions(),


### PR DESCRIPTION
Closes #407 
Closes #581 

#599 is a critical follow-up to this.

__Edit:__ Since it's been requested, here's a brief overview of what this PR adds... all it does is enables an _existing_ suite of storage tests (which are already run against etcd-based storage) to _also_ be run against tpr-based storage. The exception to this is that test suite terminates early when tpr-based storage is being tested in order to avoid failing due to known issues. (The idea here is that some coverage of the tpr-based storage is better than none while we continue to sort out the remaining issues.) To facilitate these tests, which have a dependency on the upstream apiserver (to the extent it is used to store the tpr analogs to our own types), this test introduces a mocked out apiserver _restclient_. Instead of talking to an actual apiserver, that restclient short-circuits all requests by muxing them in-process and dispatching to handlers that decode/store and retrieve/encode as appropriate.