### PR TITLE
small fixes for chart deployments

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -44,13 +44,13 @@ chart and their default values.
 | `apiserver.insecure`  | Whether to expose an insecure endpoint; keep this enabled because there are some outstanding problems with the TLS-secured endpoint | `true` |
 | `apiserver.tls.cert` | Base64-encoded x509 certificate | A self-signed certificate |
 | `apiserver.tls.key` | Base64-encoded private key | The private key for the certificate above |
-| `apiserver.service.type` | Type of service; valid values are `LoadBalancer` and `NodePort` | `LoadBalancer` |
+| `apiserver.service.type` | Type of service; valid values are `LoadBalancer` and `NodePort` | `NodePort` |
 | `apiserver.service.nodePort.securePort` | If service type is `NodePort`, specifies a port in allowable range (e.g. 30000 - 32767 on minikube); The TLS-enabled endpoint will be exposed here | `30443` |
 | `apiserver.service.nodePort.insecurePort` | If service type is `NodePort`, specifies a port in allowable range (e.g. 30000 - 32767 on minikube); The insecure endpoint, if enabled, will be exposed here | `30080` |
 | `apiserver.storage.type` | The storage backend to use; valid values are `etcd` and `tpr` | `etcd` |
 | `apiserver.storage.etcd.useEmbedded` | If storage type is `etcd`: Whether to embed an etcd container in the apiserver pod; THIS IS INADEQUATE FOR PRODUCTION USE! | `true` |
 | `apiserver.storage.etcd.servers` | If storage type is `etcd`: etcd URL(s); override this if NOT using embedded etcd | `http://localhost:2379` |
-| `apiserver.storage.tpr.useEmbedded.globalNamespace` | If storage type is `tpr`: Some service catalog resources are not namespaced, but third party resources must be; setting this designates a namespace that will be treated as a container for such resources | `servicecatalog` |
+| `apiserver.storage.tpr.globalNamespace` | If storage type is `tpr`: Some service catalog resources are not namespaced, but third party resources must be; setting this designates a namespace that will be treated as a container for such resources | `servicecatalog` |
 | `apiserver.verbosity` | Log level; valid values are in the range 0 - 10 | `10` |
 | `controllerManager.image` | controller-manager image to use | `quay.io/kubernetes-service-catalog/controller-manager:canary` |
 | `controllerManager.imagePullPolicy` | `imagePullPolicy` for the controller-manager | `Always` |


### PR DESCRIPTION
1) Changes the default service type to be LoadBalancer, to match the README
2) Makes the README refer to the correct chart parameter for "globalNamespace"