### PR TITLE
allow caps in plan names

### DIFF
--- a/pkg/apis/servicecatalog/validation/instance_test.go
+++ b/pkg/apis/servicecatalog/validation/instance_test.go
@@ -39,7 +39,7 @@ func TestValidateInstance(t *testing.T) {
 				},
 				Spec: servicecatalog.InstanceSpec{
 					ServiceClassName: "test-serviceclass",
-					PlanName:         "test-plan",
+					PlanName:         "Test-Plan",
 				},
 			},
 			valid: true,
@@ -124,7 +124,7 @@ func TestValidateInstance(t *testing.T) {
 				},
 				Spec: servicecatalog.InstanceSpec{
 					ServiceClassName: "test-serviceclass",
-					PlanName:         "9651JVHbebe",
+					PlanName:         "9651.JVHbebe",
 				},
 			},
 			valid: false,

--- a/pkg/apis/servicecatalog/validation/serviceclass.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass.go
@@ -108,7 +108,7 @@ func validateServicePlan(plan sc.ServicePlan, fldPath *field.Path) field.ErrorLi
 	return allErrs
 }
 
-const servicePlanNameFmt string = `[-_a-z0-9]+`
+const servicePlanNameFmt string = `[-_a-zA-Z0-9]+`
 const servicePlanNameMaxLength int = 63
 
 var servicePlanNameRegexp = regexp.MustCompile("^" + servicePlanNameFmt + "$")


### PR DESCRIPTION
The OSB spec has some guidance on plan name formatting, but it doesn't seem strict. In the wild, I have encountered some brokers that do not conform, specifically to the suggestion that plan names be all lower case, so I am suggesting that we invoke Postel's Law here and relax this regex to permit uppercase characters.