### PR TITLE
controller: add workqueues/ratelimiting

### DIFF
--- a/cmd/controller-manager/app/controller_manager.go
+++ b/cmd/controller-manager/app/controller_manager.go
@@ -301,7 +301,7 @@ func StartControllers(s *options.ControllerManagerServer,
 		}
 
 		glog.V(5).Info("Running controller")
-		go serviceCatalogController.Run(stop)
+		go serviceCatalogController.Run(s.ConcurrentSyncs, stop)
 
 		glog.V(1).Info("Starting shared informers")
 		informerFactory.Start(stop)

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -43,6 +43,7 @@ const defaultPort = 10000
 const defaultK8sKubeconfigPath = "./kubeconfig"
 const defaultServiceCatalogKubeconfigPath = "./service-catalog-kubeconfig"
 const defaultOSBAPIContextProfile = true
+const defaultConcurrentSyncs = 5
 
 // NewControllerManagerServer creates a new ControllerManagerServer with a
 // default config.
@@ -57,6 +58,7 @@ func NewControllerManagerServer() *ControllerManagerServer {
 			ResyncInterval:               defaultResyncInterval,
 			BrokerRelistInterval:         defaultBrokerRelistInterval,
 			OSBAPIContextProfile:         defaultOSBAPIContextProfile,
+			ConcurrentSyncs:              defaultConcurrentSyncs,
 		},
 	}
 }

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -64,4 +64,9 @@ type ControllerManagerConfiguration struct {
 	// Whether or not to send the proposed optional
 	// OpenServiceBroker API Context Profile field
 	OSBAPIContextProfile bool
+
+	// ConcurrentSyncs is the number of resources, per resource type,
+	// that are allowed to sync concurrently. Larger number = more responsive
+	// SC operations, but more CPU (and network) load.
+	ConcurrentSyncs int
 }

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -286,6 +286,7 @@ func newTestController(t *testing.T) (
 	}
 
 	stopCh := make(chan struct{})
+	go testController.Run(1, stopCh)
 	informerFactory.Start(stopCh)
 	t.Log("informers start")
 	return fakeKubeClient, catalogClient, catalogCl, instanceCl, bindingCl,


### PR DESCRIPTION
This PR adds rate limited workqueues to the controller.

https://github.com/kubernetes/client-go/tree/master/util/workqueue

The workqueues allow the reconciliation to happen asynchronously wrt the informer event handlers.  This allows us to reschedule (reinsert into the workqueue) the operation if the reconciliation fails due to transient condition like a resource not existing (yet).  Since we can retry these failed operations at a faster interval than the informer sync interval, the state can converge more quickly.

The rate limiting gives us back-off on the retry interval.

@pmorie @jpeeler @derekwaynecarr