### PR TITLE
Adding code and documentation standards

### DIFF
--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -1,0 +1,35 @@
+# Code & Documentation Standards
+
+This document details our goals for code quality, coverage and documentation standards. At the time
+of this writing, these are standards that all of our code may not meet. We should always try to 
+improve our code to meet them.
+
+## Code Quality And Documentation Standards
+
+We aim to write clear code that is easy to read and comprehend. In particular, that goal means the
+following:
+
+1. All Go code must pass the Go linter checks
+    - We have these checks integrated into our CI system
+2. All Go code should pass the `go vet`
+    - These checks are not integrated into our CI system
+    - Anyone with the Go toolchain installed on their system can run the vet checks by executing the
+    following command on their machine:
+
+    ```go
+    go vet ./pkg/... ./cmd/... ./test/...
+    ```
+3. All Go code must be formatted with [gofmt](https://golang.org/cmd/gofmt/)
+    - Anyone can run the formatter by runinng `make format` on their machine
+4. Any exported symbols (`type`s, `interface`s, `func`s, `struct`s, etc...) must have Godoc
+compatible comments associated with them
+5. Unexported symbols must be commented sufficiently to provide direction & context to a developer 
+who didn't write the code
+6. Inline code should be commented sufficiently to explain what complex code is doing. It's up to
+the developer and reviewers how much and what kind of documentation is necessary
+7. Unit, integration or end-to-end tests should be written for all business logic
+    - Reviewers should take care to ensure the right, and enough testing is written for a PR
+    - We do not yet check code coverage in our CI system
+
+
+

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -2,7 +2,11 @@
 
 This document details our goals for code quality, coverage and documentation standards. At the time
 of this writing, these are standards that all of our code may not meet. We should always try to 
-improve our code to meet them.
+improve our codebase and documentation to meet them.
+
+While we do not currently aim to adhere completely to the 
+[Kubernetes coding conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/coding-conventions.md),
+we aspire to adhere as closely as possible.
 
 ## Code Quality And Documentation Standards
 

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -15,8 +15,8 @@ following:
 
 1. All Go code must pass the Go linter checks
     - We have these checks integrated into our CI system
-2. All Go code should pass the `go vet`
-    - These checks are not integrated into our CI system
+2. All Go code should pass `go vet`
+    - This check is integrated into our CI system
     - Anyone with the Go toolchain installed on their system can run the vet checks by executing the
     following command on their machine:
 

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -59,6 +59,9 @@ please include a line in the initial comment that looks like:
 where `1234` is the issue number. This allows Github to automatically
 close the issue when the PR is merged.
 
+Also, before you start working on your issue, please read our [Code Standards](./code-standards.md)
+document.
+
 ## Prerequisites
 
 At a minimum you will need:


### PR DESCRIPTION
This is a start to our code and documentation standards. By the end of 0.0.3, our goal is not to make this a comprehensive or exhaustive doc. Please review accordingly.

Fixes https://github.com/kubernetes-incubator/service-catalog/issues/636