### PR TITLE
add create and read tests for tpr-backed storage

### DIFF
--- a/pkg/storage/tpr/kinds_test.go
+++ b/pkg/storage/tpr/kinds_test.go
@@ -18,6 +18,8 @@ package tpr
 
 import (
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestTPRName(t *testing.T) {
@@ -56,4 +58,8 @@ func TestURLName(t *testing.T) {
 			t.Errorf("expected %s, got %s", testCase.after, kind.URLName())
 		}
 	}
+}
+
+func newTypeMeta(kind Kind) metav1.TypeMeta {
+	return metav1.TypeMeta{Kind: kind.TPRName(), APIVersion: groupName + "/v1alpha1'"}
 }

--- a/pkg/storage/tpr/storage_interface.go
+++ b/pkg/storage/tpr/storage_interface.go
@@ -18,6 +18,7 @@ package tpr
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
@@ -86,7 +87,7 @@ func (t *store) Create(
 	ttl uint64,
 ) error {
 
-	ns, _, err := t.decodeKey(key)
+	ns, name, err := t.decodeKey(key)
 	if err != nil {
 		glog.Errorf("decoding key %s (%s)", key, err)
 		return err
@@ -96,7 +97,6 @@ func (t *store) Create(
 	if err != nil {
 		return err
 	}
-
 	req := t.cl.Post().AbsPath(
 		"apis",
 		groupName,
@@ -106,8 +106,18 @@ func (t *store) Create(
 		t.singularKind.URLName(),
 	).Body(data)
 
+	res := req.Do()
+	if res.Error() != nil {
+		glog.Errorf("executing POST for %s/%s (%s)", ns, name, res.Error())
+	}
+	var statusCode int
+	res.StatusCode(&statusCode)
+	if statusCode == http.StatusConflict {
+		return storage.NewKeyExistsError(key, 0)
+	}
+
 	var unknown runtime.Unknown
-	if err := req.Do().Into(&unknown); err != nil {
+	if err := res.Into(&unknown); err != nil {
 		glog.Errorf("decoding response (%s)", err)
 		return err
 	}
@@ -143,9 +153,15 @@ func (t *store) Delete(
 		t.singularKind.URLName(),
 		name,
 	)
-	if err := req.Do().Error(); err != nil {
-		glog.Errorf("error deleting (%s)", err)
-		return err
+
+	res := req.Do()
+	if res.Error() != nil {
+		glog.Errorf("executing DELETE for %s/%s (%s)", ns, name, res.Error())
+	}
+	var statusCode int
+	res.StatusCode(&statusCode)
+	if statusCode == http.StatusNotFound {
+		return storage.NewKeyNotFoundError(key, 0)
 	}
 
 	return nil
@@ -276,8 +292,22 @@ func (t *store) Get(
 		name,
 	)
 
+	res := req.Do()
+	if res.Error() != nil {
+		glog.Errorf("executing GET for %s/%s (%s)", ns, name, res.Error())
+	}
+	var statusCode int
+	res.StatusCode(&statusCode)
+	if statusCode == http.StatusNotFound {
+		if ignoreNotFound {
+			return runtime.SetZeroValue(objPtr)
+		}
+		glog.Errorf("executing GET for %s/%s: not found", ns, name)
+		return storage.NewKeyNotFoundError(key, 0)
+	}
+
 	var unknown runtime.Unknown
-	if err := req.Do().Into(&unknown); err != nil {
+	if res.Into(&unknown); err != nil {
 		glog.Errorf("decoding response (%s)", err)
 		return err
 	}

--- a/pkg/storage/tpr/storage_interface.go
+++ b/pkg/storage/tpr/storage_interface.go
@@ -18,6 +18,7 @@ package tpr
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/golang/glog"
@@ -115,6 +116,14 @@ func (t *store) Create(
 	if statusCode == http.StatusConflict {
 		return storage.NewKeyExistsError(key, 0)
 	}
+	if statusCode != http.StatusCreated {
+		return fmt.Errorf(
+			"executing POST for %s/%s, received response code %d",
+			ns,
+			name,
+			statusCode,
+		)
+	}
 
 	var unknown runtime.Unknown
 	if err := res.Into(&unknown); err != nil {
@@ -162,6 +171,14 @@ func (t *store) Delete(
 	res.StatusCode(&statusCode)
 	if statusCode == http.StatusNotFound {
 		return storage.NewKeyNotFoundError(key, 0)
+	}
+	if statusCode != http.StatusAccepted {
+		return fmt.Errorf(
+			"executing DELETE for %s/%s, received response code %d",
+			ns,
+			name,
+			statusCode,
+		)
 	}
 
 	return nil
@@ -304,6 +321,14 @@ func (t *store) Get(
 		}
 		glog.Errorf("executing GET for %s/%s: not found", ns, name)
 		return storage.NewKeyNotFoundError(key, 0)
+	}
+	if statusCode != http.StatusOK {
+		return fmt.Errorf(
+			"executing GET for %s/%s, received response code %d",
+			ns,
+			name,
+			statusCode,
+		)
 	}
 
 	var unknown runtime.Unknown

--- a/pkg/storage/tpr/storage_interface_test.go
+++ b/pkg/storage/tpr/storage_interface_test.go
@@ -18,16 +18,23 @@ package tpr
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
 	"reflect"
 	"testing"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/testapi"
-	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/client-go/pkg/api"
 	restclient "k8s.io/client-go/rest"
 )
 
@@ -36,33 +43,31 @@ const (
 	name      = "testthing"
 )
 
-func TestCreate(t *testing.T) {
+func TestCreateAndRead(t *testing.T) {
 	keyer := getKeyer()
 	fakeCl := newFakeCoreRESTClient()
 	iface := getTPRStorageIFace(t, keyer, fakeCl)
-	broker := &v1alpha1.Broker{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1alpha1.SchemeGroupVersion.String(),
-			Kind:       ServiceBrokerKind.String(),
-		},
+	origBroker := &sc.Broker{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 	}
 	key, err := keyer.Key(request.NewContext(), name)
 	if err != nil {
 		t.Fatalf("error constructing key (%s)", err)
 	}
-	outBroker := &v1alpha1.Broker{}
+
+	// Begin create test
+	createdBroker := &sc.Broker{}
 	if err := iface.Create(
 		context.Background(),
 		key,
-		broker,
-		outBroker,
+		origBroker,
+		createdBroker,
 		uint64(0),
 	); err != nil {
 		t.Fatalf("error on create (%s)", err)
 	}
 	// Confirm resource version got set during the create operation
-	if outBroker.ResourceVersion == "" {
+	if createdBroker.ResourceVersion == "" {
 		t.Fatalf("resource version was not set as expected")
 	}
 	// Confirm the output is identical to what is in storage (nothing funny
@@ -71,21 +76,196 @@ func TestCreate(t *testing.T) {
 	if obj == nil {
 		t.Fatal("no broker was in storage")
 	}
-	if !reflect.DeepEqual(outBroker, obj) {
-		t.Fatalf(
-			"output and object in storage are different: %s",
-			diff.ObjectReflectDiff(outBroker, obj),
-		)
+	err = deepCompare("output", createdBroker, "object in storage", obj)
+	if err != nil {
+		t.Fatal(err)
 	}
 	// Output and what's in storage should be known to be deeply equal at this
 	// point. Compare either of those to what was passed in. The only diff should
-	// be resource version, so we will clear that first.
-	outBroker.ResourceVersion = ""
-	if !reflect.DeepEqual(broker, outBroker) {
+	// be resource version, so we will set that first.
+	origBroker.ResourceVersion = createdBroker.ResourceVersion
+	err = deepCompare("input", origBroker, "output", createdBroker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// End create test
+
+	// Begin create existing test
+	origBroker2 := &sc.Broker{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	createdBroker2 := &sc.Broker{}
+	err = iface.Create(
+		context.Background(),
+		key,
+		origBroker2,
+		createdBroker2,
+		uint64(0),
+	)
+	if err = verifyStorageError(err, storage.ErrCodeKeyExists); err != nil {
+		t.Fatal(err)
+	}
+	// End create existing test
+
+	// Begin get test
+	gottenBroker := &sc.Broker{}
+	if err := iface.Get(
+		context.Background(),
+		key,
+		"", // TODO: Current impl ignores resource version-- may be wrong
+		gottenBroker,
+		false, // Do not ignore if not found; error instead
+	); err != nil {
+		t.Fatalf("error getting object (%s)", err)
+	}
+	// Retrieved object should be deeply equal to what we created earlier
+	if err = deepCompare(
+		"retrieved object",
+		gottenBroker,
+		"expected object",
+		createdBroker,
+	); err != nil {
+		t.Fatal(err)
+	}
+	// End get test
+
+	// Begin list test
+	gottenList := &sc.BrokerList{}
+	if err := iface.List(
+		context.Background(),
+		keyer.KeyRoot(request.NewContext()),
+		"", // TODO: Current impl ignores resource version-- may be wrong
+		// TODO: Current impl ignores selection predicate-- may be wrong
+		storage.SelectionPredicate{},
+		gottenList,
+	); err != nil {
+		t.Fatalf("error listing objects (%s)", err)
+	}
+	// List should contain precisely one item
+	if len(gottenList.Items) != 1 {
 		t.Fatalf(
-			"input and output are different: %s",
-			diff.ObjectReflectDiff(broker, outBroker),
+			"expected list to contain exactly one item, but got %d items",
+			len(gottenList.Items),
 		)
+	}
+	// That one list item should be deeply equal to the one we retrieved earlier
+	if err = deepCompare(
+		"retrieved list item",
+		&gottenList.Items[0],
+		"expected object",
+		gottenBroker,
+	); err != nil {
+		t.Fatal(err)
+	}
+	// End list test
+}
+
+func TestGetEmptyList(t *testing.T) {
+	keyer := getKeyer()
+	fakeCl := newFakeCoreRESTClient()
+	iface := getTPRStorageIFace(t, keyer, fakeCl)
+	key := keyer.KeyRoot(request.NewContext())
+	outBrokerList := &sc.BrokerList{}
+	if err := iface.List(
+		context.Background(),
+		key,
+		"", // TODO: Current impl ignores resource version-- may be wrong
+		// TODO: Current impl ignores selection predicate-- may be wrong
+		storage.SelectionPredicate{},
+		outBrokerList,
+	); err != nil {
+		t.Fatalf("error listing objects (%s)", err)
+	}
+	if len(outBrokerList.Items) != 0 {
+		t.Fatalf(
+			"expected an empty list, but got %d items",
+			len(outBrokerList.Items),
+		)
+	}
+	// Repeat using GetToList
+	if err := iface.GetToList(
+		context.Background(),
+		key,
+		"", // TODO: Current impl ignores resource version-- may be wrong
+		// TODO: Current impl ignores selection predicate-- may be wrong
+		storage.SelectionPredicate{},
+		outBrokerList,
+	); err != nil {
+		t.Fatalf("error listing objects (%s)", err)
+	}
+	if len(outBrokerList.Items) != 0 {
+		t.Fatalf(
+			"expected an empty list, but got %d items",
+			len(outBrokerList.Items),
+		)
+	}
+}
+
+func TestGetNonExistent(t *testing.T) {
+	keyer := getKeyer()
+	fakeCl := newFakeCoreRESTClient()
+	iface := getTPRStorageIFace(t, keyer, fakeCl)
+	key, err := keyer.Key(request.NewContext(), name)
+	if err != nil {
+		t.Fatalf("error constructing key (%s)", err)
+	}
+	outBroker := &sc.Broker{}
+	// Ignore not found
+	if err := iface.Get(
+		context.Background(),
+		key,
+		"", // TODO: Current impl ignores resource version-- may be wrong
+		outBroker,
+		true,
+	); err != nil {
+		t.Fatalf("expected no error, but received one (%s)", err)
+	}
+	// Object should remain unmodified-- i.e. deeply equal to a new broker
+	err = deepCompare("output", outBroker, "new broker", &sc.Broker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Do not ignore not found
+	err = iface.Get(
+		context.Background(),
+		key,
+		"", // TODO: Current impl ignores resource version-- may be wrong
+		outBroker,
+		false,
+	)
+	if err = verifyStorageError(err, storage.ErrCodeKeyNotFound); err != nil {
+		t.Fatal(err)
+	}
+	// Object should remain unmodified-- i.e. deeply equal to a new broker
+	err = deepCompare("output", outBroker, "new broker", &sc.Broker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDeleteNonExistent(t *testing.T) {
+	keyer := getKeyer()
+	fakeCl := newFakeCoreRESTClient()
+	iface := getTPRStorageIFace(t, keyer, fakeCl)
+	key, err := keyer.Key(request.NewContext(), name)
+	if err != nil {
+		t.Fatalf("error constructing key (%s)", err)
+	}
+	outBroker := &sc.Broker{}
+	// Ignore not found
+	err = iface.Delete(
+		context.Background(),
+		key,
+		outBroker,
+		nil, // TODO: Current impl ignores preconditions-- may be wrong
+	)
+	if err = verifyStorageError(err, storage.ErrCodeKeyNotFound); err != nil {
+		t.Fatal(err)
+	}
+	// Object should remain unmodified-- i.e. deeply equal to a new broker
+	err = deepCompare("output", outBroker, "new broker", &sc.Broker{})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -115,7 +295,7 @@ func getKeyer() Keyer {
 }
 
 func getTPRStorageIFace(t *testing.T, keyer Keyer, restCl restclient.Interface) *store {
-	codec, err := testapi.GetCodecForObject(&v1alpha1.Broker{})
+	codec, err := testapi.GetCodecForObject(&sc.Broker{})
 	if err != nil {
 		t.Fatalf("error getting codec (%s)", err)
 	}
@@ -125,4 +305,63 @@ func getTPRStorageIFace(t *testing.T, keyer Keyer, restCl restclient.Interface) 
 		cl:           restCl,
 		singularKind: ServiceBrokerKind,
 	}
+}
+
+func serviceCatalogAPIGroup() testapi.TestGroup {
+	groupVersion := schema.GroupVersion{Group: servicecatalog.GroupName, Version: "v1alpha1"}
+
+	externalGroupVersion := schema.GroupVersion{
+		Group:   groupName,
+		Version: api.Registry.GroupOrDie(servicecatalog.GroupName).GroupVersion.Version,
+	}
+
+	return testapi.NewTestGroup(
+		groupVersion,
+		servicecatalog.SchemeGroupVersion,
+		api.Scheme.KnownTypes(servicecatalog.SchemeGroupVersion),
+		api.Scheme.KnownTypes(externalGroupVersion),
+	)
+}
+
+func init() {
+	log.SetFlags(log.Lshortfile)
+	testapi.Groups[servicecatalog.GroupName] = serviceCatalogAPIGroup()
+}
+
+func verifyStorageError(err error, errorCode int) error {
+	if err == nil {
+		return errors.New("expected an error, but did not receive one")
+	}
+	storageErr, ok := err.(*storage.StorageError)
+	if !ok {
+		return fmt.Errorf(
+			"expected a storage.StorageError, but got a %s",
+			reflect.TypeOf(err),
+		)
+	}
+	if storageErr.Code != errorCode {
+		return fmt.Errorf(
+			"expected error code %d, but got %d",
+			errorCode,
+			storageErr.Code,
+		)
+	}
+	return nil
+}
+
+func deepCompare(
+	obj1Name string,
+	obj1 runtime.Object,
+	obj2Name string,
+	obj2 runtime.Object,
+) error {
+	if !reflect.DeepEqual(obj1, obj2) {
+		return fmt.Errorf(
+			"%s and %s are different: %s",
+			obj1Name,
+			obj2Name,
+			diff.ObjectReflectDiff(obj1, obj2),
+		)
+	}
+	return nil
 }

--- a/pkg/storage/tpr/storage_interface_test.go
+++ b/pkg/storage/tpr/storage_interface_test.go
@@ -49,6 +49,9 @@ func TestCreateAndRead(t *testing.T) {
 	iface := getTPRStorageIFace(t, keyer, fakeCl)
 	origBroker := &sc.Broker{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: sc.BrokerSpec{
+			URL: "http://my-awesome-broker.io",
+		},
 	}
 	key, err := keyer.Key(request.NewContext(), name)
 	if err != nil {


### PR DESCRIPTION
Follows up on #699 

Partially overlaps #714-- whichever is merged second will require a rebase.

Cliff notes:

1. Adds more create tests and new get/list tests to the tpr-backed storage implementation
1. To make these pass, the tpr-backed storage implementation was amended to check for the existence / non-existence of a resource before creating or retrieving... and handle appropriately. (i.e. handle consistently with the etcd3-backed storage implementation)
1. There has been a major revelation that the inputs and outputs of the storage layer should be internal / unversioned resources. There's a lot of refactoring of the tests included herein (all in commit 8368ad4f2fcd198f2f522cda62233aa6712fbda7) to account for this.
1. Update and delete tests are deliberately omitted from this PR because:
    1. This PR is already big enough
    1. I want this additional test coverage sooner, rather than later
    1. Update and delete have known issues. Correcting those issues is probably enough work that I'd like to tackle them separately from the rest of this.