### PR TITLE
Tpr delete err check

### DIFF
--- a/pkg/rest/core/fake/rest_client.go
+++ b/pkg/rest/core/fake/rest_client.go
@@ -375,7 +375,7 @@ func deleteItem(storage NamespacedStorage) func(http.ResponseWriter, *http.Reque
 			return
 		}
 		storage.Delete(ns, tipe, name)
-		rw.WriteHeader(http.StatusOK)
+		rw.WriteHeader(http.StatusAccepted)
 	}
 }
 

--- a/pkg/storage/tpr/storage_interface_test.go
+++ b/pkg/storage/tpr/storage_interface_test.go
@@ -844,6 +844,9 @@ func TestDeleteWithNoNamespace(t *testing.T) {
 		outBroker,
 		nil, // TODO: Current impl ignores preconditions-- may be wrong
 	)
+	if err != nil {
+		t.Fatalf("unexpected error deleting object (%s)", err)
+	}
 	// Object should be removed from underlying storage
 	obj := fakeCl.Storage.Get(globalNamespace, ServiceBrokerKind.URLName(), name)
 	if obj != nil {
@@ -877,6 +880,9 @@ func TestDeleteWithNamespace(t *testing.T) {
 		outInstance,
 		nil, // TODO: Current impl ignores preconditions-- may be wrong
 	)
+	if err != nil {
+		t.Fatalf("unexpected error deleting object (%s)", err)
+	}
 	// Object should be removed from underlying storage
 	obj := fakeCl.Storage.Get(namespace, ServiceInstanceKind.URLName(), name)
 	if obj != nil {


### PR DESCRIPTION
This PR adds missing assertion to the unit tests for tpr-backed storage and then fixes an issue with the fake core apiserver client that those new assertions exposed.

I'd like to get this merged today.