### PR TITLE
remove check for GUID regEx from plan externalid

### DIFF
--- a/pkg/apis/servicecatalog/validation/serviceclass.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass.go
@@ -115,10 +115,6 @@ func validateServicePlan(plan sc.ServicePlan, fldPath *field.Path) field.ErrorLi
 		allErrs = append(allErrs, field.Required(field.NewPath("description"), "description is required"))
 	}
 
-	for _, msg := range validateExternalID(plan.ExternalID) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("externalID"), plan.ExternalID, msg))
-	}
-
 	return allErrs
 }
 

--- a/pkg/apis/servicecatalog/validation/serviceclass_test.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass_test.go
@@ -91,15 +91,6 @@ func TestValidateServiceClass(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "invalid serviceClass - invalid guid",
-			serviceClass: func() *servicecatalog.ServiceClass {
-				s := validServiceClass()
-				s.ExternalID = "1234-4354a\\%-49b"
-				return s
-			}(),
-			valid: false,
-		},
-		{
 			name: "invalid serviceClass - missing description",
 			serviceClass: func() *servicecatalog.ServiceClass {
 				s := validServiceClass()
@@ -118,19 +109,19 @@ func TestValidateServiceClass(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "invalid serviceClass - invalid plan guid",
+			name: "valid serviceClass - special charaters in plan id",
 			serviceClass: func() *servicecatalog.ServiceClass {
 				s := validServiceClass()
-				s.Plans[0].ExternalID = "40d-0983-1b89-★"
+				s.Plans[0].ExternalID = "40D-0983-1b89.plan!%'<>~¥"
 				return s
 			}(),
-			valid: false,
+			valid: true,
 		},
 		{
-			name: "invalid serviceClass - missing plan guid",
+			name: "invalid serviceClass - missing plan id",
 			serviceClass: func() *servicecatalog.ServiceClass {
 				s := validServiceClass()
-				s.Plans[0].ExternalID = "40d-0983-1b89-★"
+				s.Plans[0].ExternalID = ""
 				return s
 			}(),
 			valid: false,


### PR DESCRIPTION
The hashicorp/cf-vault-service-broker appends the plan name onto the GUID for the External ID using a period as the separator. The existing regEx validation does not allow for periods. The [Pivotal docs](http://docs.pivotal.io/pivotalcf/1-8/services/api.html#PObject) do not specify an exact format and simply state `using a GUID is recommended`.

This change removes the regEx check in the api for Plan[].ExternalID so that any other brokers not following a strict GUID format will still work for k8s. 