### PR TITLE
Int test flake fixes

### DIFF
--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -49,8 +49,8 @@ func init() {
 }
 
 func getFreshApiserverAndClient(t *testing.T, storageTypeStr string) (servicecatalogclient.Interface, func()) {
-	securePort := rand.Intn(35534) + 3000
-	insecurePort := rand.Intn(35534) + 3000
+	securePort := rand.Intn(31743) + 1024
+	insecurePort := rand.Intn(31743) + 1024
 	serverIP := fmt.Sprintf("http://localhost:%d", insecurePort)
 	stopCh := make(chan struct{})
 	serverFailed := make(chan struct{})

--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -51,7 +51,7 @@ func init() {
 func getFreshApiserverAndClient(t *testing.T, storageTypeStr string) (servicecatalogclient.Interface, func()) {
 	securePort := rand.Intn(31743) + 1024
 	insecurePort := rand.Intn(31743) + 1024
-	serverIP := fmt.Sprintf("http://localhost:%d", insecurePort)
+	insecureAddr := fmt.Sprintf("http://localhost:%d", insecurePort)
 	stopCh := make(chan struct{})
 	serverFailed := make(chan struct{})
 	shutdown := func() {
@@ -93,12 +93,12 @@ func getFreshApiserverAndClient(t *testing.T, storageTypeStr string) (servicecat
 		}
 	}()
 
-	if err := waitForApiserverUp(serverIP, serverFailed); err != nil {
+	if err := waitForApiserverUp(insecureAddr, serverFailed); err != nil {
 		t.Fatalf("%v", err)
 	}
 
 	config := &restclient.Config{}
-	config.Host = serverIP
+	config.Host = insecureAddr
 	config.Insecure = true
 	clientset, err := servicecatalogclient.NewForConfig(config)
 	if nil != err {
@@ -107,7 +107,7 @@ func getFreshApiserverAndClient(t *testing.T, storageTypeStr string) (servicecat
 	return clientset, shutdown
 }
 
-func waitForApiserverUp(serverIP string, stopCh <-chan struct{}) error {
+func waitForApiserverUp(insecureAddr string, stopCh <-chan struct{}) error {
 	minuteTimeout := time.After(2 * time.Minute)
 	for {
 		select {
@@ -116,8 +116,8 @@ func waitForApiserverUp(serverIP string, stopCh <-chan struct{}) error {
 		case <-minuteTimeout:
 			return fmt.Errorf("waiting for apiserver timed out")
 		default:
-			glog.Infof("Waiting for : %#v", serverIP)
-			_, err := http.Get(serverIP)
+			glog.Infof("Waiting for : %#v", insecureAddr)
+			_, err := http.Get(insecureAddr)
 			if err == nil {
 				return nil
 			}

--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -51,11 +51,12 @@ func init() {
 
 func getFreshApiserverAndClient(t *testing.T, storageTypeStr string) (servicecatalogclient.Interface, func()) {
 	securePort := rand.Intn(35534) + 3000
+	insecurePort := rand.Intn(35534) + 3000
 	serverIP := fmt.Sprintf("https://localhost:%d", securePort)
 	stopCh := make(chan struct{})
 	serverFailed := make(chan struct{})
 	shutdown := func() {
-		t.Logf("Shutting down server on port: %d", securePort)
+		t.Logf("Shutting down server on ports: %d and %d", insecurePort, securePort)
 		close(stopCh)
 	}
 
@@ -83,6 +84,7 @@ func getFreshApiserverAndClient(t *testing.T, storageTypeStr string) (servicecat
 			AuthorizationOptions:  genericserveroptions.NewDelegatingAuthorizationOptions(),
 			StopCh:                stopCh,
 		}
+		options.InsecureServingOptions.BindPort = insecurePort
 		options.SecureServingOptions.ServingOptions.BindPort = securePort
 		options.SecureServingOptions.ServerCert.CertDirectory = certDir
 		options.EtcdOptions.StorageConfig.ServerList = []string{"http://localhost:2379"}

--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -17,7 +17,6 @@ limitations under the License.
 package integration
 
 import (
-	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -52,7 +51,7 @@ func init() {
 func getFreshApiserverAndClient(t *testing.T, storageTypeStr string) (servicecatalogclient.Interface, func()) {
 	securePort := rand.Intn(35534) + 3000
 	insecurePort := rand.Intn(35534) + 3000
-	serverIP := fmt.Sprintf("https://localhost:%d", securePort)
+	serverIP := fmt.Sprintf("http://localhost:%d", insecurePort)
 	stopCh := make(chan struct{})
 	serverFailed := make(chan struct{})
 	shutdown := func() {
@@ -118,11 +117,7 @@ func waitForApiserverUp(serverIP string, stopCh <-chan struct{}) error {
 			return fmt.Errorf("waiting for apiserver timed out")
 		default:
 			glog.Infof("Waiting for : %#v", serverIP)
-			tr := &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}
-			client := &http.Client{Transport: tr}
-			_, err := client.Get(serverIP)
+			_, err := http.Get(serverIP)
 			if err == nil {
 				return nil
 			}


### PR DESCRIPTION
I believe this will fix two sources of flakiness in the integration tests:

* Previously, by not specifying an insecure port, we _always_ got the default of 8080. That was sometimes proving problematic if a new apiserver was coming up as a previous one was still coming down and still listening on 8080. After this PR, we always specify an insecure port and sparing the slim possibility that the same port is randomly picked twice in a row, this conflict should be eliminated.
  * As a bonus, the tests stop using tls when polling the apiserver to check if it's up; this eliminates some small degree of overhead.

* Previously, ports were picked randomly like so: `rand.Intn(35534) + 3000`. This is, potentially problematic because this yields a max port number of 38534. In Linux, the ephemeral port range (which we should not use) begins at 32768. You can see there is some overlap here. I do not know if this poses a direct problem, but it's sufficiently within the realm of possibility that it should be corrected. This PR picks ports like so: `rand(32767) + 1024`. This guarantees an unprivileged port in the range 1024 to 32767.

Note that these are uncontroversial flake fixes I have extracted from #683 so that we can consider this separately and get it merged sooner than later. I will rebase #683 after this is merged.