### PR TITLE
Allow underscores in plan names

### DIFF
--- a/pkg/apis/servicecatalog/validation/instance.go
+++ b/pkg/apis/servicecatalog/validation/instance.go
@@ -55,7 +55,7 @@ func validateInstanceSpec(spec *sc.InstanceSpec, fldPath *field.Path, create boo
 		allErrs = append(allErrs, field.Required(fldPath.Child("planName"), "planName is required"))
 	}
 
-	for _, msg := range validateServicePlanName(spec.PlanName, false /* prefix */) {
+	for _, msg := range validateServicePlanName(spec.PlanName) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("planName"), spec.PlanName, msg))
 	}
 

--- a/pkg/apis/servicecatalog/validation/serviceclass_test.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass_test.go
@@ -49,6 +49,24 @@ func TestValidateServiceClass(t *testing.T) {
 			valid: true,
 		},
 		{
+			name: "valid serviceClass - plan with underscore in name",
+			serviceClass: &servicecatalog.ServiceClass{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "test-serviceclass",
+				},
+				Bindable:   true,
+				BrokerName: "test-broker",
+				OSBGUID:    "1234-4354a-49b",
+				Plans: []servicecatalog.ServicePlan{
+					{
+						Name:    "test_plan",
+						OSBGUID: "40d-0983-1b89",
+					},
+				},
+			},
+			valid: true,
+		},
+		{
 			name: "valid serviceClass - uppercase in GUID",
 			serviceClass: &servicecatalog.ServiceClass{
 				ObjectMeta: kapi.ObjectMeta{


### PR DESCRIPTION
The spec is ambiguous on the exact format (see https://github.com/openservicebrokerapi/servicebroker/issues/154), but real brokers appear to allow underscores in plan names.