### PR TITLE
Turn off garbage collection for TPR deletion

### DIFF
--- a/pkg/registry/servicecatalog/binding/storage.go
+++ b/pkg/registry/servicecatalog/binding/storage.go
@@ -140,6 +140,14 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage, error) {
 		DestroyFunc: dFunc,
 	}
 
+	//Turn Garbage Collection for TPR storage.
+	//We haven't implemented graceful delete for TPR, with garbage collection
+	//off, we are skipping all graceful deletion machanism, thus, allowing
+	//TPR to be deleted successfully
+	if t, _ := opts.StorageType(); t == server.StorageTypeTPR {
+		store.EnableGarbageCollection = false
+	}
+
 	statusStore := store
 	statusStore.UpdateStrategy = bindingStatusUpdateStrategy
 

--- a/pkg/registry/servicecatalog/binding/storage_test.go
+++ b/pkg/registry/servicecatalog/binding/storage_test.go
@@ -19,7 +19,15 @@ package binding
 import (
 	"testing"
 
+	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
+	"k8s.io/client-go/pkg/api"
+
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	"github.com/kubernetes-incubator/service-catalog/pkg/storage/etcd"
+	"github.com/kubernetes-incubator/service-catalog/pkg/storage/tpr"
 )
 
 func TestNewListNilItems(t *testing.T) {
@@ -28,5 +36,31 @@ func TestNewListNilItems(t *testing.T) {
 
 	if realObj.Items == nil {
 		t.Fatalf("nil incorrectly set on Items field")
+	}
+}
+
+func TestNewStorageWithTPR(t *testing.T) {
+	opts := server.NewOptions(
+		etcd.Options{},
+		tpr.Options{
+			RESTOptions: generic.RESTOptions{
+				StorageConfig: storagebackend.NewDefaultConfig("", api.Scheme, nil),
+			},
+		},
+		server.StorageTypeTPR,
+	)
+
+	storage, statusStorage, err := NewStorage(*opts)
+
+	if err != nil {
+		t.Fatalf("unexpected error ocurred (%s)", err)
+	}
+
+	if storage.(*registry.Store).EnableGarbageCollection != false {
+		t.Fatalf("'EnableGarbageCollection` in storage should be set to false for TPR type")
+	}
+
+	if statusStorage.(*registry.Store).EnableGarbageCollection != false {
+		t.Fatalf("'EnableGarbageCollection` in statusStorage should be set to false for TPR type")
 	}
 }


### PR DESCRIPTION
Closes #600 

Turn off the garbage collection to have 'walk-through' working for TPR.

The reason is because we have not implemented graceful deletion for TPR resource, and in the case of an object is having a `pendingFinalizers` during deletion, the `DeletionTimestamp` and `GracePeriodSeconds` are being updated to `now` and `0` respectively so the finalizer will notice and delete the object immediately. 

Our error comes from the object being immutable for the update. Turning off garbage collection will skip all graceful deletion mechanism. Furthermore, having garbage collection on has no effect in our case since graceful deletion is not implemented, thus object will be deleted immediately.