### PR TITLE
WIP: Service catalog API resources finalizer token updates

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -300,7 +300,6 @@ func TestReconcileBrokerDelete(t *testing.T) {
 
 	broker := getTestBroker()
 	broker.DeletionTimestamp = &metav1.Time{}
-	broker.Finalizers = []string{"kubernetes"}
 
 	testController.reconcileBroker(broker)
 

--- a/pkg/registry/servicecatalog/binding/strategy.go
+++ b/pkg/registry/servicecatalog/binding/strategy.go
@@ -95,8 +95,6 @@ func (bindingRESTStrategy) PrepareForCreate(ctx kapi.Context, obj runtime.Object
 	// Fill in the first entry set to "creating"?
 	binding.Status.Conditions = []sc.BindingCondition{}
 
-	// TODO: Should we use a more specific string here?
-	binding.Finalizers = []string{"kubernetes"}
 }
 
 func (bindingRESTStrategy) Validate(ctx kapi.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/servicecatalog/broker/strategy.go
+++ b/pkg/registry/servicecatalog/broker/strategy.go
@@ -95,8 +95,6 @@ func (brokerRESTStrategy) PrepareForCreate(ctx kapi.Context, obj runtime.Object)
 	// Fill in the first entry set to "creating"?
 	broker.Status.Conditions = []sc.BrokerCondition{}
 
-	// TODO: Should we use a more specific string here?
-	broker.Finalizers = []string{"kubernetes"}
 }
 
 func (brokerRESTStrategy) Validate(ctx kapi.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/servicecatalog/instance/strategy.go
+++ b/pkg/registry/servicecatalog/instance/strategy.go
@@ -93,9 +93,6 @@ func (instanceRESTStrategy) PrepareForCreate(ctx kapi.Context, obj runtime.Objec
 	instance.Status = sc.InstanceStatus{}
 	// Fill in the first entry set to "creating"?
 	instance.Status.Conditions = []sc.InstanceCondition{}
-
-	// TODO: Should we use a more specific string here?
-	instance.Finalizers = []string{"kubernetes"}
 }
 
 func (instanceRESTStrategy) Validate(ctx kapi.Context, obj runtime.Object) field.ErrorList {


### PR DESCRIPTION
A finalizer token should not be used unless paired with an actual controller that will remove it prior to object deletion.  In addition, the token must be in a domain for service catalog.  Service catalog may set a finalizer token on the associated kubernetes namespace to ensure that its resources take part in namespace lifecycle, but that is a future follow-on.

/cc @pmorie 