### PR TITLE
Make the user-provided-service bindable

### DIFF
--- a/contrib/pkg/broker/user_provided/controller/controller.go
+++ b/contrib/pkg/broker/user_provided/controller/controller.go
@@ -67,6 +67,7 @@ func (c *userProvidedController) Catalog() (*brokerapi.Catalog, error) {
 					Free:        true,
 				},
 				},
+				Bindable: true,
 			},
 		},
 	}, nil


### PR DESCRIPTION
I realized after using the new generic describer in kubectl that this service is not bindable, which is wrong.