### PR TITLE
Deploying from master and on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,8 @@ deploy:
   script: scripts/deploy.sh
   on:
     repo: kubernetes-incubator/service-catalog
-    branch: master
+    branches:
+      only:
+      - master
+      # this is for tags. see https://github.com/travis-ci/travis-ci/issues/3897#issuecomment-101623421
+      - /v\d+\.\d+.\d+[a-z]*/ # something like v1.2.1 or v1.2.1abc


### PR DESCRIPTION
This patch uses a regex to deploy from tags.

Regex tested here: https://regex101.com/r/n6k30j/1
Fixes https://github.com/kubernetes-incubator/service-catalog/issues/777