### PR TITLE
Making events and actions checks generic

### DIFF
--- a/pkg/controller/controller_actions_test.go
+++ b/pkg/controller/controller_actions_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/testing"
+)
+
+type kubeClientAction struct {
+	verb         string
+	resourceName string
+	checkType    func(testing.Action) error
+}
+
+// checkGetActionType can be used as a param for kubeClientAction.checkType. It's intended
+// to ensure an action is a testing.GetAction
+func checkGetActionType(a testing.Action) error {
+	if _, ok := a.(testing.GetAction); !ok {
+		return fmt.Errorf("expected a GetAction, got %s", reflect.TypeOf(a))
+	}
+	return nil
+}
+
+// checkUpdateActionType can be used as a param for kubeClientAction.checkType. It's intended
+// to ensure an action is a testing.UpdateAction
+func checkUpdateActionType(a testing.Action) error {
+	if _, ok := a.(testing.UpdateAction); !ok {
+		return fmt.Errorf("expected an UpdateAction, got %s", reflect.TypeOf(a))
+	}
+	return nil
+}
+
+type catalogClientAction struct {
+	verb             string
+	getRuntimeObject func(testing.Action) (runtime.Object, error)
+	checkObject      func(runtime.Object) error
+}
+
+// getObjectFromUpdate asserts that t is a testing.UpdateAction, then returns the return value
+// of calling GetObject on the UpdateAction
+func getRuntimeObjectFromUpdateAction(t testing.Action) (runtime.Object, error) {
+	up, ok := t.(testing.UpdateAction)
+	if !ok {
+		return nil, fmt.Errorf("action was not a testing.UpdateAction")
+	}
+	return up.GetObject(), nil
+}
+
+// checkInstance can be used as a param to catalogClientAction.checkObject. It's intended
+// to check that a runtime.Object is an instance, and to check some properties of that instance
+func checkInstance(descr instanceDescription) func(runtime.Object) error {
+	return func(obj runtime.Object) error {
+		inst, ok := obj.(*v1alpha1.Instance)
+		if !ok {
+			return fmt.Errorf("expected an instance, got a %s", reflect.TypeOf(obj))
+		}
+		if inst.Name != descr.name {
+			return fmt.Errorf("expected instance name %s, got %s", descr.name, inst.Name)
+		}
+		if len(descr.conditions) != len(inst.Status.Conditions) {
+			return fmt.Errorf(
+				"expected %d conditions, got %d",
+				len(descr.conditions),
+				len(inst.Status.Conditions),
+			)
+		}
+		for i, expectedCondition := range descr.conditions {
+			actualCondition := inst.Status.Conditions[i]
+			if expectedCondition != actualCondition.Reason {
+				return fmt.Errorf(
+					"condition %d: expected condition reason %s, got %s",
+					i,
+					expectedCondition,
+					actualCondition.Reason,
+				)
+			}
+		}
+		return nil
+	}
+}
+
+// instanceDescription is the description of an instance that will be checked in the function
+// returned by checkInstance
+type instanceDescription struct {
+	name       string
+	conditions []string
+}
+
+// checkKubeClientActions is the utility function for checking actions returned by the generic
+// kubernetes client
+func checkKubeClientActions(actual []testing.Action, expected []kubeClientAction) error {
+	if len(actual) != len(expected) {
+		return fmt.Errorf("expected %d kube client actions, got %d", len(expected), len(actual))
+	}
+	for i, actualAction := range actual {
+		expectedAction := expected[i]
+		if actualAction.GetVerb() != expectedAction.verb {
+			return fmt.Errorf(
+				"action %d: expected verb '%s', got '%s'",
+				i,
+				expectedAction.verb,
+				actualAction.GetVerb(),
+			)
+		}
+		getAction, ok := actualAction.(testing.GetAction)
+		if !ok {
+			return fmt.Errorf(
+				"action %d: expected a GetAction, got %s",
+				i,
+				reflect.TypeOf(actualAction),
+			)
+		}
+		if expectedAction.resourceName != getAction.GetResource().Resource {
+			return fmt.Errorf(
+				"expected resource name '%s', got '%s'",
+				expectedAction.resourceName,
+				getAction.GetResource().Resource,
+			)
+		}
+	}
+	return nil
+}
+
+// checkCatalogClientActions is the utility function for checking actions returned by
+// the catalog client
+func checkCatalogClientActions(actual []testing.Action, expected []catalogClientAction) error {
+	if len(actual) != len(expected) {
+		return fmt.Errorf("expected %d actions, got %d", len(expected), len(actual))
+	}
+	for i, actualAction := range actual {
+		expectedAction := expected[i]
+
+		if actualAction.GetVerb() != expectedAction.verb {
+			return fmt.Errorf("action %d: expected verb %s, got %s", i, expectedAction.verb, actualAction.GetVerb())
+		}
+
+		obj, err := expectedAction.getRuntimeObject(actualAction)
+		if err != nil {
+			return fmt.Errorf("action %d: %s", i, err)
+		}
+		if err := expectedAction.checkObject(obj); err != nil {
+			return fmt.Errorf("action %d: %s", i, err)
+		}
+	}
+	return nil
+}

--- a/pkg/controller/controller_actions_test.go
+++ b/pkg/controller/controller_actions_test.go
@@ -67,6 +67,10 @@ func getRuntimeObjectFromUpdateAction(t testing.Action) (runtime.Object, error) 
 
 // checkInstance can be used as a param to catalogClientAction.checkObject. It's intended
 // to check that a runtime.Object is an instance, and to check some properties of that instance
+// including:
+//
+// - the Name
+// - the conditions
 func checkInstance(descr instanceDescription) func(runtime.Object) error {
 	return func(obj runtime.Object) error {
 		inst, ok := obj.(*v1alpha1.Instance)

--- a/pkg/controller/controller_actions_test.go
+++ b/pkg/controller/controller_actions_test.go
@@ -55,7 +55,7 @@ type catalogClientAction struct {
 	checkObject      func(runtime.Object) error
 }
 
-// getObjectFromUpdate asserts that t is a testing.UpdateAction, then returns the return value
+// getRuntimeObjectFromUpdate asserts that t is a testing.UpdateAction, then returns the return value
 // of calling GetObject on the UpdateAction
 func getRuntimeObjectFromUpdateAction(t testing.Action) (runtime.Object, error) {
 	up, ok := t.(testing.UpdateAction)

--- a/pkg/controller/controller_actions_test.go
+++ b/pkg/controller/controller_actions_test.go
@@ -80,20 +80,20 @@ func checkInstance(descr instanceDescription) func(runtime.Object) error {
 		if inst.Name != descr.name {
 			return fmt.Errorf("expected instance name %s, got %s", descr.name, inst.Name)
 		}
-		if len(descr.conditions) != len(inst.Status.Conditions) {
+		if len(descr.conditionReasons) != len(inst.Status.Conditions) {
 			return fmt.Errorf(
 				"expected %d conditions, got %d",
-				len(descr.conditions),
+				len(descr.conditionReasons),
 				len(inst.Status.Conditions),
 			)
 		}
-		for i, expectedCondition := range descr.conditions {
+		for i, expectedConditionReason := range descr.conditionReasons {
 			actualCondition := inst.Status.Conditions[i]
-			if expectedCondition != actualCondition.Reason {
+			if expectedConditionReason != actualCondition.Reason {
 				return fmt.Errorf(
 					"condition %d: expected condition reason %s, got %s",
 					i,
-					expectedCondition,
+					expectedConditionReason,
 					actualCondition.Reason,
 				)
 			}
@@ -105,8 +105,8 @@ func checkInstance(descr instanceDescription) func(runtime.Object) error {
 // instanceDescription is the description of an instance that will be checked in the function
 // returned by checkInstance
 type instanceDescription struct {
-	name       string
-	conditions []string
+	name             string
+	conditionReasons []string
 }
 
 // checkKubeClientActions is the utility function for checking actions returned by the generic

--- a/pkg/controller/controller_events_test.go
+++ b/pkg/controller/controller_events_test.go
@@ -25,8 +25,7 @@ func checkEvents(actual, expected []string) error {
 		return fmt.Errorf("expected %d events, got %d", len(expected), len(actual))
 	}
 	for i, actualEvt := range actual {
-		expectedEvt := expected[i]
-		if actualEvt != expectedEvt {
+		if expectedEvt := expected[i]; actualEvt != expectedEvt {
 			return fmt.Errorf("event %d: expected '%s', got '%s'", i, expectedEvt, actualEvt)
 		}
 	}

--- a/pkg/controller/controller_events_test.go
+++ b/pkg/controller/controller_events_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controller
+
+import (
+	"fmt"
+)
+
+func checkEvents(actual, expected []string) error {
+	if len(actual) != len(expected) {
+		return fmt.Errorf("expected %d events, got %d", len(expected), len(actual))
+	}
+	for i, actualEvt := range actual {
+		expectedEvt := expected[i]
+		if actualEvt != expectedEvt {
+			return fmt.Errorf("event %d: expected '%s', got '%s'", i, expectedEvt, actualEvt)
+		}
+	}
+	return nil
+}

--- a/pkg/controller/controller_events_test.go
+++ b/pkg/controller/controller_events_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -133,8 +133,8 @@ func TestReconcileInstanceWithAuthError(t *testing.T) {
 		{
 			verb: "update",
 			checkObject: checkInstance(instanceDescription{
-				name:       testInstanceName,
-				conditions: []string{"ErrorGettingAuthCredentials"},
+				name:             testInstanceName,
+				conditionReasons: []string{"ErrorGettingAuthCredentials"},
 			}),
 			getRuntimeObject: getRuntimeObjectFromUpdateAction,
 		},
@@ -186,8 +186,8 @@ func TestReconcileInstanceNonExistentServicePlan(t *testing.T) {
 			verb:             "update",
 			getRuntimeObject: getRuntimeObjectFromUpdateAction,
 			checkObject: checkInstance(instanceDescription{
-				name:       testInstanceName,
-				conditions: []string{errorNonexistentServicePlanReason},
+				name:             testInstanceName,
+				conditionReasons: []string{errorNonexistentServicePlanReason},
 			}),
 		},
 	}); err != nil {

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -123,7 +123,7 @@ func TestReconcileInstanceWithAuthError(t *testing.T) {
 
 	testController.reconcileInstance(instance)
 
-	// vefify that no broker actions occurred
+	// verify that no broker actions occurred
 	brokerActions := fakeBrokerClient.Actions()
 	assertNumberOfBrokerActions(t, brokerActions, 0)
 

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -178,6 +178,8 @@ func TestReconcileInstanceNonExistentServicePlan(t *testing.T) {
 	brokerActions := fakeBrokerClient.Actions()
 	assertNumberOfBrokerActions(t, brokerActions, 0)
 
+	// ensure that the only action made on the catalog client was to set the condition on the
+	// instance to indicate that the service plan doesn't exist
 	actions := fakeCatalogClient.Actions()
 	if err := checkCatalogClientActions(actions, []catalogClientAction{
 		{
@@ -192,6 +194,8 @@ func TestReconcileInstanceNonExistentServicePlan(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// check to make sure the only event sent indicated that the instance references a non-existent
+	// service plan
 	events := getRecordedEvents(testController)
 	expectedEvent := api.EventTypeWarning + " " + errorNonexistentServicePlanReason + " " + "Instance \"/test-instance\" references a non-existent ServicePlan \"nothere\" on ServiceClass \"test-serviceclass\""
 	if err := checkEvents(events, []string{expectedEvent}); err != nil {


### PR DESCRIPTION
And refactoring two controller instance tests to use the new generic functions.

As a follow-up to this patch, @pmorie and I (@arschles) are going to refactor all of the controller tests to make them shorter.

This requires #954 and should be merged after that patch is merged