### PR TITLE
Support for secret parameters in Instance

### DIFF
--- a/pkg/apis/servicecatalog/checksum/unversioned/checksum.go
+++ b/pkg/apis/servicecatalog/checksum/unversioned/checksum.go
@@ -29,6 +29,7 @@ import (
 // - ServiceClassName
 // - PlanName
 // - Parameters
+// - AlphaSecretParameters
 // - ExternalID
 func InstanceSpecChecksum(spec servicecatalog.InstanceSpec) string {
 	specString := ""
@@ -37,6 +38,10 @@ func InstanceSpecChecksum(spec servicecatalog.InstanceSpec) string {
 
 	if spec.Parameters != nil {
 		specString += fmt.Sprintf("parameters:\n\n%v\n\n", string(spec.Parameters.Raw))
+	}
+	if spec.AlphaSecretParameters != nil {
+		// TODO: calc checksum of secret contents instead?
+		specString += fmt.Sprintf("alphaSecretParameters:\n\n%v\n\n", string(spec.AlphaSecretParameters.Name))
 	}
 
 	specString += fmt.Sprintf("externalID: %v\n", spec.ExternalID)

--- a/pkg/apis/servicecatalog/checksum/versioned/v1alpha1/checksum.go
+++ b/pkg/apis/servicecatalog/checksum/versioned/v1alpha1/checksum.go
@@ -38,6 +38,10 @@ func InstanceSpecChecksum(spec v1alpha1.InstanceSpec) string {
 	if spec.Parameters != nil {
 		specString += fmt.Sprintf("parameters:\n\n%v\n\n", string(spec.Parameters.Raw))
 	}
+	if spec.AlphaSecretParameters != nil {
+		// TODO: calc checksum of secret contents instead?
+		specString += fmt.Sprintf("alphaSecretParameters:\n\n%v\n\n", string(spec.AlphaSecretParameters.Name))
+	}
 
 	specString += fmt.Sprintf("externalID: %v\n", spec.ExternalID)
 

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -266,9 +266,15 @@ type InstanceSpec struct {
 	// provisioned from.
 	PlanName string
 
-	// Parameters is a YAML representation of the properties to be
+	// Parameters is set of properties to be
 	// passed to the underlying broker.
 	Parameters *runtime.RawExtension
+
+	// Optional: AlphaSecretParameters is reference to the secret object containing
+	// sensitive information to pass to the underlying broker. This may be
+	// empty if no secret object is specified.
+	// +optional
+	AlphaSecretParameters *v1.LocalObjectReference
 
 	// ExternalID is the identity of this object for use with the OSB API.
 	//

--- a/pkg/apis/servicecatalog/v1alpha1/types.generated.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.generated.go
@@ -4560,13 +4560,14 @@ func (x *InstanceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep2 := !z.EncBinary()
 			yy2arr2 := z.EncBasicHandle().StructToArray
-			var yyq2 [4]bool
+			var yyq2 [5]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
 			yyq2[2] = x.Parameters != nil
+			yyq2[3] = x.AlphaSecretParameters != nil
 			var yynn2 int
 			if yyr2 || yy2arr2 {
-				r.EncodeArrayStart(4)
+				r.EncodeArrayStart(5)
 			} else {
 				yynn2 = 3
 				for _, b := range yyq2 {
@@ -4656,8 +4657,31 @@ func (x *InstanceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym13 := z.EncBinary()
-				_ = yym13
+				if yyq2[3] {
+					if x.AlphaSecretParameters == nil {
+						r.EncodeNil()
+					} else {
+						x.AlphaSecretParameters.CodecEncodeSelf(e)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2[3] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("alphaSecretParameters"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.AlphaSecretParameters == nil {
+						r.EncodeNil()
+					} else {
+						x.AlphaSecretParameters.CodecEncodeSelf(e)
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym16 := z.EncBinary()
+				_ = yym16
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ExternalID))
@@ -4666,8 +4690,8 @@ func (x *InstanceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("externalID"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym14 := z.EncBinary()
-				_ = yym14
+				yym17 := z.EncBinary()
+				_ = yym17
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ExternalID))
@@ -4777,16 +4801,27 @@ func (x *InstanceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					z.DecFallback(x.Parameters, false)
 				}
 			}
+		case "alphaSecretParameters":
+			if r.TryDecodeAsNil() {
+				if x.AlphaSecretParameters != nil {
+					x.AlphaSecretParameters = nil
+				}
+			} else {
+				if x.AlphaSecretParameters == nil {
+					x.AlphaSecretParameters = new(pkg3_v1.LocalObjectReference)
+				}
+				x.AlphaSecretParameters.CodecDecodeSelf(d)
+			}
 		case "externalID":
 			if r.TryDecodeAsNil() {
 				x.ExternalID = ""
 			} else {
-				yyv10 := &x.ExternalID
-				yym11 := z.DecBinary()
-				_ = yym11
+				yyv11 := &x.ExternalID
+				yym12 := z.DecBinary()
+				_ = yym12
 				if false {
 				} else {
-					*((*string)(yyv10)) = r.DecodeString()
+					*((*string)(yyv11)) = r.DecodeString()
 				}
 			}
 		default:
@@ -4800,16 +4835,16 @@ func (x *InstanceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj12 int
-	var yyb12 bool
-	var yyhl12 bool = l >= 0
-	yyj12++
-	if yyhl12 {
-		yyb12 = yyj12 > l
+	var yyj13 int
+	var yyb13 bool
+	var yyhl13 bool = l >= 0
+	yyj13++
+	if yyhl13 {
+		yyb13 = yyj13 > l
 	} else {
-		yyb12 = r.CheckBreak()
+		yyb13 = r.CheckBreak()
 	}
-	if yyb12 {
+	if yyb13 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4817,21 +4852,21 @@ func (x *InstanceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ServiceClassName = ""
 	} else {
-		yyv13 := &x.ServiceClassName
-		yym14 := z.DecBinary()
-		_ = yym14
+		yyv14 := &x.ServiceClassName
+		yym15 := z.DecBinary()
+		_ = yym15
 		if false {
 		} else {
-			*((*string)(yyv13)) = r.DecodeString()
+			*((*string)(yyv14)) = r.DecodeString()
 		}
 	}
-	yyj12++
-	if yyhl12 {
-		yyb12 = yyj12 > l
+	yyj13++
+	if yyhl13 {
+		yyb13 = yyj13 > l
 	} else {
-		yyb12 = r.CheckBreak()
+		yyb13 = r.CheckBreak()
 	}
-	if yyb12 {
+	if yyb13 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4839,21 +4874,21 @@ func (x *InstanceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.PlanName = ""
 	} else {
-		yyv15 := &x.PlanName
-		yym16 := z.DecBinary()
-		_ = yym16
+		yyv16 := &x.PlanName
+		yym17 := z.DecBinary()
+		_ = yym17
 		if false {
 		} else {
-			*((*string)(yyv15)) = r.DecodeString()
+			*((*string)(yyv16)) = r.DecodeString()
 		}
 	}
-	yyj12++
-	if yyhl12 {
-		yyb12 = yyj12 > l
+	yyj13++
+	if yyhl13 {
+		yyb13 = yyj13 > l
 	} else {
-		yyb12 = r.CheckBreak()
+		yyb13 = r.CheckBreak()
 	}
-	if yyb12 {
+	if yyb13 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4866,23 +4901,44 @@ func (x *InstanceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Parameters == nil {
 			x.Parameters = new(pkg4_runtime.RawExtension)
 		}
-		yym18 := z.DecBinary()
-		_ = yym18
+		yym19 := z.DecBinary()
+		_ = yym19
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.Parameters) {
-		} else if !yym18 && z.IsJSONHandle() {
+		} else if !yym19 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.Parameters)
 		} else {
 			z.DecFallback(x.Parameters, false)
 		}
 	}
-	yyj12++
-	if yyhl12 {
-		yyb12 = yyj12 > l
+	yyj13++
+	if yyhl13 {
+		yyb13 = yyj13 > l
 	} else {
-		yyb12 = r.CheckBreak()
+		yyb13 = r.CheckBreak()
 	}
-	if yyb12 {
+	if yyb13 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		if x.AlphaSecretParameters != nil {
+			x.AlphaSecretParameters = nil
+		}
+	} else {
+		if x.AlphaSecretParameters == nil {
+			x.AlphaSecretParameters = new(pkg3_v1.LocalObjectReference)
+		}
+		x.AlphaSecretParameters.CodecDecodeSelf(d)
+	}
+	yyj13++
+	if yyhl13 {
+		yyb13 = yyj13 > l
+	} else {
+		yyb13 = r.CheckBreak()
+	}
+	if yyb13 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -4890,26 +4946,26 @@ func (x *InstanceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	if r.TryDecodeAsNil() {
 		x.ExternalID = ""
 	} else {
-		yyv19 := &x.ExternalID
-		yym20 := z.DecBinary()
-		_ = yym20
+		yyv21 := &x.ExternalID
+		yym22 := z.DecBinary()
+		_ = yym22
 		if false {
 		} else {
-			*((*string)(yyv19)) = r.DecodeString()
+			*((*string)(yyv21)) = r.DecodeString()
 		}
 	}
 	for {
-		yyj12++
-		if yyhl12 {
-			yyb12 = yyj12 > l
+		yyj13++
+		if yyhl13 {
+			yyb13 = yyj13 > l
 		} else {
-			yyb12 = r.CheckBreak()
+			yyb13 = r.CheckBreak()
 		}
-		if yyb12 {
+		if yyb13 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj12-1, "")
+		z.DecStructFieldNotFound(yyj13-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -8330,7 +8386,7 @@ func (x codecSelfer1234) decSliceInstance(v *[]Instance, d *codec1978.Decoder) {
 
 			yyrg1 := len(yyv1) > 0
 			yyv21 := yyv1
-			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 368)
+			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 376)
 			if yyrt1 {
 				if yyrl1 <= cap(yyv1) {
 					yyv1 = yyv1[:yyrl1]

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -267,9 +267,15 @@ type InstanceSpec struct {
 	// provisioned from.
 	PlanName string `json:"planName"`
 
-	// Parameters is a YAML representation of the properties to be
+	// Parameters is set of properties to be
 	// passed to the underlying broker.
 	Parameters *runtime.RawExtension `json:"parameters,omitempty"`
+
+	// Optional: AlphaSecretParameters is reference to the secret object containing
+	// sensitive information to pass to the underlying broker. This may be
+	// empty if no secret object is specified.
+	// +optional
+	AlphaSecretParameters *v1.LocalObjectReference `json:"alphaSecretParameters,omitempty"`
 
 	// ExternalID is the identity of this object for use with the OSB SB API.
 	//

--- a/pkg/apis/servicecatalog/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1alpha1/zz_generated.conversion.go
@@ -433,6 +433,7 @@ func autoConvert_v1alpha1_InstanceSpec_To_servicecatalog_InstanceSpec(in *Instan
 	out.ServiceClassName = in.ServiceClassName
 	out.PlanName = in.PlanName
 	out.Parameters = (*runtime.RawExtension)(unsafe.Pointer(in.Parameters))
+	out.AlphaSecretParameters = (*v1.LocalObjectReference)(unsafe.Pointer(in.AlphaSecretParameters))
 	out.ExternalID = in.ExternalID
 	return nil
 }
@@ -445,6 +446,7 @@ func autoConvert_servicecatalog_InstanceSpec_To_v1alpha1_InstanceSpec(in *servic
 	out.ServiceClassName = in.ServiceClassName
 	out.PlanName = in.PlanName
 	out.Parameters = (*runtime.RawExtension)(unsafe.Pointer(in.Parameters))
+	out.AlphaSecretParameters = (*v1.LocalObjectReference)(unsafe.Pointer(in.AlphaSecretParameters))
 	out.ExternalID = in.ExternalID
 	return nil
 }

--- a/pkg/apis/servicecatalog/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/v1alpha1/zz_generated.deepcopy.go
@@ -325,6 +325,11 @@ func DeepCopy_v1alpha1_InstanceSpec(in interface{}, out interface{}, c *conversi
 				*out = newVal.(*runtime.RawExtension)
 			}
 		}
+		if in.AlphaSecretParameters != nil {
+			in, out := &in.AlphaSecretParameters, &out.AlphaSecretParameters
+			*out = new(api_v1.LocalObjectReference)
+			**out = **in
+		}
 		return nil
 	}
 }

--- a/pkg/apis/servicecatalog/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/zz_generated.deepcopy.go
@@ -325,6 +325,11 @@ func DeepCopy_servicecatalog_InstanceSpec(in interface{}, out interface{}, c *co
 				*out = newVal.(*runtime.RawExtension)
 			}
 		}
+		if in.AlphaSecretParameters != nil {
+			in, out := &in.AlphaSecretParameters, &out.AlphaSecretParameters
+			*out = new(api_v1.LocalObjectReference)
+			**out = **in
+		}
 		return nil
 	}
 }

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -606,8 +606,14 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 						},
 						"parameters": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Parameters is a YAML representation of the properties to be passed to the underlying broker.",
+								Description: "Parameters is set of properties to be passed to the underlying broker.",
 								Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
+							},
+						},
+						"alphaSecretParameters": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Optional: AlphaSecretParameters is reference to the secret object containing sensitive information to pass to the underlying broker. This may be empty if no secret object is specified.",
+								Ref:         ref("k8s.io/client-go/pkg/api/v1.LocalObjectReference"),
 							},
 						},
 						"externalID": {
@@ -622,7 +628,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 				},
 			},
 			Dependencies: []string{
-				"k8s.io/apimachinery/pkg/runtime.RawExtension"},
+				"k8s.io/apimachinery/pkg/runtime.RawExtension", "k8s.io/client-go/pkg/api/v1.LocalObjectReference"},
 		},
 		"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1.InstanceStatus": {
 			Schema: spec.Schema{

--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -466,6 +466,9 @@ func testInstanceClient(sType server.StorageType, client servicecatalogclient.In
 			ServiceClassName: "service-class-name",
 			PlanName:         "plan-name",
 			Parameters:       &runtime.RawExtension{Raw: []byte(instanceParameter)},
+			AlphaSecretParameters: &v1.LocalObjectReference{
+				Name: "secret-name",
+			},
 			ExternalID:       osbGUID,
 		},
 	}
@@ -540,6 +543,14 @@ func testInstanceClient(sType server.StorageType, client servicecatalogclient.In
 	}
 	if parameters.Values["second"] != "secondvalue" {
 		return fmt.Errorf("Didn't get back 'secondvalue' value for key 'second' in Values map was %+v", parameters)
+	}
+
+	// check the reference to secret containing parameters is present
+	if instanceServer.Spec.AlphaSecretParameters == nil {
+		return errors.New("AlphaSecretParameters is missing")
+	}
+	if instanceServer.Spec.AlphaSecretParameters.Name != "secret-name" {
+		return fmt.Errorf("Didn't get back 'secret-name' value for secret name, was %+v", instanceServer.Spec.AlphaSecretParameters.Name)
 	}
 
 	// update the instance's conditions


### PR DESCRIPTION
See issue [#621](https://github.com/kubernetes-incubator/service-catalog/issues/621) for details.
Implementation described in https://github.com/kubernetes-incubator/service-catalog/issues/621#issuecomment-305356537:

```go
// InstanceSpec represents the desired state of an Instance.
type InstanceSpec struct {
	...

	// Optional: AlphaSecretParameters is reference to the secret object containing
	// sensitive information to pass to the underlying broker. This may be
	// empty if no secret object is specified.
	// +optional
	AlphaSecretParameters *v1.LocalObjectReference `json:"alphaSecretParameters,omitempty"`
}
```
- Only one of `Parameters` and `AlphaSecretParameters` can be specified at a time (no merging strategy, no separate field in OSB Instance request)
- Added unit and integration tests for `AlphaSecretParameters` based on the ones for `Parameters`