### PR TITLE
make versioning consistent in Jenkins

### DIFF
--- a/contrib/hack/test_walkthrough.sh
+++ b/contrib/hack/test_walkthrough.sh
@@ -38,9 +38,7 @@ CATALOG_RELEASE="catalog"
 K8S_KUBECONFIG="${KUBECONFIG:-~/.kube/config}"
 SC_KUBECONFIG="/tmp/sc-kubeconfig"
 
-VERSION="${VERSION:-"$(git describe --tags --always --abbrev=7 --dirty)"}" \
-  || error_exit 'Cannot determine Git commit SHA'
-
+VERSION="${VERSION:-"canary"}"
 REGISTRY="${REGISTRY:-}"
 CONTROLLER_MANAGER_IMAGE="${REGISTRY}controller-manager:${VERSION}"
 APISERVER_IMAGE="${REGISTRY}apiserver:${VERSION}"

--- a/contrib/jenkins/build.sh
+++ b/contrib/jenkins/build.sh
@@ -38,10 +38,9 @@ done
   || error_exit '--project is a required parameter'
 
 if [[ "$(uname -s)" == "Linux" ]]; then
-  GIT_HEAD="$(git describe --tags --always --abbrev=7 --dirty)"
   MAKE_VARS=(
     V=1
-    VERSION="${VERSION:-${GIT_HEAD}}"
+    VERSION="${VERSION:-"canary"}"
   )
 
   [[ -n "${NO_DOCKER_COMPILE:-}" ]] && MAKE_VARS+=(NO_DOCKER=1)


### PR DESCRIPTION
Fixes Jenkins `ErrImagePull` issue on #682 . Might be associated with issue #673.

Jenkins' version-based tagging became out of sync with the Makefile's. This PR has Jenkins decide and explicitly set the version on each of the steps it needs to run, so that it remains consistent throughout (even if different than the default Makefile version).