### PR TITLE
Reduce polling interval in broker client

### DIFF
--- a/pkg/brokerapi/openservicebroker/open_service_broker_client.go
+++ b/pkg/brokerapi/openservicebroker/open_service_broker_client.go
@@ -45,8 +45,8 @@ const (
 	bindingDeleteFormatString              = "%s/v2/service_instances/%s/service_bindings/%s?service_id=%s&plan_id=%s"
 
 	httpTimeoutSeconds     = 15
-	pollingIntervalSeconds = 1
-	pollingAmountLimit     = 30
+	pollingIntervalSeconds = 10
+	pollingAmountLimit     = 120
 )
 
 var (


### PR DESCRIPTION
This lengthens the polling interval for polling the broker from every
second to once every 30 seconds. The polling amount limit has been
raised to 120 retries, which equates to one hour.