### PR TITLE
Remove the '-' in tpr name service-class

### DIFF
--- a/pkg/storage/tpr/resources.go
+++ b/pkg/storage/tpr/resources.go
@@ -53,7 +53,7 @@ var ServiceBrokerResource = metav1.APIResource{
 var ServiceClassResource = metav1.APIResource{
 	// ServiceClass is the kind, but TPRName converts it to 'serviceclass'. For now, just hard-code
 	// it here
-	Name:       "service-class",
+	Name:       "serviceclass",
 	Namespaced: true,
 }
 


### PR DESCRIPTION
Closes: #609 

Removing the dash so the TPR name matches the actual TPR resource.

* We have a [func()](https://github.com/kubernetes-incubator/service-catalog/blob/master/pkg/storage/tpr/kinds_test.go#L28) in code to deliberately turn `ServiceClass` into `service-class`, for which I don't understand why. Maybe someone with more context can chime in.
