### PR TITLE
only skip tls verify if not behind the aggregator

### DIFF
--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - --service-catalog-api-server-url
         - https://{{ template "fullname" . }}-apiserver
         {{- end }}
-        {{ if .Values.controllerManager.apiserverSkipVerify -}}
+        {{ if and (.Values.controllerManager.apiserverSkipVerify) (not .Values.useAggregator) -}}
         - "--service-catalog-insecure-skip-verify=true"
         {{- end }}
         - -v


### PR DESCRIPTION
 - if not the in-cluster-config grabs a TLS cert from a config map and
   complains that it was told to ignore it.
 - thanks to cdoan@us.ibm.com for testing

Example error log output:
```
E0804 19:23:14.731483       1 controller_manager.go:259] Failed to get api versions from server: specifying a root certificates file with the insecure flag is not allowed
```