### PR TITLE
take out osb prefixes through rote transformation of variable names and annotations

### DIFF
--- a/pkg/apis/servicecatalog/testing/fuzzer.go
+++ b/pkg/apis/servicecatalog/testing/fuzzer.go
@@ -219,7 +219,7 @@ func FuzzerFor(t *testing.T, version schema.GroupVersion, src rand.Source) *fuzz
 				t.Errorf("Failed to create metadata object: %v", err)
 				return
 			}
-			sc.OSBMetadata = metadata
+			sc.ExternalMetadata = metadata
 		},
 		func(sp *servicecatalog.ServicePlan, c fuzz.Continue) {
 			c.FuzzNoCustom(sp)
@@ -228,7 +228,7 @@ func FuzzerFor(t *testing.T, version schema.GroupVersion, src rand.Source) *fuzz
 				t.Errorf("Failed to create metadata object: %v", err)
 				return
 			}
-			sp.OSBMetadata = metadata
+			sp.ExternalMetadata = metadata
 		},
 	)
 	return f

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -135,12 +135,11 @@ type ServiceClass struct {
 	ExternalID string
 
 	// OSB-specific
-	OSBTags     []string
-	OSBRequires []string
-
+	Tags     []string
+	Requires []string
 	// Description is a short description of the service.
-	Description string
-	OSBMetadata *runtime.RawExtension
+	Description      string
+	ExternalMetadata *runtime.RawExtension
 }
 
 // ServicePlan represents a tier of a ServiceClass.
@@ -156,10 +155,10 @@ type ServicePlan struct {
 	// Instance using this plan.  If set, overrides the value of the
 	// ServiceClass.Bindable field.
 	Bindable *bool
-	OSBFree  bool
+	Free     bool
 	// Description is a short description of the plan.
-	Description string
-	OSBMetadata *runtime.RawExtension
+	Description      string
+	ExternalMetadata *runtime.RawExtension
 }
 
 // InstanceList is a list of instances.

--- a/pkg/apis/servicecatalog/v1alpha1/types.generated.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.generated.go
@@ -2038,8 +2038,8 @@ func (x *ServiceClass) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2[0] = x.Kind != ""
 			yyq2[1] = x.APIVersion != ""
 			yyq2[2] = true
-			yyq2[8] = len(x.OSBTags) != 0
-			yyq2[9] = len(x.OSBRequires) != 0
+			yyq2[8] = len(x.Tags) != 0
+			yyq2[9] = len(x.Requires) != 0
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(12)
@@ -2238,14 +2238,14 @@ func (x *ServiceClass) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[8] {
-					if x.OSBTags == nil {
+					if x.Tags == nil {
 						r.EncodeNil()
 					} else {
 						yym30 := z.EncBinary()
 						_ = yym30
 						if false {
 						} else {
-							z.F.EncSliceStringV(x.OSBTags, false, e)
+							z.F.EncSliceStringV(x.Tags, false, e)
 						}
 					}
 				} else {
@@ -2254,16 +2254,16 @@ func (x *ServiceClass) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2[8] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("osbTags"))
+					r.EncodeString(codecSelferC_UTF81234, string("tags"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.OSBTags == nil {
+					if x.Tags == nil {
 						r.EncodeNil()
 					} else {
 						yym31 := z.EncBinary()
 						_ = yym31
 						if false {
 						} else {
-							z.F.EncSliceStringV(x.OSBTags, false, e)
+							z.F.EncSliceStringV(x.Tags, false, e)
 						}
 					}
 				}
@@ -2271,14 +2271,14 @@ func (x *ServiceClass) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[9] {
-					if x.OSBRequires == nil {
+					if x.Requires == nil {
 						r.EncodeNil()
 					} else {
 						yym33 := z.EncBinary()
 						_ = yym33
 						if false {
 						} else {
-							z.F.EncSliceStringV(x.OSBRequires, false, e)
+							z.F.EncSliceStringV(x.Requires, false, e)
 						}
 					}
 				} else {
@@ -2287,16 +2287,16 @@ func (x *ServiceClass) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2[9] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("osbRequires"))
+					r.EncodeString(codecSelferC_UTF81234, string("requires"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.OSBRequires == nil {
+					if x.Requires == nil {
 						r.EncodeNil()
 					} else {
 						yym34 := z.EncBinary()
 						_ = yym34
 						if false {
 						} else {
-							z.F.EncSliceStringV(x.OSBRequires, false, e)
+							z.F.EncSliceStringV(x.Requires, false, e)
 						}
 					}
 				}
@@ -2322,34 +2322,34 @@ func (x *ServiceClass) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if x.OSBMetadata == nil {
+				if x.ExternalMetadata == nil {
 					r.EncodeNil()
 				} else {
 					yym39 := z.EncBinary()
 					_ = yym39
 					if false {
-					} else if z.HasExtensions() && z.EncExt(x.OSBMetadata) {
+					} else if z.HasExtensions() && z.EncExt(x.ExternalMetadata) {
 					} else if !yym39 && z.IsJSONHandle() {
-						z.EncJSONMarshal(x.OSBMetadata)
+						z.EncJSONMarshal(x.ExternalMetadata)
 					} else {
-						z.EncFallback(x.OSBMetadata)
+						z.EncFallback(x.ExternalMetadata)
 					}
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("osbMetadata"))
+				r.EncodeString(codecSelferC_UTF81234, string("externalMetadata"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				if x.OSBMetadata == nil {
+				if x.ExternalMetadata == nil {
 					r.EncodeNil()
 				} else {
 					yym40 := z.EncBinary()
 					_ = yym40
 					if false {
-					} else if z.HasExtensions() && z.EncExt(x.OSBMetadata) {
+					} else if z.HasExtensions() && z.EncExt(x.ExternalMetadata) {
 					} else if !yym40 && z.IsJSONHandle() {
-						z.EncJSONMarshal(x.OSBMetadata)
+						z.EncJSONMarshal(x.ExternalMetadata)
 					} else {
-						z.EncFallback(x.OSBMetadata)
+						z.EncFallback(x.ExternalMetadata)
 					}
 				}
 			}
@@ -2511,11 +2511,11 @@ func (x *ServiceClass) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					*((*string)(yyv18)) = r.DecodeString()
 				}
 			}
-		case "osbTags":
+		case "tags":
 			if r.TryDecodeAsNil() {
-				x.OSBTags = nil
+				x.Tags = nil
 			} else {
-				yyv20 := &x.OSBTags
+				yyv20 := &x.Tags
 				yym21 := z.DecBinary()
 				_ = yym21
 				if false {
@@ -2523,11 +2523,11 @@ func (x *ServiceClass) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					z.F.DecSliceStringX(yyv20, false, d)
 				}
 			}
-		case "osbRequires":
+		case "requires":
 			if r.TryDecodeAsNil() {
-				x.OSBRequires = nil
+				x.Requires = nil
 			} else {
-				yyv22 := &x.OSBRequires
+				yyv22 := &x.Requires
 				yym23 := z.DecBinary()
 				_ = yym23
 				if false {
@@ -2547,23 +2547,23 @@ func (x *ServiceClass) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					*((*string)(yyv24)) = r.DecodeString()
 				}
 			}
-		case "osbMetadata":
+		case "externalMetadata":
 			if r.TryDecodeAsNil() {
-				if x.OSBMetadata != nil {
-					x.OSBMetadata = nil
+				if x.ExternalMetadata != nil {
+					x.ExternalMetadata = nil
 				}
 			} else {
-				if x.OSBMetadata == nil {
-					x.OSBMetadata = new(pkg4_runtime.RawExtension)
+				if x.ExternalMetadata == nil {
+					x.ExternalMetadata = new(pkg4_runtime.RawExtension)
 				}
 				yym27 := z.DecBinary()
 				_ = yym27
 				if false {
-				} else if z.HasExtensions() && z.DecExt(x.OSBMetadata) {
+				} else if z.HasExtensions() && z.DecExt(x.ExternalMetadata) {
 				} else if !yym27 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(x.OSBMetadata)
+					z.DecJSONUnmarshal(x.ExternalMetadata)
 				} else {
-					z.DecFallback(x.OSBMetadata, false)
+					z.DecFallback(x.ExternalMetadata, false)
 				}
 			}
 		default:
@@ -2769,9 +2769,9 @@ func (x *ServiceClass) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.OSBTags = nil
+		x.Tags = nil
 	} else {
-		yyv45 := &x.OSBTags
+		yyv45 := &x.Tags
 		yym46 := z.DecBinary()
 		_ = yym46
 		if false {
@@ -2791,9 +2791,9 @@ func (x *ServiceClass) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.OSBRequires = nil
+		x.Requires = nil
 	} else {
-		yyv47 := &x.OSBRequires
+		yyv47 := &x.Requires
 		yym48 := z.DecBinary()
 		_ = yym48
 		if false {
@@ -2835,21 +2835,21 @@ func (x *ServiceClass) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		if x.OSBMetadata != nil {
-			x.OSBMetadata = nil
+		if x.ExternalMetadata != nil {
+			x.ExternalMetadata = nil
 		}
 	} else {
-		if x.OSBMetadata == nil {
-			x.OSBMetadata = new(pkg4_runtime.RawExtension)
+		if x.ExternalMetadata == nil {
+			x.ExternalMetadata = new(pkg4_runtime.RawExtension)
 		}
 		yym52 := z.DecBinary()
 		_ = yym52
 		if false {
-		} else if z.HasExtensions() && z.DecExt(x.OSBMetadata) {
+		} else if z.HasExtensions() && z.DecExt(x.ExternalMetadata) {
 		} else if !yym52 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(x.OSBMetadata)
+			z.DecJSONUnmarshal(x.ExternalMetadata)
 		} else {
-			z.DecFallback(x.OSBMetadata, false)
+			z.DecFallback(x.ExternalMetadata, false)
 		}
 	}
 	for {
@@ -2997,49 +2997,49 @@ func (x *ServicePlan) CodecEncodeSelf(e *codec1978.Encoder) {
 				_ = yym18
 				if false {
 				} else {
-					r.EncodeBool(bool(x.OSBFree))
+					r.EncodeBool(bool(x.Free))
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("osbFree"))
+				r.EncodeString(codecSelferC_UTF81234, string("free"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
 				yym19 := z.EncBinary()
 				_ = yym19
 				if false {
 				} else {
-					r.EncodeBool(bool(x.OSBFree))
+					r.EncodeBool(bool(x.Free))
 				}
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if x.OSBMetadata == nil {
+				if x.ExternalMetadata == nil {
 					r.EncodeNil()
 				} else {
 					yym21 := z.EncBinary()
 					_ = yym21
 					if false {
-					} else if z.HasExtensions() && z.EncExt(x.OSBMetadata) {
+					} else if z.HasExtensions() && z.EncExt(x.ExternalMetadata) {
 					} else if !yym21 && z.IsJSONHandle() {
-						z.EncJSONMarshal(x.OSBMetadata)
+						z.EncJSONMarshal(x.ExternalMetadata)
 					} else {
-						z.EncFallback(x.OSBMetadata)
+						z.EncFallback(x.ExternalMetadata)
 					}
 				}
 			} else {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("osbMetadata"))
+				r.EncodeString(codecSelferC_UTF81234, string("externalMetadata"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				if x.OSBMetadata == nil {
+				if x.ExternalMetadata == nil {
 					r.EncodeNil()
 				} else {
 					yym22 := z.EncBinary()
 					_ = yym22
 					if false {
-					} else if z.HasExtensions() && z.EncExt(x.OSBMetadata) {
+					} else if z.HasExtensions() && z.EncExt(x.ExternalMetadata) {
 					} else if !yym22 && z.IsJSONHandle() {
-						z.EncJSONMarshal(x.OSBMetadata)
+						z.EncJSONMarshal(x.ExternalMetadata)
 					} else {
-						z.EncFallback(x.OSBMetadata)
+						z.EncFallback(x.ExternalMetadata)
 					}
 				}
 			}
@@ -3156,11 +3156,11 @@ func (x *ServicePlan) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					*((*bool)(x.Bindable)) = r.DecodeBool()
 				}
 			}
-		case "osbFree":
+		case "free":
 			if r.TryDecodeAsNil() {
-				x.OSBFree = false
+				x.Free = false
 			} else {
-				yyv12 := &x.OSBFree
+				yyv12 := &x.Free
 				yym13 := z.DecBinary()
 				_ = yym13
 				if false {
@@ -3168,23 +3168,23 @@ func (x *ServicePlan) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					*((*bool)(yyv12)) = r.DecodeBool()
 				}
 			}
-		case "osbMetadata":
+		case "externalMetadata":
 			if r.TryDecodeAsNil() {
-				if x.OSBMetadata != nil {
-					x.OSBMetadata = nil
+				if x.ExternalMetadata != nil {
+					x.ExternalMetadata = nil
 				}
 			} else {
-				if x.OSBMetadata == nil {
-					x.OSBMetadata = new(pkg4_runtime.RawExtension)
+				if x.ExternalMetadata == nil {
+					x.ExternalMetadata = new(pkg4_runtime.RawExtension)
 				}
 				yym15 := z.DecBinary()
 				_ = yym15
 				if false {
-				} else if z.HasExtensions() && z.DecExt(x.OSBMetadata) {
+				} else if z.HasExtensions() && z.DecExt(x.ExternalMetadata) {
 				} else if !yym15 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(x.OSBMetadata)
+					z.DecJSONUnmarshal(x.ExternalMetadata)
 				} else {
-					z.DecFallback(x.OSBMetadata, false)
+					z.DecFallback(x.ExternalMetadata, false)
 				}
 			}
 		default:
@@ -3305,9 +3305,9 @@ func (x *ServicePlan) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.OSBFree = false
+		x.Free = false
 	} else {
-		yyv25 := &x.OSBFree
+		yyv25 := &x.Free
 		yym26 := z.DecBinary()
 		_ = yym26
 		if false {
@@ -3327,21 +3327,21 @@ func (x *ServicePlan) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		if x.OSBMetadata != nil {
-			x.OSBMetadata = nil
+		if x.ExternalMetadata != nil {
+			x.ExternalMetadata = nil
 		}
 	} else {
-		if x.OSBMetadata == nil {
-			x.OSBMetadata = new(pkg4_runtime.RawExtension)
+		if x.ExternalMetadata == nil {
+			x.ExternalMetadata = new(pkg4_runtime.RawExtension)
 		}
 		yym28 := z.DecBinary()
 		_ = yym28
 		if false {
-		} else if z.HasExtensions() && z.DecExt(x.OSBMetadata) {
+		} else if z.HasExtensions() && z.DecExt(x.ExternalMetadata) {
 		} else if !yym28 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(x.OSBMetadata)
+			z.DecJSONUnmarshal(x.ExternalMetadata)
 		} else {
-			z.DecFallback(x.OSBMetadata, false)
+			z.DecFallback(x.ExternalMetadata, false)
 		}
 	}
 	for {

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -133,14 +133,13 @@ type ServiceClass struct {
 	ExternalID string `json:"externalID"`
 
 	// OSB-specific
-	OSBTags     []string `json:"osbTags,omitempty"`
-	OSBRequires []string `json:"osbRequires,omitempty"`
-
+	Tags     []string `json:"tags,omitempty"`
+	Requires []string `json:"requires,omitempty"`
 	// Description is a short description of the service.
 	Description string `json:"description"`
 
-	// Metadata fields
-	OSBMetadata *runtime.RawExtension `json:"osbMetadata, omitempty"`
+	// ExternalMetadata fields
+	ExternalMetadata *runtime.RawExtension `json:"externalMetadata, omitempty"`
 }
 
 // ServicePlan represents a tier of a ServiceClass.
@@ -158,9 +157,9 @@ type ServicePlan struct {
 	// Bindable indicates whether this users can create bindings to an
 	// Instance using this plan.  If set, overrides the value of the
 	// ServiceClass.Bindable field.
-	Bindable    *bool                 `json:"bindable,omitempty"`
-	OSBFree     bool                  `json:"osbFree"`
-	OSBMetadata *runtime.RawExtension `json:"osbMetadata, omitempty"`
+	Bindable         *bool                 `json:"bindable,omitempty"`
+	Free             bool                  `json:"free"`
+	ExternalMetadata *runtime.RawExtension `json:"externalMetadata, omitempty"`
 }
 
 // InstanceList is a list of instances

--- a/pkg/apis/servicecatalog/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1alpha1/zz_generated.conversion.go
@@ -452,10 +452,10 @@ func autoConvert_v1alpha1_ServiceClass_To_servicecatalog_ServiceClass(in *Servic
 	}
 	out.PlanUpdatable = in.PlanUpdatable
 	out.ExternalID = in.ExternalID
-	out.OSBTags = *(*[]string)(unsafe.Pointer(&in.OSBTags))
-	out.OSBRequires = *(*[]string)(unsafe.Pointer(&in.OSBRequires))
+	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
+	out.Requires = *(*[]string)(unsafe.Pointer(&in.Requires))
 	out.Description = in.Description
-	out.OSBMetadata = (*runtime.RawExtension)(unsafe.Pointer(in.OSBMetadata))
+	out.ExternalMetadata = (*runtime.RawExtension)(unsafe.Pointer(in.ExternalMetadata))
 	return nil
 }
 
@@ -480,10 +480,10 @@ func autoConvert_servicecatalog_ServiceClass_To_v1alpha1_ServiceClass(in *servic
 	}
 	out.PlanUpdatable = in.PlanUpdatable
 	out.ExternalID = in.ExternalID
-	out.OSBTags = *(*[]string)(unsafe.Pointer(&in.OSBTags))
-	out.OSBRequires = *(*[]string)(unsafe.Pointer(&in.OSBRequires))
+	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
+	out.Requires = *(*[]string)(unsafe.Pointer(&in.Requires))
 	out.Description = in.Description
-	out.OSBMetadata = (*runtime.RawExtension)(unsafe.Pointer(in.OSBMetadata))
+	out.ExternalMetadata = (*runtime.RawExtension)(unsafe.Pointer(in.ExternalMetadata))
 	return nil
 }
 
@@ -536,8 +536,8 @@ func autoConvert_v1alpha1_ServicePlan_To_servicecatalog_ServicePlan(in *ServiceP
 	out.Description = in.Description
 	out.ExternalID = in.ExternalID
 	out.Bindable = (*bool)(unsafe.Pointer(in.Bindable))
-	out.OSBFree = in.OSBFree
-	out.OSBMetadata = (*runtime.RawExtension)(unsafe.Pointer(in.OSBMetadata))
+	out.Free = in.Free
+	out.ExternalMetadata = (*runtime.RawExtension)(unsafe.Pointer(in.ExternalMetadata))
 	return nil
 }
 
@@ -549,9 +549,9 @@ func autoConvert_servicecatalog_ServicePlan_To_v1alpha1_ServicePlan(in *servicec
 	out.Name = in.Name
 	out.ExternalID = in.ExternalID
 	out.Bindable = (*bool)(unsafe.Pointer(in.Bindable))
-	out.OSBFree = in.OSBFree
+	out.Free = in.Free
 	out.Description = in.Description
-	out.OSBMetadata = (*runtime.RawExtension)(unsafe.Pointer(in.OSBMetadata))
+	out.ExternalMetadata = (*runtime.RawExtension)(unsafe.Pointer(in.ExternalMetadata))
 	return nil
 }
 

--- a/pkg/apis/servicecatalog/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/v1alpha1/zz_generated.deepcopy.go
@@ -342,18 +342,18 @@ func DeepCopy_v1alpha1_ServiceClass(in interface{}, out interface{}, c *conversi
 				}
 			}
 		}
-		if in.OSBTags != nil {
-			in, out := &in.OSBTags, &out.OSBTags
+		if in.Tags != nil {
+			in, out := &in.Tags, &out.Tags
 			*out = make([]string, len(*in))
 			copy(*out, *in)
 		}
-		if in.OSBRequires != nil {
-			in, out := &in.OSBRequires, &out.OSBRequires
+		if in.Requires != nil {
+			in, out := &in.Requires, &out.Requires
 			*out = make([]string, len(*in))
 			copy(*out, *in)
 		}
-		if in.OSBMetadata != nil {
-			in, out := &in.OSBMetadata, &out.OSBMetadata
+		if in.ExternalMetadata != nil {
+			in, out := &in.ExternalMetadata, &out.ExternalMetadata
 			if newVal, err := c.DeepCopy(*in); err != nil {
 				return err
 			} else {
@@ -392,8 +392,8 @@ func DeepCopy_v1alpha1_ServicePlan(in interface{}, out interface{}, c *conversio
 			*out = new(bool)
 			**out = **in
 		}
-		if in.OSBMetadata != nil {
-			in, out := &in.OSBMetadata, &out.OSBMetadata
+		if in.ExternalMetadata != nil {
+			in, out := &in.ExternalMetadata, &out.ExternalMetadata
 			if newVal, err := c.DeepCopy(*in); err != nil {
 				return err
 			} else {

--- a/pkg/apis/servicecatalog/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/zz_generated.deepcopy.go
@@ -342,18 +342,18 @@ func DeepCopy_servicecatalog_ServiceClass(in interface{}, out interface{}, c *co
 				}
 			}
 		}
-		if in.OSBTags != nil {
-			in, out := &in.OSBTags, &out.OSBTags
+		if in.Tags != nil {
+			in, out := &in.Tags, &out.Tags
 			*out = make([]string, len(*in))
 			copy(*out, *in)
 		}
-		if in.OSBRequires != nil {
-			in, out := &in.OSBRequires, &out.OSBRequires
+		if in.Requires != nil {
+			in, out := &in.Requires, &out.Requires
 			*out = make([]string, len(*in))
 			copy(*out, *in)
 		}
-		if in.OSBMetadata != nil {
-			in, out := &in.OSBMetadata, &out.OSBMetadata
+		if in.ExternalMetadata != nil {
+			in, out := &in.ExternalMetadata, &out.ExternalMetadata
 			if newVal, err := c.DeepCopy(*in); err != nil {
 				return err
 			} else {
@@ -392,8 +392,8 @@ func DeepCopy_servicecatalog_ServicePlan(in interface{}, out interface{}, c *con
 			*out = new(bool)
 			**out = **in
 		}
-		if in.OSBMetadata != nil {
-			in, out := &in.OSBMetadata, &out.OSBMetadata
+		if in.ExternalMetadata != nil {
+			in, out := &in.ExternalMetadata, &out.ExternalMetadata
 			if newVal, err := c.DeepCopy(*in); err != nil {
 				return err
 			} else {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -511,8 +511,8 @@ func (c *controller) reconcileServiceClassFromBrokerCatalog(broker *v1alpha1.Bro
 	toUpdate.Bindable = serviceClass.Bindable
 	toUpdate.Plans = serviceClass.Plans
 	toUpdate.PlanUpdatable = serviceClass.PlanUpdatable
-	toUpdate.OSBTags = serviceClass.OSBTags
-	toUpdate.OSBRequires = serviceClass.OSBRequires
+	toUpdate.Tags = serviceClass.Tags
+	toUpdate.Requires = serviceClass.Requires
 	toUpdate.Description = serviceClass.Description
 
 	if _, err := c.serviceCatalogClient.ServiceClasses().Update(toUpdate); err != nil {
@@ -1705,8 +1705,8 @@ func convertCatalog(in *brokerapi.Catalog) ([]*v1alpha1.ServiceClass, error) {
 			Plans:         plans,
 			PlanUpdatable: svc.PlanUpdateable,
 			ExternalID:    svc.ID,
-			OSBTags:       svc.Tags,
-			OSBRequires:   svc.Requires,
+			Tags:          svc.Tags,
+			Requires:      svc.Requires,
 			Description:   svc.Description,
 		}
 
@@ -1717,7 +1717,7 @@ func convertCatalog(in *brokerapi.Catalog) ([]*v1alpha1.ServiceClass, error) {
 				glog.Error(err)
 				return nil, err
 			}
-			ret[i].OSBMetadata = &runtime.RawExtension{Raw: metadata}
+			ret[i].ExternalMetadata = &runtime.RawExtension{Raw: metadata}
 		}
 
 		ret[i].SetName(svc.Name)
@@ -1731,7 +1731,7 @@ func convertServicePlans(plans []brokerapi.ServicePlan) ([]v1alpha1.ServicePlan,
 		ret[i] = v1alpha1.ServicePlan{
 			Name:        plans[i].Name,
 			ExternalID:  plans[i].ID,
-			OSBFree:     plans[i].Free,
+			Free:        plans[i].Free,
 			Description: plans[i].Description,
 		}
 		if plans[i].Bindable != nil {
@@ -1746,7 +1746,7 @@ func convertServicePlans(plans []brokerapi.ServicePlan) ([]v1alpha1.ServicePlan,
 				glog.Error(err)
 				return nil, err
 			}
-			ret[i].OSBMetadata = &runtime.RawExtension{Raw: metadata}
+			ret[i].ExternalMetadata = &runtime.RawExtension{Raw: metadata}
 		}
 
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -222,12 +222,12 @@ func getTestServiceClass() *v1alpha1.ServiceClass {
 		Plans: []v1alpha1.ServicePlan{
 			{
 				Name:       testPlanName,
-				OSBFree:    true,
+				Free:       true,
 				ExternalID: planGUID,
 			},
 			{
 				Name:       testNonbindablePlanName,
-				OSBFree:    true,
+				Free:       true,
 				ExternalID: nonbindablePlanGUID,
 				Bindable:   falsePtr(),
 			},
@@ -245,13 +245,13 @@ func getTestNonbindableServiceClass() *v1alpha1.ServiceClass {
 		Plans: []v1alpha1.ServicePlan{
 			{
 				Name:       testPlanName,
-				OSBFree:    true,
+				Free:       true,
 				ExternalID: planGUID,
 				Bindable:   truePtr(),
 			},
 			{
 				Name:       testNonbindablePlanName,
-				OSBFree:    true,
+				Free:       true,
 				ExternalID: nonbindablePlanGUID,
 			},
 		},
@@ -2582,9 +2582,9 @@ func TestCatalogConversionMultipleServiceClasses(t *testing.T) {
 			if sc.Description != "service 1 description" {
 				t.Fatalf("Expected service1's description to be \"service 1 description\", but was: %s", sc.Description)
 			}
-			if sc.OSBMetadata != nil && len(sc.OSBMetadata.Raw) > 0 {
+			if sc.ExternalMetadata != nil && len(sc.ExternalMetadata.Raw) > 0 {
 				m := make(map[string]string)
-				if err := json.Unmarshal(sc.OSBMetadata.Raw, &m); err == nil {
+				if err := json.Unmarshal(sc.ExternalMetadata.Raw, &m); err == nil {
 					if m["field1"] == "value1" {
 						foundSvcMeta1 = true
 					}
@@ -2596,10 +2596,10 @@ func TestCatalogConversionMultipleServiceClasses(t *testing.T) {
 			}
 			for _, sp := range sc.Plans {
 				if sp.Name == "s1plan2" {
-					if sp.OSBMetadata != nil && len(sp.OSBMetadata.Raw) > 0 {
+					if sp.ExternalMetadata != nil && len(sp.ExternalMetadata.Raw) > 0 {
 						m := make(map[string]string)
-						if err := json.Unmarshal(sp.OSBMetadata.Raw, &m); err != nil {
-							t.Fatalf("Failed to unmarshal plan metadata: %s: %v", string(sp.OSBMetadata.Raw), err)
+						if err := json.Unmarshal(sp.ExternalMetadata.Raw, &m); err != nil {
+							t.Fatalf("Failed to unmarshal plan metadata: %s: %v", string(sp.ExternalMetadata.Raw), err)
 						}
 						if m["planmeta"] == "planvalue" {
 							foundPlanMeta = true
@@ -2614,10 +2614,10 @@ func TestCatalogConversionMultipleServiceClasses(t *testing.T) {
 			if sc.Description != "service 2 description" {
 				t.Fatalf("Expected service2's description to be \"service 2 description\", but was: %s", sc.Description)
 			}
-			if sc.OSBMetadata != nil && len(sc.OSBMetadata.Raw) > 0 {
+			if sc.ExternalMetadata != nil && len(sc.ExternalMetadata.Raw) > 0 {
 				m := make([]string, 0)
-				if err := json.Unmarshal(sc.OSBMetadata.Raw, &m); err != nil {
-					t.Fatalf("Failed to unmarshal service metadata: %s: %v", string(sc.OSBMetadata.Raw), err)
+				if err := json.Unmarshal(sc.ExternalMetadata.Raw, &m); err != nil {
+					t.Fatalf("Failed to unmarshal service metadata: %s: %v", string(sc.ExternalMetadata.Raw), err)
 				}
 				if len(m) != 3 {
 					t.Fatalf("Expected 3 fields in metadata, but got %d", len(m))

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -691,7 +691,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 								Format:      "",
 							},
 						},
-						"osbTags": {
+						"tags": {
 							SchemaProps: spec.SchemaProps{
 								Description: "OSB-specific",
 								Type:        []string{"array"},
@@ -705,7 +705,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 								},
 							},
 						},
-						"osbRequires": {
+						"requires": {
 							SchemaProps: spec.SchemaProps{
 								Type: []string{"array"},
 								Items: &spec.SchemaOrArray{
@@ -725,9 +725,9 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 								Format:      "",
 							},
 						},
-						"osbMetadata": {
+						"externalMetadata": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Metadata fields",
+								Description: "ExternalMetadata fields",
 								Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 							},
 						},
@@ -814,19 +814,19 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 								Format:      "",
 							},
 						},
-						"osbFree": {
+						"free": {
 							SchemaProps: spec.SchemaProps{
 								Type:   []string{"boolean"},
 								Format: "",
 							},
 						},
-						"osbMetadata": {
+						"externalMetadata": {
 							SchemaProps: spec.SchemaProps{
 								Ref: ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 							},
 						},
 					},
-					Required: []string{"name", "description", "externalID", "osbFree"},
+					Required: []string{"name", "description", "externalID", "free"},
 				},
 			},
 			Dependencies: []string{


### PR DESCRIPTION
check v1alpha1/types.go for the names and annotation changes

want to make sure the this gets tested in ci stuff

 pkg/apis/servicecatalog/v1alpha1/types.go is what you should look at. everythign else is based on that or generated code. specifically confirm the annotations changes.

Closes #834 
