### PR TITLE
add colorization to e2e tests in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,13 +121,15 @@ node {
             --create-artifacts
       """
 
-      // Run the e2e test framework
-      sh """${env.ROOT}/contrib/jenkins/run_e2e.sh \
-            --registry gcr.io/${test_project}/catalog/ \
-	    --version ${version} \
-	    --cleanup \
-	    --create-artifacts
-      """
+      ansiColor('xterm-darker-gray') {
+        // Run the e2e test framework
+        sh """${env.ROOT}/contrib/jenkins/run_e2e.sh \
+              --registry gcr.io/${test_project}/catalog/ \
+              --version ${version} \
+              --cleanup \
+              --create-artifacts
+        """
+      }
 
       echo 'Run succeeded.'
     } catch (Exception e) {


### PR DESCRIPTION
Fixes the colorization in Jenkins' console output.

Closes: #844 