### PR TITLE
Only do work for instances from a single queue

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -156,7 +156,7 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 		go wait.Until(worker(c.serviceClassQueue, "ServiceClass", maxRetries, c.reconcileServiceClassKey), time.Second, stopCh)
 		go wait.Until(worker(c.instanceQueue, "Instance", maxRetries, c.reconcileInstanceKey), time.Second, stopCh)
 		go wait.Until(worker(c.bindingQueue, "Binding", maxRetries, c.reconcileBindingKey), time.Second, stopCh)
-		go wait.Until(worker(c.pollingQueue, "Poller", maxRetries, c.reconcileInstanceKey), time.Second, stopCh)
+		go wait.Until(worker(c.pollingQueue, "Poller", maxRetries, c.requeueInstanceForPoll), time.Second, stopCh)
 	}
 
 	<-stopCh
@@ -172,9 +172,6 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
 // If reconciler returns an error, requeue the item up to maxRetries before giving up.
 // It enforces that the reconciler is never invoked concurrently with the same key.
-// TODO: Consider allowing the reconciler to return an error that either specifies whether
-// this is recoverable or not, rather than always continuing on an error condition. Seems
-// like it should be possible to return an error, yet stop any further polling work.
 func worker(queue workqueue.RateLimitingInterface, resourceType string, maxRetries int, reconciler func(key string) error) func() {
 	return func() {
 		exit := false

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -578,19 +577,25 @@ func TestReconcileInstanceAsynchronous(t *testing.T) {
 	updatedInstance := assertUpdateStatus(t, actions[0], instance)
 	assertInstanceReadyFalse(t, updatedInstance)
 
-	// The item should've been added to the pollingQueue for later processing
-	if testController.pollingQueue.Len() != 1 {
-		t.Fatalf("Expected the asynchronous instance to end up in the polling queue")
-	}
-	item, _ := testController.pollingQueue.Get()
-	if item == nil {
-		t.Fatalf("Did not get back a key from polling queue")
-	}
-	actualKey := item.(string)
-	expectedKey := fmt.Sprintf("%s/%s", instance.Namespace, instance.Name)
-	if actualKey != expectedKey {
-		t.Fatalf("got key as %q expected %q", actualKey, expectedKey)
-	}
+	// Since polling is rate-limited, it is not possible to check whether the
+	// instance is in the polling queue.
+	//
+	// TODO: add a way to peek into rate-limited adds that are still pending,
+	// then uncomment.
+
+	// if testController.pollingQueue.Len() != 1 {
+	// 	t.Fatalf("Expected the asynchronous instance to end up in the polling queue")
+	// }
+	// item, _ := testController.pollingQueue.Get()
+	// if item == nil {
+	// 	t.Fatalf("Did not get back a key from polling queue")
+	// }
+	// actualKey := item.(string)
+	// expectedKey := fmt.Sprintf("%s/%s", instance.Namespace, instance.Name)
+	// if actualKey != expectedKey {
+	// 	t.Fatalf("got key as %q expected %q", actualKey, expectedKey)
+	// }
+
 	assertAsyncOpInProgressTrue(t, updatedInstance)
 	assertInstanceLastOperation(t, updatedInstance, testOperation)
 	assertInstanceDashboardURL(t, updatedInstance, testDashboardURL)
@@ -649,19 +654,24 @@ func TestReconcileInstanceAsynchronousNoOperation(t *testing.T) {
 	updatedInstance := assertUpdateStatus(t, actions[0], instance)
 	assertInstanceReadyFalse(t, updatedInstance)
 
-	// The item should've been added to the pollingQueue for later processing
-	if testController.pollingQueue.Len() != 1 {
-		t.Fatalf("Expected the asynchronous instance to end up in the polling queue")
-	}
-	item, _ := testController.pollingQueue.Get()
-	if item == nil {
-		t.Fatalf("Did not get back a key from polling queue")
-	}
-	key := item.(string)
-	expectedKey := fmt.Sprintf("%s/%s", instance.Namespace, instance.Name)
-	if key != expectedKey {
-		t.Fatalf("got key as %q expected %q", key, expectedKey)
-	}
+	// Since polling is rate-limited, it is not possible to check whether the
+	// instance is in the polling queue.
+	//
+	// TODO: add a way to peek into rate-limited adds that are still pending,
+	// then uncomment.
+
+	// if testController.pollingQueue.Len() != 1 {
+	// 	t.Fatalf("Expected the asynchronous instance to end up in the polling queue")
+	// }
+	// item, _ := testController.pollingQueue.Get()
+	// if item == nil {
+	// 	t.Fatalf("Did not get back a key from polling queue")
+	// }
+	// key := item.(string)
+	// expectedKey := fmt.Sprintf("%s/%s", instance.Namespace, instance.Name)
+	// if key != expectedKey {
+	// 	t.Fatalf("got key as %q expected %q", key, expectedKey)
+	// }
 	assertAsyncOpInProgressTrue(t, updatedInstance)
 	assertInstanceLastOperation(t, updatedInstance, "")
 }

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -65,7 +65,7 @@ func truePtr() *bool {
 	return &b
 }
 
-// TestBasicFlows tests:
+// TestBasicFlowsSync tests:
 //
 // - add Broker
 // - verify ServiceClasses added
@@ -74,7 +74,9 @@ func truePtr() *bool {
 // - unbind
 // - deprovision
 // - delete broker
-func TestBasicFlows(t *testing.T) {
+//
+// ...using purely synchronous provision/deprovision.
+func TestBasicFlowsSync(t *testing.T) {
 	_, catalogClient, _, _, _, shutdownServer := newTestController(t, fakeosb.FakeClientConfiguration{
 		CatalogReaction: &fakeosb.CatalogReaction{
 			Response: &osb.CatalogResponse{
@@ -97,21 +99,10 @@ func TestBasicFlows(t *testing.T) {
 			},
 		},
 		ProvisionReaction: &fakeosb.ProvisionReaction{
-			// Async is temporarily disabled due to a race condition where
-			// multiple goroutines can be working on the same instance at the
-			// same time.
 			Response: &osb.ProvisionResponse{
 				Async: false,
 			},
 		},
-		// Temporarily commented out because async is temporarily disabled.
-		//
-		// PollLastOperationReaction: &fakeosb.PollLastOperationReaction{
-		// 	Response: &osb.LastOperationResponse{
-		// 		State: osb.StateSucceeded,
-		// 		Async: true,
-		// 	},
-		// },
 		BindReaction: &fakeosb.BindReaction{
 			Response: &osb.BindResponse{
 				Credentials: map[string]interface{}{
@@ -124,6 +115,191 @@ func TestBasicFlows(t *testing.T) {
 		DeprovisionReaction: &fakeosb.DeprovisionReaction{
 			Response: &osb.DeprovisionResponse{
 				Async: false,
+			},
+		},
+	})
+	defer shutdownServer()
+
+	client := catalogClient.ServicecatalogV1alpha1()
+
+	broker := &v1alpha1.Broker{
+		ObjectMeta: metav1.ObjectMeta{Name: testBrokerName},
+		Spec: v1alpha1.BrokerSpec{
+			URL: testBrokerURL,
+		},
+	}
+
+	_, err := client.Brokers().Create(broker)
+	if nil != err {
+		t.Fatalf("error creating the broker %q (%q)", broker, err)
+	}
+
+	err = util.WaitForBrokerCondition(client,
+		testBrokerName,
+		v1alpha1.BrokerCondition{
+			Type:   v1alpha1.BrokerConditionReady,
+			Status: v1alpha1.ConditionTrue,
+		})
+	if err != nil {
+		t.Fatalf("error waiting for broker to become ready: %v", err)
+	}
+
+	err = util.WaitForServiceClassToExist(client, testServiceClassName)
+	if nil != err {
+		t.Fatalf("error waiting from ServiceClass to exist: %v", err)
+	}
+
+	// TODO: find some way to compose scenarios; extract method here for real
+	// logic for this test.
+
+	//-----------------
+
+	instance := &v1alpha1.Instance{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
+		Spec: v1alpha1.InstanceSpec{
+			ServiceClassName: testServiceClassName,
+			PlanName:         testPlanName,
+			ExternalID:       testExternalID,
+		},
+	}
+
+	if _, err := client.Instances(testNamespace).Create(instance); err != nil {
+		t.Fatalf("error creating Instance: %v", err)
+	}
+
+	if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1alpha1.InstanceCondition{
+		Type:   v1alpha1.InstanceConditionReady,
+		Status: v1alpha1.ConditionTrue,
+	}); err != nil {
+		t.Fatalf("error waiting for instance to become ready: %v", err)
+	}
+
+	retInst, err := client.Instances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
+	}
+	if retInst.Spec.ExternalID != instance.Spec.ExternalID {
+		t.Fatalf(
+			"returned OSB GUID '%s' doesn't match original '%s'",
+			retInst.Spec.ExternalID,
+			instance.Spec.ExternalID,
+		)
+	}
+
+	// Binding test begins here
+	//-----------------
+
+	binding := &v1alpha1.Binding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testBindingName},
+		Spec: v1alpha1.BindingSpec{
+			InstanceRef: v1.LocalObjectReference{
+				Name: testInstanceName,
+			},
+		},
+	}
+
+	_, err = client.Bindings(testNamespace).Create(binding)
+	if err != nil {
+		t.Fatalf("error creating Binding: %v", binding)
+	}
+
+	err = util.WaitForBindingCondition(client, testNamespace, testBindingName, v1alpha1.BindingCondition{
+		Type:   v1alpha1.BindingConditionReady,
+		Status: v1alpha1.ConditionTrue,
+	})
+	if err != nil {
+		t.Fatalf("error waiting for binding to become ready: %v", err)
+	}
+
+	err = client.Bindings(testNamespace).Delete(testBindingName, &metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("binding delete should have been accepted: %v", err)
+	}
+
+	err = util.WaitForBindingToNotExist(client, testNamespace, testBindingName)
+	if err != nil {
+		t.Fatalf("error waiting for binding to not exist: %v", err)
+	}
+
+	//-----------------
+	// End binding test
+
+	err = client.Instances(testNamespace).Delete(testInstanceName, &metav1.DeleteOptions{})
+	if nil != err {
+		t.Fatalf("instance delete should have been accepted: %v", err)
+	}
+
+	err = util.WaitForInstanceToNotExist(client, testNamespace, testInstanceName)
+	if err != nil {
+		t.Fatalf("error waiting for instance to be deleted: %v", err)
+	}
+
+	//-----------------
+	// End provision test
+
+	// Delete the broker
+	err = client.Brokers().Delete(testBrokerName, &metav1.DeleteOptions{})
+	if nil != err {
+		t.Fatalf("broker should be deleted (%s)", err)
+	}
+
+	err = util.WaitForServiceClassToNotExist(client, testServiceClassName)
+	if err != nil {
+		t.Fatalf("error waiting for ServiceClass to not exist: %v", err)
+	}
+
+	err = util.WaitForBrokerToNotExist(client, testBrokerName)
+	if err != nil {
+		t.Fatalf("error waiting for Broker to not exist: %v", err)
+	}
+}
+
+// TestBasicFlowsAsync tests the same flows as TestBasicFlowsSync, using
+// asynchronous provision/deprovision.
+func TestBasicFlowsAsync(t *testing.T) {
+	_, catalogClient, _, _, _, shutdownServer := newTestController(t, fakeosb.FakeClientConfiguration{
+		CatalogReaction: &fakeosb.CatalogReaction{
+			Response: &osb.CatalogResponse{
+				Services: []osb.Service{
+					{
+						Name:        testServiceClassName,
+						ID:          "12345",
+						Description: "a test service",
+						Bindable:    true,
+						Plans: []osb.Plan{
+							{
+								Name:        testPlanName,
+								Free:        truePtr(),
+								ID:          "34567",
+								Description: "a test plan",
+							},
+						},
+					},
+				},
+			},
+		},
+		ProvisionReaction: &fakeosb.ProvisionReaction{
+			Response: &osb.ProvisionResponse{
+				Async: true,
+			},
+		},
+		PollLastOperationReaction: &fakeosb.PollLastOperationReaction{
+			Response: &osb.LastOperationResponse{
+				State: osb.StateSucceeded,
+			},
+		},
+		BindReaction: &fakeosb.BindReaction{
+			Response: &osb.BindResponse{
+				Credentials: map[string]interface{}{
+					"foo": "bar",
+					"baz": "zap",
+				},
+			},
+		},
+		UnbindReaction: &fakeosb.UnbindReaction{},
+		DeprovisionReaction: &fakeosb.DeprovisionReaction{
+			Response: &osb.DeprovisionResponse{
+				Async: true,
 			},
 		},
 	})


### PR DESCRIPTION
Fixes the race condition uncovered during #1017 by only doing work for instances from a single work queue.  Instances are now added to the polling queue in a rate limited manner, and Instead of the polling queue triggering a re-reconcile of the instance, it instead adds the instance's key into the main instance work queue.  This means that only a single goroutine will do work on an instance at a time.

Fixes #780 