### PR TITLE
Send service_id and plan_id correctly for deprovision

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -238,7 +238,7 @@ imports:
 - name: github.com/pkg/errors
   version: a22138067af1c4942683050411a841ade67fe1eb
 - name: github.com/pmorie/go-open-service-broker-client
-  version: 8811635fed0170d82bfc1c3d4d7fbd5a01ae45ed
+  version: a15af7d9e6c264f61daf883b78ed3f13a0b53de6
   subpackages:
   - v2
   - v2/fake

--- a/glide.yaml
+++ b/glide.yaml
@@ -64,4 +64,4 @@ import:
 - package: code.cloudfoundry.org/lager
   version: dfcbcba2dd4a5228c43b0292d219d5c010daed3a
 - package: github.com/pmorie/go-open-service-broker-client
-  version: 8811635fed0170d82bfc1c3d4d7fbd5a01ae45ed
+  version: a15af7d9e6c264f61daf883b78ed3f13a0b53de6

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/auth_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/auth_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -24,13 +25,41 @@ func TestBasicAuth(t *testing.T) {
 
 	for _, tc := range cases {
 		client := newTestClient(t, tc.name, Version2_11(), true, httpChecks{}, httpReaction{})
-		client.BasicAuthConfig = tc.BasicAuthConfig
-		client.doRequestFunc = addAuthCheck(t, tc.name, tc.BasicAuthConfig, client.doRequestFunc)
+		client.AuthConfig = &AuthConfig{
+			BasicAuthConfig: tc.BasicAuthConfig,
+		}
+		client.doRequestFunc = addBasicAuthCheck(t, tc.name, tc.BasicAuthConfig, client.doRequestFunc)
 		client.prepareAndDo(http.MethodGet, client.URL, nil, nil)
 	}
 }
 
-func addAuthCheck(t *testing.T, name string, authConfig *BasicAuthConfig, f doRequestFunc) doRequestFunc {
+func TestBearerAuth(t *testing.T) {
+	cases := []struct {
+		*BearerConfig
+		name	 string
+	}{
+		{
+			name: "No Auth",
+		},
+		{
+			BearerConfig: &BearerConfig{
+				Token: "SuchToken",
+			},
+			name: "Bearer Auth",
+		},
+	}
+
+	for _, tc := range cases {
+		client := newTestClient(t, tc.name, Version2_11(), true, httpChecks{}, httpReaction{})
+		client.AuthConfig = &AuthConfig{
+			BearerConfig: tc.BearerConfig,
+		}
+		client.doRequestFunc = addBearerAuthCheck(t, tc.name, tc.BearerConfig, client.doRequestFunc)
+		client.prepareAndDo(http.MethodGet, client.URL, nil, nil)
+	}
+}
+
+func addBasicAuthCheck(t *testing.T, name string, authConfig *BasicAuthConfig, f doRequestFunc) doRequestFunc {
 	return func(request *http.Request) (*http.Response, error) {
 		u, p, ok := request.BasicAuth()
 		if !ok && authConfig != nil {
@@ -49,4 +78,39 @@ func addAuthCheck(t *testing.T, name string, authConfig *BasicAuthConfig, f doRe
 
 		return f(request)
 	}
+}
+
+func addBearerAuthCheck(t *testing.T, name string, authConfig *BearerConfig, f doRequestFunc) doRequestFunc {
+	return func(request *http.Request) (*http.Response, error) {
+		auth := request.Header.Get("Authorization")
+		if auth == "" {
+			if authConfig != nil {
+				t.Errorf("%s: Expected bearer auth in request but none found", name)
+				return nil, walkingGhostErr
+			}
+			return f(request)
+		}
+		token, ok := parseBearerToken(auth)
+		if !ok && authConfig != nil {
+			t.Errorf("%s: Expected bearer auth in request but none found", name)
+			return nil, walkingGhostErr
+		} else if ok && authConfig != nil {
+			if token != authConfig.Token {
+				t.Errorf("%s: bearer token test failed: expected %q but got %q", name, authConfig.Token, token)
+				return nil, walkingGhostErr
+			}
+		}
+
+		return f(request)
+	}
+}
+
+// parseBearerToken parses an HTTP Bearer Authentication token.
+// "Bearer abcde" returns ("abcde", true).
+func parseBearerToken(auth string) (token string, ok bool) {
+	const prefix = "Bearer "
+	if !strings.HasPrefix(auth, prefix) {
+		return "", false
+	}
+	return auth[len(prefix):], true
 }

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/deprovision_instance.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/deprovision_instance.go
@@ -5,13 +5,6 @@ import (
 	"net/http"
 )
 
-// internal message body types
-
-type deprovisionInstanceRequestBody struct {
-	serviceID *string `json:"service_id"`
-	planID    *string `json:"plan_id,omitempty"`
-}
-
 func (c *client) DeprovisionInstance(r *DeprovisionRequest) (*DeprovisionResponse, error) {
 	if err := validateDeprovisionRequest(r); err != nil {
 		return nil, err
@@ -19,20 +12,15 @@ func (c *client) DeprovisionInstance(r *DeprovisionRequest) (*DeprovisionRespons
 
 	fullURL := fmt.Sprintf(serviceInstanceURLFmt, c.URL, r.InstanceID)
 
-	params := map[string]string{}
+	params := map[string]string{
+		serviceIDKey: string(r.ServiceID),
+		planIDKey:    string(r.PlanID),
+	}
 	if r.AcceptsIncomplete {
 		params[asyncQueryParamKey] = "true"
 	}
 
-	requestServiceID := string(r.ServiceID)
-	requestPlanID := string(r.PlanID)
-
-	requestBody := &deprovisionInstanceRequestBody{
-		serviceID: &requestServiceID,
-		planID:    &requestPlanID,
-	}
-
-	response, err := c.prepareAndDo(http.MethodDelete, fullURL, params, requestBody)
+	response, err := c.prepareAndDo(http.MethodDelete, fullURL, params, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/deprovision_instance_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/deprovision_instance_test.go
@@ -63,6 +63,12 @@ func TestDeprovisionInstance(t *testing.T) {
 				status: http.StatusOK,
 				body:   successDeprovisionResponseBody,
 			},
+			httpChecks: httpChecks{
+				params: map[string]string{
+					serviceIDKey: string(testServiceID),
+					planIDKey:    string(testPlanID),
+				},
+			},
 			expectedResponse: successDeprovisionResponse(),
 		},
 		{
@@ -141,10 +147,6 @@ func TestDeprovisionInstance(t *testing.T) {
 
 		if tc.httpChecks.URL == "" {
 			tc.httpChecks.URL = "/v2/service_instances/test-instance-id"
-		}
-
-		if tc.httpChecks.body == "" {
-			tc.httpChecks.body = "{}"
 		}
 
 		version := Version2_11()

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/interface.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/interface.go
@@ -9,6 +9,7 @@ import (
 // supported.
 type AuthConfig struct {
 	BasicAuthConfig *BasicAuthConfig
+	BearerConfig *BearerConfig
 }
 
 // BasicAuthConfig represents a set of basic auth credentials.
@@ -17,6 +18,12 @@ type BasicAuthConfig struct {
 	Username string
 	// Password is the basic auth password.
 	Password string
+}
+
+// BearerConfig represents bearer token credentials.
+type BearerConfig struct {
+	// Token is the bearer token.
+	Token string
 }
 
 // ClientConfiguration represents the configuration of a Client.


### PR DESCRIPTION
Closes https://github.com/kubernetes-incubator/service-catalog/issues/1092

Update the github.com/pmorie/go-open-service-broker-client dependency to the latest version.