### PR TITLE
support for service catalog admission controllers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ BINDIR        ?= bin
 BUILD_DIR     ?= build
 COVERAGE      ?= $(CURDIR)/coverage.html
 SC_PKG         = github.com/kubernetes-incubator/service-catalog
-TOP_SRC_DIRS   = cmd contrib pkg
+TOP_SRC_DIRS   = cmd contrib pkg plugin
 SRC_DIRS       = $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*.go \
                    -exec dirname {} \\; | sort | uniq")
 TEST_DIRS     ?= $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go \

--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -32,6 +32,8 @@ spec:
             cpu: 100m
             memory: 30Mi
         args:
+        - --admission-control
+        - "KubernetesNamespaceLifecycle"
         - --secure-port
         - "8443"
         {{- if .Values.apiserver.insecure }}

--- a/cmd/apiserver/apiserver.go
+++ b/cmd/apiserver/apiserver.go
@@ -32,6 +32,7 @@ import (
 	// Please do not remove.
 	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
 
+	_ "github.com/kubernetes-incubator/service-catalog/cmd/apiserver/app"
 	"github.com/kubernetes-incubator/service-catalog/cmd/apiserver/app/server"
 )
 

--- a/cmd/apiserver/app/plugins.go
+++ b/cmd/apiserver/app/plugins.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+// This file exists to force the desired plugin implementations to be linked.
+// This should probably be part of some configuration fed into the build for a
+// given binary target.
+import (
+	// Admission policies
+	_ "github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/namespace/lifecycle"
+)

--- a/cmd/apiserver/app/server/options.go
+++ b/cmd/apiserver/app/server/options.go
@@ -17,6 +17,8 @@ limitations under the License.
 package server
 
 import (
+	"os"
+
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
 	"github.com/spf13/pflag"
 	genericserveroptions "k8s.io/apiserver/pkg/server/options"
@@ -44,6 +46,8 @@ type ServiceCatalogServerOptions struct {
 	// DisableAuth disables delegating authentication and authorization for testing scenarios
 	DisableAuth bool
 	StopCh      <-chan struct{}
+	// StandaloneMode if true asserts that we will not depend on a kube-apiserver
+	StandaloneMode bool
 }
 
 func (s *ServiceCatalogServerOptions) addFlags(flags *pflag.FlagSet) {
@@ -74,4 +78,12 @@ func (s *ServiceCatalogServerOptions) addFlags(flags *pflag.FlagSet) {
 // invalid storage type
 func (s *ServiceCatalogServerOptions) StorageType() (server.StorageType, error) {
 	return server.StorageTypeFromString(s.StorageTypeString)
+}
+
+// standaloneMode returns true if the env var SERVICE_CATALOG_STANALONE=true
+// If enabled, we will assume no integration with Kubernetes API server is performed.
+// It is intended for testing purposes only.
+func standaloneMode() bool {
+	val := os.Getenv("SERVICE_CATALOG_STANDALONE")
+	return val == "true"
 }

--- a/cmd/apiserver/app/server/run_server.go
+++ b/cmd/apiserver/app/server/run_server.go
@@ -66,7 +66,7 @@ func runTPRServer(opts *ServiceCatalogServerOptions) error {
 	}
 
 	glog.V(4).Infoln("Preparing to run API server")
-	genericConfig, err := setupBasicServer(opts)
+	genericConfig, scConfig, err := buildGenericConfig(opts)
 	if err != nil {
 		return err
 	}
@@ -84,6 +84,7 @@ func runTPRServer(opts *ServiceCatalogServerOptions) error {
 	if err != nil {
 		return fmt.Errorf("error completing API server configuration: %v", err)
 	}
+	addPostStartHooks(server.GenericAPIServer, scConfig, opts.StopCh)
 
 	glog.Infoln("Running the API server")
 	server.GenericAPIServer.PrepareRun().Run(opts.StopCh)
@@ -94,7 +95,7 @@ func runTPRServer(opts *ServiceCatalogServerOptions) error {
 func runEtcdServer(opts *ServiceCatalogServerOptions) error {
 	etcdOpts := opts.EtcdOptions
 	glog.V(4).Infoln("Preparing to run API server")
-	genericConfig, err := setupBasicServer(opts)
+	genericConfig, scConfig, err := buildGenericConfig(opts)
 	if err != nil {
 		return err
 	}
@@ -148,6 +149,7 @@ func runEtcdServer(opts *ServiceCatalogServerOptions) error {
 	if err != nil {
 		return fmt.Errorf("error completing API server configuration: %v", err)
 	}
+	addPostStartHooks(server.GenericAPIServer, scConfig, opts.StopCh)
 
 	// do we need to do any post api installation setup? We should have set up the api already?
 	glog.Infoln("Running the API server")

--- a/cmd/apiserver/app/server/server.go
+++ b/cmd/apiserver/app/server/server.go
@@ -73,6 +73,7 @@ func NewCommandServer(
 		EtcdOptions:             NewEtcdOptions(),
 		TPROptions:              NewTPROptions(),
 		StopCh:                  stopCh,
+		StandaloneMode:          standaloneMode(),
 	}
 	opts.addFlags(flags)
 	// Set generated SSL cert path correctly

--- a/cmd/apiserver/app/server/util.go
+++ b/cmd/apiserver/app/server/util.go
@@ -17,46 +17,156 @@ limitations under the License.
 package server
 
 import (
+	"fmt"
+	"strings"
+	"time"
+
 	"github.com/golang/glog"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	kubeinformers "k8s.io/client-go/informers"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+
+	scadmission "github.com/kubernetes-incubator/service-catalog/pkg/apiserver/admission"
+	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/internalclientset"
+	informers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/internalversion"
+	"github.com/kubernetes-incubator/service-catalog/pkg/version"
 )
 
-func setupBasicServer(s *ServiceCatalogServerOptions) (*genericapiserver.Config, error) {
-	if _, err := s.SecureServingOptions.ServingOptions.DefaultExternalAddress(); err != nil {
-		return nil, err
-	}
+// serviceCatalogConfig is a placeholder for configuration
+type serviceCatalogConfig struct {
+	// the shared informers that know how to speak back to this apiserver
+	sharedInformers informers.SharedInformerFactory
+	// the shared informers that know how to speak back to kube apiserver
+	kubeSharedInformers kubeinformers.SharedInformerFactory
+	// the configured loopback client for this apiserver
+	client internalclientset.Interface
+	// the configured client for kube apiserver
+	kubeClient kubeclientset.Interface
+}
 
-	// server configuration options
-	if err := s.SecureServingOptions.MaybeDefaultWithSelfSignedCerts(
-		s.GenericServerRunOptions.AdvertiseAddress.String(),
-	); err != nil {
-		return nil, err
+// buildGenericConfig takes the server options and produces the genericapiserver.Config associated with it
+func buildGenericConfig(s *ServiceCatalogServerOptions) (*genericapiserver.Config, *serviceCatalogConfig, error) {
+	// check if we are running in standalone mode (for test scenarios)
+	inCluster := !s.StandaloneMode
+	if !inCluster {
+		glog.Infof("service catalog is in standalone mode")
 	}
+	if _, err := s.SecureServingOptions.ServingOptions.DefaultExternalAddress(); err != nil {
+		return nil, nil, err
+	}
+	// server configuration options
+	if err := s.SecureServingOptions.MaybeDefaultWithSelfSignedCerts(s.GenericServerRunOptions.AdvertiseAddress.String()); err != nil {
+		return nil, nil, err
+	}
+	// NOTE: in k8s 1.7, this will take the explicit codec as input
 	genericConfig := genericapiserver.NewConfig()
 	if err := s.GenericServerRunOptions.ApplyTo(genericConfig); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := s.SecureServingOptions.ApplyTo(genericConfig); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-
+	// this MUST be done after secure so we have a valid loopbackClientConfig
 	if err := s.InsecureServingOptions.ApplyTo(genericConfig); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-
-	if !s.DisableAuth {
+	if !s.DisableAuth && inCluster {
 		if err := s.AuthenticationOptions.ApplyTo(genericConfig); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
 		if err := s.AuthorizationOptions.ApplyTo(genericConfig); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	} else {
 		// always warn when auth is disabled, since this should only be used for testing
 		glog.Infof("Authentication and authorization disabled for testing purposes")
 	}
 
-	return genericConfig, nil
+	// TODO: add support for audit log options
+	// see https://github.com/kubernetes-incubator/service-catalog/issues/678
+	// TODO: add support for OpenAPI config
+	// see https://github.com/kubernetes-incubator/service-catalog/issues/721
+	genericConfig.SwaggerConfig = genericapiserver.DefaultSwaggerConfig()
+	// TODO: investigate if we need metrics unique to service catalog, but take defaults for now
+	// see https://github.com/kubernetes-incubator/service-catalog/issues/677
+	genericConfig.EnableMetrics = true
+	// TODO: add support to default these values in build
+	// see https://github.com/kubernetes-incubator/service-catalog/issues/722
+	serviceCatalogVersion := version.Get()
+	genericConfig.Version = &serviceCatalogVersion
+
+	// FUTURE: use protobuf for communication back to itself?
+	client, err := internalclientset.NewForConfig(genericConfig.LoopbackClientConfig)
+	if err != nil {
+		glog.Errorf("Failed to create clientset for service catalog self-communication: %v", err)
+		return nil, nil, err
+	}
+	sharedInformers := informers.NewSharedInformerFactory(client, 10*time.Minute)
+
+	scConfig := &serviceCatalogConfig{
+		client:          client,
+		sharedInformers: sharedInformers,
+	}
+	if inCluster {
+		inClusterConfig, err := restclient.InClusterConfig()
+		if err != nil {
+			glog.Errorf("Failed to get kube client config: %v", err)
+			return nil, nil, err
+		}
+		inClusterConfig.GroupVersion = &schema.GroupVersion{}
+
+		kubeClient, err := kubeclientset.NewForConfig(inClusterConfig)
+		if err != nil {
+			glog.Errorf("Failed to create clientset interface: %v", err)
+			return nil, nil, err
+		}
+
+		kubeSharedInformers := kubeinformers.NewSharedInformerFactory(kubeClient, 10*time.Minute)
+
+		// TODO: we need upstream to package AlwaysAdmit, or stop defaulting to it!
+		// NOTE: right now, we only run admission controllers when on kube cluster.
+		genericConfig.AdmissionControl, err = buildAdmission(s, client, sharedInformers, kubeClient, kubeSharedInformers)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to initialize admission: %v", err)
+		}
+
+		scConfig.kubeClient = kubeClient
+		scConfig.kubeSharedInformers = kubeSharedInformers
+	}
+
+	return genericConfig, scConfig, nil
+}
+
+// buildAdmission constructs the admission chain
+func buildAdmission(s *ServiceCatalogServerOptions,
+	client internalclientset.Interface, sharedInformers informers.SharedInformerFactory,
+	kubeClient kubeclientset.Interface, kubeSharedInformers kubeinformers.SharedInformerFactory) (admission.Interface, error) {
+
+	admissionControlPluginNames := strings.Split(s.GenericServerRunOptions.AdmissionControl, ",")
+	glog.Infof("Admission control plugin names: %v", admissionControlPluginNames)
+	var err error
+
+	pluginInitializer := scadmission.NewPluginInitializer(client, sharedInformers, kubeClient, kubeSharedInformers)
+	admissionConfigProvider, err := admission.ReadAdmissionConfiguration(admissionControlPluginNames, s.GenericServerRunOptions.AdmissionControlConfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read plugin config: %v", err)
+	}
+	return admission.NewFromPlugins(admissionControlPluginNames, admissionConfigProvider, pluginInitializer)
+}
+
+// addPostStartHooks adds the common post start hooks we invoke when using either server storage option.
+func addPostStartHooks(server *genericapiserver.GenericAPIServer, scConfig *serviceCatalogConfig, stopCh <-chan struct{}) {
+	server.AddPostStartHook("start-service-catalog-apiserver-informers", func(context genericapiserver.PostStartHookContext) error {
+		glog.Infof("Starting shared informers")
+		scConfig.sharedInformers.Start(stopCh)
+		if scConfig.kubeSharedInformers != nil {
+			scConfig.kubeSharedInformers.Start(stopCh)
+		}
+		glog.Infof("Started shared informers")
+		return nil
+	})
 }

--- a/contrib/hack/start-server.sh
+++ b/contrib/hack/start-server.sh
@@ -38,6 +38,7 @@ docker run -d --name apiserver \
 	-v ${ROOT}/.kube:/root/.kube \
 	-e KUBERNETES_SERVICE_HOST=localhost \
 	-e KUBERNETES_SERVICE_PORT=6443 \
+	-e SERVICE_CATALOG_STANDALONE=true \
 	--privileged \
 	--net container:etcd-svc-cat \
 	scbuildimage \

--- a/pkg/apiserver/admission/initializer.go
+++ b/pkg/apiserver/admission/initializer.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"k8s.io/apiserver/pkg/admission"
+
+	kubeinformers "k8s.io/client-go/informers"
+	kubeclientset "k8s.io/client-go/kubernetes"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/internalclientset"
+	informers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/internalversion"
+)
+
+// WantsInternalServiceCatalogClientSet defines a function which sets ClientSet for admission plugins that need it
+type WantsInternalServiceCatalogClientSet interface {
+	SetInternalServiceCatalogClientSet(internalclientset.Interface)
+	admission.Validator
+}
+
+// WantsInternalServiceCatalogInformerFactory defines a function which sets InformerFactory for admission plugins that need it
+type WantsInternalServiceCatalogInformerFactory interface {
+	SetInternalServiceCatalogInformerFactory(informers.SharedInformerFactory)
+	admission.Validator
+}
+
+// WantsKubeClientSet defines a function which sets ClientSet for admission plugins that need it
+type WantsKubeClientSet interface {
+	SetKubeClientSet(kubeclientset.Interface)
+	admission.Validator
+}
+
+// WantsKubeInformerFactory defines a function which sets InformerFactory for admission plugins that need it
+type WantsKubeInformerFactory interface {
+	SetKubeInformerFactory(kubeinformers.SharedInformerFactory)
+	admission.Validator
+}
+
+type pluginInitializer struct {
+	internalClient internalclientset.Interface
+	informers      informers.SharedInformerFactory
+
+	kubeClient    kubeclientset.Interface
+	kubeInformers kubeinformers.SharedInformerFactory
+}
+
+var _ admission.PluginInitializer = pluginInitializer{}
+
+// NewPluginInitializer constructs new instance of PluginInitializer
+func NewPluginInitializer(internalClient internalclientset.Interface, sharedInformers informers.SharedInformerFactory,
+	kubeClient kubeclientset.Interface, kubeInformers kubeinformers.SharedInformerFactory) admission.PluginInitializer {
+	return pluginInitializer{
+		internalClient: internalClient,
+		informers:      sharedInformers,
+		kubeClient:     kubeClient,
+		kubeInformers:  kubeInformers,
+	}
+}
+
+// Initialize checks the initialization interfaces implemented by each plugin
+// and provide the appropriate initialization data
+func (i pluginInitializer) Initialize(plugin admission.Interface) {
+	if wants, ok := plugin.(WantsInternalServiceCatalogClientSet); ok {
+		wants.SetInternalServiceCatalogClientSet(i.internalClient)
+	}
+
+	if wants, ok := plugin.(WantsInternalServiceCatalogInformerFactory); ok {
+		wants.SetInternalServiceCatalogInformerFactory(i.informers)
+	}
+
+	if wants, ok := plugin.(WantsKubeClientSet); ok {
+		wants.SetKubeClientSet(i.kubeClient)
+	}
+
+	if wants, ok := plugin.(WantsKubeInformerFactory); ok {
+		wants.SetKubeInformerFactory(i.kubeInformers)
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+)
+
+// Get returns the overall codebase version. It's for detecting
+// what code a binary was built from.
+func Get() apimachineryversion.Info {
+	// These variables typically come from -ldflags settings and in
+	// their absence fallback to the settings in pkg/version/base.go
+	return apimachineryversion.Info{
+		Major: "", // deprecated
+		Minor: "", // deprecated
+		// TODO: we need to update these values when building a release.
+		// GitVersion:   "",
+		// GitCommit:    "",
+		// GitTreeState: "",
+		// BuildDate:    "1970-01-01T00:00:00Z",
+		GoVersion: runtime.Version(),
+		Compiler:  runtime.Compiler,
+		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}

--- a/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	kubeinformers "k8s.io/client-go/informers"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/pkg/api/v1"
+
+	scadmission "github.com/kubernetes-incubator/service-catalog/pkg/apiserver/admission"
+)
+
+const (
+	// PluginName is name of admission plug-in
+	PluginName = "KubernetesNamespaceLifecycle"
+	// how long to wait for a missing namespace before re-checking the cache (and then doing a live lookup)
+	// this accomplishes two things:
+	// 1. It allows a watch-fed cache time to observe a namespace creation event
+	// 2. It allows time for a namespace creation to distribute to members of a storage cluster,
+	//    so the live lookup has a better chance of succeeding even if it isn't performed against the leader.
+	missingNamespaceWait = 50 * time.Millisecond
+)
+
+func init() {
+	admission.RegisterPlugin(PluginName, func(io.Reader) (admission.Interface, error) {
+		return NewLifecycle()
+	})
+}
+
+// lifecycle is an implementation of admission.Interface.
+// It enforces life-cycle constraints around a Namespace depending on its Phase
+type lifecycle struct {
+	*admission.Handler
+	client          kubeclientset.Interface
+	namespaceLister corev1.NamespaceLister
+}
+
+type forceLiveLookupEntry struct {
+	expiry time.Time
+}
+
+var _ = scadmission.WantsKubeInformerFactory(&lifecycle{})
+var _ = scadmission.WantsKubeClientSet(&lifecycle{})
+
+func (l *lifecycle) Admit(a admission.Attributes) error {
+	// we need to wait for our caches to warm
+	if !l.WaitForReady() {
+		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
+	}
+
+	var (
+		exists bool
+		err    error
+	)
+
+	namespace, err := l.namespaceLister.Get(a.GetNamespace())
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return errors.NewInternalError(err)
+		}
+	} else {
+		exists = true
+	}
+
+	// we only care about namespaced resources
+	if len(a.GetNamespace()) == 0 {
+		return nil
+	}
+
+	if !exists && a.GetOperation() == admission.Create {
+		// give the cache time to observe the namespace before rejecting a create.
+		// this helps when creating a namespace and immediately creating objects within it.
+		time.Sleep(missingNamespaceWait)
+		namespace, err = l.namespaceLister.Get(a.GetNamespace())
+		switch {
+		case errors.IsNotFound(err):
+			// no-op
+		case err != nil:
+			return errors.NewInternalError(err)
+		default:
+			exists = true
+		}
+		if exists {
+			glog.V(4).Infof("found %s in cache after waiting", a.GetNamespace())
+		}
+	}
+
+	// refuse to operate on non-existent namespaces
+	if !exists {
+		// as a last resort, make a call directly to storage
+		namespace, err = l.client.Core().Namespaces().Get(a.GetNamespace(), metav1.GetOptions{})
+		switch {
+		case errors.IsNotFound(err):
+			return err
+		case err != nil:
+			return errors.NewInternalError(err)
+		}
+		glog.V(4).Infof("found %s via storage lookup", a.GetNamespace())
+	}
+
+	// ensure that we're not trying to create objects in terminating namespaces
+	if a.GetOperation() == admission.Create {
+		if namespace.Status.Phase != v1.NamespaceTerminating {
+			return nil
+		}
+
+		return admission.NewForbidden(a, fmt.Errorf("unable to create new content in namespace %s because it is being terminated", a.GetNamespace()))
+	}
+
+	return nil
+}
+
+// NewLifecycle creates a new namespace lifecycle admission control handler
+func NewLifecycle() (admission.Interface, error) {
+	return &lifecycle{
+		Handler: admission.NewHandler(admission.Create, admission.Update, admission.Delete),
+	}, nil
+}
+
+func (l *lifecycle) SetKubeInformerFactory(f kubeinformers.SharedInformerFactory) {
+	namespaceInformer := f.Core().V1().Namespaces()
+	l.namespaceLister = namespaceInformer.Lister()
+	l.SetReadyFunc(namespaceInformer.Informer().HasSynced)
+}
+
+func (l *lifecycle) SetKubeClientSet(client kubeclientset.Interface) {
+	l.client = client
+}
+
+func (l *lifecycle) Validate() error {
+	if l.namespaceLister == nil {
+		return fmt.Errorf("missing namespaceLister")
+	}
+	if l.client == nil {
+		return fmt.Errorf("missing client")
+	}
+	return nil
+}

--- a/plugin/pkg/admission/namespace/lifecycle/admission_test.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/admission"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/pkg/api/v1"
+	core "k8s.io/client-go/testing"
+
+	kubeinformers "k8s.io/client-go/informers"
+	kubeclientset "k8s.io/client-go/kubernetes"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/internalclientset"
+	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/internalclientset/fake"
+	informers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/internalversion"
+
+	scadmission "github.com/kubernetes-incubator/service-catalog/pkg/apiserver/admission"
+)
+
+// newHandlerForTest returns a configured handler for testing.
+func newHandlerForTest(internalClient internalclientset.Interface, kubeClient kubeclientset.Interface) (admission.Interface, informers.SharedInformerFactory, kubeinformers.SharedInformerFactory, error) {
+	f := informers.NewSharedInformerFactory(internalClient, 5*time.Minute)
+	kf := kubeinformers.NewSharedInformerFactory(kubeClient, 5*time.Minute)
+	handler, err := NewLifecycle()
+	if err != nil {
+		return nil, f, kf, err
+	}
+	pluginInitializer := scadmission.NewPluginInitializer(internalClient, f, kubeClient, kf)
+	pluginInitializer.Initialize(handler)
+	err = admission.Validate(handler)
+	return handler, f, kf, err
+}
+
+// newMockKubeClientForTest creates a mock client that returns a client
+// configured for the specified list of namespaces with the specified phase.
+func newMockKubeClientForTest(namespaces map[string]v1.NamespacePhase) *kubefake.Clientset {
+	mockClient := &kubefake.Clientset{}
+	mockClient.AddReactor("list", "namespaces", func(action core.Action) (bool, runtime.Object, error) {
+		namespaceList := &v1.NamespaceList{
+			ListMeta: metav1.ListMeta{
+				ResourceVersion: fmt.Sprintf("%d", len(namespaces)),
+			},
+		}
+		index := 0
+		for name, phase := range namespaces {
+			namespaceList.Items = append(namespaceList.Items, v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            name,
+					ResourceVersion: fmt.Sprintf("%d", index),
+				},
+				Status: v1.NamespaceStatus{
+					Phase: phase,
+				},
+			})
+			index++
+		}
+		return true, namespaceList, nil
+	})
+	return mockClient
+}
+
+// newMockClientForTest creates a mock client.
+func newMockClientForTest() *fake.Clientset {
+	mockClient := &fake.Clientset{}
+	return mockClient
+}
+
+// newBroker returns a new broker for testing.
+func newBroker() servicecatalog.Broker {
+	return servicecatalog.Broker{
+		ObjectMeta: metav1.ObjectMeta{Name: "broker"},
+	}
+}
+
+// newInstance returns a new instance for the specified namespace.
+func newInstance(namespace string) servicecatalog.Instance {
+	return servicecatalog.Instance{
+		ObjectMeta: metav1.ObjectMeta{Name: "instance", Namespace: namespace},
+	}
+}
+
+// TestAdmissionNamespaceDoesNotExist verifies instance is not admitted if namespace does not exist.
+func TestAdmissionNamespaceDoesNotExist(t *testing.T) {
+	namespace := "test"
+	mockClient := newMockClientForTest()
+	mockKubeClient := newMockKubeClientForTest(map[string]v1.NamespacePhase{})
+	mockKubeClient.AddReactor("get", "namespaces", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("nope, out of luck")
+	})
+	handler, informerFactory, kubeInformerFactory, err := newHandlerForTest(mockClient, mockKubeClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+	informerFactory.Start(wait.NeverStop)
+	kubeInformerFactory.Start(wait.NeverStop)
+
+	instance := newInstance(namespace)
+	err = handler.Admit(admission.NewAttributesRecord(&instance, nil, servicecatalog.Kind("Instance").WithVersion("version"), instance.Namespace, instance.Name, servicecatalog.Resource("instances").WithVersion("version"), "", admission.Create, nil))
+	if err == nil {
+		actions := ""
+		for _, action := range mockClient.Actions() {
+			actions = actions + action.GetVerb() + ":" + action.GetResource().Resource + ":" + action.GetSubresource() + ", "
+		}
+		t.Errorf("expected error returned from admission handler: %v", actions)
+	}
+}
+
+// TestAdmissionNamespaceActive verifies a resource is admitted when the namespace is active.
+func TestAdmissionNamespaceActive(t *testing.T) {
+	namespace := "test"
+	mockClient := newMockClientForTest()
+	mockKubeClient := newMockKubeClientForTest(map[string]v1.NamespacePhase{
+		namespace: v1.NamespaceActive,
+	})
+	handler, informerFactory, kubeInformerFactory, err := newHandlerForTest(mockClient, mockKubeClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+	informerFactory.Start(wait.NeverStop)
+	kubeInformerFactory.Start(wait.NeverStop)
+
+	instance := newInstance(namespace)
+	err = handler.Admit(admission.NewAttributesRecord(&instance, nil, servicecatalog.Kind("Instance").WithVersion("version"), instance.Namespace, instance.Name, servicecatalog.Resource("instances").WithVersion("version"), "", admission.Create, nil))
+	if err != nil {
+		t.Errorf("unexpected error returned from admission handler")
+	}
+}
+
+// TestAdmissionNamespaceTerminating verifies a resource is not created when the namespace is terminating.
+func TestAdmissionNamespaceTerminating(t *testing.T) {
+	namespace := "test"
+	mockClient := newMockClientForTest()
+	mockKubeClient := newMockKubeClientForTest(map[string]v1.NamespacePhase{
+		namespace: v1.NamespaceTerminating,
+	})
+	handler, informerFactory, kubeInformerFactory, err := newHandlerForTest(mockClient, mockKubeClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+	informerFactory.Start(wait.NeverStop)
+	kubeInformerFactory.Start(wait.NeverStop)
+
+	instance := newInstance(namespace)
+	err = handler.Admit(admission.NewAttributesRecord(&instance, nil, servicecatalog.Kind("Instance").WithVersion("version"), instance.Namespace, instance.Name, servicecatalog.Resource("instances").WithVersion("version"), "", admission.Create, nil))
+	if err == nil {
+		t.Errorf("Expected error rejecting creates in a namespace when it is terminating")
+	}
+
+	// verify update operations in the namespace can proceed
+	err = handler.Admit(admission.NewAttributesRecord(&instance, nil, servicecatalog.Kind("Instance").WithVersion("version"), instance.Namespace, instance.Name, servicecatalog.Resource("instances").WithVersion("version"), "", admission.Update, nil))
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler: %v", err)
+	}
+
+	// verify delete operations in the namespace can proceed
+	err = handler.Admit(admission.NewAttributesRecord(nil, nil, servicecatalog.Kind("Instance").WithVersion("version"), instance.Namespace, instance.Name, servicecatalog.Resource("instances").WithVersion("version"), "", admission.Delete, nil))
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler: %v", err)
+	}
+}

--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -85,6 +85,7 @@ func getFreshApiserverAndClient(t *testing.T, storageTypeStr string) (servicecat
 			AuthorizationOptions:  genericserveroptions.NewDelegatingAuthorizationOptions(),
 			DisableAuth:           true,
 			StopCh:                stopCh,
+			StandaloneMode:        true, // this must be true because we have no kube server for integration.
 		}
 		options.InsecureServingOptions.BindPort = insecurePort
 		options.SecureServingOptions.ServingOptions.BindPort = securePort


### PR DESCRIPTION
Introduces support for the following abilities to service catalog api server

1. ability to have its own admission chain
1. admission controller that verifies existence of a namespace in kubernetes before admitting namespaced resources
1. exposes a /metrics endpoint with all the prometheus metrics produced by our machinery
1. adds a standalone mode that tells the server to not look for a kube api server so we can run integration tests
1. adds stubs and placeholders for various other todos we need to finish to get the kube polish applied.

Updated helm charts to take advantage of new admission chain.

This works fine with either TPR or etcd backends.