### PR TITLE
re-enable integration tests for tpr-backed storage

### DIFF
--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -70,8 +70,7 @@ const (
 
 var storageTypes = []server.StorageType{
 	server.StorageTypeEtcd,
-	// disabling TPR - this will be fixed in https://github.com/kubernetes-incubator/service-catalog/pull/612
-	//server.StorageTypeTPR,
+	server.StorageTypeTPR,
 }
 
 // Used for testing binding parameters
@@ -218,14 +217,6 @@ func testBrokerClient(sType server.StorageType, client servicecatalogclient.Inte
 			"Didn't get the same instance from list and get: diff: %v",
 			diff.ObjectReflectDiff(brokerServer, brokerListed),
 		)
-	}
-
-	// TODO: Here be dragons. Tests fail beyond this point due to known issues
-	// with our TPR-based storage implementation. Bail early (until those issues)
-	// are fixed, because some tests are better than no tests. If storage isn't
-	// TPR-based, carry on.
-	if sType == server.StorageTypeTPR {
-		return nil
 	}
 
 	authSecret := &v1.ObjectReference{
@@ -399,14 +390,6 @@ func testServiceClassClient(sType server.StorageType, client servicecatalogclien
 		)
 	}
 
-	// TODO: Here be dragons. Tests fail beyond this point due to known issues
-	// with our TPR-based storage implementation. Bail early (until those issues)
-	// are fixed, because some tests are better than no tests. If storage isn't
-	// TPR-based, carry on.
-	if sType == server.StorageTypeTPR {
-		return nil
-	}
-
 	serviceClassAtServer.Bindable = false
 	_, err = serviceClassClient.Update(serviceClassAtServer)
 	if err != nil {
@@ -522,14 +505,6 @@ func testInstanceClient(sType server.StorageType, client servicecatalogclient.In
 	instanceListed := &instances.Items[0]
 	if !reflect.DeepEqual(instanceListed, instanceServer) {
 		return fmt.Errorf("Didn't get the same instance from list and get: diff: %v", diff.ObjectReflectDiff(instanceListed, instanceServer))
-	}
-
-	// TODO: Here be dragons. Tests fail beyond this point due to known issues
-	// with our TPR-based storage implementation. Bail early (until those issues)
-	// are fixed, because some tests are better than no tests. If storage isn't
-	// TPR-based, carry on.
-	if sType == server.StorageTypeTPR {
-		return nil
 	}
 
 	// check the parameters of the fetched-by-name instance with what was expected
@@ -689,14 +664,6 @@ func testBindingClient(sType server.StorageType, client servicecatalogclient.Int
 			"Didn't get the same binding from list and get: diff: %v",
 			diff.ObjectReflectDiff(bindingListed, bindingServer),
 		)
-	}
-
-	// TODO: Here be dragons. Tests fail beyond this point due to known issues
-	// with our TPR-based storage implementation. Bail early (until those issues)
-	// are fixed, because some tests are better than no tests. If storage isn't
-	// TPR-based, carry on.
-	if sType == server.StorageTypeTPR {
-		return nil
 	}
 
 	parameters := bpStruct{}


### PR DESCRIPTION
Historically, the integration tests for tpr-backed storage have been partially disabled due to numerous bugs that we had a lot of difficulty tracking down. Then the big rebase on k8s 1.6 came along and @jpeeler had to disable the remainder of those tests to accomplish that rebase in a timely fashion. (fwiw, that had my blessing because we knew tpr-backed storage was full of bugs anyway and having a small subset of tests run and leave us with a false sense of confidence in the implementation didn't see a worthy reason to delay the rebase.)

Fast forward to now. @arschles and I have painstakingly chipped away at tpr-backed storage bugs in what has been a truly agonizing process. :wink: These integration tests should _all_ work now. 🎉 

@pmorie I know we have intentions of tpr-backed storage being tested in e2e, but integration tests and e2e tests are not the same thing. Re-enabling all these tests gives us more coverage and confidence sooner.

I would very much like for this to make it into 0.0.6.