### PR TITLE
add parameterization for user-broker image to e2e tests

### DIFF
--- a/contrib/jenkins/run_e2e.sh
+++ b/contrib/jenkins/run_e2e.sh
@@ -95,6 +95,7 @@ make bin/e2e.test \
   || error_exit "Error when making e2e test binary."
 
 KUBECONFIG="${KUBECONFIG}" SERVICECATALOGCONFIG="${SC_KUBECONFIG}" ${ROOT}/bin/e2e.test \
+    -broker-image="${REGISTRY}user-broker:${VERSION}" \
   || error_exit "Error while running e2e tests."
 
 echo "'e2e.test' completed successfully."

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -18,11 +18,16 @@ package e2e
 
 import (
 	"testing"
+	"flag"
 
 	"github.com/kubernetes-incubator/service-catalog/test/e2e/framework"
 )
 
+var brokerImage string
+
 func init() {
+	flag.StringVar(&brokerImage, "broker-image", "quay.io/kubernetes-service-catalog/user-broker:latest",
+		"The container image for the broker to test against")
 	framework.RegisterParseFlags()
 }
 

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -34,7 +34,7 @@ func NewUPSBrokerPod(name string) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  name,
-					Image: "quay.io/kubernetes-service-catalog/user-broker:latest",
+					Image: brokerImage,
 					Args: []string{
 						"--port",
 						"8080",


### PR DESCRIPTION
Even if your PR changes the `user-broker` source, the e2e tests weren't able to pick it up because they were hardcoded to use our quay.io registry's `latest`-tagged image. This caused major issues last week where all CI was failing due to a freshly-exposed bug in `user-broker`.

This PR allows you to pass a flag to specify which version you want to run the e2e tests against.