### PR TITLE
Making the user provided controller concurrency-safe

### DIFF
--- a/contrib/pkg/broker/controller/controller.go
+++ b/contrib/pkg/broker/controller/controller.go
@@ -20,7 +20,8 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/pkg/brokerapi"
 )
 
-// Controller defines the APIs that all controllers are expected to support
+// Controller defines the APIs that all controllers are expected to support. Implementations
+// should be concurrency-safe
 type Controller interface {
 	Catalog() (*brokerapi.Catalog, error)
 


### PR DESCRIPTION
Also, checking to make sure an instance exists before binding.

Fixes https://github.com/kubernetes-incubator/service-catalog/issues/584