### PR TITLE
Relist broker catalogs based on when broker became ready and relist interval

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -56,7 +56,7 @@ chart and their default values.
 | `controllerManager.imagePullPolicy` | `imagePullPolicy` for the controller-manager | `Always` |
 | `controllerManager.verbosity` | Log level; valid values are in the range 0 - 10 | `10` |
 | `controllerManager.resyncInterval` | How often the controller should resync informers; duration format (`20m`, `1h`, etc) | `5m` |
-
+| `controllerManager.brokerRelistInterval` | How often the controller should relist the catalogs of ready brokers; duration format (`20m`, `1h`, etc) | `24h` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -44,6 +44,8 @@ spec:
         - "{{ .Values.controllerManager.verbosity }}"
         - --resync-interval
         - {{ .Values.controllerManager.resyncInterval }}
+        - --broker-relist-interval
+        - {{ .Values.controllerManager.brokerRelistInterval }}
         ports:
         - containerPort: 8080
         volumeMounts:

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -54,3 +54,5 @@ controllerManager:
   verbosity: 10
   # Resync interval; format is a duration (`20m`, `1h`, etc)
   resyncInterval: 5m
+  # Broker relist interval; format is a duration (`20m`, `1h`, etc)
+  brokerRelistInterval: 24h

--- a/cmd/controller-manager/app/controller_manager.go
+++ b/cmd/controller-manager/app/controller_manager.go
@@ -274,7 +274,7 @@ func StartControllers(s *options.ControllerManagerServer,
 
 	// Launch service-catalog controller
 	if availableResources[schema.GroupVersionResource{Group: "servicecatalog.k8s.io", Version: "v1alpha1", Resource: "brokers"}] {
-		glog.V(5).Info("Creating shared informers")
+		glog.V(5).Info("Creating shared informers; resync interval: %v", s.ResyncInterval)
 		// Build the informer factory for service-catalog resources
 		informerFactory := servicecataloginformers.NewSharedInformerFactory(
 			serviceCatalogClientBuilder.ClientOrDie("shared-informers"),
@@ -283,7 +283,7 @@ func StartControllers(s *options.ControllerManagerServer,
 		// All shared informers are v1alpha1 API level
 		serviceCatalogSharedInformers := informerFactory.Servicecatalog().V1alpha1()
 
-		glog.V(5).Info("Creating controller")
+		glog.V(5).Info("Creating controller; broker relist interval: %v", s.BrokerRelistInterval)
 		serviceCatalogController, err := controller.NewController(
 			coreClient,
 			serviceCatalogClientBuilder.ClientOrDie(controllerManagerAgentName).ServicecatalogV1alpha1(),
@@ -292,6 +292,7 @@ func StartControllers(s *options.ControllerManagerServer,
 			serviceCatalogSharedInformers.Instances(),
 			serviceCatalogSharedInformers.Bindings(),
 			openservicebroker.NewClient,
+			s.BrokerRelistInterval,
 			s.OSBAPIContextProfile,
 		)
 		if err != nil {

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -36,6 +36,7 @@ type ControllerManagerServer struct {
 }
 
 const defaultResyncInterval = 5 * time.Minute
+const defaultBrokerRelistInterval = 24 * time.Hour
 const defaultContentType = "application/json"
 const defaultBindAddress = "0.0.0.0"
 const defaultPort = 10000
@@ -54,6 +55,7 @@ func NewControllerManagerServer() *ControllerManagerServer {
 			K8sKubeconfigPath:            defaultK8sKubeconfigPath,
 			ServiceCatalogKubeconfigPath: defaultServiceCatalogKubeconfigPath,
 			ResyncInterval:               defaultResyncInterval,
+			BrokerRelistInterval:         defaultBrokerRelistInterval,
 			OSBAPIContextProfile:         defaultOSBAPIContextProfile,
 		},
 	}
@@ -69,5 +71,6 @@ func (s *ControllerManagerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ServiceCatalogAPIServerURL, "service-catalog-api-server-url", "", "The URL for the service-catalog API server")
 	fs.StringVar(&s.ServiceCatalogKubeconfigPath, "service-catalog-kubeconfig", s.ServiceCatalogKubeconfigPath, "Path to service-catalog kubeconfig")
 	fs.DurationVar(&s.ResyncInterval, "resync-interval", s.ResyncInterval, "The interval on which the controller will resync its informers")
+	fs.DurationVar(&s.BrokerRelistInterval, "broker-relist-interval", s.BrokerRelistInterval, "The interval on which a broker's catalog is relisted after the broker becomes ready")
 	fs.BoolVar(&s.OSBAPIContextProfile, "enable-osb-api-context-profile", s.OSBAPIContextProfile, "Whether or not to send the proposed optional OpenServiceBroker API Context Profile field")
 }

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -57,6 +57,10 @@ type ControllerManagerConfiguration struct {
 	// all informers.
 	ResyncInterval time.Duration
 
+	// BrokerRelistInterval is the interval on which Broker's catalogs are re-
+	// listed.
+	BrokerRelistInterval time.Duration
+
 	// Whether or not to send the proposed optional
 	// OpenServiceBroker API Context Profile field
 	OSBAPIContextProfile bool

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -275,6 +275,7 @@ func newTestController(t *testing.T) (
 		serviceCatalogSharedInformers.Instances(),
 		serviceCatalogSharedInformers.Bindings(),
 		brokerClFunc,
+		24*time.Hour,
 		true,
 	)
 	t.Log("controller start")


### PR DESCRIPTION
Part of #627; depends on #630.  Fixes #665.

This PR:

1.  Adds a new broker relist interval flag to the controller
2.  Only relists a ready broker's catalog when it has been longer than the relist interval since the broker became ready

I **really** want this to be in 0.0.3