### PR TITLE
Add functions on Makefile for build and tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,26 +292,24 @@ clean-coverage:
 images: user-broker-image \
     controller-manager-image apiserver-image
 
+define build-and-tag # (service, image, mutable_image, prefix)
+	$(eval build_path := "$(4)build/$(1)")
+	$(eval tmp_build_path := "$(build_path)/tmp")
+	mkdir -p $(tmp_build_path)
+	cp $(BINDIR)/$(1) $(tmp_build_path)
+	docker build -t $(2) $(build_path)
+	docker tag $(2) $(3)
+	rm -rf $(tmp_build_path)
+endef
+
 user-broker-image: contrib/build/user-broker/Dockerfile $(BINDIR)/user-broker
-	mkdir -p contrib/build/user-broker/tmp
-	cp $(BINDIR)/user-broker contrib/build/user-broker/tmp
-	docker build -t $(USER_BROKER_IMAGE) contrib/build/user-broker
-	docker tag $(USER_BROKER_IMAGE) $(USER_BROKER_MUTABLE_IMAGE)
-	rm -rf contrib/build/user-broker/tmp
+	$(call build-and-tag,"user-broker",$(USER_BROKER_IMAGE),$(USER_BROKER_MUTABLE_IMAGE),"contrib/")
 
 apiserver-image: build/apiserver/Dockerfile $(BINDIR)/apiserver
-	mkdir -p build/apiserver/tmp
-	cp $(BINDIR)/apiserver build/apiserver/tmp
-	docker build -t $(APISERVER_IMAGE) build/apiserver
-	docker tag $(APISERVER_IMAGE) $(APISERVER_MUTABLE_IMAGE)
-	rm -rf build/apiserver/tmp
+	$(call build-and-tag,"apiserver",$(APISERVER_IMAGE),$(APISERVER_MUTABLE_IMAGE))
 
 controller-manager-image: build/controller-manager/Dockerfile $(BINDIR)/controller-manager
-	mkdir -p build/controller-manager/tmp
-	cp $(BINDIR)/controller-manager build/controller-manager/tmp
-	docker build -t $(CONTROLLER_MANAGER_IMAGE) build/controller-manager
-	docker tag $(CONTROLLER_MANAGER_IMAGE) $(CONTROLLER_MANAGER_MUTABLE_IMAGE)
-	rm -rf build/controller-manager/tmp
+	$(call build-and-tag,"controller-manager",$(CONTROLLER_MANAGER_IMAGE),$(CONTROLLER_MANAGER_MUTABLE_IMAGE))
 
 # Push our Docker Images to a registry
 ######################################


### PR DESCRIPTION
*Before reviewing this PR I want to let you know that I am not pretty sure it's a good solution because it seems that is adding complexity. Probably a copy/paste in this case would be better.*

*I just did it because [it was discussed here](https://github.com/kubernetes-incubator/service-catalog/pull/525#issuecomment-286012282) and I thought it could be interesting to see.*

---

Instead copy/pasting the steps needed for building and tagging a Docker image
we are adding a function for doing it.

The function receives 4 parameters commented on the code:

- name of the service we are building
- image
- mutable image (at the moment, just a different Docker tag)
- prefix, mainly used for contrib/