### PR TITLE
Requiring broker auth info

### DIFF
--- a/pkg/apis/servicecatalog/v1alpha1/types.generated.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.generated.go
@@ -835,12 +835,11 @@ func (x *BrokerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2 [2]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[1] = x.AuthInfo != nil
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(2)
 			} else {
-				yynn2 = 1
+				yynn2 = 2
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
@@ -870,25 +869,19 @@ func (x *BrokerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[1] {
-					if x.AuthInfo == nil {
-						r.EncodeNil()
-					} else {
-						x.AuthInfo.CodecEncodeSelf(e)
-					}
-				} else {
+				if x.AuthInfo == nil {
 					r.EncodeNil()
+				} else {
+					x.AuthInfo.CodecEncodeSelf(e)
 				}
 			} else {
-				if yyq2[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("authInfo"))
-					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.AuthInfo == nil {
-						r.EncodeNil()
-					} else {
-						x.AuthInfo.CodecEncodeSelf(e)
-					}
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("authInfo"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				if x.AuthInfo == nil {
+					r.EncodeNil()
+				} else {
+					x.AuthInfo.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2 || yy2arr2 {

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -51,7 +51,7 @@ type BrokerSpec struct {
 
 	// AuthInfo contains the data that the service catalog should use to authenticate
 	// with the Broker.
-	AuthInfo *BrokerAuthInfo `json:"authInfo,omitempty"`
+	AuthInfo *BrokerAuthInfo `json:"authInfo"`
 }
 
 // BrokerAuthInfo is a union type that contains information on one of the authentication methods

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -425,7 +425,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 					},
-					Required: []string{"url"},
+					Required: []string{"url", "authInfo"},
 				},
 			},
 			Dependencies: []string{


### PR DESCRIPTION
If a user submits a `Broker` that doesn't have a `spec.authInfo` field, then service-catalog will send no basic auth credentials to the broker server. This behavior violates the [spec](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#authentication), which says "The marketplace MUST authenticate with the service broker using HTTP basic authentication". This patch makes `authInfo` required.

Fixes https://github.com/kubernetes-incubator/service-catalog/issues/948

Please see https://github.com/kubernetes-incubator/service-catalog/issues/948 for background on this issue.