### PR TITLE
add TPR, cleanup support to walkthrough e2e script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,12 +102,12 @@ node {
       // Run through the walkthrough on the cluster, once with an etcd-backed API server and once
       // with a TPR-backed one.
       sh """${env.ROOT}/contrib/hack/test_walkthrough.sh \
-            --registry gcr.io/${test_project}/catalog \
+            --registry gcr.io/${test_project}/catalog/ \
             --cleanup
       """
 
       sh """${env.ROOT}/contrib/hack/test_walkthrough.sh \
-            --registry gcr.io/${test_project}/catalog \
+            --registry gcr.io/${test_project}/catalog/ \
             --with-tpr \
             --cleanup
       """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,9 +99,16 @@ node {
         }
       )
 
-      // Run through the walkthrough on the cluster.
+      // Run through the walkthrough on the cluster, once with an etcd-backed API server and once
+      // with a TPR-backed one.
       sh """${env.ROOT}/contrib/hack/test_walkthrough.sh \
             --registry gcr.io/${test_project}/catalog \
+            --cleanup
+      """
+
+      sh """${env.ROOT}/contrib/hack/test_walkthrough.sh \
+            --registry gcr.io/${test_project}/catalog \
+            --with-tpr \
             --cleanup
       """
     } catch (Exception e) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,8 +73,7 @@ node {
   env.GOPATH = env.WORKSPACE
   env.ROOT = "${env.WORKSPACE}/${root_path}"
 
-  env.K8S_KUBECONFIG = "${env.ROOT}/k8s-kubeconfig"
-  env.SC_KUBECONFIG = "${env.ROOT}/sc-kubeconfig"
+  env.KUBECONFIG = "${env.ROOT}/k8s-kubeconfig"
 
   dir([path: env.ROOT]) {
     // Run build.
@@ -102,13 +101,14 @@ node {
 
       // Run through the walkthrough on the cluster.
       sh """${env.ROOT}/contrib/hack/test_walkthrough.sh \
-            --registry gcr.io/${test_project}/catalog
+            --registry gcr.io/${test_project}/catalog \
+            --cleanup
       """
     } catch (Exception e) {
       currentBuild.result = 'FAILURE'
     } finally {
       try {
-        sh """${env.ROOT}/contrib/jenkins/cleanup_cluster.sh --kubeconfig ${K8S_KUBECONFIG}"""
+        sh """${env.ROOT}/contrib/jenkins/cleanup_cluster.sh --kubeconfig ${KUBECONFIG}"""
       } catch (Exception e) {
         currentBuild.result = 'FAILURE'
       }

--- a/contrib/jenkins/build.sh
+++ b/contrib/jenkins/build.sh
@@ -38,7 +38,7 @@ done
   || error_exit '--project is a required parameter'
 
 if [[ "$(uname -s)" == "Linux" ]]; then
-  GIT_HEAD="$(git describe --always --abbrev=7 --dirty)"
+  GIT_HEAD="$(git describe --tags --always --abbrev=7 --dirty)"
   MAKE_VARS=(
     V=1
     VERSION="${VERSION:-${GIT_HEAD}}"

--- a/contrib/jenkins/cleanup_cluster.sh
+++ b/contrib/jenkins/cleanup_cluster.sh
@@ -51,9 +51,6 @@ else
   DELETECONFIG='YES'
 fi
 
-KUBECONFIG="${CONFIG}" wipe_cluster \
-  || error_exit 'Failed to shutdown Kubernetes resources on cluster.'
-
 gcloud container clusters delete "${CLUSTERNAME}" --project="${PROJECT}" \
     --zone="${ZONE}" --quiet --async \
   || error_exit 'Failed to delete cluster on Google Cloud Platform.'

--- a/contrib/jenkins/init_cluster.sh
+++ b/contrib/jenkins/init_cluster.sh
@@ -50,10 +50,8 @@ gcloud container clusters create "${CLUSTERNAME}" --project="${PROJECT}" --zone=
 
 echo "Using cluster ${CLUSTERNAME}."
 
-export KUBECONFIG="${K8S_KUBECONFIG}"
 gcloud container clusters get-credentials "${CLUSTERNAME}" --project="${PROJECT}" --zone="${ZONE}" \
   || { echo 'Cannot get credentials for cluster.'; exit 1; }
 
 helm init \
   || { echo 'Cannot initialize Helm.'; exit 1; }
-export KUBECONFIG=


### PR DESCRIPTION
1) Now `test_walkthrough.sh` will use a tpr-backed API server if you pass in `--with-tpr`.
2) `--cleanup` will get rid of all resources spun up during walkthrough.

Although the output is still quite ugly, this allows for people to test the walkthrough easily on their local machine.

~~Jenkins will still only run the etcd-based walkthrough; there is an issue outstanding ( #600 ) that prevents the deletion of TPR resources.~~
**EDIT**: Now Jenkins will run the tests on a TPR-based walkthrough as well up until deletion, and then hackily deletes the resources manually.

Closes: #632 