### PR TITLE
Checking for returned errors when updating conditions & finalizers

### DIFF
--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -102,13 +102,16 @@ func (c *controller) reconcileBinding(binding *v1alpha1.Binding) error {
 			binding.Spec.InstanceRef.Name,
 			err,
 		)
-		c.updateBindingCondition(
+		if err := c.updateBindingCondition(
 			binding,
 			v1alpha1.BindingConditionReady,
 			v1alpha1.ConditionFalse,
 			errorNonexistentInstanceReason,
 			"The binding references an Instance that does not exist. "+s,
-		)
+		); err != nil {
+			glog.Errorf("updating binding condition (%s)", err)
+			return err
+		}
 		c.recorder.Event(binding, api.EventTypeWarning, errorNonexistentInstanceReason, s)
 		return err
 	}
@@ -122,13 +125,16 @@ func (c *controller) reconcileBinding(binding *v1alpha1.Binding) error {
 			binding.Spec.InstanceRef.Name,
 		)
 		glog.Info(s)
-		c.updateBindingCondition(
+		if err := c.updateBindingCondition(
 			binding,
 			v1alpha1.BindingConditionReady,
 			v1alpha1.ConditionFalse,
 			errorWithOngoingAsyncOperation,
 			errorWithOngoingAsyncOperationMessage,
-		)
+		); err != nil {
+			glog.Errorf("updating binding condition (%s)", err)
+			return err
+		}
 		c.recorder.Event(binding, api.EventTypeWarning, errorWithOngoingAsyncOperation, s)
 		return fmt.Errorf("Ongoing Asynchronous operation")
 	}
@@ -147,13 +153,16 @@ func (c *controller) reconcileBinding(binding *v1alpha1.Binding) error {
 			instance.Spec.PlanName,
 		)
 		glog.Warning(s)
-		c.updateBindingCondition(
+		if err := c.updateBindingCondition(
 			binding,
 			v1alpha1.BindingConditionReady,
 			v1alpha1.ConditionFalse,
 			errorNonbindableServiceClassReason,
 			s,
-		)
+		); err != nil {
+			glog.Errorf("updating binding condition (%s)", err)
+			return err
+		}
 		c.recorder.Event(binding, api.EventTypeWarning, errorNonbindableServiceClassReason, s)
 		return nil
 	}
@@ -167,13 +176,16 @@ func (c *controller) reconcileBinding(binding *v1alpha1.Binding) error {
 			if err != nil {
 				s := fmt.Sprintf("Failed to unmarshal Binding parameters\n%s\n %s", binding.Spec.Parameters, err)
 				glog.Warning(s)
-				c.updateBindingCondition(
+				if err := c.updateBindingCondition(
 					binding,
 					v1alpha1.BindingConditionReady,
 					v1alpha1.ConditionFalse,
 					errorWithParameters,
 					"Error unmarshaling binding parameters. "+s,
-				)
+				); err != nil {
+					glog.Errorf("updating binding condition (%s)", err)
+					return err
+				}
 				c.recorder.Event(binding, api.EventTypeWarning, errorWithParameters, s)
 				return err
 			}
@@ -183,13 +195,16 @@ func (c *controller) reconcileBinding(binding *v1alpha1.Binding) error {
 		if err != nil {
 			s := fmt.Sprintf("Failed to get namespace %q during binding: %s", instance.Namespace, err)
 			glog.Info(s)
-			c.updateBindingCondition(
+			if err := c.updateBindingCondition(
 				binding,
 				v1alpha1.BindingConditionReady,
 				v1alpha1.ConditionFalse,
 				errorFindingNamespaceInstanceReason,
 				"Error finding namespace for instance. "+s,
-			)
+			); err != nil {
+				glog.Errorf("updating binding condition (%s)", err)
+				return err
+			}
 			c.recorder.Eventf(binding, api.EventTypeWarning, errorFindingNamespaceInstanceReason, s)
 			return err
 		}
@@ -197,13 +212,16 @@ func (c *controller) reconcileBinding(binding *v1alpha1.Binding) error {
 		if !isInstanceReady(instance) {
 			s := fmt.Sprintf(`Binding cannot begin because referenced instance "%v/%v" is not ready`, instance.Namespace, instance.Name)
 			glog.Info(s)
-			c.updateBindingCondition(
+			if err := c.updateBindingCondition(
 				binding,
 				v1alpha1.BindingConditionReady,
 				v1alpha1.ConditionFalse,
 				errorInstanceNotReadyReason,
 				s,
-			)
+			); err != nil {
+				glog.Errorf("updating binding condition (%s)", err)
+				return err
+			}
 			c.recorder.Eventf(binding, api.EventTypeWarning, errorInstanceNotReadyReason, s)
 			return nil
 		}
@@ -245,12 +263,16 @@ func (c *controller) reconcileBinding(binding *v1alpha1.Binding) error {
 
 			s := fmt.Sprintf("Error creating Binding \"%s/%s\" for Instance \"%s/%s\" of ServiceClass %q at Broker %q: %s", binding.Name, binding.Namespace, instance.Namespace, instance.Name, serviceClass.Name, brokerName, err)
 			glog.Warning(s)
-			c.updateBindingCondition(
+			if err := c.updateBindingCondition(
 				binding,
 				v1alpha1.BindingConditionReady,
 				v1alpha1.ConditionFalse,
 				errorBindCallReason,
-				"Bind call failed. "+s)
+				"Bind call failed. "+s,
+			); err != nil {
+				glog.Errorf("updating binding condition (%s)", err)
+				return err
+			}
 			c.recorder.Event(binding, api.EventTypeWarning, errorBindCallReason, s)
 			return err
 		}
@@ -259,23 +281,29 @@ func (c *controller) reconcileBinding(binding *v1alpha1.Binding) error {
 		if err != nil {
 			s := fmt.Sprintf("Error injecting binding results for Binding \"%s/%s\": %s", binding.Namespace, binding.Name, err)
 			glog.Warning(s)
-			c.updateBindingCondition(
+			if err := c.updateBindingCondition(
 				binding,
 				v1alpha1.BindingConditionReady,
 				v1alpha1.ConditionFalse,
 				errorInjectingBindResultReason,
 				"Error injecting bind result "+s,
-			)
+			); err != nil {
+				glog.Errorf("updating binding condition (%s)", err)
+				return err
+			}
 			c.recorder.Event(binding, api.EventTypeWarning, errorInjectingBindResultReason, s)
 			return err
 		}
-		c.updateBindingCondition(
+		if err := c.updateBindingCondition(
 			binding,
 			v1alpha1.BindingConditionReady,
 			v1alpha1.ConditionTrue,
 			successInjectedBindResultReason,
 			successInjectedBindResultMessage,
-		)
+		); err != nil {
+			glog.Errorf("updating binding condition (%s)", err)
+			return err
+		}
 		c.recorder.Event(binding, api.EventTypeNormal, successInjectedBindResultReason, successInjectedBindResultMessage)
 
 		glog.V(5).Infof("Successfully bound to Instance %v/%v of ServiceClass %v at Broker %v", instance.Namespace, instance.Name, serviceClass.Name, brokerName)
@@ -296,13 +324,16 @@ func (c *controller) reconcileBinding(binding *v1alpha1.Binding) error {
 		if err != nil {
 			s := fmt.Sprintf("Error deleting secret: %s", err)
 			glog.Warning(s)
-			c.updateBindingCondition(
+			if err := c.updateBindingCondition(
 				binding,
 				v1alpha1.BindingConditionReady,
 				v1alpha1.ConditionUnknown,
 				errorEjectingBindReason,
 				errorEjectingBindMessage+s,
-			)
+			); err != nil {
+				glog.Errorf("updating binding condition (%s)", err)
+				return err
+			}
 			c.recorder.Eventf(binding, api.EventTypeWarning, errorEjectingBindReason, "%v %v", errorEjectingBindMessage, s)
 			return err
 		}
@@ -347,26 +378,36 @@ func (c *controller) reconcileBinding(binding *v1alpha1.Binding) error {
 				err,
 			)
 			glog.Warning(s)
-			c.updateBindingCondition(
+			if err := c.updateBindingCondition(
 				binding,
 				v1alpha1.BindingConditionReady,
 				v1alpha1.ConditionFalse,
 				errorUnbindCallReason,
-				"Unbind call failed. "+s)
+				"Unbind call failed. "+s,
+			); err != nil {
+				glog.Errorf("updating binding condition (%s)", err)
+				return err
+			}
 			c.recorder.Event(binding, api.EventTypeWarning, errorUnbindCallReason, s)
 			return err
 		}
 
-		c.updateBindingCondition(
+		if err := c.updateBindingCondition(
 			binding,
 			v1alpha1.BindingConditionReady,
 			v1alpha1.ConditionFalse,
 			successUnboundReason,
 			"The binding was deleted successfully",
-		)
+		); err != nil {
+			glog.Errorf("updating binding condition (%s)", err)
+			return err
+		}
 		// Clear the finalizer
 		finalizers.Delete(v1alpha1.FinalizerServiceCatalog)
-		c.updateBindingFinalizers(binding, finalizers.List())
+		if err := c.updateBindingFinalizers(binding, finalizers.List()); err != nil {
+			glog.Errorf("updating binding finalizers (%s)", err)
+			return err
+		}
 		c.recorder.Event(binding, api.EventTypeNormal, successUnboundReason, "This binding was deleted successfully")
 
 		glog.V(5).Infof("Successfully deleted Binding %v/%v of Instance %v/%v of ServiceClass %v at Broker %v", binding.Namespace, binding.Name, instance.Namespace, instance.Name, serviceClass.Name, brokerName)

--- a/pkg/controller/controller_reconcile_binding_table_test.go
+++ b/pkg/controller/controller_reconcile_binding_table_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	scfake "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/fake"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+// bindingTestCase represents a single row of a table driven test for reconciling bindings
+type reconcileBindingTestCase struct {
+	// the name of the test
+	name string
+	// mutator for the service catalog fake client set - called before reconcileBinding is called
+	modifyCatalogClient func(*scfake.Clientset) error
+	// function to check the error returned by reconcileBinding
+	checkReconcileErr func(error) error
+	// the number of actions that should have occurred after reconcileBinding
+	numActions int
+	// function to check each update action. the int is the action number
+	checkAction func(int, clientgotesting.Action) error
+	// the number of events that should have occurred after reconcileBinding
+	numEvents int
+	// function to check each event. the int is the event number
+	checkEvent func(int, string) error
+}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -76,7 +76,10 @@ const (
 	testNsUID                       = "test-ns-uid"
 )
 
-var testDashboardURL = "http://dashboard"
+var (
+	testDashboardURL      = "http://dashboard"
+	errStatusUpdateFailed = errors.New("status update failed")
+)
 
 const testCatalog = `{
   "services": [{


### PR DESCRIPTION
This patch adds error checks to all `update{Broker,Binding,Instance}Condition` calls in the controller, along with tests to ensure that the errors are properly handled.

Fixes https://github.com/kubernetes-incubator/service-catalog/issues/925