### PR TITLE
msg on Environment Variables to set for e2e

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package e2e
 
 import (
-	"testing"
 	"flag"
+	"testing"
 
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/service-catalog/test/e2e/framework"
 )
 
@@ -29,6 +32,13 @@ func init() {
 	flag.StringVar(&brokerImageFlag, "broker-image", "quay.io/kubernetes-service-catalog/user-broker:latest",
 		"The container image for the broker to test against")
 	framework.RegisterParseFlags()
+
+	if "" == framework.TestContext.KubeConfig {
+		glog.Fatalf("environment variable %v must be set", clientcmd.RecommendedConfigPathEnvVar)
+	}
+	if "" == framework.TestContext.ServiceCatalogConfig {
+		glog.Fatalf("environment variable %v must be set", framework.RecommendedConfigPathEnvVar)
+	}
 }
 
 func TestE2E(t *testing.T) {

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -52,10 +52,10 @@ func RegisterCommonFlags() {
 	config.GinkgoConfig.RandomizeAllSpecs = true
 
 	flag.StringVar(&TestContext.KubeHost, "kubernetes-host", "http://127.0.0.1:8080", "The kubernetes host, or apiserver, to connect to")
-	flag.StringVar(&TestContext.KubeConfig, "kubernetes-config", os.Getenv(clientcmd.RecommendedConfigPathEnvVar), "Path to config containing embedded authinfo for kubernetes.")
+	flag.StringVar(&TestContext.KubeConfig, "kubernetes-config", os.Getenv(clientcmd.RecommendedConfigPathEnvVar), "Path to config containing embedded authinfo for kubernetes. Default value is from environment variable "+clientcmd.RecommendedConfigPathEnvVar)
 	flag.StringVar(&TestContext.KubeContext, "kubernetes-context", "", "config context to use for kuberentes. If unset, will use value from 'current-context'")
 	flag.StringVar(&TestContext.ServiceCatalogHost, "service-catalog-host", "http://127.0.0.1:30000", "The service catalog host, or apiserver, to connect to")
-	flag.StringVar(&TestContext.ServiceCatalogConfig, "service-catalog-config", os.Getenv(RecommendedConfigPathEnvVar), "Path to config containing embedded authinfo for service catalog.")
+	flag.StringVar(&TestContext.ServiceCatalogConfig, "service-catalog-config", os.Getenv(RecommendedConfigPathEnvVar), "Path to config containing embedded authinfo for service catalog. Default value is from environment variable "+RecommendedConfigPathEnvVar)
 	flag.StringVar(&TestContext.ServiceCatalogContext, "service-catalog-context", "", "config context to use for service catalog. If unset, will use value from 'current-context'")
 }
 


### PR DESCRIPTION
I've been running the e2e a lot latery and can never remember what I need exactly. If it's not there you end up with a really unhelpful "config is blank, please set the config" message.

Before
```
Jul 27 15:27:49.081: INFO: >>> config:

         s: "Config file must be specified to load client config",
      Config file must be specified to load client config
```

After
```
F0727 15:35:13.326214   77729 e2e_test.go:37] environment variable KUBECONFIG must be set
F0727 15:35:35.655993   77753 e2e_test.go:40] environment variable SERVICECATALOGCONFIG must be set
```