### PR TITLE
comment correction about finalizers

### DIFF
--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -289,10 +289,6 @@ func (c *controller) reconcileBinding(binding *v1alpha1.Binding) error {
 	// All updates not having a DeletingTimestamp will have been handled above
 	// and returned early. If we reach this point, we're dealing with an update
 	// that's actually a soft delete-- i.e. we have some finalization to do.
-	// Since the potential exists for a binding to have multiple finalizers and
-	// since those most be cleared in order, we proceed with the soft delete
-	// only if it's "our turn--" i.e. only if the finalizer we care about is at
-	// the head of the finalizers list.
 	if finalizers := sets.NewString(binding.Finalizers...); finalizers.Has(v1alpha1.FinalizerServiceCatalog) {
 		glog.V(4).Infof("Finalizing Binding %v/%v", binding.Namespace, binding.Name)
 		err = c.ejectBinding(binding)

--- a/pkg/controller/controller_broker.go
+++ b/pkg/controller/controller_broker.go
@@ -267,10 +267,6 @@ func (c *controller) reconcileBroker(broker *v1alpha1.Broker) error {
 	// All updates not having a DeletingTimestamp will have been handled above
 	// and returned early. If we reach this point, we're dealing with an update
 	// that's actually a soft delete-- i.e. we have some finalization to do.
-	// Since the potential exists for a broker to have multiple finalizers and
-	// since those most be cleared in order, we proceed with the soft delete
-	// only if it's "our turn--" i.e. only if the finalizer we care about is at
-	// the head of the finalizers list.
 	if finalizers := sets.NewString(broker.Finalizers...); finalizers.Has(v1alpha1.FinalizerServiceCatalog) {
 		glog.V(4).Infof("Finalizing Broker %v", broker.Name)
 

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -149,10 +149,6 @@ func (c *controller) reconcileInstanceDelete(instance *v1alpha1.Instance) error 
 	// All updates not having a DeletingTimestamp will have been handled above
 	// and returned early. If we reach this point, we're dealing with an update
 	// that's actually a soft delete-- i.e. we have some finalization to do.
-	// Since the potential exists for an instance to have multiple finalizers and
-	// since those most be cleared in order, we proceed with the soft delete
-	// only if it's "our turn--" i.e. only if the finalizer we care about is at
-	// the head of the finalizers list.
 	serviceClass, servicePlan, brokerName, brokerClient, err := c.getServiceClassPlanAndBroker(instance)
 	if err != nil {
 		return err


### PR DESCRIPTION
re  https://github.com/kubernetes-incubator/service-catalog/issues/1093

remove old/misleading comments about only doing soft delete if it's our turn i.e. only if the finalizer we care about is at the head of the finalizers list