### PR TITLE
Make ups-broker return valid unbind response

### DIFF
--- a/contrib/pkg/broker/server/server.go
+++ b/contrib/pkg/broker/server/server.go
@@ -157,7 +157,8 @@ func (s *server) unBind(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.controller.UnBind(instanceID, bindingID); err == nil {
 		w.WriteHeader(http.StatusOK)
-		fmt.Print(w, "{}") //id)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, "{}") //id)
 	} else {
 		util.WriteResponse(w, http.StatusBadRequest, err)
 	}


### PR DESCRIPTION
The ups-broker would write a valid JSON response.... to stdout.  This broke the walkthrough, because the current client tries to parse the response (the old client did not try to parse the response).