### PR TITLE
Fix internal clientgen for servicecatalog group

### DIFF
--- a/pkg/apis/servicecatalog/doc.go
+++ b/pkg/apis/servicecatalog/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 
 // Package servicecatalog contains all of the sources needed to make
 // servicebrokers and their related service objects.
-// +groupName=
+// +groupName=servicecatalog.k8s.io
 package servicecatalog

--- a/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/fake/fake_binding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/fake/fake_binding.go
@@ -32,7 +32,7 @@ type FakeBindings struct {
 	ns   string
 }
 
-var bindingsResource = schema.GroupVersionResource{Group: "", Version: "", Resource: "bindings"}
+var bindingsResource = schema.GroupVersionResource{Group: "servicecatalog.k8s.io", Version: "", Resource: "bindings"}
 
 func (c *FakeBindings) Create(binding *servicecatalog.Binding) (result *servicecatalog.Binding, err error) {
 	obj, err := c.Fake.

--- a/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/fake/fake_broker.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/fake/fake_broker.go
@@ -31,7 +31,7 @@ type FakeBrokers struct {
 	Fake *FakeServicecatalog
 }
 
-var brokersResource = schema.GroupVersionResource{Group: "", Version: "", Resource: "brokers"}
+var brokersResource = schema.GroupVersionResource{Group: "servicecatalog.k8s.io", Version: "", Resource: "brokers"}
 
 func (c *FakeBrokers) Create(broker *servicecatalog.Broker) (result *servicecatalog.Broker, err error) {
 	obj, err := c.Fake.

--- a/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/fake/fake_instance.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/fake/fake_instance.go
@@ -32,7 +32,7 @@ type FakeInstances struct {
 	ns   string
 }
 
-var instancesResource = schema.GroupVersionResource{Group: "", Version: "", Resource: "instances"}
+var instancesResource = schema.GroupVersionResource{Group: "servicecatalog.k8s.io", Version: "", Resource: "instances"}
 
 func (c *FakeInstances) Create(instance *servicecatalog.Instance) (result *servicecatalog.Instance, err error) {
 	obj, err := c.Fake.

--- a/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/fake/fake_serviceclass.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/fake/fake_serviceclass.go
@@ -31,7 +31,7 @@ type FakeServiceClasses struct {
 	Fake *FakeServicecatalog
 }
 
-var serviceclassesResource = schema.GroupVersionResource{Group: "", Version: "", Resource: "serviceclasses"}
+var serviceclassesResource = schema.GroupVersionResource{Group: "servicecatalog.k8s.io", Version: "", Resource: "serviceclasses"}
 
 func (c *FakeServiceClasses) Create(serviceClass *servicecatalog.ServiceClass) (result *servicecatalog.ServiceClass, err error) {
 	obj, err := c.Fake.

--- a/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/servicecatalog_client.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/servicecatalog/internalversion/servicecatalog_client.go
@@ -29,7 +29,7 @@ type ServicecatalogInterface interface {
 	ServiceClassesGetter
 }
 
-// ServicecatalogClient is used to interact with features provided by the  group.
+// ServicecatalogClient is used to interact with features provided by the servicecatalog.k8s.io group.
 type ServicecatalogClient struct {
 	restClient rest.Interface
 }
@@ -79,7 +79,7 @@ func New(c rest.Interface) *ServicecatalogClient {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	g, err := scheme.Registry.Group("")
+	g, err := scheme.Registry.Group("servicecatalog.k8s.io")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The internal version client had an incorrect API group specified.  This blocked the ability to use the internal version client in any future admission controllers that would be authored in the service catalog api server.