### PR TITLE
Remove incorrect fields from example Binding

### DIFF
--- a/contrib/examples/apiserver/binding.yaml
+++ b/contrib/examples/apiserver/binding.yaml
@@ -7,5 +7,3 @@ spec:
   instanceRef:
     name: test-instance
   secretName: my-secret
-  configMapName: my-configmap
-  serviceName: my-service


### PR DESCRIPTION
We removed these fields; they shouldn't be in the example and have mislead at least one user.