### PR TITLE
Adding feature flag for broker relist interval

### DIFF
--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -46,8 +46,10 @@ spec:
         - "{{ .Values.controllerManager.verbosity }}"
         - --resync-interval
         - {{ .Values.controllerManager.resyncInterval }}
+        {{ if .Values.controllerManager.brokerRelistIntervalActivated -}}
         - --broker-relist-interval
         - {{ .Values.controllerManager.brokerRelistInterval }}
+        {{- end }}
         ports:
         - containerPort: 8080
         volumeMounts:

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -56,4 +56,7 @@ controllerManager:
   resyncInterval: 5m
   # Broker relist interval; format is a duration (`20m`, `1h`, etc)
   brokerRelistInterval: 24h
+  # Whether or not the controller supports a --broker-relist-interval flag. If this is 
+  # set to true, brokerRelistInterval will be used as the value for that flag
+  brokerRelistIntervalActivated: false
 useAggregator: false


### PR DESCRIPTION
This patch adds a "feature flag" to the helm chart, so that it can support controllers that don't support the `--broker-relist-interval` flag.

Fixes https://github.com/kubernetes-incubator/service-catalog/issues/713