### PR TITLE
Pushing the build image to a Docker image repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ contrib/build/*/tmp/*
 .pkg
 .kube
 .var
+build-image
+push-build-image

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ contrib/build/*/tmp/*
 .var
 .build-image
 .push-build-image
+.build-image-push

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ contrib/build/*/tmp/*
 .pkg
 .kube
 .var
-build-image
-push-build-image
+.build-image
+.push-build-image

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ CONTROLLER_MANAGER_IMAGE          = $(REGISTRY)controller-manager:$(VERSION)
 CONTROLLER_MANAGER_MUTABLE_IMAGE  = $(REGISTRY)controller-manager:$(MUTABLE_TAG)
 USER_BROKER_IMAGE                 = $(REGISTRY)user-broker:$(VERSION)
 USER_BROKER_MUTABLE_IMAGE         = $(REGISTRY)user-broker:$(MUTABLE_TAG)
-BUILD_IMAGE_REGISTRY             ?= quay.io/kubernetes-service-catalog/
+BUILD_IMAGE_REGISTRY             ?= $(REGISTRY)
 BUILD_IMAGE                      ?= $(BUILD_IMAGE_REGISTRY)build-image:$(VERSION)
 BUILD_IMAGE_MUTABLE              ?= $(BUILD_IMAGE_REGISTRY)build-image:$(MUTABLE_TAG)
 

--- a/Makefile
+++ b/Makefile
@@ -89,21 +89,21 @@ NON_VENDOR_DIRS = $(shell $(DOCKER_CMD) glide nv)
 # Some will have dedicated targets to make it easier to type, for example
 # "apiserver" instead of "bin/apiserver".
 #########################################################################
-build: .init .generate_files \
+build: .generate_files \
        $(BINDIR)/controller-manager $(BINDIR)/apiserver \
        $(BINDIR)/user-broker
 
-user-broker: .init $(BINDIR)/user-broker
+user-broker: $(BINDIR)/user-broker
 $(BINDIR)/user-broker: contrib/cmd/user-broker \
 	  $(shell find contrib/cmd/user-broker -type f)
 	$(DOCKER_CMD) $(GO_BUILD) -o $@ $(SC_PKG)/contrib/cmd/user-broker
 
 # We'll rebuild apiserver if any go file has changed (ie. NEWEST_GO_FILE)
-apiserver: .init $(BINDIR)/apiserver
+apiserver: $(BINDIR)/apiserver
 $(BINDIR)/apiserver: .generate_files cmd/apiserver $(NEWEST_GO_FILE)
 	$(DOCKER_CMD) $(GO_BUILD) -o $@ $(SC_PKG)/cmd/apiserver
 
-controller-manager: .init $(BINDIR)/controller-manager
+controller-manager: $(BINDIR)/controller-manager
 $(BINDIR)/controller-manager: .generate_files cmd/controller-manager $(NEWEST_GO_FILE)
 	$(DOCKER_CMD) $(GO_BUILD) -o $@ $(SC_PKG)/cmd/controller-manager
 
@@ -118,32 +118,32 @@ $(BINDIR)/controller-manager: .generate_files cmd/controller-manager $(NEWEST_GO
                 $(BINDIR)/openapi-gen
 	touch $@
 
-$(BINDIR)/defaulter-gen: .init
+$(BINDIR)/defaulter-gen:
 	$(DOCKER_CMD) go build -o $@ $(SC_PKG)/vendor/k8s.io/kubernetes/cmd/libs/go2idl/defaulter-gen
 
-$(BINDIR)/deepcopy-gen: .init
+$(BINDIR)/deepcopy-gen:
 	$(DOCKER_CMD) go build -o $@ $(SC_PKG)/vendor/k8s.io/kubernetes/cmd/libs/go2idl/deepcopy-gen
 
-$(BINDIR)/conversion-gen: .init
+$(BINDIR)/conversion-gen:
 	$(DOCKER_CMD) go build -o $@ $(SC_PKG)/vendor/k8s.io/kubernetes/cmd/libs/go2idl/conversion-gen
 
-$(BINDIR)/client-gen: .init
+$(BINDIR)/client-gen:
 	$(DOCKER_CMD) go build -o $@ $(SC_PKG)/vendor/k8s.io/kubernetes/cmd/libs/go2idl/client-gen
 
-$(BINDIR)/lister-gen: .init
+$(BINDIR)/lister-gen:
 	$(DOCKER_CMD) go build -o $@ $(SC_PKG)/vendor/k8s.io/kubernetes/cmd/libs/go2idl/lister-gen
 
-$(BINDIR)/informer-gen: .init
+$(BINDIR)/informer-gen:
 	$(DOCKER_CMD) go build -o $@ $(SC_PKG)/vendor/k8s.io/kubernetes/cmd/libs/go2idl/informer-gen
 
 $(BINDIR)/openapi-gen: vendor/k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen
 	$(DOCKER_CMD) go build -o $@ $(SC_PKG)/$^
 
-$(BINDIR)/e2e.test: .init
+$(BINDIR)/e2e.test:
 	$(DOCKER_CMD) go test -c -o $@ $(SC_PKG)/test/e2e
 
 # Regenerate all files if the gen exes changed or any "types.go" files changed
-.generate_files: .init .generate_exes $(TYPES_FILES)
+.generate_files: .generate_exes $(TYPES_FILES)
 	# Generate defaults
 	$(DOCKER_CMD) $(BINDIR)/defaulter-gen \
 		--v 1 --logtostderr \
@@ -183,10 +183,9 @@ $(BINDIR)/e2e.test: .init
 # Some prereq stuff
 ###################
 
-.init: $(scBuildImageTarget)
+pull-build-image:
 	docker pull $(BUILD_IMAGE)
 	docker pull $(BUILD_IMAGE_MUTABLE)
-	touch $@
 
 .PHONY: .build-image
 .build-image: build/build-image/Dockerfile
@@ -204,7 +203,7 @@ $(BINDIR)/e2e.test: .init
 # Util targets
 ##############
 .PHONY: verify verify-client-gen
-verify: .init .generate_files verify-client-gen
+verify: .generate_files verify-client-gen
 	@echo Running gofmt:
 	@$(DOCKER_CMD) gofmt -l -s $(TOP_SRC_DIRS) > .out 2>&1 || true
 	@bash -c '[ "`cat .out`" == "" ] || \
@@ -234,24 +233,24 @@ verify: .init .generate_files verify-client-gen
 	@echo Running errexit checker:
 	@$(DOCKER_CMD) build/verify-errexit.sh
 
-verify-client-gen: .init .generate_files
+verify-client-gen: .generate_files
 	$(DOCKER_CMD) $(BUILD_DIR)/verify-client-gen.sh
 
-format: .init
+format:
 	$(DOCKER_CMD) gofmt -w -s $(TOP_SRC_DIRS)
 
-coverage: .init
+coverage:
 	$(DOCKER_CMD) contrib/hack/coverage.sh --html "$(COVERAGE)" \
 	  $(addprefix ./,$(TEST_DIRS))
 
-test: .init build test-unit test-integration
+test: build test-unit test-integration
 
-test-unit: .init build
+test-unit: build
 	@echo Running tests:
 	$(DOCKER_CMD) go test -race $(UNIT_TEST_FLAGS) \
 	  $(addprefix $(SC_PKG)/,$(TEST_DIRS))
 
-test-integration: .init $(scBuildImageTarget) build
+test-integration: $(scBuildImageTarget) build
 	# test kubectl
 	contrib/hack/setup-kubectl.sh
 	contrib/hack/test-apiserver.sh

--- a/Makefile
+++ b/Makefile
@@ -304,8 +304,10 @@ controller-manager-image: build/controller-manager/Dockerfile $(BINDIR)/controll
 	rm -rf build/controller-manager/tmp
 
 # Push our Docker Images to a registry
+# note: .push-build-image should be the first dependency, because all others rely on the build
+# image
 ######################################
-push: user-broker-push controller-manager-push apiserver-push .push-build-image
+push: .push-build-image user-broker-push controller-manager-push apiserver-push
 
 user-broker-push: user-broker-image
 	docker push $(USER_BROKER_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ GO_BUILD       = env GOOS=$(PLATFORM) GOARCH=$(ARCH) go build -i $(GOFLAGS) \
 BASE_PATH      = $(ROOT:/src/github.com/kubernetes-incubator/service-catalog/=)
 export GOPATH  = $(BASE_PATH):$(ROOT)/vendor
 
+REGISTRY                         ?= quay.io/kubernetes-service-catalog/
 MUTABLE_TAG                      ?= canary
 APISERVER_IMAGE                   = $(REGISTRY)apiserver:$(VERSION)
 APISERVER_MUTABLE_IMAGE           = $(REGISTRY)apiserver:$(MUTABLE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ clean-coverage:
 # Building Docker Images for our executables
 ############################################
 images: user-broker-image \
-    controller-manager-image apiserver-image build-image
+    controller-manager-image apiserver-image .build-image
 
 .PHONY: .build-image
 .build-image: build/build-image/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ $(BINDIR)/e2e.test: .init
 ###################
 
 .init: $(scBuildImageTarget)
+	docker pull $(BUILD_IMAGE_MUTABLE)
 	touch $@
 
 build-image: build/build-image/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ else
 	# Mount .pkg as pkg so that we save our cached "go build" output files
 	DOCKER_CMD = docker run --rm -v $(PWD):/go/src/$(SC_PKG) \
 	  -v $(PWD)/.pkg:/go/pkg $(BUILD_IMAGE_MUTABLE)
-	scBuildImageTarget = build-image
+	scBuildImageTarget = .build-image
 endif
 
 NON_VENDOR_DIRS = $(shell $(DOCKER_CMD) glide nv)
@@ -184,12 +184,14 @@ $(BINDIR)/e2e.test: .init
 	docker pull $(BUILD_IMAGE_MUTABLE)
 	touch $@
 
-build-image: build/build-image/Dockerfile
+.PHONY: .build-image
+.build-image: build/build-image/Dockerfile
 	sed "s/GO_VERSION/$(GO_VERSION)/g" < build/build-image/Dockerfile | \
 	  docker build -t $(BUILD_IMAGE_MUTABLE) -
 	touch $@
 
-push-build-image: build-image
+.PHONY: .push-build-image
+.push-build-image: .build-image
 	docker push $(BUILD_IMAGE_MUTABLE)
 	touch $@
 
@@ -260,11 +262,11 @@ clean-bin:
 	rm -f .generate_exes
 
 clean-build-image:
-	rm -f build-image
+	rm -f .build-image
 	docker rmi -f $(BUILD_IMAGE_MUTABLE) > /dev/null 2>&1 || true
 
 clean-push-build-image:
-	rm -rf push-build-image
+	rm -rf .push-build-image
 
 clean-generated:
 	rm -f .generate_files

--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ controller-manager-image: build/controller-manager/Dockerfile $(BINDIR)/controll
 
 # Push our Docker Images to a registry
 ######################################
-push: user-broker-push controller-manager-push apiserver-push push-build-image
+push: user-broker-push controller-manager-push apiserver-push .push-build-image
 
 user-broker-push: user-broker-image
 	docker push $(USER_BROKER_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ $(BINDIR)/e2e.test:
 # Some prereq stuff
 ###################
 
+.PHONY: pull-build-image
 pull-build-image:
 	docker pull $(BUILD_IMAGE)
 	docker pull $(BUILD_IMAGE_MUTABLE)

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,8 @@ CONTROLLER_MANAGER_IMAGE          = $(REGISTRY)controller-manager:$(VERSION)
 CONTROLLER_MANAGER_MUTABLE_IMAGE  = $(REGISTRY)controller-manager:$(MUTABLE_TAG)
 USER_BROKER_IMAGE                 = $(REGISTRY)user-broker:$(VERSION)
 USER_BROKER_MUTABLE_IMAGE         = $(REGISTRY)user-broker:$(MUTABLE_TAG)
-BUILD_IMAGE_MUTABLE               = $(REGISTRY)build-image:$(MUTABLE_TAG)
+BUILD_IMAGE_REGISTRY             ?= quay.io/kubernetes-service-catalog/
+BUILD_IMAGE_MUTABLE               = $(BUILD_IMAGE_REGISTRY)build-image:$(MUTABLE_TAG)
 
 # precheck to avoid kubernetes-incubator/service-catalog#361
 $(if $(realpath vendor/k8s.io/kubernetes/vendor), \

--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ controller-manager-image: build/controller-manager/Dockerfile $(BINDIR)/controll
 
 # Push our Docker Images to a registry
 ######################################
-push: user-broker-push controller-manager-push apiserver-push
+push: user-broker-push controller-manager-push apiserver-push push-build-image
 
 user-broker-push: user-broker-image
 	docker push $(USER_BROKER_IMAGE)

--- a/contrib/hack/start-server.sh
+++ b/contrib/hack/start-server.sh
@@ -40,7 +40,7 @@ docker run -d --name apiserver \
 	-e KUBERNETES_SERVICE_PORT=6443 \
 	--privileged \
 	--net container:etcd-svc-cat \
-	scbuildimage \
+	quay.io/kubernetes-service-catalog/build-image:canary \
 	bin/apiserver -v 10 --etcd-servers http://localhost:2379 \
 		--insecure-bind-address=0.0.0.0 --insecure-port=8081 \
 		--storage-type=etcd --disable-auth

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -120,9 +120,6 @@ To deploy to Kubernetes, see the
 * The Makefile assumes you're running `make` from the root of the repo.
 * There are some source files that are generated during the build process.
   These will be prefixed with `zz`.
-* A Docker Image called "scbuildimage" will be used. The image isn't pre-built
-  and pulled from a public registry. Instead, it is built from source contained
-  within the service catalog repository.
 * While many people have utilities, such as editor hooks, that auto-format
   their go source files with `gofmt`, there is a Makefile target called
   `format` which can be used to do this task for you.


### PR DESCRIPTION
By pushing the build image to a repo and `docker pull`-ing it, developers no longer need to build it locally. This patch also modifies the Makefile to push and use the new build image. 

See https://quay.io/repository/kubernetes-service-catalog/build-image for the build image's location.

Fixes https://github.com/kubernetes-incubator/service-catalog/issues/778