### PR TITLE
Add option to automatically deploy the Broker resource with the sample broker app

### DIFF
--- a/charts/ups-broker/README.md
+++ b/charts/ups-broker/README.md
@@ -36,6 +36,7 @@ Service Broker
 |-----------|-------------|---------|
 | `image` | Image to use | `quay.io/kubernetes-service-catalog/user-broker:v0.0.23` |
 | `imagePullPolicy` | `imagePullPolicy` for the ups-broker | `Always` |
+| `deployUPSBroker` | Whether the `User Provided Service Broker` Service Catalog resource should be automatically created or not. Requires running behind the aggregator. | `true` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/charts/ups-broker/templates/broker-deployment.yaml
+++ b/charts/ups-broker/templates/broker-deployment.yaml
@@ -1,4 +1,5 @@
 kind: Deployment
+# TODO: Migrate to apps/v1beta2 or apps/v1 when available
 apiVersion: extensions/v1beta1
 metadata:
   name: {{ template "fullname" . }}
@@ -25,15 +26,12 @@ spec:
         image: {{ .Values.image }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         args:
-        - --port
-        - "8080"
+        - --port=8080
         {{- if .Values.tls.cert}}
-        - --tlsCert
-        - "{{ .Values.tls.cert }}"
+        - --tlsCert="{{ .Values.tls.cert }}"
         {{- end}}
         {{- if .Values.tls.key}}
-        - --tlsKey
-        - "{{ .Values.tls.key }}"
+        - --tlsKey="{{ .Values.tls.key }}"
         {{- end}}
         ports:
         - containerPort: 8080

--- a/charts/ups-broker/templates/broker.yaml
+++ b/charts/ups-broker/templates/broker.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.deployUPSBroker }}
+apiVersion: servicecatalog.k8s.io/v1alpha1
+kind: ServiceBroker
+metadata:
+  name: ups-broker
+spec:
+  url: http://{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+{{ end }}

--- a/charts/ups-broker/values.yaml
+++ b/charts/ups-broker/values.yaml
@@ -9,3 +9,6 @@ tls:
   cert:
   # base-64 encoded PEM data for the private key matching the certificate
   key:
+# Specifies whether to deploy the ups-broker Broker object for this Deployment.
+# Requires running behind the aggregator.
+deployUPSBroker: false


### PR DESCRIPTION
No-op.
Just makes the chart automatically create the Broker object; convenient since the Chart knows how to talk to the ups-broker service.

Currently this is in an example, and assumes you've installed things in a certain fashion.
With this it's easy to just assume that when you install the broker using the chart, you get the Broker registration for free