### PR TITLE
Secret upsert: OwnerReference, safe Secret create/update, appropriate error messages

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -27,6 +27,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	runtimeutil "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -521,4 +522,42 @@ func isInstanceReady(instance *v1alpha1.Instance) bool {
 	}
 
 	return false
+}
+
+// TODO (nilebox): The controllerRef methods below are merged into apimachinery and will be released in 1.8:
+// https://github.com/kubernetes/kubernetes/pull/48319
+// Remove them after 1.8 is released and Service Catalog is migrated to it
+
+// IsControlledBy checks if the given object has a controller ownerReference set to the given owner
+func IsControlledBy(obj metav1.Object, owner metav1.Object) bool {
+	ref := GetControllerOf(obj)
+	if ref == nil {
+		return false
+	}
+	return ref.UID == owner.GetUID()
+}
+
+// GetControllerOf returns the controllerRef if controllee has a controller,
+// otherwise returns nil.
+func GetControllerOf(controllee metav1.Object) *metav1.OwnerReference {
+	for _, ref := range controllee.GetOwnerReferences() {
+		if ref.Controller != nil && *ref.Controller == true {
+			return &ref
+		}
+	}
+	return nil
+}
+
+// NewControllerRef creates an OwnerReference pointing to the given owner.
+func NewControllerRef(owner metav1.Object, gvk schema.GroupVersionKind) *metav1.OwnerReference {
+	blockOwnerDeletion := true
+	isController := true
+	return &metav1.OwnerReference{
+		APIVersion:         gvk.GroupVersion().String(),
+		Kind:               gvk.Kind,
+		Name:               owner.GetName(),
+		UID:                owner.GetUID(),
+		BlockOwnerDeletion: &blockOwnerDeletion,
+		Controller:         &isController,
+	}
 }

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -25,7 +25,7 @@ import (
 
 	checksum "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/checksum/versioned/v1alpha1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/pkg/api"
@@ -33,6 +33,9 @@ import (
 	settingsv1alpha1 "k8s.io/client-go/pkg/apis/settings/v1alpha1"
 	"k8s.io/client-go/tools/cache"
 )
+
+// bindingControllerKind contains the schema.GroupVersionKind for this controller type.
+var bindingControllerKind = v1alpha1.SchemeGroupVersion.WithKind("Binding")
 
 // Binding handlers and control-loop
 
@@ -51,7 +54,7 @@ func (c *controller) reconcileBindingKey(key string) error {
 		return err
 	}
 	binding, err := c.bindingLister.Bindings(namespace).Get(name)
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		glog.Infof("Not doing work for Binding %v because it has been deleted", key)
 		return nil
 	}
@@ -391,39 +394,76 @@ func isPlanBindable(serviceClass *v1alpha1.ServiceClass, plan *v1alpha1.ServiceP
 }
 
 func (c *controller) injectBinding(binding *v1alpha1.Binding, credentials map[string]interface{}) error {
-	glog.V(5).Infof("Creating Secret %v/%v", binding.Namespace, binding.Spec.SecretName)
-	secret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      binding.Spec.SecretName,
-			Namespace: binding.Namespace,
-		},
-		Data: make(map[string][]byte),
-	}
+	glog.V(5).Infof("Creating/updating Secret %v/%v", binding.Namespace, binding.Spec.SecretName)
 
+	secretData := make(map[string][]byte)
 	for k, v := range credentials {
 		var err error
-		secret.Data[k], err = serialize(v)
+		secretData[k], err = serialize(v)
 		if err != nil {
+			// Terminal error
+			// TODO mark as terminal error once we have the terminal condition
 			return fmt.Errorf("Unable to serialize credential value %q: %v; %s",
 				k, v, err)
 		}
 	}
 
-	found := false
-
-	_, err := c.kubeClient.Core().Secrets(binding.Namespace).Get(binding.Spec.SecretName, metav1.GetOptions{})
+	// Creating/updating the Secret
+	secretClient := c.kubeClient.Core().Secrets(binding.Namespace)
+	existingSecret, err := secretClient.Get(binding.Spec.SecretName, metav1.GetOptions{})
 	if err == nil {
-		found = true
-	}
-
-	if found {
-		_, err = c.kubeClient.Core().Secrets(binding.Namespace).Update(secret)
+		// Update existing secret
+		if !IsControlledBy(existingSecret, binding) {
+			controllerRef := GetControllerOf(existingSecret)
+			// TODO mark as terminal error once we have the terminal condition
+			return fmt.Errorf("Secret '%s' is not owned by Binding, controllerRef: %v",
+				existingSecret.Name, controllerRef)
+		}
+		existingSecret.Data = secretData
+		_, err = secretClient.Update(existingSecret)
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				// Conflicting update detected, try again later
+				return fmt.Errorf("Conflicting Secret '%s' update detected", existingSecret.Name)
+			}
+			// Terminal error
+			// TODO mark as terminal error once we have the terminal condition
+			return fmt.Errorf("Unexpected error in response: %v", err)
+		}
 	} else {
-		_, err = c.kubeClient.Core().Secrets(binding.Namespace).Create(secret)
+		if !apierrors.IsNotFound(err) {
+			// Terminal error
+			// TODO mark as terminal error once we have the terminal condition
+			return fmt.Errorf("Unexpected error in response: %v", err)
+		}
+		err = nil
+
+		// Create new secret
+		secret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      binding.Spec.SecretName,
+				Namespace: binding.Namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					*NewControllerRef(binding, bindingControllerKind),
+				},
+			},
+			Data: secretData,
+		}
+		_, err = secretClient.Create(secret)
+		if err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				// Concurrent controller has created secret under the same name,
+				// Update the secret at the next retry iteration
+				return fmt.Errorf("Conflicting Secret '%s' creation detected", secret.Name)
+			}
+			// Terminal error
+			// TODO mark as terminal error once we have the terminal condition
+			return fmt.Errorf("Unexpected error in response: %v", err)
+		}
 	}
 
-	if err != nil || binding.Spec.AlphaPodPresetTemplate == nil {
-		return err
+	if binding.Spec.AlphaPodPresetTemplate == nil {
+		return nil
 	}
 
 	podPreset := &settingsv1alpha1.PodPreset{
@@ -446,7 +486,6 @@ func (c *controller) injectBinding(binding *v1alpha1.Binding, credentials map[st
 	}
 
 	_, err = c.kubeClient.SettingsV1alpha1().PodPresets(binding.Namespace).Create(podPreset)
-
 	return err
 }
 
@@ -457,14 +496,14 @@ func (c *controller) ejectBinding(binding *v1alpha1.Binding) error {
 		podPresetName := binding.Spec.AlphaPodPresetTemplate.Name
 		glog.V(5).Infof("Deleting PodPreset %v/%v", binding.Namespace, podPresetName)
 		err := c.kubeClient.SettingsV1alpha1().PodPresets(binding.Namespace).Delete(podPresetName, &metav1.DeleteOptions{})
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}
 
 	glog.V(5).Infof("Deleting Secret %v/%v", binding.Namespace, binding.Spec.SecretName)
 	err = c.kubeClient.Core().Secrets(binding.Namespace).Delete(binding.Spec.SecretName, &metav1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http/httptest"
 	"reflect"
 	"runtime/debug"
@@ -33,6 +32,7 @@ import (
 	v1alpha1informers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/externalversions/servicecatalog/v1alpha1"
 
 	servicecatalogclientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/fake"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -1488,6 +1488,12 @@ func addGetNamespaceReaction(fakeKubeClient *clientgofake.Clientset) {
 
 func addGetSecretNotFoundReaction(fakeKubeClient *clientgofake.Clientset) {
 	fakeKubeClient.AddReactor("get", "secrets", func(action clientgotesting.Action) (bool, runtime.Object, error) {
-		return true, nil, errors.New("not found")
+		return true, nil, apierrors.NewNotFound(action.GetResource().GroupResource(), action.(clientgotesting.GetAction).GetName())
+	})
+}
+
+func addGetSecretReaction(fakeKubeClient *clientgofake.Clientset, secret *v1.Secret) {
+	fakeKubeClient.AddReactor("get", "secrets", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, secret, nil
 	})
 }


### PR DESCRIPTION
See https://github.com/kubernetes-incubator/service-catalog/issues/978:
`Binding` implicitly creates `Secret` and `PodPreset` objects.
We need to set the `ownerReferences` meta field to link those objects with parent Binding. We should also check this link before updating the existing Secret/PodPreset object.