### PR TITLE
Converting the AuthSecret field to a union AuthInfo type

### DIFF
--- a/contrib/examples/apiserver/broker.yaml
+++ b/contrib/examples/apiserver/broker.yaml
@@ -7,6 +7,7 @@ spec:
   # put the basic auth for the broker in a secret, and reference the secret here.
   # service-catalog will use the contents of the secret. The secret should have "username"
   # and "password" keys
-  authSecret:
-    namespace: some-namespace
-    name: secret-name
+  authInfo:
+    basicAuthSecret:
+      namespace: some-namespace
+      name: secret-name

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -49,7 +49,7 @@ type BrokerSpec struct {
 	URL string
 
 	// AuthInfo contains the data that the service catalog should use to authenticate
-	// with the Broker
+	// with the Broker.
 	AuthInfo *BrokerAuthInfo
 }
 

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -48,9 +48,21 @@ type BrokerSpec struct {
 	// URL is the address used to communicate with the Broker.
 	URL string
 
-	// AuthSecret is a reference to a Secret containing auth information the
-	// catalog should use to authenticate to this Broker.
-	AuthSecret *v1.ObjectReference
+	// AuthInfo contains the data that the service catalog should use to authenticate
+	// with the Broker
+	AuthInfo *BrokerAuthInfo
+}
+
+// BrokerAuthInfo is a union type that contains information on one of the authentication methods
+// the the service catalog and brokers may support, according to the OpenServiceBroker API
+// specification (https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md).
+//
+// Note that we currently restrict a single broker to have only one of these fields
+// set on it.
+type BrokerAuthInfo struct {
+	// BasicAuthSecret is a reference to a Secret containing auth information the
+	// catalog should use to authenticate to this Broker using basic auth.
+	BasicAuthSecret *v1.ObjectReference
 }
 
 // BrokerStatus represents the current status of a Broker.

--- a/pkg/apis/servicecatalog/v1alpha1/types.generated.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.generated.go
@@ -835,7 +835,7 @@ func (x *BrokerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [2]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[1] = x.AuthSecret != nil
+			yyq2[1] = x.AuthInfo != nil
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(2)
@@ -871,10 +871,10 @@ func (x *BrokerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[1] {
-					if x.AuthSecret == nil {
+					if x.AuthInfo == nil {
 						r.EncodeNil()
 					} else {
-						x.AuthSecret.CodecEncodeSelf(e)
+						x.AuthInfo.CodecEncodeSelf(e)
 					}
 				} else {
 					r.EncodeNil()
@@ -882,12 +882,12 @@ func (x *BrokerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2[1] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("authSecret"))
+					r.EncodeString(codecSelferC_UTF81234, string("authInfo"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.AuthSecret == nil {
+					if x.AuthInfo == nil {
 						r.EncodeNil()
 					} else {
-						x.AuthSecret.CodecEncodeSelf(e)
+						x.AuthInfo.CodecEncodeSelf(e)
 					}
 				}
 			}
@@ -964,16 +964,16 @@ func (x *BrokerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					*((*string)(yyv4)) = r.DecodeString()
 				}
 			}
-		case "authSecret":
+		case "authInfo":
 			if r.TryDecodeAsNil() {
-				if x.AuthSecret != nil {
-					x.AuthSecret = nil
+				if x.AuthInfo != nil {
+					x.AuthInfo = nil
 				}
 			} else {
-				if x.AuthSecret == nil {
-					x.AuthSecret = new(pkg3_v1.ObjectReference)
+				if x.AuthInfo == nil {
+					x.AuthInfo = new(BrokerAuthInfo)
 				}
-				x.AuthSecret.CodecDecodeSelf(d)
+				x.AuthInfo.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3)
@@ -1023,14 +1023,14 @@ func (x *BrokerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		if x.AuthSecret != nil {
-			x.AuthSecret = nil
+		if x.AuthInfo != nil {
+			x.AuthInfo = nil
 		}
 	} else {
-		if x.AuthSecret == nil {
-			x.AuthSecret = new(pkg3_v1.ObjectReference)
+		if x.AuthInfo == nil {
+			x.AuthInfo = new(BrokerAuthInfo)
 		}
-		x.AuthSecret.CodecDecodeSelf(d)
+		x.AuthInfo.CodecDecodeSelf(d)
 	}
 	for {
 		yyj7++
@@ -1044,6 +1044,183 @@ func (x *BrokerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 		z.DecStructFieldNotFound(yyj7-1, "")
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+}
+
+func (x *BrokerAuthInfo) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym1 := z.EncBinary()
+		_ = yym1
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep2 := !z.EncBinary()
+			yy2arr2 := z.EncBasicHandle().StructToArray
+			var yyq2 [1]bool
+			_, _, _ = yysep2, yyq2, yy2arr2
+			const yyr2 bool = false
+			yyq2[0] = x.BasicAuthSecret != nil
+			var yynn2 int
+			if yyr2 || yy2arr2 {
+				r.EncodeArrayStart(1)
+			} else {
+				yynn2 = 0
+				for _, b := range yyq2 {
+					if b {
+						yynn2++
+					}
+				}
+				r.EncodeMapStart(yynn2)
+				yynn2 = 0
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[0] {
+					if x.BasicAuthSecret == nil {
+						r.EncodeNil()
+					} else {
+						x.BasicAuthSecret.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("basicAuthSecret"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.BasicAuthSecret == nil {
+						r.EncodeNil()
+					} else {
+						x.BasicAuthSecret.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd1234)
+			}
+		}
+	}
+}
+
+func (x *BrokerAuthInfo) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1 := z.DecBinary()
+	_ = yym1
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		yyct2 := r.ContainerType()
+		if yyct2 == codecSelferValueTypeMap1234 {
+			yyl2 := r.ReadMapStart()
+			if yyl2 == 0 {
+				z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+			} else {
+				x.codecDecodeSelfFromMap(yyl2, d)
+			}
+		} else if yyct2 == codecSelferValueTypeArray1234 {
+			yyl2 := r.ReadArrayStart()
+			if yyl2 == 0 {
+				z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+			} else {
+				x.codecDecodeSelfFromArray(yyl2, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *BrokerAuthInfo) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys3Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3Slc
+	var yyhl3 bool = l >= 0
+	for yyj3 := 0; ; yyj3++ {
+		if yyhl3 {
+			if yyj3 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		z.DecSendContainerState(codecSelfer_containerMapKey1234)
+		yys3Slc = r.DecodeBytes(yys3Slc, true, true)
+		yys3 := string(yys3Slc)
+		z.DecSendContainerState(codecSelfer_containerMapValue1234)
+		switch yys3 {
+		case "basicAuthSecret":
+			if r.TryDecodeAsNil() {
+				if x.BasicAuthSecret != nil {
+					x.BasicAuthSecret = nil
+				}
+			} else {
+				if x.BasicAuthSecret == nil {
+					x.BasicAuthSecret = new(pkg3_v1.ObjectReference)
+				}
+				x.BasicAuthSecret.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys3)
+		} // end switch yys3
+	} // end for yyj3
+	z.DecSendContainerState(codecSelfer_containerMapEnd1234)
+}
+
+func (x *BrokerAuthInfo) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj5 int
+	var yyb5 bool
+	var yyhl5 bool = l >= 0
+	yyj5++
+	if yyhl5 {
+		yyb5 = yyj5 > l
+	} else {
+		yyb5 = r.CheckBreak()
+	}
+	if yyb5 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.BasicAuthSecret != nil {
+			x.BasicAuthSecret = nil
+		}
+	} else {
+		if x.BasicAuthSecret == nil {
+			x.BasicAuthSecret = new(pkg3_v1.ObjectReference)
+		}
+		x.BasicAuthSecret.CodecDecodeSelf(d)
+	}
+	for {
+		yyj5++
+		if yyhl5 {
+			yyb5 = yyj5 > l
+		} else {
+			yyb5 = r.CheckBreak()
+		}
+		if yyb5 {
+			break
+		}
+		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+		z.DecStructFieldNotFound(yyj5-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -50,7 +50,7 @@ type BrokerSpec struct {
 	URL string `json:"url"`
 
 	// AuthInfo contains the data that the service catalog should use to authenticate
-	// with the Broker
+	// with the Broker.
 	AuthInfo *BrokerAuthInfo `json:"authInfo,omitempty"`
 }
 

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -49,9 +49,21 @@ type BrokerSpec struct {
 	// URL is the address used to communicate with the Broker.
 	URL string `json:"url"`
 
-	// AuthSecret is a reference to a Secret containing auth information the
-	// catalog should use to authenticate to this Broker.
-	AuthSecret *v1.ObjectReference `json:"authSecret,omitempty"`
+	// AuthInfo contains the data that the service catalog should use to authenticate
+	// with the Broker
+	AuthInfo *BrokerAuthInfo `json:"authInfo,omitempty"`
+}
+
+// BrokerAuthInfo is a union type that contains information on one of the authentication methods
+// the the service catalog and brokers may support, according to the OpenServiceBroker API
+// specification (https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md).
+//
+// Note that we currently restrict a single broker to have only one of these fields
+// set on it.
+type BrokerAuthInfo struct {
+	// BasicAuthSecret is a reference to a Secret containing auth information the
+	// catalog should use to authenticate to this Broker using basic auth.
+	BasicAuthSecret *v1.ObjectReference `json:"basicAuthSecret,omitempty"`
 }
 
 // BrokerStatus represents the current status of a Broker.

--- a/pkg/apis/servicecatalog/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1alpha1/zz_generated.conversion.go
@@ -48,6 +48,8 @@ func RegisterConversions(scheme *runtime.Scheme) error {
 		Convert_servicecatalog_BindingStatus_To_v1alpha1_BindingStatus,
 		Convert_v1alpha1_Broker_To_servicecatalog_Broker,
 		Convert_servicecatalog_Broker_To_v1alpha1_Broker,
+		Convert_v1alpha1_BrokerAuthInfo_To_servicecatalog_BrokerAuthInfo,
+		Convert_servicecatalog_BrokerAuthInfo_To_v1alpha1_BrokerAuthInfo,
 		Convert_v1alpha1_BrokerCondition_To_servicecatalog_BrokerCondition,
 		Convert_servicecatalog_BrokerCondition_To_v1alpha1_BrokerCondition,
 		Convert_v1alpha1_BrokerList_To_servicecatalog_BrokerList,
@@ -225,6 +227,24 @@ func Convert_servicecatalog_Broker_To_v1alpha1_Broker(in *servicecatalog.Broker,
 	return autoConvert_servicecatalog_Broker_To_v1alpha1_Broker(in, out, s)
 }
 
+func autoConvert_v1alpha1_BrokerAuthInfo_To_servicecatalog_BrokerAuthInfo(in *BrokerAuthInfo, out *servicecatalog.BrokerAuthInfo, s conversion.Scope) error {
+	out.BasicAuthSecret = (*v1.ObjectReference)(unsafe.Pointer(in.BasicAuthSecret))
+	return nil
+}
+
+func Convert_v1alpha1_BrokerAuthInfo_To_servicecatalog_BrokerAuthInfo(in *BrokerAuthInfo, out *servicecatalog.BrokerAuthInfo, s conversion.Scope) error {
+	return autoConvert_v1alpha1_BrokerAuthInfo_To_servicecatalog_BrokerAuthInfo(in, out, s)
+}
+
+func autoConvert_servicecatalog_BrokerAuthInfo_To_v1alpha1_BrokerAuthInfo(in *servicecatalog.BrokerAuthInfo, out *BrokerAuthInfo, s conversion.Scope) error {
+	out.BasicAuthSecret = (*v1.ObjectReference)(unsafe.Pointer(in.BasicAuthSecret))
+	return nil
+}
+
+func Convert_servicecatalog_BrokerAuthInfo_To_v1alpha1_BrokerAuthInfo(in *servicecatalog.BrokerAuthInfo, out *BrokerAuthInfo, s conversion.Scope) error {
+	return autoConvert_servicecatalog_BrokerAuthInfo_To_v1alpha1_BrokerAuthInfo(in, out, s)
+}
+
 func autoConvert_v1alpha1_BrokerCondition_To_servicecatalog_BrokerCondition(in *BrokerCondition, out *servicecatalog.BrokerCondition, s conversion.Scope) error {
 	out.Type = servicecatalog.BrokerConditionType(in.Type)
 	out.Status = servicecatalog.ConditionStatus(in.Status)
@@ -273,7 +293,7 @@ func Convert_servicecatalog_BrokerList_To_v1alpha1_BrokerList(in *servicecatalog
 
 func autoConvert_v1alpha1_BrokerSpec_To_servicecatalog_BrokerSpec(in *BrokerSpec, out *servicecatalog.BrokerSpec, s conversion.Scope) error {
 	out.URL = in.URL
-	out.AuthSecret = (*v1.ObjectReference)(unsafe.Pointer(in.AuthSecret))
+	out.AuthInfo = (*servicecatalog.BrokerAuthInfo)(unsafe.Pointer(in.AuthInfo))
 	return nil
 }
 
@@ -283,7 +303,7 @@ func Convert_v1alpha1_BrokerSpec_To_servicecatalog_BrokerSpec(in *BrokerSpec, ou
 
 func autoConvert_servicecatalog_BrokerSpec_To_v1alpha1_BrokerSpec(in *servicecatalog.BrokerSpec, out *BrokerSpec, s conversion.Scope) error {
 	out.URL = in.URL
-	out.AuthSecret = (*v1.ObjectReference)(unsafe.Pointer(in.AuthSecret))
+	out.AuthInfo = (*BrokerAuthInfo)(unsafe.Pointer(in.AuthInfo))
 	return nil
 }
 

--- a/pkg/apis/servicecatalog/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/v1alpha1/zz_generated.deepcopy.go
@@ -42,6 +42,7 @@ func RegisterDeepCopies(scheme *runtime.Scheme) error {
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_BindingSpec, InType: reflect.TypeOf(&BindingSpec{})},
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_BindingStatus, InType: reflect.TypeOf(&BindingStatus{})},
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_Broker, InType: reflect.TypeOf(&Broker{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_BrokerAuthInfo, InType: reflect.TypeOf(&BrokerAuthInfo{})},
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_BrokerCondition, InType: reflect.TypeOf(&BrokerCondition{})},
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_BrokerList, InType: reflect.TypeOf(&BrokerList{})},
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_BrokerSpec, InType: reflect.TypeOf(&BrokerSpec{})},
@@ -165,6 +166,20 @@ func DeepCopy_v1alpha1_Broker(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
+func DeepCopy_v1alpha1_BrokerAuthInfo(in interface{}, out interface{}, c *conversion.Cloner) error {
+	{
+		in := in.(*BrokerAuthInfo)
+		out := out.(*BrokerAuthInfo)
+		*out = *in
+		if in.BasicAuthSecret != nil {
+			in, out := &in.BasicAuthSecret, &out.BasicAuthSecret
+			*out = new(api_v1.ObjectReference)
+			**out = **in
+		}
+		return nil
+	}
+}
+
 func DeepCopy_v1alpha1_BrokerCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*BrokerCondition)
@@ -198,10 +213,12 @@ func DeepCopy_v1alpha1_BrokerSpec(in interface{}, out interface{}, c *conversion
 		in := in.(*BrokerSpec)
 		out := out.(*BrokerSpec)
 		*out = *in
-		if in.AuthSecret != nil {
-			in, out := &in.AuthSecret, &out.AuthSecret
-			*out = new(api_v1.ObjectReference)
-			**out = **in
+		if in.AuthInfo != nil {
+			in, out := &in.AuthInfo, &out.AuthInfo
+			*out = new(BrokerAuthInfo)
+			if err := DeepCopy_v1alpha1_BrokerAuthInfo(*in, *out, c); err != nil {
+				return err
+			}
 		}
 		return nil
 	}

--- a/pkg/apis/servicecatalog/validation/broker_test.go
+++ b/pkg/apis/servicecatalog/validation/broker_test.go
@@ -32,6 +32,8 @@ func TestValidateBroker(t *testing.T) {
 		valid  bool
 	}{
 		{
+			// covers the case where there is no AuthInfo field specified. the validator should
+			// ignore the field and still succeed the validation
 			name: "valid broker - no auth secret",
 			broker: &servicecatalog.Broker{
 				ObjectMeta: metav1.ObjectMeta{
@@ -51,9 +53,11 @@ func TestValidateBroker(t *testing.T) {
 				},
 				Spec: servicecatalog.BrokerSpec{
 					URL: "http://example.com",
-					AuthSecret: &v1.ObjectReference{
-						Namespace: "test-ns",
-						Name:      "test-secret",
+					AuthInfo: &servicecatalog.BrokerAuthInfo{
+						BasicAuthSecret: &v1.ObjectReference{
+							Namespace: "test-ns",
+							Name:      "test-secret",
+						},
 					},
 				},
 			},
@@ -80,8 +84,10 @@ func TestValidateBroker(t *testing.T) {
 				},
 				Spec: servicecatalog.BrokerSpec{
 					URL: "http://example.com",
-					AuthSecret: &v1.ObjectReference{
-						Name: "test-secret",
+					AuthInfo: &servicecatalog.BrokerAuthInfo{
+						BasicAuthSecret: &v1.ObjectReference{
+							Name: "test-secret",
+						},
 					},
 				},
 			},
@@ -95,8 +101,10 @@ func TestValidateBroker(t *testing.T) {
 				},
 				Spec: servicecatalog.BrokerSpec{
 					URL: "http://example.com",
-					AuthSecret: &v1.ObjectReference{
-						Namespace: "test-ns",
+					AuthInfo: &servicecatalog.BrokerAuthInfo{
+						BasicAuthSecret: &v1.ObjectReference{
+							Namespace: "test-ns",
+						},
 					},
 				},
 			},

--- a/pkg/apis/servicecatalog/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/zz_generated.deepcopy.go
@@ -42,6 +42,7 @@ func RegisterDeepCopies(scheme *runtime.Scheme) error {
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_servicecatalog_BindingSpec, InType: reflect.TypeOf(&BindingSpec{})},
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_servicecatalog_BindingStatus, InType: reflect.TypeOf(&BindingStatus{})},
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_servicecatalog_Broker, InType: reflect.TypeOf(&Broker{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_servicecatalog_BrokerAuthInfo, InType: reflect.TypeOf(&BrokerAuthInfo{})},
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_servicecatalog_BrokerCondition, InType: reflect.TypeOf(&BrokerCondition{})},
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_servicecatalog_BrokerList, InType: reflect.TypeOf(&BrokerList{})},
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_servicecatalog_BrokerSpec, InType: reflect.TypeOf(&BrokerSpec{})},
@@ -165,6 +166,20 @@ func DeepCopy_servicecatalog_Broker(in interface{}, out interface{}, c *conversi
 	}
 }
 
+func DeepCopy_servicecatalog_BrokerAuthInfo(in interface{}, out interface{}, c *conversion.Cloner) error {
+	{
+		in := in.(*BrokerAuthInfo)
+		out := out.(*BrokerAuthInfo)
+		*out = *in
+		if in.BasicAuthSecret != nil {
+			in, out := &in.BasicAuthSecret, &out.BasicAuthSecret
+			*out = new(api_v1.ObjectReference)
+			**out = **in
+		}
+		return nil
+	}
+}
+
 func DeepCopy_servicecatalog_BrokerCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*BrokerCondition)
@@ -198,10 +213,12 @@ func DeepCopy_servicecatalog_BrokerSpec(in interface{}, out interface{}, c *conv
 		in := in.(*BrokerSpec)
 		out := out.(*BrokerSpec)
 		*out = *in
-		if in.AuthSecret != nil {
-			in, out := &in.AuthSecret, &out.AuthSecret
-			*out = new(api_v1.ObjectReference)
-			**out = **in
+		if in.AuthInfo != nil {
+			in, out := &in.AuthInfo, &out.AuthInfo
+			*out = new(BrokerAuthInfo)
+			if err := DeepCopy_servicecatalog_BrokerAuthInfo(*in, *out, c); err != nil {
+				return err
+			}
 		}
 		return nil
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -350,11 +350,19 @@ func (c *controller) getServiceClassPlanAndBrokerForBinding(instance *v1alpha1.I
 // returns an error. If the AuthSecret field is nil, empty values are
 // returned.
 func getAuthCredentialsFromBroker(client kubernetes.Interface, broker *v1alpha1.Broker) (username, password string, err error) {
-	if broker.Spec.AuthSecret == nil {
+	// TODO: when we start supporting additional auth schemes, this code will have to accommodate
+	// the new schemes
+	if broker.Spec.AuthInfo == nil {
 		return "", "", nil
 	}
 
-	authSecret, err := client.Core().Secrets(broker.Spec.AuthSecret.Namespace).Get(broker.Spec.AuthSecret.Name, metav1.GetOptions{})
+	basicAuthSecret := broker.Spec.AuthInfo.BasicAuthSecret
+
+	if basicAuthSecret == nil {
+		return "", "", nil
+	}
+
+	authSecret, err := client.Core().Secrets(basicAuthSecret.Namespace).Get(basicAuthSecret.Name, metav1.GetOptions{})
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/controller/controller_broker_test.go
+++ b/pkg/controller/controller_broker_test.go
@@ -293,9 +293,11 @@ func TestReconcileBrokerWithAuthError(t *testing.T) {
 	fakeKubeClient, fakeCatalogClient, _, testController, _ := newTestController(t)
 
 	broker := getTestBroker()
-	broker.Spec.AuthSecret = &v1.ObjectReference{
-		Namespace: "does_not_exist",
-		Name:      "auth-name",
+	broker.Spec.AuthInfo = &v1alpha1.BrokerAuthInfo{
+		BasicAuthSecret: &v1.ObjectReference{
+			Namespace: "does_not_exist",
+			Name:      "auth-name",
+		},
 	}
 
 	fakeKubeClient.AddReactor("get", "secrets", func(action clientgotesting.Action) (bool, runtime.Object, error) {
@@ -335,9 +337,11 @@ func TestReconcileBrokerWithReconcileError(t *testing.T) {
 	fakeKubeClient, fakeCatalogClient, _, testController, _ := newTestController(t)
 
 	broker := getTestBroker()
-	broker.Spec.AuthSecret = &v1.ObjectReference{
-		Namespace: "does_not_exist",
-		Name:      "auth-name",
+	broker.Spec.AuthInfo = &v1alpha1.BrokerAuthInfo{
+		BasicAuthSecret: &v1.ObjectReference{
+			Namespace: "does_not_exist",
+			Name:      "auth-name",
+		},
 	}
 
 	fakeCatalogClient.AddReactor("create", "serviceclasses", func(action clientgotesting.Action) (bool, runtime.Object, error) {

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -97,9 +97,11 @@ func TestReconcileInstanceWithAuthError(t *testing.T) {
 	fakeKubeClient, fakeCatalogClient, _, testController, sharedInformers := newTestController(t)
 
 	broker := getTestBroker()
-	broker.Spec.AuthSecret = &v1.ObjectReference{
-		Namespace: "does_not_exist",
-		Name:      "auth-name",
+	broker.Spec.AuthInfo = &v1alpha1.BrokerAuthInfo{
+		BasicAuthSecret: &v1.ObjectReference{
+			Namespace: "does_not_exist",
+			Name:      "auth-name",
+		},
 	}
 	sharedInformers.Brokers().Informer().GetStore().Add(broker)
 	sharedInformers.ServiceClasses().Informer().GetStore().Add(getTestServiceClass())

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -193,6 +193,131 @@ const testCatalogWithMultipleServices = `{
     }
 ]}`
 
+const alphaParameterSchemaCatalogBytes = `{
+  "services": [{
+    "name": "fake-service",
+    "id": "acb56d7c-XXXX-XXXX-XXXX-feb140a59a66",
+    "description": "fake service",
+    "tags": ["tag1", "tag2"],
+    "requires": ["route_forwarding"],
+    "bindable": true,
+    "metadata": {
+    	"a": "b",
+    	"c": "d"
+    },
+    "dashboard_client": {
+      "id": "398e2f8e-XXXX-XXXX-XXXX-19a71ecbcf64",
+      "secret": "277cabb0-XXXX-XXXX-XXXX-7822c0a90e5d",
+      "redirect_uri": "http://localhost:1234"
+    },
+    "plan_updateable": true,
+    "plans": [{
+      "name": "fake-plan-1",
+      "id": "d3031751-XXXX-XXXX-XXXX-a42377d3320e",
+      "description": "description1",
+      "metadata": {
+      	"b": "c",
+      	"d": "e"
+      },
+      "schemas": {
+      	"service_instance": {
+	  	  "create": {
+	  	  	"parameters": {
+	          "$schema": "http://json-schema.org/draft-04/schema",
+	          "type": "object",
+	          "title": "Parameters",
+	          "properties": {
+	            "name": {
+	              "title": "Queue Name",
+	              "type": "string",
+	              "maxLength": 63,
+	              "default": "My Queue"
+	            },
+	            "email": {
+	              "title": "Email",
+	              "type": "string",
+	              "pattern": "^\\S+@\\S+$",
+	              "description": "Email address for alerts."
+	            },
+	            "protocol": {
+	              "title": "Protocol",
+	              "type": "string",
+	              "default": "Java Message Service (JMS) 1.1",
+	              "enum": [
+	                "Java Message Service (JMS) 1.1",
+	                "Transmission Control Protocol (TCP)",
+	                "Advanced Message Queuing Protocol (AMQP) 1.0"
+	              ]
+	            },
+	            "secure": {
+	              "title": "Enable security",
+	              "type": "boolean",
+	              "default": true
+	            }
+	          },
+	          "required": [
+	            "name",
+	            "protocol"
+	          ]
+	  	  	}
+	  	  },
+	  	  "update": {
+	  	  	"parameters": {
+	  		  "baz": "zap"
+	  	    }
+	  	  }
+      	},
+      	"service_binding": {
+      	  "create": {
+	  	  	"parameters": {
+      	  	  "zoo": "blu"
+      	    }
+      	  }
+      	}
+      }
+    }]
+  }]
+}`
+
+const instanceParameterSchemaBytes = `{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "type": "object",
+  "title": "Parameters",
+  "properties": {
+    "name": {
+      "title": "Queue Name",
+      "type": "string",
+      "maxLength": 63,
+      "default": "My Queue"
+    },
+    "email": {
+      "title": "Email",
+      "type": "string",
+      "pattern": "^\\S+@\\S+$",
+      "description": "Email address for alerts."
+    },
+    "protocol": {
+      "title": "Protocol",
+      "type": "string",
+      "default": "Java Message Service (JMS) 1.1",
+      "enum": [
+        "Java Message Service (JMS) 1.1",
+        "Transmission Control Protocol (TCP)",
+        "Advanced Message Queuing Protocol (AMQP) 1.0"
+      ]
+    },
+    "secure": {
+      "title": "Enable security",
+      "type": "boolean",
+      "default": true
+    }
+  },
+  "required": [
+    "name",
+    "protocol"
+  ]
+}`
+
 // broker used in most of the tests that need a broker
 func getTestBroker() *v1alpha1.Broker {
 	return &v1alpha1.Broker{
@@ -432,131 +557,6 @@ func TestCatalogConversion(t *testing.T) {
 	checkPlan(serviceClass, 0, "fake-plan-1", "Shared fake Server, 5tb persistent disk, 40 max concurrent connections", t)
 	checkPlan(serviceClass, 1, "fake-plan-2", "Shared fake Server, 5tb persistent disk, 40 max concurrent connections. 100 async", t)
 }
-
-const alphaParameterSchemaCatalogBytes = `{
-  "services": [{
-    "name": "fake-service",
-    "id": "acb56d7c-XXXX-XXXX-XXXX-feb140a59a66",
-    "description": "fake service",
-    "tags": ["tag1", "tag2"],
-    "requires": ["route_forwarding"],
-    "bindable": true,
-    "metadata": {
-    	"a": "b",
-    	"c": "d"
-    },
-    "dashboard_client": {
-      "id": "398e2f8e-XXXX-XXXX-XXXX-19a71ecbcf64",
-      "secret": "277cabb0-XXXX-XXXX-XXXX-7822c0a90e5d",
-      "redirect_uri": "http://localhost:1234"
-    },
-    "plan_updateable": true,
-    "plans": [{
-      "name": "fake-plan-1",
-      "id": "d3031751-XXXX-XXXX-XXXX-a42377d3320e",
-      "description": "description1",
-      "metadata": {
-      	"b": "c",
-      	"d": "e"
-      },
-      "schemas": {
-      	"service_instance": {
-	  	  "create": {
-	  	  	"parameters": {
-	          "$schema": "http://json-schema.org/draft-04/schema",
-	          "type": "object",
-	          "title": "Parameters",
-	          "properties": {
-	            "name": {
-	              "title": "Queue Name",
-	              "type": "string",
-	              "maxLength": 63,
-	              "default": "My Queue"
-	            },
-	            "email": {
-	              "title": "Email",
-	              "type": "string",
-	              "pattern": "^\\S+@\\S+$",
-	              "description": "Email address for alerts."
-	            },
-	            "protocol": {
-	              "title": "Protocol",
-	              "type": "string",
-	              "default": "Java Message Service (JMS) 1.1",
-	              "enum": [
-	                "Java Message Service (JMS) 1.1",
-	                "Transmission Control Protocol (TCP)",
-	                "Advanced Message Queuing Protocol (AMQP) 1.0"
-	              ]
-	            },
-	            "secure": {
-	              "title": "Enable security",
-	              "type": "boolean",
-	              "default": true
-	            }
-	          },
-	          "required": [
-	            "name",
-	            "protocol"
-	          ]
-	  	  	}
-	  	  },
-	  	  "update": {
-	  	  	"parameters": {
-	  		  "baz": "zap"
-	  	    }
-	  	  }
-      	},
-      	"service_binding": {
-      	  "create": {
-	  	  	"parameters": {
-      	  	  "zoo": "blu"
-      	    }
-      	  }
-      	}
-      }
-    }]
-  }]
-}`
-
-const instanceParameterSchemaBytes = `{
-  "$schema": "http://json-schema.org/draft-04/schema",
-  "type": "object",
-  "title": "Parameters",
-  "properties": {
-    "name": {
-      "title": "Queue Name",
-      "type": "string",
-      "maxLength": 63,
-      "default": "My Queue"
-    },
-    "email": {
-      "title": "Email",
-      "type": "string",
-      "pattern": "^\\S+@\\S+$",
-      "description": "Email address for alerts."
-    },
-    "protocol": {
-      "title": "Protocol",
-      "type": "string",
-      "default": "Java Message Service (JMS) 1.1",
-      "enum": [
-        "Java Message Service (JMS) 1.1",
-        "Transmission Control Protocol (TCP)",
-        "Advanced Message Queuing Protocol (AMQP) 1.0"
-      ]
-    },
-    "secure": {
-      "title": "Enable security",
-      "type": "boolean",
-      "default": true
-    }
-  },
-  "required": [
-    "name",
-    "protocol"
-  ]
-}`
 
 func TestCatalogConversionWithAlphaParameterSchemas(t *testing.T) {
 	catalog := &brokerapi.Catalog{}

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -269,6 +269,23 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 			Dependencies: []string{
 				"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1.BrokerSpec", "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1.BrokerStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 		},
+		"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1.BrokerAuthInfo": {
+			Schema: spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Description: "BrokerAuthInfo is a union type that contains information on one of the authentication methods the the service catalog and brokers may support, according to the OpenServiceBroker API specification (https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md).\n\nNote that we currently restrict a single broker to have only one of these fields set on it.",
+					Properties: map[string]spec.Schema{
+						"basicAuthSecret": {
+							SchemaProps: spec.SchemaProps{
+								Description: "BasicAuthSecret is a reference to a Secret containing auth information the catalog should use to authenticate to this Broker using basic auth.",
+								Ref:         ref("k8s.io/client-go/pkg/api/v1.ObjectReference"),
+							},
+						},
+					},
+				},
+			},
+			Dependencies: []string{
+				"k8s.io/client-go/pkg/api/v1.ObjectReference"},
+		},
 		"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1.BrokerCondition": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
@@ -370,10 +387,10 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 								Format:      "",
 							},
 						},
-						"authSecret": {
+						"authInfo": {
 							SchemaProps: spec.SchemaProps{
-								Description: "AuthSecret is a reference to a Secret containing auth information the catalog should use to authenticate to this Broker.",
-								Ref:         ref("k8s.io/client-go/pkg/api/v1.ObjectReference"),
+								Description: "AuthInfo contains the data that the service catalog should use to authenticate with the Broker",
+								Ref:         ref("github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1.BrokerAuthInfo"),
 							},
 						},
 					},
@@ -381,7 +398,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 				},
 			},
 			Dependencies: []string{
-				"k8s.io/client-go/pkg/api/v1.ObjectReference"},
+				"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1.BrokerAuthInfo"},
 		},
 		"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1.BrokerStatus": {
 			Schema: spec.Schema{

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -389,7 +389,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 						},
 						"authInfo": {
 							SchemaProps: spec.SchemaProps{
-								Description: "AuthInfo contains the data that the service catalog should use to authenticate with the Broker",
+								Description: "AuthInfo contains the data that the service catalog should use to authenticate with the Broker.",
 								Ref:         ref("github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1.BrokerAuthInfo"),
 							},
 						},

--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -230,12 +230,12 @@ func testBrokerClient(sType server.StorageType, client servicecatalogclient.Inte
 		Name:      "test-name",
 	}
 
-	brokerServer.Spec.AuthSecret = authSecret
+	brokerServer.Spec.AuthInfo = &v1alpha1.BrokerAuthInfo{BasicAuthSecret: authSecret}
 
 	brokerUpdated, err := brokerClient.Update(brokerServer)
 	if nil != err ||
-		"test-namespace" != brokerUpdated.Spec.AuthSecret.Namespace ||
-		"test-name" != brokerUpdated.Spec.AuthSecret.Name {
+		"test-namespace" != brokerUpdated.Spec.AuthInfo.BasicAuthSecret.Namespace ||
+		"test-name" != brokerUpdated.Spec.AuthInfo.BasicAuthSecret.Name {
 		return fmt.Errorf("broker wasn't updated, %v, %v", brokerServer, brokerUpdated)
 	}
 
@@ -278,8 +278,8 @@ func testBrokerClient(sType server.StorageType, client servicecatalogclient.Inte
 
 	brokerServer, err = brokerClient.Get(name, metav1.GetOptions{})
 	if nil != err ||
-		"test-namespace" != brokerServer.Spec.AuthSecret.Namespace ||
-		"test-name" != brokerServer.Spec.AuthSecret.Name {
+		"test-namespace" != brokerServer.Spec.AuthInfo.BasicAuthSecret.Namespace ||
+		"test-name" != brokerServer.Spec.AuthInfo.BasicAuthSecret.Name {
 		return fmt.Errorf("broker wasn't updated (%v)", brokerServer)
 	}
 	if e, a := readyConditionFalse, brokerServer.Status.Conditions[0]; !reflect.DeepEqual(e, a) {


### PR DESCRIPTION
This change will enable operators to chose different auth schemes for brokers, as the OSB API spec begins to support more in the future.

Fixes https://github.com/kubernetes-incubator/service-catalog/issues/864