### PR TITLE
Add `--version` to apiserver/controller-manager

### DIFF
--- a/cmd/apiserver/app/server/server.go
+++ b/cmd/apiserver/app/server/server.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/golang/glog"
+	"github.com/kubernetes-incubator/service-catalog/pkg"
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -77,7 +78,11 @@ func NewCommandServer(
 	// Set generated SSL cert path correctly
 	opts.SecureServingOptions.ServerCert.CertDirectory = certDirectory
 
+	version := pkg.VersionFlag(cmd.Flags())
+
 	flags.Parse(os.Args[1:])
+
+	version.PrintAndExitIfRequested()
 
 	storageType, err := opts.StorageType()
 	if err != nil {

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -26,11 +26,11 @@ import (
 
 	"github.com/kubernetes-incubator/service-catalog/cmd/controller-manager/app"
 	"github.com/kubernetes-incubator/service-catalog/cmd/controller-manager/app/options"
+	"github.com/kubernetes-incubator/service-catalog/pkg"
 
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
-	"k8s.io/kubernetes/pkg/version/verflag"
 
 	"github.com/spf13/pflag"
 )
@@ -42,12 +42,13 @@ func init() {
 func main() {
 	s := options.NewControllerManagerServer()
 	s.AddFlags(pflag.CommandLine)
+	version := pkg.VersionFlag(pflag.CommandLine)
 
 	flag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	verflag.PrintAndExitIfRequested()
+	version.PrintAndExitIfRequested()
 
 	if err := app.Run(s); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -16,6 +16,33 @@ limitations under the License.
 
 package pkg
 
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
 // VERSION is the version string for built artifacts. It's set by the build system, and should
 // not be changed in this codebase
 var VERSION = "UNKNOWN"
+
+// Version decides whether we should print the version and leave.
+type Version struct {
+	print bool
+}
+
+// VersionFlag creates the version flag for your application.
+func VersionFlag(fs *pflag.FlagSet) *Version {
+	v := Version{}
+	fs.BoolVar(&v.print, "version", false, "Print version information and quit")
+	return &v
+}
+
+// PrintAndExitIfRequested will print the version if requested, and exit.
+func (v Version) PrintAndExitIfRequested() {
+	if v.print {
+		fmt.Println(VERSION)
+		os.Exit(0)
+	}
+}


### PR DESCRIPTION
Also uses `--tag` to `git describe` as existing tags are not annotated
tags.

```
> bin/apiserver --version
0aece9a
> bin/controller-manager --version
0aece9a
```

Fixes #624 