### PR TITLE
Moved adding the Content-Type header from sendOSBRequest() to newOSBR…

### DIFF
--- a/pkg/brokerapi/openservicebroker/open_service_broker_client.go
+++ b/pkg/brokerapi/openservicebroker/open_service_broker_client.go
@@ -331,8 +331,6 @@ func sendOSBRequest(c *openServiceBrokerClient, method string, url string, objec
 		return nil, fmt.Errorf("Failed to create request object: %s", err.Error())
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-
 	resp, err := c.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to send request: %s", err.Error())
@@ -345,6 +343,9 @@ func (c *openServiceBrokerClient) newOSBRequest(method, urlStr string, body io.R
 	req, err := http.NewRequest(method, urlStr, body)
 	if err != nil {
 		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Add(constants.APIVersionHeader, constants.APIVersion)
 	req.SetBasicAuth(c.username, c.password)

--- a/pkg/brokerapi/openservicebroker/open_service_broker_client_test.go
+++ b/pkg/brokerapi/openservicebroker/open_service_broker_client_test.go
@@ -74,6 +74,8 @@ func TestProvisionInstanceCreated(t *testing.T) {
 	if _, err := c.CreateServiceInstance(testServiceInstanceID, &brokerapi.CreateServiceInstanceRequest{}); err != nil {
 		t.Fatal(err.Error())
 	}
+
+	verifyRequestContentType(fbs.Request, t)
 }
 
 func TestProvisionInstanceOK(t *testing.T) {
@@ -251,6 +253,8 @@ func TestBindOk(t *testing.T) {
 	if fbs.RequestObject == nil {
 		t.Fatalf("BindingRequest was not received correctly")
 	}
+	verifyRequestContentType(fbs.Request, t)
+
 	actual := reflect.TypeOf(fbs.RequestObject)
 	expected := reflect.TypeOf(&brokerapi.BindingRequest{})
 	if actual != expected {
@@ -337,4 +341,11 @@ func verifyBindingMethodAndPath(method, serviceID, bindingID string, req *http.R
 		t.Fatalf("Expected binding create path to have suffix %s but was: %s", expectPath, req.URL.Path)
 	}
 
+}
+
+func verifyRequestContentType(req *http.Request, t *testing.T) {
+	contentType := req.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		t.Fatalf("Expected the request content-type to be application/json, but was %s", contentType)
+	}
 }

--- a/pkg/brokerapi/openservicebroker/util/fake_broker_server.go
+++ b/pkg/brokerapi/openservicebroker/util/fake_broker_server.go
@@ -117,6 +117,7 @@ func (f *FakeBrokerServer) lastOperationHandler(w http.ResponseWriter, r *http.R
 
 func (f *FakeBrokerServer) provisionHandler(w http.ResponseWriter, r *http.Request) {
 	glog.Info("fake provision called")
+	f.Request = r
 	req := &brokerapi.CreateServiceInstanceRequest{}
 	if err := util.BodyToObject(r, req); err != nil {
 		w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
…equest()

 Bind requests did not include the Content-Type: application/json header. Since all OSB requests (that include a body) should use this content-type, I've moved it to newOSBRequest().