### PR TITLE
Push images with latest sha instead tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ SRC_DIRS       = $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*.go \
                    -exec dirname {} \\; | sort | uniq")
 TEST_DIRS     ?= $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go \
                    -exec dirname {} \\; | sort | uniq")
-VERSION       ?= $(shell git describe --tags --always --abbrev=7 --dirty)
+VERSION       ?= $(shell git describe --always --abbrev=7 --dirty)
 ifeq ($(shell uname -s),Darwin)
 STAT           = stat -f '%c %N'
 else

--- a/contrib/jenkins/build.sh
+++ b/contrib/jenkins/build.sh
@@ -38,7 +38,7 @@ done
   || error_exit '--project is a required parameter'
 
 if [[ "$(uname -s)" == "Linux" ]]; then
-  GIT_HEAD="$(git describe --tags --always --abbrev=7 --dirty)"
+  GIT_HEAD="$(git describe --always --abbrev=7 --dirty)"
   MAKE_VARS=(
     V=1
     VERSION="${VERSION:-${GIT_HEAD}}"


### PR DESCRIPTION
Closes: #604

We want to name the images we push with the latest sha (e.g. `e2dadc4`) instead of tags (e.g.`v0.0.1-RC1-4-ge2dadc4`)