### PR TITLE
Bump osb client

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 032aec8c6821f4680e264073c082306d7f00699969b3625bc4bf43c7f35c629a
-updated: 2017-06-20T23:19:35.658336981-04:00
+hash: 0da417eb8f27a15c12e088e8841e7005691815a042e3481afd6382790bd972e2
+updated: 2017-06-23T12:36:40.079115175-04:00
 imports:
 - name: code.cloudfoundry.org/lager
   version: 62951a8009ab331bb21dc418074fa54e66eb9b6a
@@ -58,7 +58,7 @@ imports:
 - name: github.com/pkg/errors
   version: a22138067af1c4942683050411a841ade67fe1eb
 - name: github.com/pmorie/go-open-service-broker-client
-  version: 2da30f3feb6e22a9e32786f57f64102967d58f40
+  version: 8d5b522ee2fe5ebc914b56dbb6cc4591eded469d
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc

--- a/glide.yaml
+++ b/glide.yaml
@@ -68,4 +68,4 @@ import:
 - package: github.com/pivotal-cf/brokerapi
 - package: code.cloudfoundry.org/lager
 - package: github.com/pmorie/go-open-service-broker-client
-  version: 2da30f3feb6e22a9e32786f57f64102967d58f40 
+  version: 8d5b522ee2fe5ebc914b56dbb6cc4591eded469d 

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -291,7 +291,7 @@ func (c *controller) reconcileInstance(instance *v1alpha1.Instance) error {
 		SpaceGUID:         string(ns.UID),
 	}
 	if c.enableOSBAPIContextProfle {
-		request.AlphaContext = map[string]interface{}{
+		request.Context = map[string]interface{}{
 			"platform":  brokerapi.ContextProfilePlatformKubernetes,
 			"namespace": instance.Namespace,
 		}

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -232,7 +232,7 @@ func TestReconcileInstanceWithParameters(t *testing.T) {
 		InstanceID:        instanceGUID,
 		ServiceID:         serviceClassGUID,
 		PlanID:            planGUID,
-		AlphaContext: map[string]interface{}{
+		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
 		},
@@ -339,7 +339,7 @@ func TestReconcileInstanceWithProvisionFailure(t *testing.T) {
 		InstanceID:        instanceGUID,
 		ServiceID:         serviceClassGUID,
 		PlanID:            planGUID,
-		AlphaContext: map[string]interface{}{
+		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
 		},
@@ -398,7 +398,7 @@ func TestReconcileInstance(t *testing.T) {
 		PlanID:            planGUID,
 		OrganizationGUID:  testNsUID,
 		SpaceGUID:         testNsUID,
-		AlphaContext: map[string]interface{}{
+		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
 		},
@@ -470,7 +470,7 @@ func TestReconcileInstanceAsynchronous(t *testing.T) {
 		PlanID:            planGUID,
 		OrganizationGUID:  testNsUID,
 		SpaceGUID:         testNsUID,
-		AlphaContext: map[string]interface{}{
+		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": testNamespace,
 		},
@@ -545,7 +545,7 @@ func TestReconcileInstanceAsynchronousNoOperation(t *testing.T) {
 		PlanID:            planGUID,
 		OrganizationGUID:  testNsUID,
 		SpaceGUID:         testNsUID,
-		AlphaContext: map[string]interface{}{
+		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
 		},

--- a/vendor/github.com/pmorie/go-open-service-broker-client/README.md
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/README.md
@@ -33,8 +33,15 @@ func GetBrokerCatalog(URL string) (*osb.CatalogResponse, error) {
 
 ## Documentation
 
-This client library supports the current version (v2.11) of the
-[Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker).
+This client library supports the following versions of the
+[Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker):
+
+- [v2.12](https://github.com/openservicebrokerapi/servicebroker/tree/v2.12)
+- [v2.11](https://github.com/openservicebrokerapi/servicebroker/tree/v2.11)
+
+Only fields supported by the version configured for a client are
+sent/returned.
+
 Check out the
 [API specification](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md).
 
@@ -70,9 +77,9 @@ This project does not aim to provide:
 
 ## Current status
 
-I'm currently just sketching around in my free time, but would love to
-eventually donate this repo to an organization if people decide that it is
-useful.
+This repository is used in the 
+[Kubernetes `service-catalog`](https://github.com/kubernetes-incubator/service-catalog)
+incubator repo.
 
 ## Why?
 

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/bind.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/bind.go
@@ -51,7 +51,7 @@ func (c *client) Bind(r *BindRequest) (*BindResponse, error) {
 	case http.StatusOK, http.StatusCreated:
 		userResponse := &BindResponse{}
 		if err := c.unmarshalResponse(response, userResponse); err != nil {
-			return nil, err
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
 		return userResponse, nil

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/bind_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/bind_test.go
@@ -119,7 +119,7 @@ func TestBind(t *testing.T) {
 				status: http.StatusOK,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 200; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with malformed response",
@@ -127,7 +127,7 @@ func TestBind(t *testing.T) {
 				status: http.StatusInternalServerError,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 500; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with conventional failure response",
@@ -152,7 +152,8 @@ func TestBind(t *testing.T) {
 			tc.httpChecks.body = defaultBindRequestBody
 		}
 
-		klient := newTestClient(t, tc.name, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		version := Version2_11()
+		klient := newTestClient(t, tc.name, version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.Bind(tc.request)
 

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/client.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/client.go
@@ -17,7 +17,7 @@ import (
 const (
 	// XBrokerAPIVersion is the header for the Open Service Broker API
 	// version.
-	XBrokerAPIVersion = "X-Broker-Api-Version"
+	XBrokerAPIVersion = "X-Broker-API-Version"
 
 	catalogURL            = "%s/v2/catalog"
 	serviceInstanceURLFmt = "%s/v2/service_instances/%s"
@@ -119,7 +119,7 @@ func (c *client) prepareAndDo(method, URL string, params map[string]string, body
 		return nil, err
 	}
 
-	request.Header.Set(XBrokerAPIVersion, string(c.APIVersion))
+	request.Header.Set(XBrokerAPIVersion, c.APIVersion.HeaderValue())
 	if bodyReader != nil {
 		request.Header.Set(contentType, jsonType)
 	}
@@ -173,7 +173,7 @@ func (c *client) handleFailureResponse(response *http.Response) error {
 	glog.Info("handling failure responses")
 	brokerResponse := &failureResponseBody{}
 	if err := c.unmarshalResponse(response, brokerResponse); err != nil {
-		return err
+		return HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 	}
 
 	return HTTPStatusCodeError{

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/client_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/client_test.go
@@ -25,7 +25,11 @@ const conventionalFailureResponseBody = `{
 func testHttpStatusCodeError() error {
 	errorMessage := "TestError"
 	description := "test error description"
-	return HTTPStatusCodeError{http.StatusInternalServerError, &errorMessage, &description}
+	return HTTPStatusCodeError{
+		StatusCode:   http.StatusInternalServerError,
+		ErrorMessage: &errorMessage,
+		Description:  &description,
+	}
 }
 
 func truePtr() *bool {
@@ -60,9 +64,10 @@ type httpReaction struct {
 	err    error
 }
 
-func newTestClient(t *testing.T, name string, enableAlpha bool, httpChecks httpChecks, httpReaction httpReaction) *client {
+func newTestClient(t *testing.T, name string, version APIVersion, enableAlpha bool, httpChecks httpChecks, httpReaction httpReaction) *client {
 	return &client{
 		Name:                "test client",
+		APIVersion:          version,
 		Verbose:             true,
 		URL:                 "https://example.com",
 		EnableAlphaFeatures: enableAlpha,

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/deprovision_instance_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/deprovision_instance_test.go
@@ -122,7 +122,7 @@ func TestDeprovisionInstance(t *testing.T) {
 				status: http.StatusInternalServerError,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 500; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with conventional failure response",
@@ -147,7 +147,8 @@ func TestDeprovisionInstance(t *testing.T) {
 			tc.httpChecks.body = "{}"
 		}
 
-		klient := newTestClient(t, tc.name, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		version := Version2_11()
+		klient := newTestClient(t, tc.name, version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.DeprovisionInstance(tc.request)
 

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/get_catalog.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/get_catalog.go
@@ -17,7 +17,7 @@ func (c *client) GetCatalog() (*CatalogResponse, error) {
 	case http.StatusOK:
 		catalogResponse := &CatalogResponse{}
 		if err := c.unmarshalResponse(response, catalogResponse); err != nil {
-			return nil, err
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
 		if !c.EnableAlphaFeatures {

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/get_catalog_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/get_catalog_test.go
@@ -229,7 +229,7 @@ func TestGetCatalog(t *testing.T) {
 				status: http.StatusOK,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 200; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with malformed response",
@@ -237,10 +237,10 @@ func TestGetCatalog(t *testing.T) {
 				status: http.StatusInternalServerError,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 500; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
-			name: "500 with malformed response",
+			name: "500 with conventional response",
 			httpReaction: httpReaction{
 				status: http.StatusInternalServerError,
 				body:   conventionalFailureResponseBody,
@@ -271,7 +271,8 @@ func TestGetCatalog(t *testing.T) {
 			URL: "/v2/catalog",
 		}
 
-		klient := newTestClient(t, tc.name, tc.enableAlpha, httpChecks, tc.httpReaction)
+		version := Version2_11()
+		klient := newTestClient(t, tc.name, version, tc.enableAlpha, httpChecks, tc.httpReaction)
 
 		response, err := klient.GetCatalog()
 

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/interface.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/interface.go
@@ -4,20 +4,6 @@ import (
 	"crypto/tls"
 )
 
-type APIVersion string
-
-const (
-	// APIVersion2_11 represents the 2.11 version of the Open Service Broker
-	// API.
-	APIVersion2_11 APIVersion = "2.11"
-)
-
-// LatestAPIVersion returns the latest supported API version in the current
-// release of this library.
-func LatestAPIVersion() APIVersion {
-	return APIVersion2_11
-}
-
 // AuthConfig is a union-type representing the possible auth configurations a
 // client may use to authenticate to a broker.  Currently, only basic auth is
 // supported.

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/poll_last_operation.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/poll_last_operation.go
@@ -40,7 +40,7 @@ func (c *client) PollLastOperation(r *LastOperationRequest) (*LastOperationRespo
 	case http.StatusOK:
 		userResponse := &LastOperationResponse{}
 		if err := c.unmarshalResponse(response, userResponse); err != nil {
-			return nil, err
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
 		return userResponse, nil

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/poll_last_operation_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/poll_last_operation_test.go
@@ -91,7 +91,7 @@ func TestPollLastOperation(t *testing.T) {
 				status: http.StatusOK,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 200; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with malformed response",
@@ -99,10 +99,10 @@ func TestPollLastOperation(t *testing.T) {
 				status: http.StatusInternalServerError,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 500; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
-			name: "500 with malformed response",
+			name: "500 with convential response",
 			httpReaction: httpReaction{
 				status: http.StatusInternalServerError,
 				body:   conventionalFailureResponseBody,
@@ -126,7 +126,8 @@ func TestPollLastOperation(t *testing.T) {
 			tc.httpChecks.params[planIDKey] = testPlanID
 		}
 
-		klient := newTestClient(t, tc.name, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		version := Version2_11()
+		klient := newTestClient(t, tc.name, version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.PollLastOperation(tc.request)
 

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/provision_instance.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/provision_instance.go
@@ -15,7 +15,7 @@ type provisionRequestBody struct {
 	OrganizationGUID string                 `json:"organization_guid"`
 	SpaceGUID        string                 `json:"space_guid"`
 	Parameters       map[string]interface{} `json:"parameters,omitempty"`
-	AlphaContext     map[string]interface{} `json:"context,omitempty"`
+	Context          map[string]interface{} `json:"context,omitempty"`
 }
 
 type provisionSuccessResponseBody struct {
@@ -43,8 +43,8 @@ func (c *client) ProvisionInstance(r *ProvisionRequest) (*ProvisionResponse, err
 		Parameters:       r.Parameters,
 	}
 
-	if c.EnableAlphaFeatures {
-		requestBody.AlphaContext = r.AlphaContext
+	if c.APIVersion.AtLeast(Version2_12()) {
+		requestBody.Context = r.Context
 	}
 
 	response, err := c.prepareAndDo(http.MethodPut, fullURL, params, requestBody)
@@ -56,7 +56,7 @@ func (c *client) ProvisionInstance(r *ProvisionRequest) (*ProvisionResponse, err
 	case http.StatusCreated, http.StatusOK, http.StatusAccepted:
 		responseBodyObj := &provisionSuccessResponseBody{}
 		if err := c.unmarshalResponse(response, responseBodyObj); err != nil {
-			return nil, err
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
 		var opPtr *OperationKey

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/types.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/types.go
@@ -149,15 +149,10 @@ type ProvisionRequest struct {
 	// Parameters is a set of configuration options for the service instance.
 	// Optional.
 	Parameters map[string]interface{} `json:"parameters,omitempty"`
-	// AlphaContext is an ALPHA field and may change or disappear at any time.
-	// AlphaContext will only be sent if alpha features are enabled in the
-	// client.
-	//
-	// AlphaContext is platform-specific contextual information under which
-	// the service instance is to be provisioned.
-	//
-	// For more information, see: https://github.com/openservicebrokerapi/servicebroker/issues/115
-	AlphaContext map[string]interface{} `json:"context,omitempty"`
+	// Context is platform-specific contextual information under which the
+	// service instance is to be provisioned.  Context was added in version
+	// 2.12 of the OSB API and is only sent for versions 2.12 or later.
+	Context map[string]interface{} `json:"context,omitempty"`
 }
 
 // ProvisionResponse is sent in response to a provision call

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/unbind.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/unbind.go
@@ -24,7 +24,7 @@ func (c *client) Unbind(r *UnbindRequest) (*UnbindResponse, error) {
 	case http.StatusOK, http.StatusGone:
 		userResponse := &UnbindResponse{}
 		if err := c.unmarshalResponse(response, userResponse); err != nil {
-			return nil, err
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
 		return userResponse, nil

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/unbind_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/unbind_test.go
@@ -62,7 +62,7 @@ func TestUnbind(t *testing.T) {
 				status: http.StatusOK,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 200; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with malformed response",
@@ -70,7 +70,7 @@ func TestUnbind(t *testing.T) {
 				status: http.StatusInternalServerError,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 500; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with conventional failure response",
@@ -97,7 +97,8 @@ func TestUnbind(t *testing.T) {
 			tc.httpChecks.params[planIDKey] = testPlanID
 		}
 
-		klient := newTestClient(t, tc.name, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		version := Version2_11()
+		klient := newTestClient(t, tc.name, version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.Unbind(tc.request)
 

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/update_instance.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/update_instance.go
@@ -40,11 +40,15 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 
 	switch response.StatusCode {
 	case http.StatusOK:
+		if err := c.unmarshalResponse(response, &struct{}{}); err != nil {
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
+		}
+
 		return &UpdateInstanceResponse{}, nil
 	case http.StatusAccepted:
 		responseBodyObj := &asyncSuccessResponseBody{}
 		if err := c.unmarshalResponse(response, responseBodyObj); err != nil {
-			return nil, err
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
 		var opPtr *OperationKey

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/update_instance_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/update_instance_test.go
@@ -91,7 +91,7 @@ func TestUpdateInstanceInstance(t *testing.T) {
 				status: http.StatusAccepted,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 202; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "http error",
@@ -106,7 +106,7 @@ func TestUpdateInstanceInstance(t *testing.T) {
 				status: http.StatusOK,
 				body:   malformedResponse,
 			},
-			expectedResponse: successUpdateInstanceResponse(),
+			expectedErrMessage: "Status: 200; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with malformed response",
@@ -114,7 +114,7 @@ func TestUpdateInstanceInstance(t *testing.T) {
 				status: http.StatusInternalServerError,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 500; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with conventional failure response",
@@ -139,7 +139,8 @@ func TestUpdateInstanceInstance(t *testing.T) {
 			tc.httpChecks.body = "{}"
 		}
 
-		klient := newTestClient(t, tc.name, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		version := Version2_11()
+		klient := newTestClient(t, tc.name, version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.UpdateInstance(tc.request)
 

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/version.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/version.go
@@ -1,0 +1,43 @@
+package v2
+
+// APIVersion represents a specific version of the OSB API.
+type APIVersion struct {
+	label string
+	order byte
+}
+
+// AtLeast returns whether the API version is greater than or equal to the
+// given API version.
+func (v APIVersion) AtLeast(test APIVersion) bool {
+	return v.order >= test.order
+}
+
+// HeaderValue returns the value that should be sent in the API version header
+// for this API version.
+func (v APIVersion) HeaderValue() string {
+	return v.label
+}
+
+const (
+	// internalAPIVersion2_11 represents the 2.11 version of the Open Service
+	// Broker API.
+	internalAPIVersion2_11 = "2.11"
+
+	// internalAPIVersion2_11 represents the 2.11 version of the Open Service
+	// Broker API.
+	internalAPIVersion2_12 = "2.12"
+)
+
+func Version2_12() APIVersion {
+	return APIVersion{label: internalAPIVersion2_12, order: 1}
+}
+
+func Version2_11() APIVersion {
+	return APIVersion{label: internalAPIVersion2_12, order: 0}
+}
+
+// LatestAPIVersion returns the latest supported API version in the current
+// release of this library.
+func LatestAPIVersion() APIVersion {
+	return Version2_12()
+}

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/version_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/version_test.go
@@ -1,0 +1,18 @@
+package v2
+
+import (
+	"testing"
+)
+
+func TestAtLeast(t *testing.T) {
+	v2_12 := Version2_12()
+	v2_11 := Version2_11()
+
+	if !v2_12.AtLeast(v2_11) {
+		t.Error("Expected 2.12 >= 2.11")
+	}
+
+	if v2_11.AtLeast(v2_12) {
+		t.Error("Expected 2.11 < 2.12")
+	}
+}


### PR DESCRIPTION
Changes:

1.  Controller will now send v2.12 for all brokers
2.  Context is always sent
3.  This version of the client distinguishes status codes when a malformed response is sent, which is necessary to implement the orphan management part of the spec

We should remove the 'enable-osb-context' option from the controller manager at this point, I think, and add a 'supports alpha' flag to the broker resource to drive alpha features of the OSB api.  The client has a flag that could be wired from such an API field.