### PR TITLE
Instance never provisioned should not invoke broker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,9 @@ test-integration: .init $(scBuildImageTarget) build
 	# golang integration tests
 	$(DOCKER_CMD) test/integration.sh
 
+clean-e2e:
+	rm -f $(BINDIR)/e2e.test
+
 test-e2e: .generate_files $(BINDIR)/e2e.test
 	$(BINDIR)/e2e.test
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	// How often to poll for conditions
-	defaultPoll = 2 * time.Second
+	Poll = 2 * time.Second
 
 	// Default time to wait for operations to complete
 	defaultTimeout = 30 * time.Second
@@ -104,7 +104,7 @@ func CreateKubeNamespace(baseName string, c kubernetes.Interface) (*v1.Namespace
 	Logf("namespace: %v", ns)
 	// Be robust about making the namespace creation call.
 	var got *v1.Namespace
-	err := wait.PollImmediate(defaultPoll, defaultTimeout, func() (bool, error) {
+	err := wait.PollImmediate(Poll, defaultTimeout, func() (bool, error) {
 		var err error
 		got, err = c.Core().Namespaces().Create(ns)
 		if err != nil {
@@ -140,7 +140,7 @@ func WaitForPodRunningInNamespace(c kubernetes.Interface, pod *v1.Pod) error {
 }
 
 func waitTimeoutForPodRunningInNamespace(c kubernetes.Interface, podName, namespace string, timeout time.Duration) error {
-	return wait.PollImmediate(defaultPoll, defaultTimeout, podRunning(c, podName, namespace))
+	return wait.PollImmediate(Poll, defaultTimeout, podRunning(c, podName, namespace))
 }
 
 func podRunning(c kubernetes.Interface, podName, namespace string) wait.ConditionFunc {

--- a/test/e2e/instance.go
+++ b/test/e2e/instance.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"time"
+
+	v1alpha1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
+	"github.com/kubernetes-incubator/service-catalog/test/e2e/framework"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	// how long to wait for an instance to be deleted.
+	instanceDeleteTimeout = 30 * time.Second
+)
+
+func newTestInstance(name, serviceClassName, planName string) *v1alpha1.Instance {
+	return &v1alpha1.Instance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1alpha1.InstanceSpec{
+			PlanName:         planName,
+			ServiceClassName: serviceClassName,
+		},
+	}
+}
+
+// createInstance in the specified namespace
+func createInstance(c clientset.Interface, namespace string, instance *v1alpha1.Instance) (*v1alpha1.Instance, error) {
+	return c.ServicecatalogV1alpha1().Instances(namespace).Create(instance)
+}
+
+// deleteInstance with the specified namespace and name
+func deleteInstance(c clientset.Interface, namespace, name string) error {
+	return c.ServicecatalogV1alpha1().Instances(namespace).Delete(name, nil)
+}
+
+// waitForInstanceToBeDeleted waits for the instance to be removed.
+func waitForInstanceToBeDeleted(c clientset.Interface, namespace, name string) error {
+	return wait.Poll(framework.Poll, instanceDeleteTimeout, func() (bool, error) {
+		_, err := c.ServicecatalogV1alpha1().Instances(namespace).Get(name, metav1.GetOptions{})
+		if err == nil {
+			framework.Logf("waiting for instance %s to be deleted", name)
+			return false, nil
+		}
+		if errors.IsNotFound(err) {
+			framework.Logf("verified instance %s is deleted", name)
+			return true, nil
+		}
+		return false, err
+	})
+}
+
+var _ = framework.ServiceCatalogDescribe("Instance", func() {
+	f := framework.NewDefaultFramework("instance")
+
+	It("should verify an Instance can be deleted if referenced service class does not exist.", func() {
+		By("Creating an Instance")
+		instance := newTestInstance("test-instance", "no-service-class", "no-plan")
+		instance, err := createInstance(f.ServiceCatalogClientSet, f.Namespace.Name, instance)
+		Expect(err).NotTo(HaveOccurred())
+		By("Deleting the Instance")
+		err = deleteInstance(f.ServiceCatalogClientSet, f.Namespace.Name, instance.Name)
+		Expect(err).NotTo(HaveOccurred())
+		err = waitForInstanceToBeDeleted(f.ServiceCatalogClientSet, f.Namespace.Name, instance.Name)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/service-catalog/issues/878

If you create an Instance that references a ServiceClass that does not exist, you were never able to delete the Instance, as the controller error-ed out when the ServiceClass is not resolvable.  In this scenario, the Instance is never able to be provisioned, so there is no need to gate deletion on ability to deprovision.  For this PR, we do not invoke the broker upon deletion if an instance never actually provisioned.