### PR TITLE
add Jenkins badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## `service-catalog`
 
-[![Build Status](https://travis-ci.org/kubernetes-incubator/service-catalog.svg?branch=master)](https://travis-ci.org/kubernetes-incubator/service-catalog)
+[![Build Status](https://travis-ci.org/kubernetes-incubator/service-catalog.svg?branch=master)](https://travis-ci.org/kubernetes-incubator/service-catalog "Travis")
+[![Build Status](https://service-catalog-jenkins.appspot.com/buildStatus/icon?job=service-catalog-master-testing)](https://service-catalog-jenkins.appspot.com/job/service-catalog-master-testing/ "Jenkins")
 
 ### Introduction
 


### PR DESCRIPTION
Expected output can be seen here: https://github.com/kibbles-n-bytes/service-catalog/tree/badge

@pmorie et al., Let me know if there's a preferred way you'd like to have the badges displayed. I cannot edit the content of the badge image itself.