### PR TITLE
Update PodPreset if it already exists

### DIFF
--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -408,7 +408,12 @@ func (c *controller) injectBinding(binding *v1alpha1.Binding, credentials map[st
 
 	if found {
 		// TODO: Check ownerReferences first?
-		_, err = c.kubeClient.SettingsV1alpha1().PodPresets(binding.Namespace).Update(podPreset)
+		// NOTE: PodPresets don't support Update requests
+		err = c.kubeClient.SettingsV1alpha1().PodPresets(binding.Namespace).Delete(podPreset.ObjectMeta.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+		_, err = c.kubeClient.SettingsV1alpha1().PodPresets(binding.Namespace).Create(podPreset)
 
 	} else {
 		_, err = c.kubeClient.SettingsV1alpha1().PodPresets(binding.Namespace).Create(podPreset)

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -365,13 +365,13 @@ func (c *controller) injectBinding(binding *v1alpha1.Binding, credentials map[st
 	}
 
 	found := false
-
 	_, err := c.kubeClient.Core().Secrets(binding.Namespace).Get(binding.Spec.SecretName, metav1.GetOptions{})
 	if err == nil {
 		found = true
 	}
 
 	if found {
+		// TODO: Check ownerReferences first?
 		_, err = c.kubeClient.Core().Secrets(binding.Namespace).Update(secret)
 	} else {
 		_, err = c.kubeClient.Core().Secrets(binding.Namespace).Create(secret)
@@ -400,7 +400,19 @@ func (c *controller) injectBinding(binding *v1alpha1.Binding, credentials map[st
 		},
 	}
 
-	_, err = c.kubeClient.SettingsV1alpha1().PodPresets(binding.Namespace).Create(podPreset)
+	found = false
+	_, err = c.kubeClient.SettingsV1alpha1().PodPresets(binding.Namespace).Get(podPreset.ObjectMeta.Name, metav1.GetOptions{})
+	if err == nil {
+		found = true
+	}
+
+	if found {
+		// TODO: Check ownerReferences first?
+		_, err = c.kubeClient.SettingsV1alpha1().PodPresets(binding.Namespace).Update(podPreset)
+
+	} else {
+		_, err = c.kubeClient.SettingsV1alpha1().PodPresets(binding.Namespace).Create(podPreset)
+	}
 
 	return err
 }


### PR DESCRIPTION
Fix for https://github.com/kubernetes-incubator/service-catalog/issues/976
If the PodPreset already exists, the Create request will fail.
Check if PodPreset exists first, and if it is, update instead of creating.

P.S. We probably need to be smarter than that, and ensure that existing PodPreset belongs to the Binding (the same applies to Secrets, and possibly other resource types).