### PR TITLE
Remove different-org rule for LGTM

### DIFF
--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -7,8 +7,7 @@ situations for which process is not specified.
 
 PRs may only be merged after the following criteria are met:
 
-1. It has been 'LGTM'-ed by 2 different reviewers, each from a different
-  organization and different from the author's organization
+1. It has been 'LGTM'-ed by 2 different reviewers
 1. It has all appropriate corresponding documentation and testcases
 
 ## LGTMs


### PR DESCRIPTION
We recently added a new rule to say that LGTM can only come from a different org from the submitter of a PR.  In practice, I'm finding that:

1.  Very few people actively review PRs and respond to changes that address PR feedback on a daily basis
2.  We only have a single organization with multiple people who actively contribute code on a regular basis
3.  I do not think that we have the problem of undue leniency between people from the same organization that this rule was intended to prevent

For me personally, as the most active contributor to the project and arguably most qualified to review a change, I cannot give LGTM to the people from RH that I work closely with on this project, which means additional latency / lots of extra work hounding people who may not review on a daily basis for reviews.  That doesn't make sense to me.

So, I propose that we remove the rule.  Note that any substantial changes should already have consensus around the need for the change and broad strokes of the approach.