### PR TITLE
Adding watch endpoint to the fake REST client

### DIFF
--- a/test/integration/fake_core_rest_client.go
+++ b/test/integration/fake_core_rest_client.go
@@ -141,6 +141,7 @@ func getRouter() http.Handler {
 	r.HandleFunc("/apis/servicecatalog.k8s.io/v1alpha1/namespaces/{namespace}/{type}/{name}", getItem).Methods("GET")
 	r.HandleFunc("/apis/servicecatalog.k8s.io/v1alpha1/namespaces/{namespace}/{type}/{name}", updateItem).Methods("PUT")
 	r.HandleFunc("/apis/servicecatalog.k8s.io/v1alpha1/namespaces/{namespace}/{type}/{name}", deleteItem).Methods("DELETE")
+	r.HandleFunc("/apis/servicecatalog.k8s.i0/v1alpha1/watch/namespaces/{namespace}/{type}/{name}", watchItem).Methods("GET")
 	r.NotFoundHandler = http.HandlerFunc(notFoundHandler)
 	return r
 }

--- a/test/integration/fake_core_rest_client.go
+++ b/test/integration/fake_core_rest_client.go
@@ -316,6 +316,10 @@ func deleteItem(rw http.ResponseWriter, r *http.Request) {
 	rw.WriteHeader(http.StatusOK)
 }
 
+func watchItem(rw http.ResponseWriter, r *http.Request) {
+
+}
+
 func notFoundHandler(rw http.ResponseWriter, r *http.Request) {
 	rw.WriteHeader(http.StatusNotFound)
 }


### PR DESCRIPTION
This PR adds a watch endpoint to the fake REST client. This sets us up to add integration tests for watching resources, to be done in a follow-up