### PR TITLE
storage setup does complete with options

### DIFF
--- a/pkg/apiserver/etcd_config.go
+++ b/pkg/apiserver/etcd_config.go
@@ -88,6 +88,8 @@ func (c completedEtcdConfig) NewServer() (*ServiceCatalogAPIServer, error) {
 
 	roFactory := etcdRESTOptionsFactory{
 		deleteCollectionWorkers: c.extraConfig.deleteCollectionWorkers,
+		// TODO https://github.com/kubernetes/kubernetes/issues/44507
+		// we still need to enable it so finalizers are respected.
 		enableGarbageCollection: true,
 		storageFactory:          c.extraConfig.storageFactory,
 		storageDecorator:        generic.UndecoratedStorage,

--- a/pkg/apiserver/etcd_rest_options_factory.go
+++ b/pkg/apiserver/etcd_rest_options_factory.go
@@ -45,6 +45,6 @@ func (f etcdRESTOptionsFactory) GetRESTOptions(resource schema.GroupResource) (g
 		Decorator:               f.storageDecorator,
 		DeleteCollectionWorkers: f.deleteCollectionWorkers,
 		EnableGarbageCollection: f.enableGarbageCollection,
-		ResourcePrefix:          f.storageFactory.ResourcePrefix(resource),
+		ResourcePrefix:          resource.Group + "/" + resource.Resource,
 	}, nil
 }

--- a/pkg/apiserver/tpr_rest_options_factory.go
+++ b/pkg/apiserver/tpr_rest_options_factory.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/server/storage"
+)
+
+type tprRESTOptionsFactory struct {
+	storageFactory storage.StorageFactory
+}
+
+func (t tprRESTOptionsFactory) GetRESTOptions(resource schema.GroupResource) (generic.RESTOptions, error) {
+	storageConfig, err := t.storageFactory.NewConfig(resource)
+	if err != nil {
+		return generic.RESTOptions{}, err
+	}
+	// this function should create a RESTOptions that contains a Decorator function to create
+	// a TPR based storage config. This should be done in a follow up to
+	// https://github.com/kubernetes-incubator/service-catalog/pull/338. When this decorator
+	// function is implemented, the 'NewStorage' functions in
+	// ./pkg/registry/servicecatalog/{binding,broker,instance,serviceclass} no longer will need
+	// to have the switching logic to choose between TPR and etcd
+	return generic.RESTOptions{
+		StorageConfig:  storageConfig,
+		ResourcePrefix: resource.Group + "/" + resource.Resource,
+	}, nil
+}

--- a/pkg/registry/servicecatalog/binding/storage.go
+++ b/pkg/registry/servicecatalog/binding/storage.go
@@ -139,6 +139,11 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage, error) {
 		DestroyFunc: dFunc,
 	}
 
+	options := &generic.StoreOptions{RESTOptions: opts.EtcdOptions.RESTOptions, AttrFunc: GetAttrs}
+	if err := store.CompleteWithOptions(options); err != nil {
+		panic(err) // TODO: Propagate error up
+	}
+
 	statusStore := store
 	statusStore.UpdateStrategy = bindingStatusUpdateStrategy
 

--- a/pkg/registry/servicecatalog/broker/storage.go
+++ b/pkg/registry/servicecatalog/broker/storage.go
@@ -139,6 +139,11 @@ func NewStorage(opts server.Options) (brokers, brokersStatus rest.Storage) {
 		DestroyFunc: dFunc,
 	}
 
+	options := &generic.StoreOptions{RESTOptions: opts.EtcdOptions.RESTOptions, AttrFunc: GetAttrs}
+	if err := store.CompleteWithOptions(options); err != nil {
+		panic(err) // TODO: Propagate error up
+	}
+
 	statusStore := store
 	statusStore.UpdateStrategy = brokerStatusUpdateStrategy
 

--- a/pkg/registry/servicecatalog/instance/storage.go
+++ b/pkg/registry/servicecatalog/instance/storage.go
@@ -137,6 +137,10 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage, rest.Storage) 
 		Storage:     storageInterface,
 		DestroyFunc: dFunc,
 	}
+	options := &generic.StoreOptions{RESTOptions: opts.EtcdOptions.RESTOptions, AttrFunc: GetAttrs}
+	if err := store.CompleteWithOptions(options); err != nil {
+		panic(err) // TODO: Propagate error up
+	}
 
 	statusStore := store
 	statusStore.UpdateStrategy = instanceStatusUpdateStrategy

--- a/pkg/registry/servicecatalog/rest/storage_servicecatalog_test.go
+++ b/pkg/registry/servicecatalog/rest/storage_servicecatalog_test.go
@@ -36,7 +36,8 @@ type GetRESTOptionsHelper struct {
 
 func (g GetRESTOptionsHelper) GetRESTOptions(resource schema.GroupResource) (generic.RESTOptions, error) {
 	return generic.RESTOptions{
-		StorageConfig: &storagebackend.Config{},
+		ResourcePrefix: resource.Group + "/" + resource.Resource,
+		StorageConfig:  &storagebackend.Config{},
 		Decorator: generic.StorageDecorator(func(
 			copier runtime.ObjectCopier,
 			config *storagebackend.Config,

--- a/pkg/registry/servicecatalog/serviceclass/storage.go
+++ b/pkg/registry/servicecatalog/serviceclass/storage.go
@@ -144,6 +144,11 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 		DestroyFunc:    dFunc,
 	}
 
+	options := &generic.StoreOptions{RESTOptions: opts.EtcdOptions.RESTOptions, AttrFunc: GetAttrs}
+	if err := store.CompleteWithOptions(options); err != nil {
+		panic(err) // TODO: Propagate error up
+	}
+
 	statusStore := store
 	statusStore.UpdateStrategy = serviceClassStatusUpdateStrategy
 


### PR DESCRIPTION
Update how storage is configured as follows:

* store keys like /servicecatalog.k8s.io/brokers where before /brokers
* ensure we call complete with options to pickup validation

see: https://github.com/kubernetes/kubernetes/pull/47060
