### PR TITLE
Return description for ServicePlan

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1080,7 +1080,8 @@ func convertServicePlans(plans []brokerapi.ServicePlan) ([]v1alpha1.ServicePlan,
 			Name:    plan.Name,
 			OSBGUID: plan.ID,
 			// OSBMetadata: plan.Metadata,
-			OSBFree: plan.Free,
+			OSBFree:     plan.Free,
+			Description: &plan.Description,
 		}
 		if plan.Metadata != nil {
 			metadata, err := json.Marshal(plan.Metadata)


### PR DESCRIPTION
Just adding a missing copy. Test results:

```
apiVersion: servicecatalog.k8s.io/v1alpha1
bindable: false
brokerName: ups-broker
description: User Provided Service
kind: ServiceClass
metadata:
  creationTimestamp: 2017-04-07T19:39:16Z
  name: user-provided-service
  resourceVersion: "6"
  selfLink: /apis/servicecatalog.k8s.io/v1alpha1/serviceclassesuser-provided-service
  uid: e2ab0535-1bc9-11e7-9f29-0242ac110005
osbGuid: 4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
osbMetadata: null
planUpdatable: false
plans:
- description: User Provided Service
  name: default
  osbFree: true
  osbGuid: 86064792-7ea2-467b-af93-ac9694d96d52
  osbMetadata: null
```

Fixes #666