### PR TITLE
make e2e look for pods' existence before checking status

### DIFF
--- a/contrib/hack/test_walkthrough.sh
+++ b/contrib/hack/test_walkthrough.sh
@@ -150,11 +150,11 @@ retry -n 10 \
 
 echo 'Waiting on pods to come up...'
 
-wait_for_expected_output -x -e 'Pending' -n 10 \
+wait_for_expected_output -e 'ups-broker-ups-broker' \
     kubectl get pods --namespace ups-broker \
-  || error_exit 'Timed out waiting for user-provided-service broker pod to come up.'
-
-wait_for_expected_output -x -e 'ContainerCreating' -n 10 \
+  && wait_for_expected_output -x -e 'Pending' \
+    kubectl get pods --namespace ups-broker \
+  && wait_for_expected_output -x -e 'ContainerCreating' \
     kubectl get pods --namespace ups-broker \
   || error_exit 'Timed out waiting for user-provided-service broker pod to come up.'
 
@@ -166,11 +166,13 @@ wait_for_expected_output -x -e 'ContainerCreating' -n 10 \
     error_exit 'User provided service broker pod did not come up successfully.'
   }
 
-wait_for_expected_output -x -e 'Pending' -n 10 \
+wait_for_expected_output -e 'catalog-catalog-controller-manager' \
     kubectl get pods --namespace catalog \
-  || error_exit 'Timed out waiting for service catalog pods to come up.'
-
-wait_for_expected_output -x -e 'ContainerCreating' -n 10 \
+  && wait_for_expected_output -e 'catalog-catalog-apiserver' \
+    kubectl get pods --namespace catalog \
+  && wait_for_expected_output -x -e 'Pending' \
+    kubectl get pods --namespace catalog \
+  && wait_for_expected_output -x -e 'ContainerCreating' \
     kubectl get pods --namespace catalog \
   || error_exit 'Timed out waiting for service catalog pods to come up.'
 

--- a/contrib/hack/utilities.sh
+++ b/contrib/hack/utilities.sh
@@ -83,7 +83,7 @@ function retry() {
 function wait_for_expected_output() {
   local OPTIND OPTARG ARG
   local negate=''
-  local count=0
+  local count=10
   local sleep_amount=5
   local max_sleep=60
   local expected=''

--- a/contrib/jenkins/install_catalog.sh
+++ b/contrib/jenkins/install_catalog.sh
@@ -86,11 +86,13 @@ retry -n 10 \
 
 echo 'Waiting on pods to come up...'
 
-wait_for_expected_output -x -e 'Pending' -n 10 \
+wait_for_expected_output -e 'catalog-catalog-controller-manager' \
     kubectl get pods --namespace catalog \
-  || error_exit 'Timed out waiting for service catalog pods to come up.'
-
-wait_for_expected_output -x -e 'ContainerCreating' -n 10 \
+  && wait_for_expected_output -e 'catalog-catalog-apiserver' \
+    kubectl get pods --namespace catalog \
+  && wait_for_expected_output -x -e 'Pending' \
+    kubectl get pods --namespace catalog \
+  && wait_for_expected_output -x -e 'ContainerCreating' \
     kubectl get pods --namespace catalog \
   || error_exit 'Timed out waiting for service catalog pods to come up.'
 


### PR DESCRIPTION
Fixes CI issue in #936 . The tests were assuming the pods existed before checking their status, but the changes in this PR seem to have slowed down the catalog chart installation enough that this assumption was failing consistently.