### PR TITLE
Populate OrgID and SpaceID in Instance create

### DIFF
--- a/pkg/brokerapi/fake/fake.go
+++ b/pkg/brokerapi/fake/fake.go
@@ -209,6 +209,7 @@ func convertBindingRequest(req *brokerapi.BindingRequest) *brokerapi.ServiceBind
 		ServiceID:     req.ServiceID,
 		ServicePlanID: req.PlanID,
 		Parameters:    req.Parameters,
+		AppID:         req.AppGUID,
 	}
 }
 

--- a/pkg/brokerapi/fake/fake.go
+++ b/pkg/brokerapi/fake/fake.go
@@ -151,15 +151,19 @@ func convertInstanceRequest(req *brokerapi.CreateServiceInstanceRequest) *broker
 
 // BindingClient implements a fake CF binding API client
 type BindingClient struct {
-	Bindings    map[string]*brokerapi.ServiceBinding
-	CreateCreds brokerapi.Credential
-	CreateErr   error
-	DeleteErr   error
+	Bindings        map[string]*brokerapi.ServiceBinding
+	BindingRequests map[string]*brokerapi.BindingRequest
+	CreateCreds     brokerapi.Credential
+	CreateErr       error
+	DeleteErr       error
 }
 
 // NewBindingClient creates a new empty binding client, ready for use
 func NewBindingClient() *BindingClient {
-	return &BindingClient{Bindings: make(map[string]*brokerapi.ServiceBinding)}
+	return &BindingClient{
+		Bindings:        make(map[string]*brokerapi.ServiceBinding),
+		BindingRequests: make(map[string]*brokerapi.BindingRequest),
+	}
 }
 
 // CreateServiceBinding returns b.CreateErr if it was non-nil. Otherwise, returns
@@ -180,6 +184,7 @@ func (b *BindingClient) CreateServiceBinding(
 	}
 
 	b.Bindings[BindingsMapKey(sID, bID)] = convertBindingRequest(req)
+	b.BindingRequests[BindingsMapKey(sID, bID)] = req
 	return &brokerapi.CreateServiceBindingResponse{Credentials: b.CreateCreds}, nil
 }
 

--- a/pkg/brokerapi/fake/fake.go
+++ b/pkg/brokerapi/fake/fake.go
@@ -142,7 +142,7 @@ func convertInstanceRequest(req *brokerapi.CreateServiceInstanceRequest) *broker
 		InternalID:       uuid.NewV4().String(),
 		ServiceID:        req.ServiceID,
 		PlanID:           req.PlanID,
-		OrganizationGUID: uuid.NewV4().String(),
+		OrganizationGUID: req.OrgID,
 		SpaceGUID:        req.SpaceID,
 		LastOperation:    nil,
 		Parameters:       req.Parameters,

--- a/pkg/brokerapi/service_binding.go
+++ b/pkg/brokerapi/service_binding.go
@@ -24,6 +24,7 @@ type ServiceBinding struct {
 	ServicePlanID     string                 `json:"service_plan_id"`
 	PrivateKey        string                 `json:"private_key"`
 	ServiceInstanceID string                 `json:"service_instance_id"`
+	BindResource      map[string]interface{} `json:"bind_resource,omitempty"`
 	Parameters        map[string]interface{} `json:"parameters, omitempty"`
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -480,7 +480,12 @@ func (c *controller) reconcileInstance(instance *v1alpha1.Instance) {
 			}
 		}
 
-		ns, _ := c.kubeClient.Core().Namespaces().Get(instance.Namespace)
+		ns, err := c.kubeClient.Core().Namespaces().Get(instance.Namespace)
+		if err != nil {
+			glog.Errorf("Failed to get namespace during instance create (%s)", err)
+			return
+		}
+
 		request := &brokerapi.CreateServiceInstanceRequest{
 			ServiceID:  serviceClass.OSBGUID,
 			PlanID:     servicePlan.OSBGUID,
@@ -740,7 +745,12 @@ func (c *controller) reconcileBinding(binding *v1alpha1.Binding) {
 			}
 		}
 
-		ns, _ := c.kubeClient.Core().Namespaces().Get(instance.Namespace)
+		ns, err := c.kubeClient.Core().Namespaces().Get(instance.Namespace)
+		if err != nil {
+			glog.Errorf("Failed to get namespace during binding (%s)", err)
+			return
+		}
+
 		request := &brokerapi.BindingRequest{
 			ServiceID:    serviceClass.OSBGUID,
 			PlanID:       servicePlan.OSBGUID,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -740,10 +740,12 @@ func (c *controller) reconcileBinding(binding *v1alpha1.Binding) {
 			}
 		}
 
+		ns, _ := c.kubeClient.Core().Namespaces().Get(instance.Namespace)
 		request := &brokerapi.BindingRequest{
 			ServiceID:  serviceClass.OSBGUID,
 			PlanID:     servicePlan.OSBGUID,
 			Parameters: parameters,
+			AppGUID:    string(ns.UID),
 		}
 		response, err := brokerClient.CreateServiceBinding(instance.Spec.OSBGUID, binding.Spec.OSBGUID, request)
 		if err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -742,10 +742,11 @@ func (c *controller) reconcileBinding(binding *v1alpha1.Binding) {
 
 		ns, _ := c.kubeClient.Core().Namespaces().Get(instance.Namespace)
 		request := &brokerapi.BindingRequest{
-			ServiceID:  serviceClass.OSBGUID,
-			PlanID:     servicePlan.OSBGUID,
-			Parameters: parameters,
-			AppGUID:    string(ns.UID),
+			ServiceID:    serviceClass.OSBGUID,
+			PlanID:       servicePlan.OSBGUID,
+			Parameters:   parameters,
+			AppGUID:      string(ns.UID),
+			BindResource: map[string]interface{}{"app_guid": string(ns.UID)},
 		}
 		response, err := brokerClient.CreateServiceBinding(instance.Spec.OSBGUID, binding.Spec.OSBGUID, request)
 		if err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -480,10 +480,13 @@ func (c *controller) reconcileInstance(instance *v1alpha1.Instance) {
 			}
 		}
 
+		ns, _ := c.kubeClient.Core().Namespaces().Get(instance.Namespace)
 		request := &brokerapi.CreateServiceInstanceRequest{
 			ServiceID:  serviceClass.OSBGUID,
 			PlanID:     servicePlan.OSBGUID,
 			Parameters: parameters,
+			OrgID:      string(ns.UID),
+			SpaceID:    string(ns.UID),
 		}
 
 		// TODO: handle async provisioning

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
@@ -1163,6 +1164,11 @@ func TestReconcileBindingWithParameters(t *testing.T) {
 	ns, _ := fakeKubeClient.Core().Namespaces().Get(binding.ObjectMeta.Namespace)
 	if string(ns.UID) != fakeBrokerClient.Bindings[fakebrokerapi.BindingsMapKey(instanceGUID, bindingGUID)].AppID {
 		t.Fatalf("Unexpected borker AppID: expected %q, got %q", string(ns.UID), fakeBrokerClient.Bindings[instanceGUID+":"+bindingGUID].AppID)
+	}
+
+	bindResource := fakeBrokerClient.BindingRequests[fakebrokerapi.BindingsMapKey(instanceGUID, bindingGUID)].BindResource
+	if appGUID := bindResource["app_guid"]; string(ns.UID) != fmt.Sprintf("%v", appGUID) {
+		t.Fatalf("Unexpected borker AppID: expected %q, got %q", string(ns.UID), appGUID)
 	}
 
 	actions := filterActions(fakeCatalogClient.Actions())


### PR DESCRIPTION
Instead of leaving them empty, we could fill these properties with namespace.uid. The 2 fields are a required field in openservice api spec

Also populate AppID in binding with namespace.uid

Closes: #528