### PR TITLE
Make it so that binding.spec.secretName defaults to binding name

### DIFF
--- a/contrib/examples/walkthrough/ups-binding.yaml
+++ b/contrib/examples/walkthrough/ups-binding.yaml
@@ -6,4 +6,3 @@ metadata:
 spec:
   instanceRef:
     name: ups-instance
-  secretName: my-secret

--- a/contrib/examples/walkthrough/ups-instance.yaml
+++ b/contrib/examples/walkthrough/ups-instance.yaml
@@ -6,3 +6,7 @@ metadata:
 spec:
   serviceClassName: user-provided-service
   planName: default
+  parameters:
+    credentials:
+      name: root
+      password: letmein

--- a/contrib/hack/test_walkthrough.sh
+++ b/contrib/hack/test_walkthrough.sh
@@ -76,7 +76,7 @@ function cleanup() {
     helm delete --purge "${BROKER_RELEASE}" || true
     helm delete --purge "${CATALOG_RELEASE}" || true
     rm -f "${SC_KUBECONFIG}"
-    kubectl delete secret -n test-ns my-secret || true
+    kubectl delete secret -n test-ns ups-binding || true
     kubectl delete namespace test-ns || true
 
     wait_for_expected_output -x -e 'test-ns' -n 10 \
@@ -279,8 +279,8 @@ wait_for_expected_output -e 'InjectedBindResult' -n 10 \
     error_exit 'Failure status reported when attempting to inject ups-binding.'
   }
 
-[[ "$(KUBECONFIG="${K8S_KUBECONFIG}" kubectl get secrets -n test-ns)" == *my-secret* ]] \
-  || error_exit '"my-secret" not present when listing secrets.'
+[[ "$(KUBECONFIG="${K8S_KUBECONFIG}" kubectl get secrets -n test-ns)" == *ups-binding* ]] \
+  || error_exit '"ups-binding" not present when listing secrets.'
 
 
 # TODO: Cannot currently test TPR deletion; only delete if using an etcd-backed
@@ -294,9 +294,9 @@ if [[ -z "${WITH_TPR:-}" ]]; then
     || error_exit 'Error when deleting ups-binding.'
 
   export KUBECONFIG="${K8S_KUBECONFIG}"
-  wait_for_expected_output -x -e "my-secret" -n 10 \
+  wait_for_expected_output -x -e "ups-binding" -n 10 \
       kubectl get secrets -n test-ns \
-    || error_exit '"my-secret" not removed upon deleting ups-binding.'
+    || error_exit '"ups-binding" not removed upon deleting ups-binding.'
   export KUBECONFIG="${SC_KUBECONFIG}"
 
   # Deprovision the instance

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -404,7 +404,7 @@ spec:
   instanceRef:
     name: ups-instance
   externalID: b041db94-a5a0-41a2-87ae-1025ba760918
-  secretName: my-secret
+  secretName: ups-binding
 status:
   conditions:
   - message: Injected bind result
@@ -421,10 +421,10 @@ see a new one:
 kubectl get secrets -n test-ns
 NAME                  TYPE                                  DATA      AGE
 default-token-3k61z   kubernetes.io/service-account-token   3         29m
-my-secret             Opaque                                2         1m
+ups-binding           Opaque                                2         1m
 ```
 
-Notice that a new `Secret` named `my-secret` has been created.
+Notice that a new `Secret` named `ups-binding` has been created.
 
 ## Step 10 - Unbinding from the Instance
 
@@ -436,7 +436,7 @@ kubectl --context=service-catalog delete -n test-ns bindings ups-binding
 ```
 
 Checking the `Secret`s in the `test-ns` namespace, we should see that
-`my-secret` has also been deleted:
+`ups-binding` has also been deleted:
 
 ```console
 kubectl get secrets -n test-ns

--- a/pkg/apis/servicecatalog/testing/fuzzer.go
+++ b/pkg/apis/servicecatalog/testing/fuzzer.go
@@ -205,6 +205,13 @@ func FuzzerFor(t *testing.T, version schema.GroupVersion, src rand.Source) *fuzz
 		func(bs *servicecatalog.BindingSpec, c fuzz.Continue) {
 			c.FuzzNoCustom(bs)
 			bs.ExternalID = uuid.NewV4().String()
+			// Don't allow the SecretName to be an empty string because
+			// the defaulter for this object (on the server) will set it to
+			// a non-empty string, which means the round-trip checking will
+			// fail since the checker will look for an empty string.
+			for bs.SecretName == "" {
+				bs.SecretName = c.RandString()
+			}
 			parameters, err := createParameter(c)
 			if err != nil {
 				t.Errorf("Failed to create parameter object: %v", err)

--- a/pkg/apis/servicecatalog/v1alpha1/defaults.go
+++ b/pkg/apis/servicecatalog/v1alpha1/defaults.go
@@ -26,6 +26,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return scheme.AddDefaultingFuncs(
 		SetDefaults_InstanceSpec,
 		SetDefaults_BindingSpec,
+		SetDefaults_Binding,
 	)
 }
 
@@ -38,5 +39,12 @@ func SetDefaults_InstanceSpec(spec *InstanceSpec) {
 func SetDefaults_BindingSpec(spec *BindingSpec) {
 	if spec.ExternalID == "" {
 		spec.ExternalID = uuid.NewV4().String()
+	}
+}
+
+func SetDefaults_Binding(binding *Binding) {
+	// If not specified, make the SecretName default to the binding name
+	if binding.Spec.SecretName == "" {
+		binding.Spec.SecretName = binding.Name
 	}
 }

--- a/pkg/apis/servicecatalog/v1alpha1/types.generated.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.generated.go
@@ -6540,12 +6540,13 @@ func (x *BindingSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
 			yyq2[1] = x.Parameters != nil
+			yyq2[2] = x.SecretName != ""
 			yyq2[4] = x.AlphaPodPresetTemplate != nil
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(5)
 			} else {
-				yynn2 = 3
+				yynn2 = 2
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
@@ -6606,21 +6607,27 @@ func (x *BindingSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym12 := z.EncBinary()
-				_ = yym12
-				if false {
+				if yyq2[2] {
+					yym12 := z.EncBinary()
+					_ = yym12
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.SecretName))
+					}
 				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.SecretName))
+					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("secretName"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym13 := z.EncBinary()
-				_ = yym13
-				if false {
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, string(x.SecretName))
+				if yyq2[2] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("secretName"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					yym13 := z.EncBinary()
+					_ = yym13
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.SecretName))
+					}
 				}
 			}
 			if yyr2 || yy2arr2 {

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -364,7 +364,7 @@ type BindingSpec struct {
 
 	// SecretName is the name of the secret to create in the Binding's
 	// namespace that will hold the credentials associated with the Binding.
-	SecretName string `json:"secretName"`
+	SecretName string `json:"secretName,omitempty"`
 
 	// ExternalID is the identity of this object for use with the OSB API.
 	//

--- a/pkg/apis/servicecatalog/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/servicecatalog/v1alpha1/zz_generated.defaults.go
@@ -36,6 +36,7 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 }
 
 func SetObjectDefaults_Binding(in *Binding) {
+	SetDefaults_Binding(in)
 	SetDefaults_BindingSpec(&in.Spec)
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -221,7 +221,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 					},
-					Required: []string{"instanceRef", "secretName", "externalID"},
+					Required: []string{"instanceRef", "externalID"},
 				},
 			},
 			Dependencies: []string{

--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -627,7 +627,6 @@ func testBindingClient(sType server.StorageType, client servicecatalogclient.Int
 				Name: "bar",
 			},
 			Parameters: &runtime.RawExtension{Raw: []byte(bindingParameter)},
-			SecretName: "secret-name",
 			ExternalID: "UUID-string",
 		},
 	}
@@ -652,6 +651,13 @@ func testBindingClient(sType server.StorageType, client servicecatalogclient.Int
 			"didn't get the same binding back from the server \n%+v\n%+v",
 			binding,
 			bindingServer,
+		)
+	}
+	if bindingServer.Spec.SecretName != "test-binding" {
+		return fmt.Errorf(
+			"didn't get the right secret name back from the server \n%+v\n%+v",
+			"test-binding",
+			bindingServer.Spec.SecretName,
 		)
 	}
 

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -195,7 +195,6 @@ func TestBasicFlows(t *testing.T) {
 			InstanceRef: v1.LocalObjectReference{
 				Name: testInstanceName,
 			},
-			SecretName: testSecretName,
 		},
 	}
 


### PR DESCRIPTION
modified walkthru too so that the instance has some credentials otherwise
the instance isn't very useful.

Closes: #850 
Closes #849

Signed-off-by: Doug Davis <dug@us.ibm.com>