### PR TITLE
Fix usage of finalizers

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -396,3 +396,8 @@ const (
 	// BindingConditionReady represents a BindingCondition is in ready state.
 	BindingConditionReady BindingConditionType = "Ready"
 )
+
+// These are internal finalizer values to service catalog, must be qualified name.
+const (
+	FinalizerServiceCatalog string = "kubernetes-incubator/service-catalog"
+)

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -397,3 +397,8 @@ const (
 	// BindingConditionReady represents a binding condition is in ready state.
 	BindingConditionReady BindingConditionType = "Ready"
 )
+
+// These are external finalizer values to service catalog, must be qualified name.
+const (
+	FinalizerServiceCatalog string = "kubernetes-incubator/service-catalog"
+)

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -474,7 +474,7 @@ func TestReconcileBindingDelete(t *testing.T) {
 			Name:              testBindingName,
 			Namespace:         testNamespace,
 			DeletionTimestamp: &metav1.Time{},
-			Finalizers:        []string{"kubernetes"},
+			Finalizers:        []string{v1alpha1.FinalizerServiceCatalog},
 		},
 		Spec: v1alpha1.BindingSpec{
 			InstanceRef: v1.LocalObjectReference{Name: testInstanceName},

--- a/pkg/controller/controller_broker_test.go
+++ b/pkg/controller/controller_broker_test.go
@@ -232,7 +232,7 @@ func TestReconcileBrokerDelete(t *testing.T) {
 
 	broker := getTestBroker()
 	broker.DeletionTimestamp = &metav1.Time{}
-	broker.Finalizers = []string{"kubernetes"}
+	broker.Finalizers = []string{v1alpha1.FinalizerServiceCatalog}
 
 	testController.reconcileBroker(broker)
 

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -602,7 +602,7 @@ func TestReconcileInstanceDelete(t *testing.T) {
 
 	instance := getTestInstance()
 	instance.ObjectMeta.DeletionTimestamp = &metav1.Time{}
-	instance.ObjectMeta.Finalizers = []string{"kubernetes"}
+	instance.ObjectMeta.Finalizers = []string{v1alpha1.FinalizerServiceCatalog}
 
 	fakeCatalogClient.AddReactor("get", "instances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		return true, instance, nil

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -376,7 +376,7 @@ func getTestInstanceAsyncDeprovisioning(operation string) *v1alpha1.Instance {
 
 func getTestInstanceAsyncDeprovisioningWithFinalizer(operation string) *v1alpha1.Instance {
 	instance := getTestInstanceAsyncDeprovisioning(operation)
-	instance.ObjectMeta.Finalizers = []string{"kubernetes"}
+	instance.ObjectMeta.Finalizers = []string{v1alpha1.FinalizerServiceCatalog}
 	return instance
 }
 

--- a/pkg/registry/servicecatalog/binding/strategy.go
+++ b/pkg/registry/servicecatalog/binding/strategy.go
@@ -96,9 +96,7 @@ func (bindingRESTStrategy) PrepareForCreate(ctx genericapirequest.Context, obj r
 	binding.Status = sc.BindingStatus{}
 	// Fill in the first entry set to "creating"?
 	binding.Status.Conditions = []sc.BindingCondition{}
-
-	// TODO: Should we use a more specific string here?
-	binding.Finalizers = []string{"kubernetes"}
+	binding.Finalizers = []string{sc.FinalizerServiceCatalog}
 }
 
 func (bindingRESTStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/servicecatalog/broker/strategy.go
+++ b/pkg/registry/servicecatalog/broker/strategy.go
@@ -96,9 +96,7 @@ func (brokerRESTStrategy) PrepareForCreate(ctx genericapirequest.Context, obj ru
 	broker.Status = sc.BrokerStatus{}
 	// Fill in the first entry set to "creating"?
 	broker.Status.Conditions = []sc.BrokerCondition{}
-
-	// TODO: Should we use a more specific string here?
-	broker.Finalizers = []string{"kubernetes"}
+	broker.Finalizers = []string{sc.FinalizerServiceCatalog}
 }
 
 func (brokerRESTStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/servicecatalog/instance/strategy.go
+++ b/pkg/registry/servicecatalog/instance/strategy.go
@@ -97,9 +97,7 @@ func (instanceRESTStrategy) PrepareForCreate(ctx genericapirequest.Context, obj 
 	instance.Status = sc.InstanceStatus{}
 	// Fill in the first entry set to "creating"?
 	instance.Status.Conditions = []sc.InstanceCondition{}
-
-	// TODO: Should we use a more specific string here?
-	instance.Finalizers = []string{"kubernetes"}
+	instance.Finalizers = []string{sc.FinalizerServiceCatalog}
 }
 
 func (instanceRESTStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/storage/tpr/storage_interface.go
+++ b/pkg/storage/tpr/storage_interface.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/golang/glog"
 	scmeta "github.com/kubernetes-incubator/service-catalog/pkg/api/meta"
-	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
 	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,7 +39,6 @@ import (
 
 var (
 	errNotImplemented = errors.New("not implemented for third party resources")
-	tprFinalizer      = fmt.Sprintf("%s/%s", servicecatalog.GroupName, tprVersion)
 )
 
 type store struct {
@@ -101,7 +100,7 @@ func (t *store) Create(
 		return err
 	}
 
-	if err := scmeta.AddFinalizer(obj, tprFinalizer); err != nil {
+	if err := scmeta.AddFinalizer(obj, v1alpha1.FinalizerServiceCatalog); err != nil {
 		glog.Errorf("adding finalizer to %s (%s)", key, err)
 		return err
 	}
@@ -194,7 +193,7 @@ func (t *store) Delete(
 		return err
 	}
 
-	if _, err := scmeta.RemoveFinalizer(out, tprFinalizer); err != nil {
+	if _, err := scmeta.RemoveFinalizer(out, v1alpha1.FinalizerServiceCatalog); err != nil {
 		glog.Errorf("removing finalizer from %#v (%s)", out, err)
 		return err
 	}

--- a/pkg/storage/tpr/storage_interface_test.go
+++ b/pkg/storage/tpr/storage_interface_test.go
@@ -28,6 +28,7 @@ import (
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/testapi"
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/rest/core/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -873,7 +874,7 @@ func TestDeleteWithNoNamespace(t *testing.T) {
 		},
 	}
 	brokerWithFinalizers := *brokerNoFinalizers
-	brokerWithFinalizers.Finalizers = append(brokerWithFinalizers.Finalizers, tprFinalizer)
+	brokerWithFinalizers.Finalizers = append(brokerWithFinalizers.Finalizers, v1alpha1.FinalizerServiceCatalog)
 	fakeCl.Storage.Set(globalNamespace, ServiceBrokerKind.URLName(), name, &brokerWithFinalizers)
 	key, err := keyer.Key(request.NewContext(), name)
 	if err != nil {
@@ -923,7 +924,7 @@ func TestDeleteWithNamespace(t *testing.T) {
 		},
 	}
 	instanceWithFinalizers := *instanceNoFinalizers
-	instanceWithFinalizers.Finalizers = append(instanceWithFinalizers.Finalizers, tprFinalizer)
+	instanceWithFinalizers.Finalizers = append(instanceWithFinalizers.Finalizers, v1alpha1.FinalizerServiceCatalog)
 	fakeCl.Storage.Set(namespace, ServiceInstanceKind.URLName(), name, &instanceWithFinalizers)
 	ctx := request.NewContext()
 	ctx = request.WithNamespace(ctx, namespace)


### PR DESCRIPTION
Fix usage of finalizers
1. The "kubernetes" finalizer is a special finalizer token not meant for use by other projects.
1. The finalizer token values should also be qualified names.
1. Updated the code  to use sets for handling finalizers (ordering is not required)