### PR TITLE
clean generated client code and cached packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,7 @@ clean-bin:
 	rm -f .generate_exes
 
 clean-build-image:
+	rm -rf .pkg
 	rm -f .scBuildImage
 	docker rmi -f scbuildimage > /dev/null 2>&1 || true
 

--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,7 @@ clean-generated:
 	rm -f .generate_files
 	find $(TOP_SRC_DIRS) -name zz_generated* -exec rm {} \;
 	rm -rf pkg/client/*_generated
+	rm -f pkg/openapi/openapi_generated.go
 
 clean-coverage:
 	rm -f $(COVERAGE)

--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,7 @@ clean-build-image:
 clean-generated:
 	rm -f .generate_files
 	find $(TOP_SRC_DIRS) -name zz_generated* -exec rm {} \;
+	rm -rf pkg/client/*_generated
 
 clean-coverage:
 	rm -f $(COVERAGE)


### PR DESCRIPTION
 - clean the generated clientset, listeners & informers

in addition to the conversions deepcopies and defaults.