### PR TITLE
Kubectl plugin for service catalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,8 @@ NON_VENDOR_DIRS = $(shell $(DOCKER_CMD) glide nv)
 #########################################################################
 build: .init .generate_files \
 	$(BINDIR)/service-catalog \
-	$(BINDIR)/user-broker
+	$(BINDIR)/user-broker \
+	   plugins
 
 user-broker: $(BINDIR)/user-broker
 $(BINDIR)/user-broker: .init contrib/cmd/user-broker \
@@ -291,6 +292,7 @@ clean: clean-bin clean-build-image clean-generated clean-coverage
 clean-bin:
 	$(DOCKER_CMD) rm -rf $(BINDIR)
 	rm -f .generate_exes
+	rm -f $(PLUGINS)
 
 clean-build-image:
 	$(DOCKER_CMD) rm -rf .pkg
@@ -386,3 +388,39 @@ release-push-%:
 	$(MAKE) clean-bin
 	$(MAKE) ARCH=$* build
 	$(MAKE) ARCH=$* push
+
+
+# kubectl plugin stuff
+######################
+PLUGIN_EXES=bind-service create-service-broker create-service-instance
+
+plugins: $(BINDIR)/bind-service/bind-service \
+			$(BINDIR)/create-service-broker/create-service-broker \
+			$(BINDIR)/create-service-instance/create-service-instance
+
+$(BINDIR)/bind-service/bind-service: \
+		plugin/cmd/kubectl/bind-service/bind-service.go \
+		plugin/cmd/kubectl/bind-service/plugin.yaml
+	rm -rf $(BINDIR)/bind-service
+	mkdir $(BINDIR)/bind-service
+	$(DOCKER_CMD) go build -o $@ $<
+	cp plugin/cmd/kubectl/bind-service/*yaml $(BINDIR)/bind-service/
+
+$(BINDIR)/create-service-broker/create-service-broker: \
+		plugin/cmd/kubectl/create-service-broker/create-service-broker.go \
+		plugin/cmd/kubectl/create-service-broker/plugin.yaml
+	rm -rf $(BINDIR)/create-service-broker
+	mkdir $(BINDIR)/create-service-broker
+	$(DOCKER_CMD) go build -o $@ $<
+	cp plugin/cmd/kubectl/create-service-broker/*yaml \
+		$(BINDIR)/create-service-broker/
+
+$(BINDIR)/create-service-instance/create-service-instance: \
+		plugin/cmd/kubectl/create-service-instance/create-service-instance.go \
+		plugin/cmd/kubectl/create-service-instance/plugin.yaml
+	rm -rf $(BINDIR)/create-service-instance
+	mkdir $(BINDIR)/create-service-instance
+	$(DOCKER_CMD) go build -o $@ $<
+	cp plugin/cmd/kubectl/create-service-instance/*yaml \
+		$(BINDIR)/create-service-instance/
+

--- a/Makefile
+++ b/Makefile
@@ -393,15 +393,16 @@ release-push-%:
 ######################
 PLUGIN_EXES=bind-service create-service-broker create-service-instance
 
-plugins: $(BINDIR)/bind-service/bind-service \
-			$(BINDIR)/create-service-broker/create-service-broker \
-			$(BINDIR)/create-service-instance/create-service-instance
+plugins: .init .generate_files \
+		$(BINDIR)/bind-service/bind-service \
+		$(BINDIR)/create-service-broker/create-service-broker \
+		$(BINDIR)/create-service-instance/create-service-instance
 
 $(BINDIR)/bind-service/bind-service: \
 		plugin/cmd/kubectl/bind-service/bind-service.go \
 		plugin/cmd/kubectl/bind-service/plugin.yaml
 	rm -rf $(BINDIR)/bind-service
-	$(DOCKER_CMD) go build -o $@ $<
+	$(DOCKER_CMD) $(GO_BUILD) -o $@ $<
 	$(DOCKER_CMD) cp plugin/cmd/kubectl/bind-service/*yaml \
 		$(BINDIR)/bind-service/
 
@@ -409,7 +410,7 @@ $(BINDIR)/create-service-broker/create-service-broker: \
 		plugin/cmd/kubectl/create-service-broker/create-service-broker.go \
 		plugin/cmd/kubectl/create-service-broker/plugin.yaml
 	rm -rf $(BINDIR)/create-service-broker
-	$(DOCKER_CMD) go build -o $@ $<
+	$(DOCKER_CMD) $(GO_BUILD) -o $@ $<
 	$(DOCKER_CMD) cp plugin/cmd/kubectl/create-service-broker/*yaml \
 		$(BINDIR)/create-service-broker/
 
@@ -417,7 +418,7 @@ $(BINDIR)/create-service-instance/create-service-instance: \
 		plugin/cmd/kubectl/create-service-instance/create-service-instance.go \
 		plugin/cmd/kubectl/create-service-instance/plugin.yaml
 	rm -rf $(BINDIR)/create-service-instance
-	$(DOCKER_CMD) go build -o $@ $<
+	$(DOCKER_CMD) $(GO_BUILD) -o $@ $<
 	$(DOCKER_CMD) cp plugin/cmd/kubectl/create-service-instance/*yaml \
 		$(BINDIR)/create-service-instance/
 

--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,6 @@ clean: clean-bin clean-build-image clean-generated clean-coverage
 clean-bin:
 	$(DOCKER_CMD) rm -rf $(BINDIR)
 	rm -f .generate_exes
-	rm -f $(PLUGINS)
 
 clean-build-image:
 	$(DOCKER_CMD) rm -rf .pkg
@@ -402,25 +401,23 @@ $(BINDIR)/bind-service/bind-service: \
 		plugin/cmd/kubectl/bind-service/bind-service.go \
 		plugin/cmd/kubectl/bind-service/plugin.yaml
 	rm -rf $(BINDIR)/bind-service
-	mkdir $(BINDIR)/bind-service
 	$(DOCKER_CMD) go build -o $@ $<
-	cp plugin/cmd/kubectl/bind-service/*yaml $(BINDIR)/bind-service/
+	$(DOCKER_CMD) cp plugin/cmd/kubectl/bind-service/*yaml \
+		$(BINDIR)/bind-service/
 
 $(BINDIR)/create-service-broker/create-service-broker: \
 		plugin/cmd/kubectl/create-service-broker/create-service-broker.go \
 		plugin/cmd/kubectl/create-service-broker/plugin.yaml
 	rm -rf $(BINDIR)/create-service-broker
-	mkdir $(BINDIR)/create-service-broker
 	$(DOCKER_CMD) go build -o $@ $<
-	cp plugin/cmd/kubectl/create-service-broker/*yaml \
+	$(DOCKER_CMD) cp plugin/cmd/kubectl/create-service-broker/*yaml \
 		$(BINDIR)/create-service-broker/
 
 $(BINDIR)/create-service-instance/create-service-instance: \
 		plugin/cmd/kubectl/create-service-instance/create-service-instance.go \
 		plugin/cmd/kubectl/create-service-instance/plugin.yaml
 	rm -rf $(BINDIR)/create-service-instance
-	mkdir $(BINDIR)/create-service-instance
 	$(DOCKER_CMD) go build -o $@ $<
-	cp plugin/cmd/kubectl/create-service-instance/*yaml \
+	$(DOCKER_CMD) cp plugin/cmd/kubectl/create-service-instance/*yaml \
 		$(BINDIR)/create-service-instance/
 

--- a/plugin/cmd/kubectl/bind-service/bind-service.go
+++ b/plugin/cmd/kubectl/bind-service/bind-service.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	v1alpha1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	clientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
+	"github.com/kubernetes-incubator/service-catalog/plugin/cmd/kubectl/utils"
+
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
+)
+
+const USAGE = `Usage:
+  kubectl plugin bind-service INSTANCE_NAME BINDING_NAME NAMESPACE`
+
+func main() {
+	svcURL := utils.SCUrlEnv()
+	if svcURL == "" {
+		svcURL = "192.168.99.100:30080"
+	}
+
+	if len(os.Args) != 4 {
+		utils.Exit1(USAGE)
+	}
+
+	binding := v1alpha1.Binding{}
+	binding.Kind = "binding"
+	binding.Name = os.Args[2]
+	binding.Namespace = os.Args[3]
+	binding.Spec.InstanceRef = v1.LocalObjectReference{
+		Name: os.Args[1],
+	}
+	binding.Spec.SecretName = os.Args[2]
+
+	fmt.Printf("Looking up Namespace %s...\n", utils.Entity(binding.Name))
+	if err := utils.CheckNamespaceExists(binding.Namespace); err != nil {
+		utils.Exit1(err.Error())
+	}
+	utils.Ok()
+
+	restConfig := rest.Config{
+		Host:    svcURL,
+		APIPath: "/apis/servicecatalog.k8s.io/v1alpha1",
+	}
+
+	svcClient, err := clientset.NewForConfig(&restConfig)
+	if err != nil {
+		utils.Exit1(fmt.Sprintf("Error initializing client for service catalog (%s)", err))
+	}
+
+	fmt.Printf("Creating binding %s to %s in Namespace %s...\n", utils.Entity(binding.Name), utils.Entity(binding.Spec.InstanceRef.Name), utils.Entity(binding.Namespace))
+	resp, err := svcClient.Bindings(binding.Namespace).Create(&binding)
+	if err != nil {
+		utils.Exit1(fmt.Sprintf("Error binding service instance (%s)", err))
+	}
+	utils.Ok()
+
+	table := utils.NewTable("BINDING NAME", "NAMESPACE", "INSTANCE NAME", "SECRET NAME")
+	table.AddRow(resp.Name, resp.Namespace, resp.Spec.InstanceRef.Name, resp.Spec.SecretName)
+	err = table.Print()
+	if err != nil {
+		utils.Exit1(fmt.Sprintf("Error printing result (%s)", err))
+	}
+}

--- a/plugin/cmd/kubectl/bind-service/bind-service.go
+++ b/plugin/cmd/kubectl/bind-service/bind-service.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
@@ -12,7 +28,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const USAGE = `Usage:
+const usage = `Usage:
   kubectl plugin bind-service INSTANCE_NAME BINDING_NAME NAMESPACE`
 
 func main() {
@@ -22,7 +38,7 @@ func main() {
 	}
 
 	if len(os.Args) != 4 {
-		utils.Exit1(USAGE)
+		utils.Exit1(usage)
 	}
 
 	binding := v1alpha1.Binding{}
@@ -34,7 +50,7 @@ func main() {
 	}
 	binding.Spec.SecretName = os.Args[2]
 
-	fmt.Printf("Looking up Namespace %s...\n", utils.Entity(binding.Name))
+	fmt.Printf("Looking up Namespace %s...\n", utils.Entity(binding.Namespace))
 	if err := utils.CheckNamespaceExists(binding.Namespace); err != nil {
 		utils.Exit1(err.Error())
 	}

--- a/plugin/cmd/kubectl/bind-service/bind-service.go
+++ b/plugin/cmd/kubectl/bind-service/bind-service.go
@@ -41,11 +41,11 @@ func main() {
 		utils.Exit1(usage)
 	}
 
-	binding := v1alpha1.Binding{}
+	binding := v1alpha1.ServiceInstanceCredential{}
 	binding.Kind = "binding"
 	binding.Name = os.Args[2]
 	binding.Namespace = os.Args[3]
-	binding.Spec.InstanceRef = v1.LocalObjectReference{
+	binding.Spec.ServiceInstanceRef = v1.LocalObjectReference{
 		Name: os.Args[1],
 	}
 	binding.Spec.SecretName = os.Args[2]
@@ -66,15 +66,18 @@ func main() {
 		utils.Exit1(fmt.Sprintf("Error initializing client for service catalog (%s)", err))
 	}
 
-	fmt.Printf("Creating binding %s to %s in Namespace %s...\n", utils.Entity(binding.Name), utils.Entity(binding.Spec.InstanceRef.Name), utils.Entity(binding.Namespace))
-	resp, err := svcClient.Bindings(binding.Namespace).Create(&binding)
+	fmt.Printf("Creating binding %s to %s in Namespace %s...\n",
+		utils.Entity(binding.Name),
+		utils.Entity(binding.Spec.ServiceInstanceRef.Name),
+		utils.Entity(binding.Namespace))
+	resp, err := svcClient.ServiceInstanceCredentials(binding.Namespace).Create(&binding)
 	if err != nil {
 		utils.Exit1(fmt.Sprintf("Error binding service instance (%s)", err))
 	}
 	utils.Ok()
 
 	table := utils.NewTable("BINDING NAME", "NAMESPACE", "INSTANCE NAME", "SECRET NAME")
-	table.AddRow(resp.Name, resp.Namespace, resp.Spec.InstanceRef.Name, resp.Spec.SecretName)
+	table.AddRow(resp.Name, resp.Namespace, resp.Spec.ServiceInstanceRef.Name, resp.Spec.SecretName)
 	err = table.Print()
 	if err != nil {
 		utils.Exit1(fmt.Sprintf("Error printing result (%s)", err))

--- a/plugin/cmd/kubectl/bind-service/bind-service.go
+++ b/plugin/cmd/kubectl/bind-service/bind-service.go
@@ -33,9 +33,6 @@ const usage = `Usage:
 
 func main() {
 	svcURL := utils.SCUrlEnv()
-	if svcURL == "" {
-		svcURL = "192.168.99.100:30080"
-	}
 
 	if len(os.Args) != 4 {
 		utils.Exit1(usage)

--- a/plugin/cmd/kubectl/bind-service/plugin.yaml
+++ b/plugin/cmd/kubectl/bind-service/plugin.yaml
@@ -1,0 +1,3 @@
+name: "bind-service"
+shortDesc: "This command binds a service class to a service instance"
+command: "./bind-service"

--- a/plugin/cmd/kubectl/create-service-broker/create-service-broker.go
+++ b/plugin/cmd/kubectl/create-service-broker/create-service-broker.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
@@ -11,7 +27,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const USAGE = `Usage:
+const usage = `Usage:
   kubectl plugin create-service-broker BROKER_NAME BROKER_URL`
 
 func main() {
@@ -21,7 +37,7 @@ func main() {
 	}
 
 	if len(os.Args) != 3 {
-		utils.Exit1(USAGE)
+		utils.Exit1(usage)
 	}
 
 	broker := v1alpha1.Broker{}

--- a/plugin/cmd/kubectl/create-service-broker/create-service-broker.go
+++ b/plugin/cmd/kubectl/create-service-broker/create-service-broker.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	v1alpha1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	clientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
+	"github.com/kubernetes-incubator/service-catalog/plugin/cmd/kubectl/utils"
+
+	"k8s.io/client-go/rest"
+)
+
+const USAGE = `Usage:
+  kubectl plugin create-service-broker BROKER_NAME BROKER_URL`
+
+func main() {
+	svcURL := utils.SCUrlEnv()
+	if svcURL == "" {
+		svcURL = "192.168.99.100:30080"
+	}
+
+	if len(os.Args) != 3 {
+		utils.Exit1(USAGE)
+	}
+
+	broker := v1alpha1.Broker{}
+	broker.Kind = "Broker"
+	broker.Name = os.Args[1]
+	broker.Spec.URL = os.Args[2]
+
+	restConfig := rest.Config{
+		Host:    svcURL,
+		APIPath: "/apis/servicecatalog.k8s.io/v1alpha1",
+	}
+
+	svcClient, err := clientset.NewForConfig(&restConfig)
+	if err != nil {
+		utils.Exit1(fmt.Sprintf("Initializing client for service catalog (%s)", err))
+	}
+
+	fmt.Printf("Creating broker %s...\n", utils.Entity(broker.Name))
+	resp, err := svcClient.Brokers().Create(&broker)
+	if err != nil {
+		utils.Exit1(fmt.Sprintf("Creating broker resource (%s)", err))
+	}
+
+	utils.Ok()
+
+	table := utils.NewTable("BROKER NAME", "NAMESPACE", "URL")
+	table.AddRow(resp.Name, resp.Namespace, resp.Spec.URL)
+	err = table.Print()
+	if err != nil {
+		utils.Exit1(fmt.Sprintf("Error printing result (%s)", err))
+	}
+}

--- a/plugin/cmd/kubectl/create-service-broker/create-service-broker.go
+++ b/plugin/cmd/kubectl/create-service-broker/create-service-broker.go
@@ -40,7 +40,7 @@ func main() {
 		utils.Exit1(usage)
 	}
 
-	broker := v1alpha1.Broker{}
+	broker := v1alpha1.ServiceBroker{}
 	broker.Kind = "Broker"
 	broker.Name = os.Args[1]
 	broker.Spec.URL = os.Args[2]
@@ -56,7 +56,7 @@ func main() {
 	}
 
 	fmt.Printf("Creating broker %s...\n", utils.Entity(broker.Name))
-	resp, err := svcClient.Brokers().Create(&broker)
+	resp, err := svcClient.ServiceBrokers().Create(&broker)
 	if err != nil {
 		utils.Exit1(fmt.Sprintf("Creating broker resource (%s)", err))
 	}

--- a/plugin/cmd/kubectl/create-service-broker/create-service-broker.go
+++ b/plugin/cmd/kubectl/create-service-broker/create-service-broker.go
@@ -32,9 +32,6 @@ const usage = `Usage:
 
 func main() {
 	svcURL := utils.SCUrlEnv()
-	if svcURL == "" {
-		svcURL = "192.168.99.100:30080"
-	}
 
 	if len(os.Args) != 3 {
 		utils.Exit1(usage)

--- a/plugin/cmd/kubectl/create-service-broker/plugin.yaml
+++ b/plugin/cmd/kubectl/create-service-broker/plugin.yaml
@@ -1,0 +1,3 @@
+name: "create-service-broker"
+shortDesc: "This registers a service broker with the service catalog"
+command: "./create-service-broker"

--- a/plugin/cmd/kubectl/create-service-instance/create-service-instance.go
+++ b/plugin/cmd/kubectl/create-service-instance/create-service-instance.go
@@ -32,9 +32,6 @@ const usage = `Usage:
 
 func main() {
 	svcURL := utils.SCUrlEnv()
-	if svcURL == "" {
-		svcURL = "192.168.99.100:30080"
-	}
 
 	if len(os.Args) != 5 {
 		utils.Exit1(usage)

--- a/plugin/cmd/kubectl/create-service-instance/create-service-instance.go
+++ b/plugin/cmd/kubectl/create-service-instance/create-service-instance.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
@@ -11,7 +27,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const USAGE = `Usage:
+const usage = `Usage:
   kubectl plugin create-service-instance SERVICE_CLASS_NAME PLAN_NAME INSTANCE_NAME NAMESPACE`
 
 func main() {
@@ -21,7 +37,7 @@ func main() {
 	}
 
 	if len(os.Args) != 5 {
-		utils.Exit1(USAGE)
+		utils.Exit1(usage)
 	}
 
 	instance := v1alpha1.Instance{}
@@ -31,7 +47,7 @@ func main() {
 	instance.Spec.PlanName = os.Args[2]
 	instance.Spec.ServiceClassName = os.Args[1]
 
-	fmt.Printf("Looking up Namespace %s...\n", utils.Entity(instance.Name))
+	fmt.Printf("Looking up Namespace %s...\n", utils.Entity(instance.Namespace))
 	if err := utils.CheckNamespaceExists(instance.Namespace); err != nil {
 		utils.Exit1(err.Error())
 	}

--- a/plugin/cmd/kubectl/create-service-instance/create-service-instance.go
+++ b/plugin/cmd/kubectl/create-service-instance/create-service-instance.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	v1alpha1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	clientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
+	"github.com/kubernetes-incubator/service-catalog/plugin/cmd/kubectl/utils"
+
+	"k8s.io/client-go/rest"
+)
+
+const USAGE = `Usage:
+  kubectl plugin create-service-instance SERVICE_CLASS_NAME PLAN_NAME INSTANCE_NAME NAMESPACE`
+
+func main() {
+	svcURL := utils.SCUrlEnv()
+	if svcURL == "" {
+		svcURL = "192.168.99.100:30080"
+	}
+
+	if len(os.Args) != 5 {
+		utils.Exit1(USAGE)
+	}
+
+	instance := v1alpha1.Instance{}
+	instance.Kind = "Instance"
+	instance.Name = os.Args[3]
+	instance.Namespace = os.Args[4]
+	instance.Spec.PlanName = os.Args[2]
+	instance.Spec.ServiceClassName = os.Args[1]
+
+	fmt.Printf("Looking up Namespace %s...\n", utils.Entity(instance.Name))
+	if err := utils.CheckNamespaceExists(instance.Namespace); err != nil {
+		utils.Exit1(err.Error())
+	}
+	utils.Ok()
+
+	restConfig := rest.Config{
+		Host:    svcURL,
+		APIPath: "/apis/servicecatalog.k8s.io/v1alpha1",
+	}
+
+	svcClient, err := clientset.NewForConfig(&restConfig)
+	if err != nil {
+		utils.Exit1(fmt.Sprintf("Failed to initializing client for service catalog (%s)", err))
+	}
+
+	fmt.Printf("Creating service instance %s in Namespace %s...\n", utils.Entity(instance.Name), utils.Entity(instance.Namespace))
+	resp, err := svcClient.Instances(instance.Namespace).Create(&instance)
+	if err != nil {
+		utils.Exit1(fmt.Sprintf("Failed to creating service instance (%s)", err))
+	}
+	utils.Ok()
+
+	table := utils.NewTable("INSTANCE NAME", "NAMESPACE", "PLAN NAME", "SERVICE CLASS NAME")
+	table.AddRow(resp.Name, resp.Namespace, resp.Spec.PlanName, resp.Spec.ServiceClassName)
+	err = table.Print()
+	if err != nil {
+		utils.Exit1(fmt.Sprintf("Error printing result (%s)", err))
+	}
+}

--- a/plugin/cmd/kubectl/create-service-instance/create-service-instance.go
+++ b/plugin/cmd/kubectl/create-service-instance/create-service-instance.go
@@ -40,7 +40,7 @@ func main() {
 		utils.Exit1(usage)
 	}
 
-	instance := v1alpha1.Instance{}
+	instance := v1alpha1.ServiceInstance{}
 	instance.Kind = "Instance"
 	instance.Name = os.Args[3]
 	instance.Namespace = os.Args[4]
@@ -64,7 +64,7 @@ func main() {
 	}
 
 	fmt.Printf("Creating service instance %s in Namespace %s...\n", utils.Entity(instance.Name), utils.Entity(instance.Namespace))
-	resp, err := svcClient.Instances(instance.Namespace).Create(&instance)
+	resp, err := svcClient.ServiceInstances(instance.Namespace).Create(&instance)
 	if err != nil {
 		utils.Exit1(fmt.Sprintf("Failed to creating service instance (%s)", err))
 	}

--- a/plugin/cmd/kubectl/create-service-instance/plugin.yaml
+++ b/plugin/cmd/kubectl/create-service-instance/plugin.yaml
@@ -1,0 +1,3 @@
+name: "create-service-instance"
+shortDesc: "This command creates a service instance that is ready to be bound to"
+command: "./create-service-instance"

--- a/plugin/cmd/kubectl/utils/table_printer.go
+++ b/plugin/cmd/kubectl/utils/table_printer.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils
 
 import (
@@ -6,6 +22,7 @@ import (
 	"text/tabwriter"
 )
 
+// Table defines a tabular output - obviously in table format
 type Table struct {
 	headers []string
 	rows    [][]string
@@ -18,10 +35,12 @@ func NewTable(headers ...string) *Table {
 	}
 }
 
+// AddRow will append the specified row to the table
 func (t *Table) AddRow(row ...string) {
 	t.rows = append(t.rows, row)
 }
 
+// Print prints the table to the screen
 func (t *Table) Print() error {
 	padding := 3
 

--- a/plugin/cmd/kubectl/utils/table_printer.go
+++ b/plugin/cmd/kubectl/utils/table_printer.go
@@ -6,22 +6,23 @@ import (
 	"text/tabwriter"
 )
 
-type table struct {
+type Table struct {
 	headers []string
 	rows    [][]string
 }
 
-func NewTable(headers ...string) *table {
-	return &table{
+// NewTable creates a new table based on the passed in header names
+func NewTable(headers ...string) *Table {
+	return &Table{
 		headers: headers,
 	}
 }
 
-func (t *table) AddRow(row ...string) {
+func (t *Table) AddRow(row ...string) {
 	t.rows = append(t.rows, row)
 }
 
-func (t *table) Print() error {
+func (t *Table) Print() error {
 	padding := 3
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, padding, ' ', 0)

--- a/plugin/cmd/kubectl/utils/table_printer.go
+++ b/plugin/cmd/kubectl/utils/table_printer.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+)
+
+type table struct {
+	headers []string
+	rows    [][]string
+}
+
+func NewTable(headers ...string) *table {
+	return &table{
+		headers: headers,
+	}
+}
+
+func (t *table) AddRow(row ...string) {
+	t.rows = append(t.rows, row)
+}
+
+func (t *table) Print() error {
+	padding := 3
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, padding, ' ', 0)
+
+	//Print header
+	printStr := ""
+	for _, h := range t.headers {
+		printStr = printStr + h + "\t"
+	}
+	fmt.Fprintln(w, printStr)
+
+	//Print rows
+	printStr = ""
+	for _, rows := range t.rows {
+		for _, row := range rows {
+			printStr = printStr + row + "\t"
+		}
+		fmt.Fprintln(w, printStr)
+	}
+	fmt.Fprintln(w)
+
+	return w.Flush()
+}

--- a/plugin/cmd/kubectl/utils/ui.go
+++ b/plugin/cmd/kubectl/utils/ui.go
@@ -1,0 +1,22 @@
+package utils
+
+import "fmt"
+
+func Green(str string) string {
+	return fmt.Sprintf("\x1b[32;1m%s\x1b[0m", str)
+}
+
+func Red(str string) string {
+	return fmt.Sprintf("\x1b[31;1m%s\x1b[0m", str)
+}
+
+func Entity(str string) string {
+	return fmt.Sprintf("\x1b[36;1m%s\x1b[0m", str)
+}
+
+func Error(msg string) {
+	fmt.Printf("%s\n\n%s\n\n", Red("ERROR"), msg)
+}
+func Ok() {
+	fmt.Printf("%s\n\n", Green("OK"))
+}

--- a/plugin/cmd/kubectl/utils/ui.go
+++ b/plugin/cmd/kubectl/utils/ui.go
@@ -1,22 +1,44 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils
 
 import "fmt"
 
+// Green will print the specified string in green text
 func Green(str string) string {
 	return fmt.Sprintf("\x1b[32;1m%s\x1b[0m", str)
 }
 
+// Red will print the specified string in red text
 func Red(str string) string {
 	return fmt.Sprintf("\x1b[31;1m%s\x1b[0m", str)
 }
 
+// Entity will print the specified string in bold text
 func Entity(str string) string {
 	return fmt.Sprintf("\x1b[36;1m%s\x1b[0m", str)
 }
 
+// Error will print the specified error string in red text
 func Error(msg string) {
 	fmt.Printf("%s\n\n%s\n\n", Red("ERROR"), msg)
 }
+
+// Ok will print "OK" in green
 func Ok() {
 	fmt.Printf("%s\n\n", Green("OK"))
 }

--- a/plugin/cmd/kubectl/utils/utils.go
+++ b/plugin/cmd/kubectl/utils/utils.go
@@ -1,0 +1,72 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+)
+
+type namespace struct {
+	Metadata metadata `json:"metadata"`
+	Code     int      `json:"code"`
+}
+
+type metadata struct {
+	Name string `json:"name"`
+}
+
+func CheckNamespaceExists(name string) error {
+	proxyURL := "http://127.0.0.1"
+	proxyPort := "8881"
+
+	kubeProxy := exec.Command("kubectl", "proxy", "-p", proxyPort)
+	defer func() {
+		if err := kubeProxy.Process.Kill(); err != nil {
+			Exit1(fmt.Sprintf("failed to kill kubectl proxy (%s)", err))
+		}
+	}()
+
+	err := kubeProxy.Start()
+	if err != nil {
+		return fmt.Errorf("Cannot start kubectl proxy (%s)", err)
+	}
+
+	resp, err := http.Get(fmt.Sprintf("%s:%s/api/v1/namespaces/%s", proxyURL, proxyPort, name))
+	if err != nil {
+		fmt.Errorf("Error looking up namespace from core api server (%s)", err)
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("Error retrieving core api server response body during namespace lookup (%s)", err)
+	}
+
+	ns := namespace{}
+	err = json.Unmarshal(body, &ns)
+	if err != nil {
+		return fmt.Errorf("Error parsing core api server response body during namespace lookup (%s)", err)
+	}
+
+	if ns.Code == 404 || ns.Metadata.Name == "" {
+		return fmt.Errorf("Namespace not found")
+	}
+
+	return nil
+}
+
+func SCUrlEnv() string {
+	url := os.Getenv("SERVICE_CATALOG_URL")
+	if url == "" {
+		return ""
+	}
+	return url
+}
+
+func Exit1(errStr string) {
+	Error(errStr)
+	os.Exit(1)
+}

--- a/plugin/cmd/kubectl/utils/utils.go
+++ b/plugin/cmd/kubectl/utils/utils.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils
 
 import (
@@ -18,6 +34,8 @@ type metadata struct {
 	Name string `json:"name"`
 }
 
+// CheckNamespaceExists will query our kube apiserver to see if the
+// specified namespace exists - if not it returns an error
 func CheckNamespaceExists(name string) error {
 	proxyURL := "http://127.0.0.1"
 	proxyPort := "8881"
@@ -36,10 +54,14 @@ func CheckNamespaceExists(name string) error {
 
 	resp, err := http.Get(fmt.Sprintf("%s:%s/api/v1/namespaces/%s", proxyURL, proxyPort, name))
 	if err != nil {
-		fmt.Errorf("Error looking up namespace from core api server (%s)", err)
+		return fmt.Errorf("Error looking up namespace from core api server (%s)", err)
 	}
 
-	defer resp.Body.Close()
+	defer func() {
+		if resp.Body != nil {
+			resp.Body.Close()
+		}
+	}()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("Error retrieving core api server response body during namespace lookup (%s)", err)
@@ -58,6 +80,7 @@ func CheckNamespaceExists(name string) error {
 	return nil
 }
 
+// SCUrlEnv will return the value of the SERVICE_CATALOG_URL env var
 func SCUrlEnv() string {
 	url := os.Getenv("SERVICE_CATALOG_URL")
 	if url == "" {
@@ -66,6 +89,8 @@ func SCUrlEnv() string {
 	return url
 }
 
+// Exit1 will print the specified error string to the screen and
+// then stop the program, with an exit code of 1
 func Exit1(errStr string) {
 	Error(errStr)
 	os.Exit(1)


### PR DESCRIPTION
Plugin commands `create-service-broker`, `create-service`, `bind-service`
To use, compile the commands, and set the env var KUBECTL_PLUGINS_PATH and SERVICE_CATALOG_URL
```
Example:
export KUBECTL_PLUGINS_PATH=$PWD/kubernetes-incubator/service-catalog/bin
export SERVICE_CATALOG_URL={SERVICE_CATALOG_URL}
```
** if SERVICE_CATALOG_URL is not set, it defaults to minikube IP `192.168.99.100:30080`

USAGE:
```
  kubectl plugin create-service-broker BROKER_NAME BROKER_URL

  kubectl plugin create-service-instance SERVICE_CLASS_NAME PLAN_NAME NAMESPACE INSTANCE_NAME

  kubectl plugin bind-service INSTANCE_NAME BINDING_NAME NAMESPACE
  *secret name defaults to the BINDING_NAME
```
Currently I do not intent to include unit tests for these plugins, since the kubectl plugin architecture might still be changing. However, integration test make sense and is coming soon.

Current kubectl plugin limitation:
- Plugins must be invoked with the `plugin` command
- No custom command flags allowed, kubectl global flags are allowed.

