### PR TITLE
Broker unit test cleanup

### DIFF
--- a/pkg/controller/controller_broker.go
+++ b/pkg/controller/controller_broker.go
@@ -389,7 +389,7 @@ func (c *controller) reconcileServiceClassFromBrokerCatalog(broker *v1alpha1.Bro
 	return nil
 }
 
-// updateBrokerReadyCondition updates the ready condition for the given Broker
+// updateBrokerCondition updates the ready condition for the given Broker
 // with the given status, reason, and message.
 func (c *controller) updateBrokerCondition(broker *v1alpha1.Broker, conditionType v1alpha1.BrokerConditionType, status v1alpha1.ConditionStatus, reason, message string) error {
 	clone, err := api.Scheme.DeepCopy(broker)


### PR DESCRIPTION
Associated with Controller unit test bullet-proofing #1077 
This PR is specifically for the controller_broker_test with a minor comment cleanup in controller_broker.

These tests all looked solid to me complete with client actions count checks and event & state verification.  The main thing I found was lack of test descriptions.  The changes below cover the updated descriptions.
