### PR TITLE
Adding target to unit test on the host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,19 @@ coverage: .init
 
 test: .init build test-unit test-integration
 
+# this target checks to see if the go binary is installed on the host
+.PHONY: check-go
+check-go:
+	@if [ -z $$(which go) ]; then \
+	  echo "Missing \`go\` binary which is required for development"; \
+	  exit 1; \
+	fi
+
+# this target uses the host-local go installation to test 
+.PHONY: test-unit-native
+test-unit-native: check-go
+	go test $(addprefix ${SC_PKG}/,${TEST_DIRS})
+
 test-unit: .init build
 	@echo Running tests:
 	$(DOCKER_CMD) go test -race $(UNIT_TEST_FLAGS) \


### PR DESCRIPTION
This patch adds a `test-unit-native` target as well as a target -- which it depends on -- called `check-go`, which ensures that `go` is installed on the host. The purpose of this target it to allow developers to more quickly run unit tests than when using the development docker image. It also allows developers to run tests without depending on the development docker image.

As a follow-up, I may add a target to build on the host