### PR TITLE
Update README for ups-broker.

### DIFF
--- a/charts/ups-broker/README.md
+++ b/charts/ups-broker/README.md
@@ -1,11 +1,12 @@
 # User Provided Service Broker
 
-User Provided Service Broker is an example [Open Service Broker]
-(https://www.openservicebrokerapi.org/) for use demonstrating the Kubernetes
+User Provided Service Broker is an example
+[Open Service Broker](https://www.openservicebrokerapi.org/)
+for use demonstrating the Kubernetes
 Service Catalog.
 
-For more information, [visit the Service Catalog project on github]
-(https://github.com/kubernetes-incubator/service-catalog).
+For more information,
+[visit the Service Catalog project on github](https://github.com/kubernetes-incubator/service-catalog).
 
 ## Installing the Chart
 


### PR DESCRIPTION
In https://github.com/kubernetes-incubator/service-catalog/tree/master/charts/ups-broker#user-provided-service-broker , the link for `[Open Service Broker]` and `[visit the Service Catalog project on github] ` is not correctly set, we should make sure there is a **hyperlink** for those two entries.