### PR TITLE
make the apiserver test use tls

### DIFF
--- a/contrib/hack/kubectl
+++ b/contrib/hack/kubectl
@@ -32,14 +32,6 @@ mkdir -p ${ROOT}/.var/run/kubernetes-service-catalog ${ROOT}/.kube ${ROOT}/.run
 # based on the current working dir. Yes, this assumes that you're running
 # this script from within our git repo source tree
 
-# Override the server port info based on current apiserver container's info.
-# If etcd-svc-cat isn't running then assume the caller already set up the
-# kubectl config info and we don't want to override it.
-PORT=$(docker port etcd-svc-cat 8081 | sed "s/.*://")
-if [ -n "${PORT}" ]; then
-	SERVER_INFO="--server localhost:${PORT}"
-fi
-
 docker run ${TTY_ARGS} --rm --net host \
 	-w /root/service-catalog${PWD#${ROOT}} \
 	-v ${ROOT}/.var/run/kubernetes-service-catalog:/var/run/kubernetes-service-catalog \

--- a/contrib/hack/setup-kubectl.sh
+++ b/contrib/hack/setup-kubectl.sh
@@ -39,7 +39,7 @@ stop-server.sh > /dev/null 2>&1 || true
 start-server.sh
 
 # Find the port # that Docker assigned to the server
-PORT=$(docker port etcd-svc-cat 8081 | sed "s/.*://")
+PORT=$(docker port etcd-svc-cat 443 | sed "s/.*://")
 
 D_HOST=${DOCKER_HOST:-localhost}
 D_HOST=${D_HOST#*//}   # remove leading proto://
@@ -48,6 +48,6 @@ D_HOST=${D_HOST%:*}    # remove trailing port #
 # Setup our credentials
 NO_TTY=1 kubectl config set-credentials service-catalog-creds --username=admin --password=admin
 #NO_TTY=1 kubectl config set-cluster service-catalog-cluster --server=https://${D_HOST}:${PORT} --certificate-authority=/var/run/kubernetes-service-catalog/apiserver.crt
-NO_TTY=1 kubectl config set-cluster service-catalog-cluster --server=http://${D_HOST}:${PORT}
+NO_TTY=1 kubectl config set-cluster service-catalog-cluster --server=https://${D_HOST}:${PORT}
 NO_TTY=1 kubectl config set-context service-catalog-ctx --cluster=service-catalog-cluster --user=service-catalog-creds
 NO_TTY=1 kubectl config use-context service-catalog-ctx

--- a/contrib/hack/start-server.sh
+++ b/contrib/hack/start-server.sh
@@ -23,12 +23,13 @@ export PATH=${ROOT}/contrib/hack:${PATH}
 # Clean up old containers if still around
 docker rm -f etcd-svc-cat apiserver > /dev/null 2>&1 || true
 
-# Start etcd, our DB. Also, map 8081 (api server port) to some random
-# port on the host - then ask Docker for the port # as we'll need to use
-# that when we talk to it.
+# Start etcd, our DB.
 echo Starting etcd
-docker run --name etcd-svc-cat -d -p 8081 quay.io/coreos/etcd > /dev/null
-PORT=$(docker port etcd-svc-cat 8081 | sed "s/.*://")
+# we map the port here (even though etcd doesn't use 443) because we
+# can't map it later when we put the apiserver into the same network
+# namespace as etcd
+docker run --name etcd-svc-cat -p 443 -d quay.io/coreos/etcd > /dev/null
+PORT=$(docker port etcd-svc-cat 443 | sed "s/.*://")
 
 # And now our API Server
 echo Starting the API Server
@@ -43,7 +44,6 @@ docker run -d --name apiserver \
 	--net container:etcd-svc-cat \
 	scbuildimage \
 	bin/apiserver -v 10 --etcd-servers http://localhost:2379 \
-		--insecure-bind-address=0.0.0.0 --insecure-port=8081 \
 		--storage-type=etcd --disable-auth
 
 # Wait for apiserver to be up and running
@@ -52,7 +52,7 @@ count=0
 D_HOST=${DOCKER_HOST:-localhost}
 D_HOST=${D_HOST#*//}   # remove leading proto://
 D_HOST=${D_HOST%:*}    # remove trailing port #
-while ! curl http://${D_HOST}:${PORT} > /dev/null 2>&1 ; do
+while ! curl --cacert ${ROOT}/.var/run/kubernetes-service-catalog/apiserver.crt https://${D_HOST}:${PORT} > /dev/null 2>&1 ; do
 	sleep 1
 	(( count++ )) || true
 	if [ "${count}" == "30" ]; then

--- a/contrib/hack/test-apiserver.sh
+++ b/contrib/hack/test-apiserver.sh
@@ -31,7 +31,10 @@ function cleanup {
 
 start-server.sh
 
-PORT=$(docker port etcd-svc-cat 8081 | sed "s/.*://")
+# Kubectl needs to be configured with the current cluster
+# setup. Kubectl was initially configured in a different script and
+# the port mapping may have changed by the time we get here.
+PORT=$(docker port etcd-svc-cat 443 | sed "s/.*://")
 D_HOST=${DOCKER_HOST:-localhost}
 D_HOST=${D_HOST#*//}   # remove leading proto://
 D_HOST=${D_HOST%:*}    # remove trailing port #


### PR DESCRIPTION
 - kubectl was hardcoded to use http

If the unsecure endpoint is really going away, we'll need this.

I think we should be testing https anyway.