### PR TITLE
Add asynchronous provisioning test using the fake broker server

### DIFF
--- a/pkg/apis/servicecatalog/fake/const.go
+++ b/pkg/apis/servicecatalog/fake/const.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+const (
+	// Namespace is a name used for test namespaces
+	Namespace = "test-ns"
+	// NamespaceUID is a UID used for test namespaces
+	NamespaceUID = "test-ns-uid"
+
+	// BrokerURL is the URL used for test brokers
+	BrokerURL = "http://example.com"
+	// BrokerName is the name used for test brokers
+	BrokerName = "test-broker"
+
+	// ServiceClassName is the name used for test service classes
+	ServiceClassName = "test-serviceclass"
+	// ServiceClassGUID is the GUID used for test service classes
+	ServiceClassGUID = "SCGUID"
+	// PlanName is the name used for test plans
+	PlanName = "test-plan"
+	// PlanGUID is the GUID used for test plans
+	PlanGUID = "PGUID"
+	//NonBindablePlanName is the name used for test plans that should not be bindable
+	NonBindablePlanName = "test-unbindable-plan"
+	// NonBindablePlanGUID is the GUID used for test plans that should not be bindable
+	NonBindablePlanGUID = "UNBINDABLE-PLAN"
+
+	// InstanceName is a name used for test instances
+	InstanceName = "test-instance"
+	// InstanceGUID is the GUID used for test instances
+	InstanceGUID = "IGUID"
+)

--- a/pkg/apis/servicecatalog/fake/pointers.go
+++ b/pkg/apis/servicecatalog/fake/pointers.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/pkg/apis/servicecatalog/fake/types.go
+++ b/pkg/apis/servicecatalog/fake/types.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetBroker is a convenience function to get a *v1alpha1.Broker for use in tests
+func GetBroker() *v1alpha1.Broker {
+	return &v1alpha1.Broker{
+		ObjectMeta: metav1.ObjectMeta{Name: BrokerName},
+		Spec: v1alpha1.BrokerSpec{
+			URL: BrokerURL,
+		},
+	}
+}
+
+// GetServiceClass returns a ServiceClass that can be used by tests
+func GetServiceClass() *v1alpha1.ServiceClass {
+	return &v1alpha1.ServiceClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: ServiceClassName},
+		BrokerName:  BrokerName,
+		Description: "a test service",
+		ExternalID:  ServiceClassGUID,
+		Bindable:    true,
+		Plans: []v1alpha1.ServicePlan{
+			{
+				Name:        PlanName,
+				Description: "a test plan",
+				Free:        true,
+				ExternalID:  PlanGUID,
+			},
+			{
+				Name:        NonBindablePlanName,
+				Description: "a test plan",
+				Free:        true,
+				ExternalID:  NonBindablePlanGUID,
+				Bindable:    boolPtr(false),
+			},
+		},
+	}
+
+}
+
+// GetInstance returns an Instance that can be used by tests
+func GetInstance() *v1alpha1.Instance {
+	return &v1alpha1.Instance{
+		ObjectMeta: metav1.ObjectMeta{Name: InstanceName, Namespace: Namespace},
+		Spec: v1alpha1.InstanceSpec{
+			ServiceClassName: ServiceClassName,
+			PlanName:         PlanName,
+			ExternalID:       InstanceGUID,
+		},
+	}
+}

--- a/pkg/brokerapi/fake/data.go
+++ b/pkg/brokerapi/fake/data.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+)
+
+const (
+	// ServiceClassName is the static name for service classes in test data
+	ServiceClassName = "testserviceclass"
+	// ServiceClassGUID is the static guid for service classes in test data
+	ServiceClassGUID = "testserviceclassGUID"
+	// PlanName is the static name for plans in test data
+	PlanName = "testplan"
+	// PlanGUID is the static name for plan GUIDs in test data
+	PlanGUID = "testPlanGUID"
+	// NonBindablePlanName is the static name for non-bindable plans in test data
+	NonBindablePlanName = "testNonBindablePlan"
+	// NonBindablePlanGUID is the static GUID for non-bindable plans in test data
+	NonBindablePlanGUID = "testNonBinablePlanGUID"
+)
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+// GetTestCatalog returns a static osb.CatalogResponse for use in testing
+func GetTestCatalog() *osb.CatalogResponse {
+	return &osb.CatalogResponse{
+		Services: []osb.Service{
+			{
+				Name:        ServiceClassName,
+				ID:          ServiceClassGUID,
+				Description: "a test service",
+				Bindable:    true,
+				Plans: []osb.Plan{
+					{
+						Name:        PlanName,
+						Free:        boolPtr(true),
+						ID:          PlanGUID,
+						Description: "a test plan",
+					},
+					{
+						Name:        NonBindablePlanName,
+						Free:        boolPtr(true),
+						ID:          NonBindablePlanGUID,
+						Description: "a test plan",
+						Bindable:    boolPtr(false),
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/controller/actions.go
+++ b/pkg/controller/actions.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+// TestNumberOfActions checks to ensure that actions has the given (in number) number of actions
+// in it. Calls f with the failure if it doesn't have that number of actions
+func TestNumberOfActions(t *testing.T, name string, f FailfFunc, actions []clientgotesting.Action, number int) bool {
+	logContext := ""
+	if len(name) > 0 {
+		logContext = name + ": "
+	}
+
+	if e, a := number, len(actions); e != a {
+		t.Logf("%+v\n", actions)
+		f(t, "%vUnexpected number of actions: expected %v, got %v;\nactions: %+v", logContext, e, a, actions)
+		return false
+	}
+
+	return true
+}
+
+// AssertNumberOfActions fails if actions was not of length number
+func AssertNumberOfActions(t *testing.T, actions []clientgotesting.Action, number int) {
+	TestNumberOfActions(t, "" /* name */, Fatalf, actions, number)
+}
+
+// AssertUpdateStatus ensures that the status of action is an update on obj
+func AssertUpdateStatus(t *testing.T, action clientgotesting.Action, obj interface{}) runtime.Object {
+	return AssertActionFor(t, action, "update", "status", obj)
+}
+
+// AssertActionFor tests for that verb and subresource are set on action for the given object
+func AssertActionFor(t *testing.T, action clientgotesting.Action, verb, subresource string, obj interface{}) runtime.Object {
+	r, _ := TestActionFor(t, "" /* name */, Fatalf, action, verb, subresource, obj)
+	return r
+}
+
+// TestActionFor ensures that the given action, verb and subresource are set on obj
+func TestActionFor(
+	t *testing.T,
+	name string,
+	f FailfFunc,
+	action clientgotesting.Action,
+	verb,
+	subresource string,
+	obj interface{},
+) (runtime.Object, bool) {
+	logContext := ""
+	if len(name) > 0 {
+		logContext = name + ": "
+	}
+
+	if e, a := verb, action.GetVerb(); e != a {
+		f(t, "%vUnexpected verb: expected %v, got %v", logContext, e, a)
+		return nil, false
+	}
+
+	var resource string
+
+	switch obj.(type) {
+	case *v1alpha1.Broker:
+		resource = "brokers"
+	case *v1alpha1.ServiceClass:
+		resource = "serviceclasses"
+	case *v1alpha1.Instance:
+		resource = "instances"
+	case *v1alpha1.Binding:
+		resource = "bindings"
+	}
+
+	if e, a := resource, action.GetResource().Resource; e != a {
+		f(t, "%vUnexpected resource; expected %v, got %v", logContext, e, a)
+		return nil, false
+	}
+
+	if e, a := subresource, action.GetSubresource(); e != a {
+		f(t, "%vUnexpected subresource; expected %v, got %v", logContext, e, a)
+		return nil, false
+	}
+
+	rtObject, ok := obj.(runtime.Object)
+	if !ok {
+		f(t, "%vObject %+v was not a runtime.Object", logContext, obj)
+		return nil, false
+	}
+
+	paramAccessor, err := metav1.ObjectMetaFor(rtObject)
+	if err != nil {
+		f(t, "%vError creating ObjectMetaAccessor for param object %+v: %v", logContext, rtObject, err)
+		return nil, false
+	}
+
+	var (
+		objectMeta   metav1.Object
+		fakeRtObject runtime.Object
+	)
+
+	switch verb {
+	case "get":
+		getAction, ok := action.(clientgotesting.GetAction)
+		if !ok {
+			f(t, "%vUnexpected type; failed to convert action %+v to DeleteAction", logContext, action)
+			return nil, false
+		}
+
+		if e, a := paramAccessor.GetName(), getAction.GetName(); e != a {
+			f(t, "%vUnexpected name: expected %v, got %v", logContext, e, a)
+			return nil, false
+		}
+
+		return nil, true
+	case "delete":
+		deleteAction, ok := action.(clientgotesting.DeleteAction)
+		if !ok {
+			f(t, "%vUnexpected type; failed to convert action %+v to DeleteAction", logContext, action)
+			return nil, false
+		}
+
+		if e, a := paramAccessor.GetName(), deleteAction.GetName(); e != a {
+			f(t, "%vUnexpected name: expected %v, got %v", logContext, e, a)
+			return nil, false
+		}
+
+		return nil, true
+	case "create":
+		createAction, ok := action.(clientgotesting.CreateAction)
+		if !ok {
+			f(t, "%vUnexpected type; failed to convert action %+v to CreateAction", logContext, action)
+			return nil, false
+		}
+
+		fakeRtObject = createAction.GetObject()
+		objectMeta, err = metav1.ObjectMetaFor(fakeRtObject)
+		if err != nil {
+			f(t, "%vError creating ObjectMetaAccessor for %+v", logContext, fakeRtObject)
+			return nil, false
+		}
+	case "update":
+		updateAction, ok := action.(clientgotesting.UpdateAction)
+		if !ok {
+			f(t, "%vUnexpected type; failed to convert action %+v to UpdateAction", logContext, action)
+			return nil, false
+		}
+
+		fakeRtObject = updateAction.GetObject()
+		objectMeta, err = metav1.ObjectMetaFor(fakeRtObject)
+		if err != nil {
+			f(t, "%vError creating ObjectMetaAccessor for %+v", logContext, fakeRtObject)
+			return nil, false
+		}
+	}
+
+	if e, a := paramAccessor.GetName(), objectMeta.GetName(); e != a {
+		f(t, "%vUnexpected name: expected %v, got %v", logContext, e, a)
+		return nil, false
+	}
+
+	fakeValue := reflect.ValueOf(fakeRtObject)
+	paramValue := reflect.ValueOf(obj)
+
+	if e, a := paramValue.Type(), fakeValue.Type(); e != a {
+		f(t, "%vUnexpected type of object passed to fake client; expected %v, got %v", logContext, e, a)
+		return nil, false
+	}
+
+	return fakeRtObject, true
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -119,6 +119,10 @@ type Controller interface {
 	// workers specifies the number of goroutines, per resource, processing work
 	// from the resource workqueues
 	Run(workers int, stopCh <-chan struct{})
+	// PollingQueueLen returns the length of pending asynchronous instances to be polled
+	PollingQueueLen() int
+	// ReconcileInstance reconciles the given instance to its desired state
+	ReconcileInstance(*v1alpha1.Instance) error
 }
 
 // controller is a concrete Controller.
@@ -142,6 +146,10 @@ type controller struct {
 	//  a reconciling of an instance.
 	// TODO(vaikas): get rid of two queues per instance.
 	pollingQueue workqueue.RateLimitingInterface
+}
+
+func (c *controller) PollingQueueLen() int {
+	return c.pollingQueue.Len()
 }
 
 // Run runs the controller until the given stop channel can be read from.

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -59,7 +59,7 @@ func TestReconcileBindingNonExistingInstance(t *testing.T) {
 	assertNumberOfBrokerActions(t, brokerActions, 0)
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	AssertNumberOfActions(t, actions, 1)
 
 	// There should only be one action that says it failed because no such instance exists.
 	updateAction := actions[0].(clientgotesting.UpdateAction)
@@ -110,7 +110,7 @@ func TestReconcileBindingNonExistingServiceClass(t *testing.T) {
 	assertNumberOfBrokerActions(t, brokerActions, 0)
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	AssertNumberOfActions(t, actions, 1)
 
 	// There should only be one action that says it failed because no such service class.
 	updatedBinding := assertUpdateStatus(t, actions[0], binding)
@@ -188,12 +188,12 @@ func TestReconcileBindingWithParameters(t *testing.T) {
 	})
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	AssertNumberOfActions(t, actions, 1)
 	updatedBinding := assertUpdateStatus(t, actions[0], binding)
 	assertBindingReadyTrue(t, updatedBinding)
 
 	kubeActions := fakeKubeClient.Actions()
-	assertNumberOfActions(t, kubeActions, 3)
+	AssertNumberOfActions(t, kubeActions, 3)
 
 	// first action is a get on the namespace
 	// second action is a get on the secret
@@ -260,7 +260,7 @@ func TestReconcileBindingNonbindableServiceClass(t *testing.T) {
 	assertNumberOfBrokerActions(t, brokerActions, 0)
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	AssertNumberOfActions(t, actions, 1)
 
 	// There should only be one action that says binding was created
 	updatedBinding := assertUpdateStatus(t, actions[0], binding)
@@ -333,12 +333,12 @@ func TestReconcileBindingNonbindableServiceClassBindablePlan(t *testing.T) {
 	})
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	AssertNumberOfActions(t, actions, 1)
 	updatedBinding := assertUpdateStatus(t, actions[0], binding)
 	assertBindingReadyTrue(t, updatedBinding)
 
 	kubeActions := fakeKubeClient.Actions()
-	assertNumberOfActions(t, kubeActions, 3)
+	AssertNumberOfActions(t, kubeActions, 3)
 
 	// first action is a get on the namespace
 	// second action is a get on the secret
@@ -400,7 +400,7 @@ func TestReconcileBindingBindableServiceClassNonbindablePlan(t *testing.T) {
 	assertNumberOfBrokerActions(t, brokerActions, 0)
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	AssertNumberOfActions(t, actions, 1)
 
 	// There should only be one action that says binding was created
 	updatedBinding := assertUpdateStatus(t, actions[0], binding)
@@ -445,10 +445,10 @@ func TestReconcileBindingFailsWithInstanceAsyncOngoing(t *testing.T) {
 	// verify no kube resources created.
 	// No actions
 	kubeActions := fakeKubeClient.Actions()
-	assertNumberOfActions(t, kubeActions, 0)
+	AssertNumberOfActions(t, kubeActions, 0)
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	AssertNumberOfActions(t, actions, 1)
 
 	// There should only be one action that says binding was created
 	updatedBinding := assertUpdateStatus(t, actions[0], binding)
@@ -494,7 +494,7 @@ func TestReconcileBindingInstanceNotReady(t *testing.T) {
 	assertNumberOfBrokerActions(t, brokerActions, 0)
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	AssertNumberOfActions(t, actions, 1)
 
 	// There should only be one action that says binding was created
 	updatedBinding := assertUpdateStatus(t, actions[0], binding)
@@ -537,7 +537,7 @@ func TestReconcileBindingNamespaceError(t *testing.T) {
 	assertNumberOfBrokerActions(t, brokerActions, 0)
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	AssertNumberOfActions(t, actions, 1)
 	updatedBinding := assertUpdateStatus(t, actions[0], binding)
 	assertBindingReadyFalse(t, updatedBinding)
 
@@ -594,7 +594,7 @@ func TestReconcileBindingDelete(t *testing.T) {
 	kubeActions := fakeKubeClient.Actions()
 	// The two actions should be:
 	// 0. Deleting the secret
-	assertNumberOfActions(t, kubeActions, 1)
+	AssertNumberOfActions(t, kubeActions, 1)
 
 	deleteAction := kubeActions[0].(clientgotesting.DeleteActionImpl)
 	if e, a := "delete", deleteAction.GetVerb(); e != a {
@@ -610,7 +610,7 @@ func TestReconcileBindingDelete(t *testing.T) {
 	// 0. Updating the ready condition
 	// 1. Get against the binding in question
 	// 2. Removing the finalizer
-	assertNumberOfActions(t, actions, 3)
+	AssertNumberOfActions(t, actions, 3)
 
 	updatedBinding := assertUpdateStatus(t, actions[0], binding)
 	assertBindingReadyFalse(t, updatedBinding)
@@ -690,14 +690,14 @@ func TestReconcileBindingWithPodPresetTemplate(t *testing.T) {
 	})
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	AssertNumberOfActions(t, actions, 1)
 
 	// There should only be one action that says binding was created
 	updatedBinding := assertUpdateStatus(t, actions[0], binding)
 	assertBindingReadyTrue(t, updatedBinding)
 
 	kubeActions := fakeKubeClient.Actions()
-	assertNumberOfActions(t, kubeActions, 4)
+	AssertNumberOfActions(t, kubeActions, 4)
 
 	action := kubeActions[2].(clientgotesting.CreateAction)
 	if e, a := "create", action.GetVerb(); e != a {

--- a/pkg/controller/controller_broker_test.go
+++ b/pkg/controller/controller_broker_test.go
@@ -128,7 +128,7 @@ func TestReconcileBrokerExistingServiceClass(t *testing.T) {
 	assertGetCatalog(t, brokerActions[0])
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 2)
+	AssertNumberOfActions(t, actions, 2)
 
 	// first action should be an update action for a service class
 	assertUpdate(t, actions[0], testServiceClass)
@@ -139,7 +139,7 @@ func TestReconcileBrokerExistingServiceClass(t *testing.T) {
 
 	// verify no kube resources created
 	kubeActions := fakeKubeClient.Actions()
-	assertNumberOfActions(t, kubeActions, 0)
+	AssertNumberOfActions(t, kubeActions, 0)
 }
 
 func TestReconcileBrokerExistingServiceClassDifferentExternalID(t *testing.T) {
@@ -158,14 +158,14 @@ func TestReconcileBrokerExistingServiceClassDifferentExternalID(t *testing.T) {
 	assertGetCatalog(t, brokerActions[0])
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	AssertNumberOfActions(t, actions, 1)
 
 	updatedBroker := assertUpdateStatus(t, actions[0], getTestBroker())
 	assertBrokerReadyFalse(t, updatedBroker)
 
 	// verify no kube resources created
 	kubeActions := fakeKubeClient.Actions()
-	assertNumberOfActions(t, kubeActions, 0)
+	AssertNumberOfActions(t, kubeActions, 0)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -192,14 +192,14 @@ func TestReconcileBrokerExistingServiceClassDifferentBroker(t *testing.T) {
 	assertGetCatalog(t, brokerActions[0])
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	AssertNumberOfActions(t, actions, 1)
 
 	updatedBroker := assertUpdateStatus(t, actions[0], getTestBroker())
 	assertBrokerReadyFalse(t, updatedBroker)
 
 	// verify no kube resources created
 	kubeActions := fakeKubeClient.Actions()
-	assertNumberOfActions(t, kubeActions, 0)
+	AssertNumberOfActions(t, kubeActions, 0)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -233,7 +233,7 @@ func TestReconcileBrokerDelete(t *testing.T) {
 
 	// Verify no core kube actions occurred
 	kubeActions := fakeKubeClient.Actions()
-	assertNumberOfActions(t, kubeActions, 0)
+	AssertNumberOfActions(t, kubeActions, 0)
 
 	actions := fakeCatalogClient.Actions()
 	// The three actions should be:
@@ -241,7 +241,7 @@ func TestReconcileBrokerDelete(t *testing.T) {
 	// 1. Updating the ready condition
 	// 2. Getting the broker
 	// 3. Removing the finalizer
-	assertNumberOfActions(t, actions, 4)
+	AssertNumberOfActions(t, actions, 4)
 
 	assertDelete(t, actions[0], testServiceClass)
 
@@ -280,12 +280,12 @@ func TestReconcileBrokerErrorFetchingCatalog(t *testing.T) {
 	assertGetCatalog(t, brokerActions[0])
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	AssertNumberOfActions(t, actions, 1)
 
 	updatedBroker := assertUpdateStatus(t, actions[0], broker)
 	assertBrokerReadyFalse(t, updatedBroker)
 
-	assertNumberOfActions(t, fakeKubeClient.Actions(), 0)
+	AssertNumberOfActions(t, fakeKubeClient.Actions(), 0)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -314,12 +314,12 @@ func TestReconcileBrokerZeroServices(t *testing.T) {
 	assertGetCatalog(t, brokerActions[0])
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	AssertNumberOfActions(t, actions, 1)
 
 	updatedBroker := assertUpdateStatus(t, actions[0], broker)
 	assertBrokerReadyFalse(t, updatedBroker)
 
-	assertNumberOfActions(t, fakeKubeClient.Actions(), 0)
+	AssertNumberOfActions(t, fakeKubeClient.Actions(), 0)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -353,14 +353,14 @@ func TestReconcileBrokerWithAuthError(t *testing.T) {
 	assertNumberOfBrokerActions(t, brokerActions, 0)
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	AssertNumberOfActions(t, actions, 1)
 
 	updatedBroker := assertUpdateStatus(t, actions[0], broker)
 	assertBrokerReadyFalse(t, updatedBroker)
 
 	// verify one kube action occurred
 	kubeActions := fakeKubeClient.Actions()
-	assertNumberOfActions(t, kubeActions, 1)
+	AssertNumberOfActions(t, kubeActions, 1)
 
 	getAction := kubeActions[0].(clientgotesting.GetAction)
 	if e, a := "get", getAction.GetVerb(); e != a {
@@ -397,7 +397,7 @@ func TestReconcileBrokerWithReconcileError(t *testing.T) {
 	assertGetCatalog(t, brokerActions[0])
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 2)
+	AssertNumberOfActions(t, actions, 2)
 
 	createSCAction := actions[0].(clientgotesting.CreateAction)
 	createdSC, ok := createSCAction.GetObject().(*v1alpha1.ServiceClass)
@@ -411,7 +411,7 @@ func TestReconcileBrokerWithReconcileError(t *testing.T) {
 	assertBrokerReadyFalse(t, updatedBroker)
 
 	kubeActions := fakeKubeClient.Actions()
-	assertNumberOfActions(t, kubeActions, 0)
+	AssertNumberOfActions(t, kubeActions, 0)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -203,9 +203,14 @@ func (c *controller) reconcileInstanceDelete(instance *v1alpha1.Instance) error 
 	return nil
 }
 
-// reconcileInstance is the control-loop for reconciling Instances. An
-// error is returned to indicate that the binding has not been fully
+// ReconcileInstance is the Controller interface implementation. It is the control-loop for
+// reconciling Instances. An error is returned to indicate that the binding has not been fully
 // processed and should be resubmitted at a later time.
+func (c *controller) ReconcileInstance(i *v1alpha1.Instance) error {
+	return c.reconcileInstance(i)
+}
+
+// reconcileInstance is the control-loop for reconciling Instances.
 func (c *controller) reconcileInstance(instance *v1alpha1.Instance) error {
 
 	// If there's no async op in progress, determine whether the checksum

--- a/pkg/controller/fake.go
+++ b/pkg/controller/fake.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"net/http/httptest"
+	"time"
+
+	fakebrokerserver "github.com/kubernetes-incubator/service-catalog/pkg/brokerapi/fake/server"
+	servicecatalogclientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/fake"
+	servicecataloginformers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/externalversions"
+	v1alpha1informers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/externalversions/servicecatalog/v1alpha1"
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+)
+
+// TestControllerWithBrokerServer contains information about a controller that uses mock clients
+// except one that points to a broker server that runs in-memory
+type TestControllerWithBrokerServer struct {
+	FakeKubeClient      *clientgofake.Clientset
+	FakeCatalogClient   *servicecatalogclientset.Clientset
+	Controller          Controller
+	Informers           v1alpha1informers.Interface
+	BrokerServerHandler *fakebrokerserver.Handler
+	BrokerServer        *httptest.Server
+}
+
+// Close releases all resources associated with t. It generally should be called in a defer after
+// calling NewTestControllerWithBrokerServer
+func (t *TestControllerWithBrokerServer) Close() {
+	t.BrokerServer.Close()
+}
+
+// NewTestControllerWithBrokerServer creates a new TestControllerWithBrokerServer, or returns a
+// non-nil error if there was a problem creating it. When a non-nil TestControllerWithBrokerServer
+// is returned, it should be Close()-ed when the caller is done using it
+func NewTestControllerWithBrokerServer(
+	brokerUsername,
+	brokerPassword string,
+) (*TestControllerWithBrokerServer, error) {
+	// create a fake kube client
+	fakeKubeClient := &clientgofake.Clientset{}
+	// create a fake sc client
+	fakeCatalogClient := &servicecatalogclientset.Clientset{}
+
+	brokerHandler := fakebrokerserver.NewHandler()
+	brokerServer := fakebrokerserver.Run(brokerHandler, brokerUsername, brokerPassword)
+
+	// create informers
+	informerFactory := servicecataloginformers.NewSharedInformerFactory(fakeCatalogClient, 0)
+	serviceCatalogSharedInformers := informerFactory.Servicecatalog().V1alpha1()
+
+	fakeRecorder := record.NewFakeRecorder(5)
+
+	// create a test controller
+	testController, err := NewController(
+		fakeKubeClient,
+		fakeCatalogClient.ServicecatalogV1alpha1(),
+		serviceCatalogSharedInformers.Brokers(),
+		serviceCatalogSharedInformers.ServiceClasses(),
+		serviceCatalogSharedInformers.Instances(),
+		serviceCatalogSharedInformers.Bindings(),
+		osb.NewClient,
+		24*time.Hour,
+		true, /* enable OSB context profile */
+		fakeRecorder,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TestControllerWithBrokerServer{
+		FakeKubeClient:      fakeKubeClient,
+		FakeCatalogClient:   fakeCatalogClient,
+		Controller:          testController,
+		Informers:           serviceCatalogSharedInformers,
+		BrokerServerHandler: brokerHandler,
+		BrokerServer:        brokerServer,
+	}, nil
+}

--- a/pkg/controller/funcs.go
+++ b/pkg/controller/funcs.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+// FailfFunc is a type that defines the common signatures of T.Fatalf and T.Errorf
+type FailfFunc func(t *testing.T, msg string, args ...interface{})
+
+// Fatalf is a FailfFunc that logs a stack trace and then calls t.Fatalf
+func Fatalf(t *testing.T, msg string, args ...interface{}) {
+	t.Log(string(debug.Stack()))
+	t.Fatalf(msg, args...)
+}
+
+// Errorf is a FailfFunc that logs a stack trace and then calls t.Errorf
+func Errorf(t *testing.T, msg string, args ...interface{}) {
+	t.Log(string(debug.Stack()))
+	t.Errorf(msg, args...)
+}

--- a/pkg/controller/reactions.go
+++ b/pkg/controller/reactions.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	faketypes "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/pkg/api/v1"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+// AddGetNamespaceReaction adds a "get", "namespaces" reactor to fakeKubeClient for tests
+func AddGetNamespaceReaction(fakeKubeClient *clientgofake.Clientset) {
+	fakeKubeClient.AddReactor("get", "namespaces", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: types.UID(faketypes.NamespaceUID),
+			},
+		}, nil
+	})
+}

--- a/pkg/controller/status.go
+++ b/pkg/controller/status.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// AssertInstanceReadyTrue ensures that obj is an instance and has a ready condition of True
+// on it
+func AssertInstanceReadyTrue(t *testing.T, obj runtime.Object) {
+	AssertInstanceReadyCondition(t, obj, v1alpha1.ConditionTrue)
+}
+
+// this function is here to maintain compatibility of existing controller test code
+func assertInstanceReadyTrue(t *testing.T, obj runtime.Object) {
+	AssertInstanceReadyTrue(t, obj)
+}
+
+// AssertInstanceReadyFalse ensures that obj is an instance, has a ready condition of False
+// on it, and the reason for that ready condition is reason
+func AssertInstanceReadyFalse(t *testing.T, obj runtime.Object, reason ...string) {
+	AssertInstanceReadyCondition(t, obj, v1alpha1.ConditionFalse, reason...)
+}
+
+// this function is here to maintain compatibility of existing controller code
+func assertInstanceReadyFalse(t *testing.T, obj runtime.Object, reason ...string) {
+	AssertInstanceReadyFalse(t, obj, reason...)
+}
+
+// AssertAsyncOpInProgressFalse fails if obj does not have a condition on it that has the type
+// of async op in progress and the status of it as false
+func AssertAsyncOpInProgressFalse(t *testing.T, obj runtime.Object) {
+	instance, ok := obj.(*v1alpha1.Instance)
+	if !ok {
+		t.Fatalf("Couldn't convert object %+v into a *v1alpha1.Instance", obj)
+	}
+	if instance.Status.AsyncOpInProgress {
+		t.Fatalf("expected AsyncOpInProgress to be false but was %v", instance.Status.AsyncOpInProgress)
+	}
+}
+
+// AssertAsyncOpInProgressTrue fails if obj does not have a condition on it that has the type
+// of async op in progress and the status of it as true
+func AssertAsyncOpInProgressTrue(t *testing.T, obj runtime.Object) {
+	instance, ok := obj.(*v1alpha1.Instance)
+	if !ok {
+		t.Fatalf("Couldn't convert object %+v into a *v1alpha1.Instance", obj)
+	}
+	if !instance.Status.AsyncOpInProgress {
+		t.Fatalf("expected AsyncOpInProgress to be true but was %v", instance.Status.AsyncOpInProgress)
+	}
+}
+
+// AssertInstanceReadyCondition ensures that obj is an instance and that it has a ready condition
+// with the given status and reason on it
+func AssertInstanceReadyCondition(t *testing.T, obj runtime.Object, status v1alpha1.ConditionStatus, reason ...string) {
+	instance, ok := obj.(*v1alpha1.Instance)
+	if !ok {
+		Fatalf(t, "Couldn't convert object %+v into a *v1alpha1.Instance", obj)
+	}
+
+	for _, condition := range instance.Status.Conditions {
+		if condition.Type == v1alpha1.InstanceConditionReady && condition.Status != status {
+			Fatalf(t, "ready condition had unexpected status; expected %v, got %v", status, condition.Status)
+		}
+		if len(reason) == 1 && condition.Reason != reason[0] {
+			Fatalf(t, "unexpected reason; expected %v, got %v", reason[0], condition.Reason)
+		}
+	}
+}

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	faketypes "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/fake"
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	fakebrokerapi "github.com/kubernetes-incubator/service-catalog/pkg/brokerapi/fake"
+	fakebrokerserver "github.com/kubernetes-incubator/service-catalog/pkg/brokerapi/fake/server"
+	"github.com/kubernetes-incubator/service-catalog/pkg/controller"
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/pkg/api/v1"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+// TestReconcileInstanceAsynchronousUnsupportedBrokerError tests to ensure that, on an asynchronous
+// provision, an Instance's conditions get set with a Broker failure that is not one of the
+// "expected" response codes in the OSB API spec for provision.
+// See https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#response-2 for
+// the list of expected codes and a description of what we should do if another code is returned
+func TestReconcileInstanceAsynchronousUnsupportedBrokerError(t *testing.T) {
+	const (
+		brokerUsername = "testbrokeruser"
+		brokerPassword = "testbrokerpass"
+	)
+	controllerItems, err := controller.NewTestControllerWithBrokerServer(brokerUsername, brokerPassword)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer controllerItems.Close()
+
+	fakeKubeClient := controllerItems.FakeKubeClient
+	fakeCatalogClient := controllerItems.FakeCatalogClient
+	fakeBrokerServerHandler := controllerItems.BrokerServerHandler
+	testController := controllerItems.Controller
+	sharedInformers := controllerItems.Informers
+
+	fakeBrokerServerHandler.Catalog = fakebrokerserver.ConvertCatalog(fakebrokerapi.GetTestCatalog())
+
+	controller.AddGetNamespaceReaction(fakeKubeClient)
+
+	// create the secret that the Broker resource will use for auth to the fake broker server
+	fakeKubeClient.AddReactor("get", "secrets", func(clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, &v1.Secret{
+			Data: map[string][]byte{
+				"username": []byte(brokerUsername),
+				"password": []byte(brokerPassword),
+			},
+		}, nil
+	})
+
+	// build the chain from Instance -> ServiceClass -> Broker
+	testBroker := faketypes.GetBroker()
+	testBroker.Spec.URL = controllerItems.BrokerServer.URL
+	testBroker.Spec.AuthInfo = &v1alpha1.BrokerAuthInfo{
+		BasicAuthSecret: &v1.ObjectReference{
+			Namespace: "test",
+			Name:      "test",
+		},
+	}
+	testServiceClass := faketypes.GetServiceClass()
+	testInstance := faketypes.GetInstance()
+
+	sharedInformers.Brokers().Informer().GetStore().Add(testBroker)
+	sharedInformers.ServiceClasses().Informer().GetStore().Add(testServiceClass)
+
+	fakeCatalogClient.AddReactor("get", "serviceclasses", func(clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, testServiceClass, nil
+	})
+	fakeCatalogClient.AddReactor("get", "brokers", func(clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, testBroker, nil
+	})
+
+	// Make the provision return an error that is "unexpected"
+	fakeBrokerServerHandler.ProvisionRespError = errors.New("test provision error")
+
+	// there should be nothing that is polling since no instances have been reconciled yet
+	if testController.PollingQueueLen() != 0 {
+		t.Fatalf("Expected the polling queue to be empty")
+	}
+
+	reconcileErr := testController.ReconcileInstance(testInstance)
+	if reconcileErr == nil {
+		t.Fatalf("expected an error from reconcileInstance")
+	}
+	statusCodeErr, ok := reconcileErr.(osb.HTTPStatusCodeError)
+	if !ok {
+		t.Fatalf("expected an OSB client HTTPStatusCodeError, got %#v", reconcileErr)
+	}
+	if statusCodeErr.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected an internal server error, got %d", statusCodeErr.StatusCode)
+	}
+
+	actions := fakeCatalogClient.Actions()
+	controller.AssertNumberOfActions(t, actions, 1)
+
+	// verify that 2 kubernetes actions occurred - a GET to the ServiceClass, then a GET to the
+	// Broker
+	kubeActions := fakeKubeClient.Actions()
+	controller.AssertNumberOfActions(t, kubeActions, 2)
+
+	updatedInstance := controller.AssertUpdateStatus(t, actions[0], testInstance)
+	controller.AssertInstanceReadyFalse(t, updatedInstance)
+
+	// there should be 1 request to the provision endpoint
+	numProvReqs := len(fakeBrokerServerHandler.ProvisionRequests)
+	if numProvReqs != 1 {
+		t.Fatalf("%d provision requests were made, expected 1", numProvReqs)
+	}
+
+	// The item should not have been added to the polling queue for later processing
+	if testController.PollingQueueLen() != 0 {
+		t.Fatalf("Expected polling queue to be empty")
+	}
+	controller.AssertAsyncOpInProgressFalse(t, updatedInstance)
+	controller.AssertInstanceReadyFalse(t, updatedInstance)
+	controller.AssertInstanceReadyCondition(t, updatedInstance, v1alpha1.ConditionFalse)
+}


### PR DESCRIPTION
# Overview

This patch creates a new test at `./test/integration/controller_instance_test.go`, which exercises the controller's `ReconcileInstance` function against fake clients for everything except for a broker API. This test ensures that, if the broker API returns an HTTP response with a 500 error code, the controller will write the results of that response into the `Instance`'s conditions.


# Refactors 

The new test borrows a lot of logic from the existing controller unit tests, but it lives alongside the integration tests. I've done quite a bit of refactoring to enable this test to use functions that were previously only available to unit tests. Note that I've done the least amount of refactoring I had to, but there are still quite a few changes here. The result is that the unit test code is slightly more factored and reusable as well.

# Follow-ups

While this PR only adds a single additional test, I plan to do several further follow-ups to add several additional tests that would best be written as this type of integration test (such as #984 and #985). The result of those additions will be further (but smaller) refactors and, of course, additional test coverage.

# Related Issues

See #914 for details on motivations behind this test.

Partially addresses https://github.com/kubernetes-incubator/service-catalog/issues/914
Requires https://github.com/kubernetes-incubator/service-catalog/pull/928