### PR TITLE
docs: fix quoting issue, clarify naming in auth.md

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -136,12 +136,18 @@ use the following commands:
 
 ```shell
 export SERVICE_NAME=<service>
-export ALT_NAMES="<service>.<namespace>,<service>.<namespace>.svc"
+export ALT_NAMES='"<service>.<namespace>","<service>.<namespace>.svc"'
 echo '{"CN":"'${SERVICE_NAME}'","hosts":['${ALT_NAMES}'],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=server-ca.crt -ca-key=server-ca.key -config=server-ca-config.json - | cfssljson -bare apiserver
 ```
 
 `<service>` should be the name of the Service for service
 catalog API server (e.g. `<release>-<chart>` when using Helm).
+
+This will create a pair of files named `apiserver-key.pem` and
+`apiserver.pem`.  These are the private key and public certificate,
+respectively.  The private key and certificate are commonly referred to
+with `.key ` and `.crt` extensions, respectively: `apiserver.key` and
+`apiserver.crt`.
 
 To base64 encode these files for passing to the Helm charts, run `base64
 --wrap=0 <file>`.  The resulting output may be passed to the Helm charts


### PR DESCRIPTION
The steps for creating serving certificates were missing a pair of
quotes, which could have lead to some confusion.

This also clarifies the naming of the serving certs a bit: many places
refer to the cert and key as `.crt` and `.key`, but `cfssl` outputs them
as `.pem` and `-key.pem`.