### PR TITLE
Parameter ordering

### DIFF
--- a/pkg/brokerapi/schemas.go
+++ b/pkg/brokerapi/schemas.go
@@ -16,9 +16,7 @@ limitations under the License.
 
 package brokerapi
 
-import (
-	"k8s.io/apimachinery/pkg/runtime"
-)
+import "encoding/json"
 
 // Schemas represents a plan's schemas for service instance and binding create
 // and update.
@@ -43,5 +41,5 @@ type ServiceBindingSchema struct {
 // InputParameters represents a schema for input parameters for creation or
 // update of an API resource.
 type InputParameters struct {
-	Parameters *runtime.RawExtension `json:"parameters,omitempty"`
+	Parameters json.RawMessage `json:"parameters,omitempty"`
 }

--- a/pkg/brokerapi/schemas.go
+++ b/pkg/brokerapi/schemas.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package brokerapi
 
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
 // Schemas represents a plan's schemas for service instance and binding create
 // and update.
 type Schemas struct {
@@ -39,5 +43,5 @@ type ServiceBindingSchema struct {
 // InputParameters represents a schema for input parameters for creation or
 // update of an API resource.
 type InputParameters struct {
-	Parameters interface{} `json:"parameters,omitempty"`
+	Parameters *runtime.RawExtension `json:"parameters,omitempty"`
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -440,38 +440,19 @@ func convertServicePlans(plans []brokerapi.ServicePlan) ([]v1alpha1.ServicePlan,
 
 		if schemas := plans[i].Schemas; schemas != nil {
 			if instanceSchemas := schemas.ServiceInstances; instanceSchemas != nil {
-				if instanceCreateSchema := instanceSchemas.Create; instanceCreateSchema != nil && instanceCreateSchema.Parameters != nil {
-					schema, err := json.Marshal(instanceCreateSchema.Parameters)
-					if err != nil {
-						err = fmt.Errorf("Failed to marshal instance create schema \n%+v\n %v", instanceCreateSchema.Parameters, err)
-						glog.Error(err)
-						return nil, err
-					}
-					ret[i].AlphaInstanceCreateParameterSchema = &runtime.RawExtension{Raw: schema}
+				if instanceCreateSchema := instanceSchemas.Create; instanceCreateSchema != nil {
+					ret[i].AlphaInstanceCreateParameterSchema = instanceCreateSchema.Parameters
 				}
-				if instanceUpdateSchema := instanceSchemas.Update; instanceUpdateSchema != nil && instanceUpdateSchema.Parameters != nil {
-					schema, err := json.Marshal(instanceUpdateSchema.Parameters)
-					if err != nil {
-						err = fmt.Errorf("Failed to marshal instance update schema \n%+v\n %v", instanceUpdateSchema.Parameters, err)
-						glog.Error(err)
-						return nil, err
-					}
-					ret[i].AlphaInstanceUpdateParameterSchema = &runtime.RawExtension{Raw: schema}
+				if instanceUpdateSchema := instanceSchemas.Update; instanceUpdateSchema != nil {
+					ret[i].AlphaInstanceUpdateParameterSchema = instanceUpdateSchema.Parameters
 				}
 			}
 			if bindingSchemas := schemas.ServiceBindings; bindingSchemas != nil {
-				if bindingCreateSchema := bindingSchemas.Create; bindingCreateSchema != nil && bindingCreateSchema.Parameters != nil {
-					schema, err := json.Marshal(bindingCreateSchema.Parameters)
-					if err != nil {
-						err = fmt.Errorf("Failed to marshal binding create schema \n%+v\n %v", bindingCreateSchema.Parameters, err)
-						glog.Error(err)
-						return nil, err
-					}
-					ret[i].AlphaBindingCreateParameterSchema = &runtime.RawExtension{Raw: schema}
+				if bindingCreateSchema := bindingSchemas.Create; bindingCreateSchema != nil {
+					ret[i].AlphaBindingCreateParameterSchema = bindingCreateSchema.Parameters
 				}
 			}
 		}
-
 	}
 	return ret, nil
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -441,15 +441,15 @@ func convertServicePlans(plans []brokerapi.ServicePlan) ([]v1alpha1.ServicePlan,
 		if schemas := plans[i].Schemas; schemas != nil {
 			if instanceSchemas := schemas.ServiceInstances; instanceSchemas != nil {
 				if instanceCreateSchema := instanceSchemas.Create; instanceCreateSchema != nil {
-					ret[i].AlphaInstanceCreateParameterSchema = instanceCreateSchema.Parameters
+					ret[i].AlphaInstanceCreateParameterSchema = &runtime.RawExtension{Raw: instanceCreateSchema.Parameters}
 				}
 				if instanceUpdateSchema := instanceSchemas.Update; instanceUpdateSchema != nil {
-					ret[i].AlphaInstanceUpdateParameterSchema = instanceUpdateSchema.Parameters
+					ret[i].AlphaInstanceUpdateParameterSchema = &runtime.RawExtension{Raw: instanceUpdateSchema.Parameters}
 				}
 			}
 			if bindingSchemas := schemas.ServiceBindings; bindingSchemas != nil {
 				if bindingCreateSchema := bindingSchemas.Create; bindingCreateSchema != nil {
-					ret[i].AlphaBindingCreateParameterSchema = bindingCreateSchema.Parameters
+					ret[i].AlphaBindingCreateParameterSchema = &runtime.RawExtension{Raw: bindingCreateSchema.Parameters}
 				}
 			}
 		}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http/httptest"
 	"reflect"
@@ -583,16 +584,10 @@ func TestCatalogConversionWithAlphaParameterSchemas(t *testing.T) {
 		t.Fatalf("Expected plan.AlphaInstanceCreateParameterSchema to be set, but was nil")
 	}
 
-	cSchema := make(map[string]interface{})
-	if err := json.Unmarshal(plan.AlphaInstanceCreateParameterSchema.Raw, &cSchema); err == nil {
-		schema := make(map[string]interface{})
-		if err := json.Unmarshal([]byte(instanceParameterSchemaBytes), &schema); err != nil {
-			t.Fatalf("Error unmarshalling schema bytes: %v", err)
-		}
-
-		if e, a := schema, cSchema; !reflect.DeepEqual(e, a) {
-			t.Fatalf("Unexpected value of alphaInstanceCreateParameterSchema; expected %v, got %v", e, a)
-		}
+	expectedSchemaBytes := normalizeJSON([]byte(instanceParameterSchemaBytes))
+	actualSchemaBytes := normalizeJSON(plan.AlphaInstanceCreateParameterSchema.Raw)
+	if !reflect.DeepEqual(expectedSchemaBytes, actualSchemaBytes) {
+		t.Fatalf("Unexpected value of alphaInstanceCreateParameterSchema; expected %v, got %v", string(expectedSchemaBytes), string(actualSchemaBytes))
 	}
 
 	if plan.AlphaInstanceUpdateParameterSchema == nil {
@@ -614,6 +609,12 @@ func TestCatalogConversionWithAlphaParameterSchemas(t *testing.T) {
 			t.Fatalf("Unexpected value of alphaBindingCreateParameterSchema; expected %v, got %v", e, a)
 		}
 	}
+}
+
+func normalizeJSON(jsonBytes []byte) []byte {
+	var buf bytes.Buffer
+	json.Indent(&buf, jsonBytes, "", "  ")
+	return buf.Bytes()
 }
 
 func checkPlan(serviceClass *v1alpha1.ServiceClass, index int, planName, planDescription string, t *testing.T) {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -225,44 +225,7 @@ const alphaParameterSchemaCatalogBytes = `{
       "schemas": {
       	"service_instance": {
 	  	  "create": {
-	  	  	"parameters": {
-	          "$schema": "http://json-schema.org/draft-04/schema",
-	          "type": "object",
-	          "title": "Parameters",
-	          "properties": {
-	            "name": {
-	              "title": "Queue Name",
-	              "type": "string",
-	              "maxLength": 63,
-	              "default": "My Queue"
-	            },
-	            "email": {
-	              "title": "Email",
-	              "type": "string",
-	              "pattern": "^\\S+@\\S+$",
-	              "description": "Email address for alerts."
-	            },
-	            "protocol": {
-	              "title": "Protocol",
-	              "type": "string",
-	              "default": "Java Message Service (JMS) 1.1",
-	              "enum": [
-	                "Java Message Service (JMS) 1.1",
-	                "Transmission Control Protocol (TCP)",
-	                "Advanced Message Queuing Protocol (AMQP) 1.0"
-	              ]
-	            },
-	            "secure": {
-	              "title": "Enable security",
-	              "type": "boolean",
-	              "default": true
-	            }
-	          },
-	          "required": [
-	            "name",
-	            "protocol"
-	          ]
-	  	  	}
+	  	  	"parameters": ` + instanceParameterSchemaBytes + `
 	  	  },
 	  	  "update": {
 	  	  	"parameters": {


### PR DESCRIPTION
Fixes #937

I'm not sure what the implications of changing the `Parameters` field from `interface{}` to `*runtime.RawExtension` are, but this patch does fix the ordering issue.

Note that using `kubectl get serviceclass -o json` to see if order is preserved doesn't work, as kubectl itself changes the order. You need to hit the REST endpoint directly to see the correct order. I've also tested this with the service catalog UI.