### PR TITLE
Cross-build all the things!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,25 @@ NEWEST_GO_FILE = $(shell find $(SRC_DIRS) -name \*.go -exec $(STAT) {} \; \
 TYPES_FILES    = $(shell find pkg/apis -name types.go)
 GO_VERSION     = 1.8
 
+ALL_ARCH=amd64 arm arm64 ppc64le s390x
+
 PLATFORM?=linux
 ARCH?=amd64
+
+# TODO: Consider using busybox instead of debian
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=debian:jessie
+else ifeq ($(ARCH),arm)
+	BASEIMAGE?=arm32v7/debian:jessie
+else ifeq ($(ARCH),arm64)
+	BASEIMAGE?=arm64v8/debian:jessie
+else ifeq ($(ARCH),ppc64le)
+	BASEIMAGE?=ppc64le/debian:jessie
+else ifeq ($(ARCH),s390x)
+	BASEIMAGE?=s390x/debian:jessie
+else
+$(error Unsupported platform to compile for)
+endif
 
 GO_BUILD       = env GOOS=$(PLATFORM) GOARCH=$(ARCH) go build -i $(GOFLAGS) \
                    -ldflags "-X $(SC_PKG)/pkg.VERSION=$(VERSION)"
@@ -57,12 +74,12 @@ BASE_PATH      = $(ROOT:/src/github.com/kubernetes-incubator/service-catalog/=)
 export GOPATH  = $(BASE_PATH):$(ROOT)/vendor
 
 MUTABLE_TAG                      ?= canary
-APISERVER_IMAGE                   = $(REGISTRY)apiserver:$(VERSION)
-APISERVER_MUTABLE_IMAGE           = $(REGISTRY)apiserver:$(MUTABLE_TAG)
-CONTROLLER_MANAGER_IMAGE          = $(REGISTRY)controller-manager:$(VERSION)
-CONTROLLER_MANAGER_MUTABLE_IMAGE  = $(REGISTRY)controller-manager:$(MUTABLE_TAG)
-USER_BROKER_IMAGE                 = $(REGISTRY)user-broker:$(VERSION)
-USER_BROKER_MUTABLE_IMAGE         = $(REGISTRY)user-broker:$(MUTABLE_TAG)
+APISERVER_IMAGE                   = $(REGISTRY)apiserver-$(ARCH):$(VERSION)
+APISERVER_MUTABLE_IMAGE           = $(REGISTRY)apiserver-$(ARCH):$(MUTABLE_TAG)
+CONTROLLER_MANAGER_IMAGE          = $(REGISTRY)controller-manager-$(ARCH):$(VERSION)
+CONTROLLER_MANAGER_MUTABLE_IMAGE  = $(REGISTRY)controller-manager-$(ARCH):$(MUTABLE_TAG)
+USER_BROKER_IMAGE                 = $(REGISTRY)user-broker-$(ARCH):$(VERSION)
+USER_BROKER_MUTABLE_IMAGE         = $(REGISTRY)user-broker-$(ARCH):$(MUTABLE_TAG)
 
 # precheck to avoid kubernetes-incubator/service-catalog#361
 $(if $(realpath vendor/k8s.io/kubernetes/vendor), \
@@ -94,18 +111,18 @@ build: .init .generate_files \
        $(BINDIR)/controller-manager $(BINDIR)/apiserver \
        $(BINDIR)/user-broker
 
-user-broker: .init $(BINDIR)/user-broker
-$(BINDIR)/user-broker: contrib/cmd/user-broker \
+user-broker: $(BINDIR)/user-broker
+$(BINDIR)/user-broker: .init contrib/cmd/user-broker \
 	  $(shell find contrib/cmd/user-broker -type f)
 	$(DOCKER_CMD) $(GO_BUILD) -o $@ $(SC_PKG)/contrib/cmd/user-broker
 
 # We'll rebuild apiserver if any go file has changed (ie. NEWEST_GO_FILE)
-apiserver: .init $(BINDIR)/apiserver
-$(BINDIR)/apiserver: .generate_files cmd/apiserver $(NEWEST_GO_FILE)
+apiserver: $(BINDIR)/apiserver
+$(BINDIR)/apiserver: .init .generate_files cmd/apiserver $(NEWEST_GO_FILE)
 	$(DOCKER_CMD) $(GO_BUILD) -o $@ $(SC_PKG)/cmd/apiserver
 
-controller-manager: .init $(BINDIR)/controller-manager
-$(BINDIR)/controller-manager: .generate_files cmd/controller-manager $(NEWEST_GO_FILE)
+controller-manager: $(BINDIR)/controller-manager
+$(BINDIR)/controller-manager: .init .generate_files cmd/controller-manager $(NEWEST_GO_FILE)
 	$(DOCKER_CMD) $(GO_BUILD) -o $@ $(SC_PKG)/cmd/controller-manager
 
 # This section contains the code generation stuff
@@ -305,27 +322,47 @@ clean-coverage:
 
 # Building Docker Images for our executables
 ############################################
-images: user-broker-image \
-    controller-manager-image apiserver-image
+images: user-broker-image controller-manager-image apiserver-image
+
+images-all: $(addprefix arch-image-,$(ALL_ARCH))
+arch-image-%:
+	$(MAKE) ARCH=$* images
 
 define build-and-tag # (service, image, mutable_image, prefix)
 	$(eval build_path := "$(4)build/$(1)")
 	$(eval tmp_build_path := "$(build_path)/tmp")
 	mkdir -p $(tmp_build_path)
 	cp $(BINDIR)/$(1) $(tmp_build_path)
-	docker build -t $(2) $(build_path)
+	cp $(build_path)/Dockerfile $(tmp_build_path)
+	# -i.bak is required for cross-platform compat: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
+	sed -i.bak "s|BASEIMAGE|$(BASEIMAGE)|g" $(tmp_build_path)/Dockerfile
+	rm $(tmp_build_path)/Dockerfile.bak
+	docker build -t $(2) $(tmp_build_path)
 	docker tag $(2) $(3)
 	rm -rf $(tmp_build_path)
 endef
 
 user-broker-image: contrib/build/user-broker/Dockerfile $(BINDIR)/user-broker
 	$(call build-and-tag,"user-broker",$(USER_BROKER_IMAGE),$(USER_BROKER_MUTABLE_IMAGE),"contrib/")
+ifeq ($(ARCH),amd64)
+	docker tag $(USER_BROKER_IMAGE) $(REGISTRY)user-broker:$(VERSION)
+	docker tag $(USER_BROKER_MUTABLE_IMAGE) $(REGISTRY)user-broker:$(MUTABLE_TAG)
+endif
 
 apiserver-image: build/apiserver/Dockerfile $(BINDIR)/apiserver
 	$(call build-and-tag,"apiserver",$(APISERVER_IMAGE),$(APISERVER_MUTABLE_IMAGE))
+ifeq ($(ARCH),amd64)
+	docker tag $(APISERVER_IMAGE) $(REGISTRY)apiserver:$(VERSION)
+	docker tag $(APISERVER_MUTABLE_IMAGE) $(REGISTRY)apiserver:$(MUTABLE_TAG)
+endif
 
 controller-manager-image: build/controller-manager/Dockerfile $(BINDIR)/controller-manager
 	$(call build-and-tag,"controller-manager",$(CONTROLLER_MANAGER_IMAGE),$(CONTROLLER_MANAGER_MUTABLE_IMAGE))
+ifeq ($(ARCH),amd64)
+	docker tag $(CONTROLLER_MANAGER_IMAGE) $(REGISTRY)controller-manager:$(VERSION)
+	docker tag $(CONTROLLER_MANAGER_MUTABLE_IMAGE) $(REGISTRY)controller-manager:$(MUTABLE_TAG)
+endif
+
 
 # Push our Docker Images to a registry
 ######################################
@@ -334,11 +371,28 @@ push: user-broker-push controller-manager-push apiserver-push
 user-broker-push: user-broker-image
 	docker push $(USER_BROKER_IMAGE)
 	docker push $(USER_BROKER_MUTABLE_IMAGE)
+ifeq ($(ARCH),amd64)
+	docker push $(REGISTRY)user-broker:$(VERSION)
+	docker push $(REGISTRY)user-broker:$(MUTABLE_TAG)
+endif
 
 controller-manager-push: controller-manager-image
 	docker push $(CONTROLLER_MANAGER_IMAGE)
 	docker push $(CONTROLLER_MANAGER_MUTABLE_IMAGE)
+ifeq ($(ARCH),amd64)
+	docker push $(REGISTRY)controller-manager:$(VERSION)
+	docker push $(REGISTRY)controller-manager:$(MUTABLE_TAG)
+endif
 
 apiserver-push: apiserver-image
 	docker push $(APISERVER_IMAGE)
 	docker push $(APISERVER_MUTABLE_IMAGE)
+ifeq ($(ARCH),amd64)
+	docker push $(REGISTRY)apiserver:$(VERSION)
+	docker push $(REGISTRY)apiserver:$(MUTABLE_TAG)
+endif
+
+
+release-push: $(addprefix release-push-,$(ALL_ARCH))
+release-push-%:
+	$(MAKE) ARCH=$* push

--- a/build/apiserver/Dockerfile
+++ b/build/apiserver/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian
+FROM BASEIMAGE
 
-ADD tmp/apiserver /opt/services/
+ADD apiserver /opt/services/
 
-ENTRYPOINT ["/opt/services/apiserver" ]
-CMD [ "--etcd-servers" , "localhost" ]
+ENTRYPOINT ["/opt/services/apiserver"]
+CMD ["--etcd-servers" , "localhost"]

--- a/build/controller-manager/Dockerfile
+++ b/build/controller-manager/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian
+FROM BASEIMAGE
 
-ADD tmp/controller-manager /opt/services/
+ADD controller-manager /opt/services/
 
 ENTRYPOINT ["/opt/services/controller-manager" ]

--- a/contrib/build/user-broker/Dockerfile
+++ b/contrib/build/user-broker/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian
+FROM BASEIMAGE
 
-ADD tmp/user-broker /opt/services/user-broker
+ADD user-broker /opt/services/user-broker
 
 ENTRYPOINT ["/opt/services/user-broker"]


### PR DESCRIPTION
Implement https://github.com/kubernetes/community/blob/master/contributors/design-proposals/multi-platform.md for service-catalog without breaking backwards compat.

Should be pretty straightforward, if you want to do a new release hit `make release-push`

cc @pmorie @arschles @MHBauer PTAL and merge into the next release