### PR TITLE
clean up tpr-storage unit tests

### DIFF
--- a/pkg/storage/tpr/list_resources_test.go
+++ b/pkg/storage/tpr/list_resources_test.go
@@ -96,11 +96,11 @@ func TestListResource(t *testing.T) {
 	if len(objs) != 0 {
 		t.Fatalf("expected 0 objects returned, got %d instead", len(objs))
 	}
-	cl.storage.set(ns, "brokers", "broker1", &sc.Broker{
+	cl.storage.set(ns, ServiceBrokerKind.URLName(), "broker1", &sc.Broker{
 		TypeMeta:   newTypeMeta(kind),
 		ObjectMeta: metav1.ObjectMeta{Name: "broker1"},
 	})
-	cl.storage.set(ns, "brokers", "broker2", &sc.Broker{
+	cl.storage.set(ns, ServiceBrokerKind.URLName(), "broker2", &sc.Broker{
 		TypeMeta:   newTypeMeta(kind),
 		ObjectMeta: metav1.ObjectMeta{Name: "broker2"},
 	})
@@ -108,10 +108,10 @@ func TestListResource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error listing resource (%s)", err)
 	}
-	if len(objs) != len(cl.storage[ns]["brokers"]) {
+	if len(objs) != len(cl.storage[ns][ServiceBrokerKind.URLName()]) {
 		t.Fatalf(
 			"expected %d objects returned, got %d instead",
-			len(cl.storage[ns]["brokers"]),
+			len(cl.storage[ns][ServiceBrokerKind.URLName()]),
 			len(objs),
 		)
 	}


### PR DESCRIPTION
This is a follow up to #714 and #715 with some cleanup for both. Most of the cleanup is for what was in #715. I was inspired by @arschles testing approach in #714 where he manipulated the fake core apiserver client's in-memory storage directly to satisfy preconditions for tests. I had used an alternative approach of a longer narrative in a single `TestCreateAndRead()` test wherein the resources required to exist to test `Get()` and `List()` where guaranteed to exist by testing `Create()` first. Needless to say, I like @arschles approach better, so here I am emulating it.