### PR TITLE
use GKE's default K8S version for Jenkins

### DIFF
--- a/contrib/jenkins/init_cluster.sh
+++ b/contrib/jenkins/init_cluster.sh
@@ -46,20 +46,7 @@ gcloud auth activate-service-account \
 
 echo "Creating cluster ${CLUSTERNAME}"
 
-# TODO: Currently, GKE's default master version is 1.5.6, but the catalog needs
-# >=1.6.0 to run. However, the patch version keeps changing. Until the default is
-# >=1.6.0, manually grab the latest GKE master version from the list of valid
-# versions, and use that.
-CLUSTER_VERSION="$(gcloud container get-server-config --zone "${ZONE}" \
-  | awk 'BEGIN {p=0}; /validMasterVersions:/ {p=1; next}; p {print $2; exit}')"
-
-[[ "${CLUSTER_VERSION}" == *1.6.* ]] \
-  || error_exit "Invalid cluster version. Expected 1.6.X, got: ${CLUSTER_VERSION}"
-
-echo "Using cluster version ${CLUSTER_VERSION}"
-
 gcloud container clusters create "${CLUSTERNAME}" --project="${PROJECT}" --zone="${ZONE}" \
-    --cluster-version "${CLUSTER_VERSION}" \
   || { echo 'Cannot create cluster.'; exit 1; }
 
 echo "Using cluster ${CLUSTERNAME}."


### PR DESCRIPTION
When 1.5.X was still the default for GKE, we needed special code when initializing the test cluster so that we'd get the latest 1.6.X version. This code assumed that:

1) The latest cluster version would be no later than 1.6.X
2) The default was earlier than 1.6.X

I just noticed that on the us-west1-a zone, 1.7.0 is the latest version and 1.6.4 is the default, meaning these two assumptions no longer hold, and Jenkins (which runs in the us-west1-b zone) is a ticking time bomb that is set to fail as soon as us-west1-b gets updated.

So for the time being, let's fix this to use the default version quickly (the default in us-west1-b is also 1.6.4), and then we can make a follow-up once time is on our side!