### PR TITLE
fix conditions for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,4 @@ deploy:
   script: scripts/deploy.sh
   on:
     repo: kubernetes-incubator/service-catalog
-    branches:
-      only:
-      - master
-      # this is for tags. see https://github.com/travis-ci/travis-ci/issues/3897#issuecomment-101623421
-      - /v\d+\.\d+.\d+[a-z]*/ # something like v1.2.1 or v1.2.1abc
+    all_branches: true

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,10 +22,12 @@ export REGISTRY=quay.io/kubernetes-service-catalog/
 
 docker login -e="${QUAY_EMAIL}" -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
 
-if [[ -n "${TRAVIS_TAG}" ]]; then
+if [[ "${TRAVIS_TAG}" =~ ^v[0-9]\.[0-9]\.[0-9][a-z]*$ ]]; then
     echo "Pushing images with tag ${TRAVIS_TAG}."
     VERSION="${TRAVIS_TAG}" make push
-elif [[ "${TRAVIS_PULL_REQUEST}" == "false" && "${TRAVIS_BRANCH}" == "master" ]]; then
+elif [[ "${TRAVIS_BRANCH}" == "master" ]]; then
     echo "Pushing images with sha tag."
     make push
+else
+    echo "Nothing to deploy"
 fi


### PR DESCRIPTION
I spent a few hours scouring Travis documentation and experimenting with a sandbox project. It turns out `branches` (_plural_) is not a valid constraint for conditional deployment. (It's valid just for conditional _build_ as it turns out.) Because of this, `branch` (singular) defaults to `master`, effectively making `master` the only branch from which a deployment can occur. The problem with this is that Travis considers git tags to be branches. So if tagging with semver `v1.0.0`, for example, Travis considers the branch to be `v1.0.0` (not `master`) and a deploy will not occur at the end of the corresponding build. This is a problem because it means we can always deploy sha/canary images from the head of master upon merge, but can never release.

This PR fixes all of the above by allowing "deployment" for _all branches_, but _only_ branches of `kubernetes-incubator/service-catalog` (i.e. _not_ branches of forks). I quote "deployment" in the previous sentence because this PR also updates the `deploy.sh` script with additional intelligence about the conditions that prescribe a semver/latest deployment vs the conditions that prescribe a sha/canary deployment vs those that prescribe no deployment at all (branch is neither `master` _nor_ a semver tag).

Note the `deploy.sh` script does not concern itself with whether the current build is for a PR or not, because Travis automatically skips deployment for all PR builds anyway.

This _must_ be in for v0.6.0 unless we want to do extra, manual work to facilitate that release.