### PR TITLE
Tweaks to the walkthrough for local-up-cluster

### DIFF
--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -55,7 +55,9 @@ spec:
         - --service-catalog-api-server-url
         - https://{{ template "fullname" . }}-apiserver
         {{- end }}
+        {{ if .Values.controllerManager.apiserverSkipVerify -}}
         - "--service-catalog-insecure-skip-verify=true"
+        {{- end }}
         - -v
         - "{{ .Values.controllerManager.verbosity }}"
         - --resync-interval

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -1,4 +1,6 @@
 # Default values for Service Catalog
+# determines whether the API server should be registered with the kube-aggregator
+useAggregator: false
 apiserver:
   # apiserver image to use
   image: quay.io/kubernetes-service-catalog/apiserver:v0.0.14
@@ -93,4 +95,5 @@ controllerManager:
     # Whether the controller has option to set leader election namespace.
     activated: false
   serviceAccount: service-catalog-controller-manager
-useAggregator: false
+  # Controls whether the API server's TLS verification should be skipped.
+  apiserverSkipVerify: true

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -16,9 +16,9 @@ DNS enabled already.
 * If you are using hack/local-up-cluster.sh, ensure the
 `KUBE_ENABLE_CLUSTER_DNS` environment variable is set as follows:
 
-  ```console
-  KUBE_ENABLE_CLUSTER_DNS=true hack/local-up-cluster.sh -O
-  ```
+```console
+hack/local-up-cluster.sh -O
+```
 
 ### Getting Helm and installing Tiller
 
@@ -31,6 +31,18 @@ be done with Helm setup.
 
 If you don't already have Helm v2, see the
 [installation instructions](https://github.com/kubernetes/helm/blob/master/docs/install.md).
+
+### RBAC Considerations
+
+If your kubernetes cluster has [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/)
+enabled, you must ensure that the default service account for the `kube-system`
+namespace has the `cluster-admin` role:
+
+```console
+kubectl create clusterrolebinding default-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
+```
+
+This is required in order for helm to work correctly in clusters with RBAC enabled.
 
 ## Step 1 - Installing the Service Catalog
 


### PR DESCRIPTION
A couple tweaks were necessary for me to make the walkthrough run on a cluster created with `local-up-cluster.sh`:

- Needed to make the default service account for the `kube-system` namespace a cluster admin
- Needed a knob to turn off TLS skip verify for the controller -> SC API server connection (you can't set insecure skip verify AND provide root cert data at the same time)

