### PR TITLE
push all arch images on release tags

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -24,7 +24,7 @@ docker login -e="${QUAY_EMAIL}" -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay
 
 if [[ "${TRAVIS_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[a-z]*$ ]]; then
     echo "Pushing images with tags '${TRAVIS_TAG}' and 'latest'."
-    VERSION="${TRAVIS_TAG}" MUTABLE_TAG="latest" make push
+    VERSION="${TRAVIS_TAG}" MUTABLE_TAG="latest" make release-push
 elif [[ "${TRAVIS_BRANCH}" == "master" ]]; then
     echo "Pushing images with default tags (git sha and 'canary')."
     make push


### PR DESCRIPTION
I'm not sure if we want to do this on every intermediate build, but we definitely want these images built and pushed on the versioned releases.