### PR TITLE
Allow bindings only to bindable service classes

### DIFF
--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -80,6 +80,7 @@ func TestBasicFlows(t *testing.T) {
 				Name:        testServiceClassName,
 				ID:          "12345",
 				Description: "a test service",
+				Bindable:    true,
 				Plans: []brokerapi.ServicePlan{
 					{
 						Name:        testPlanName,


### PR DESCRIPTION
Fixes #727 

Depends on #726 and #743 

The controller now errors a binding if it references a ServiceClass that is not bindable.