### PR TITLE
Use the chart name instead of the namespace

### DIFF
--- a/contrib/svc-cat-apiserver-aggregation-tls-setup.sh
+++ b/contrib/svc-cat-apiserver-aggregation-tls-setup.sh
@@ -14,15 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export HELM_NAME=catalog
-export SVCCAT_NAMESPACE=catalog
-export SVCCAT_SERVICE_NAME=${HELM_NAME}-${SVCCAT_NAMESPACE}-apiserver
+export HELM_RELEASE_NAME=${HELM_RELEASE_NAME:-catalog}
+export SVCCAT_NAMESPACE=${SVCCAT_NAMESPACE:-catalog}
+SVCCAT_SERVICE_NAME=${HELM_RELEASE_NAME}-catalog-apiserver
 
-export CA_NAME=ca
+CA_NAME=ca
 
-export ALT_NAMES="\"${SVCCAT_SERVICE_NAME}.${SVCCAT_NAMESPACE}\",\"${SVCCAT_SERVICE_NAME}.${SVCCAT_NAMESPACE}.svc"\"
+ALT_NAMES="\"${SVCCAT_SERVICE_NAME}.${SVCCAT_NAMESPACE}\",\"${SVCCAT_SERVICE_NAME}.${SVCCAT_NAMESPACE}.svc"\"
 
-export SVCCAT_CA_SETUP=svc-cat-ca.json
+SVCCAT_CA_SETUP=svc-cat-ca.json
 cat > ${SVCCAT_CA_SETUP} << EOF
 {
     "hosts": [ ${ALT_NAMES} ],
@@ -46,10 +46,10 @@ EOF
 cfssl genkey --initca ${SVCCAT_CA_SETUP} | cfssljson -bare ${CA_NAME}
 # now the files 'ca.csr  ca-key.pem  ca.pem' exist
 
-export SVCCAT_CA_CERT=${CA_NAME}.pem
-export SVCCAT_CA_KEY=${CA_NAME}-key.pem
+SVCCAT_CA_CERT=${CA_NAME}.pem
+SVCCAT_CA_KEY=${CA_NAME}-key.pem
 
-export PURPOSE=server
+PURPOSE=server
 echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","'${PURPOSE}'"]}}}' > "${PURPOSE}-ca-config.json"
 
 echo '{"CN":"'${SVCCAT_SERVICE_NAME}'","hosts":['${ALT_NAMES}'],"key":{"algo":"rsa","size":2048}}' \

--- a/docs/api-aggregation-setup.md
+++ b/docs/api-aggregation-setup.md
@@ -61,9 +61,9 @@ that is useless for the purposes of aggregation. All of the DNS
 entries must match.
 
 ```
-export HELM_NAME=catalog
+export HELM_RELEASE_NAME=catalog
 export SVCCAT_NAMESPACE=catalog
-export SVCCAT_SERVICE_NAME=${HELM_NAME}-${SVCCAT_NAMESPACE}-apiserver
+export SVCCAT_SERVICE_NAME=${HELM_RELEASE_NAME}-catalog-apiserver
 ```
 
 ## Set up the certificate bundle
@@ -179,7 +179,7 @@ keys we just generated inline.
 
 ```
 helm install charts/catalog \
-    --name ${HELM_NAME} --namespace ${SVCCAT_NAMESPACE} \
+    --name ${HELM_RELEASE_NAME} --namespace ${SVCCAT_NAMESPACE} \
     --set apiserver.auth.enabled=true \
         --set useAggregator=true \
         --set apiserver.tls.ca=$(base64 --wrap 0 ${SC_SERVING_CA}) \


### PR DESCRIPTION
 - add the ability to set some variables externally and default if they
   are not set.
 - I was under the impression that the service name was based on the
   namespace, but it was based on the chart name
 - found while troubleshooting with cdoan@us.ibm.com, who is the only
   person so far to attempt to install into the non-default namespace.
 - stop exporting unneeded environment variables