### PR TITLE
move instance reconciliation to one queue

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -51,8 +51,8 @@ const (
 	// 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.3s, 2.6s, 5.1s, 10.2s, 20.4s, 41s, 82s
 	maxRetries = 15
 	//
-	pollingStartInterval      = 1 * time.Second
-	pollingMaxBackoffDuration = 1 * time.Hour
+	//pollingInterval is the length of time between each polling attempt for a currently ongoing asynchronous operation.
+	pollingInterval = 30 * time.Second
 )
 
 // NewController returns a new Open Service Broker catalog controller.
@@ -79,7 +79,6 @@ func NewController(
 		serviceClassQueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "service-class"),
 		instanceQueue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "instance"),
 		bindingQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "binding"),
-		pollingQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(pollingStartInterval, pollingMaxBackoffDuration), "poller"),
 	}
 
 	brokerInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -154,9 +153,8 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 	for i := 0; i < workers; i++ {
 		go wait.Until(worker(c.brokerQueue, "Broker", maxRetries, c.reconcileBrokerKey), time.Second, stopCh)
 		go wait.Until(worker(c.serviceClassQueue, "ServiceClass", maxRetries, c.reconcileServiceClassKey), time.Second, stopCh)
-		go wait.Until(worker(c.instanceQueue, "Instance", maxRetries, c.reconcileInstanceKey), time.Second, stopCh)
+		go wait.Until(workerWithPolling(c.instanceQueue, "Instance", maxRetries, c.reconcileInstanceKey), time.Second, stopCh)
 		go wait.Until(worker(c.bindingQueue, "Binding", maxRetries, c.reconcileBindingKey), time.Second, stopCh)
-		go wait.Until(worker(c.pollingQueue, "Poller", maxRetries, c.reconcileInstanceKey), time.Second, stopCh)
 	}
 
 	<-stopCh
@@ -170,11 +168,8 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
-// If reconciler returns an error, requeue the item up to maxRetries before giving up.
+// If the reconciler returns an error, requeue the item up to maxRetries before giving up.
 // It enforces that the reconciler is never invoked concurrently with the same key.
-// TODO: Consider allowing the reconciler to return an error that either specifies whether
-// this is recoverable or not, rather than always continuing on an error condition. Seems
-// like it should be possible to return an error, yet stop any further polling work.
 func worker(queue workqueue.RateLimitingInterface, resourceType string, maxRetries int, reconciler func(key string) error) func() {
 	return func() {
 		exit := false
@@ -189,6 +184,46 @@ func worker(queue workqueue.RateLimitingInterface, resourceType string, maxRetri
 				err := reconciler(key.(string))
 				if err == nil {
 					queue.Forget(key)
+					return false
+				}
+
+				if queue.NumRequeues(key) < maxRetries {
+					glog.V(4).Infof("Error syncing %s %v: %v", resourceType, key, err)
+					queue.AddRateLimited(key)
+					return false
+				}
+
+				glog.V(4).Infof("Dropping %s %q out of the queue: %v", resourceType, key, err)
+				queue.Forget(key)
+				return false
+			}()
+		}
+	}
+}
+
+// workerWithPolling runs a worker thread that just dequeues items, processes them, and marks them done.
+// If the reconciler returns that it should poll, requeue the item after the default polling interval elapses.
+// If the reconciler returns an error, requeue the item up to maxRetries before giving up.
+// It enforces that the reconciler is never invoked concurrently with the same key.
+func workerWithPolling(queue workqueue.RateLimitingInterface, resourceType string, maxRetries int, reconciler func(key string) (bool, error)) func() {
+	return func() {
+		exit := false
+		for !exit {
+			exit = func() bool {
+				key, quit := queue.Get()
+				if quit {
+					return true
+				}
+				defer queue.Done(key)
+
+				shouldPoll, err := reconciler(key.(string))
+				if err == nil {
+					queue.Forget(key)
+
+					if shouldPoll {
+						queue.AddAfter(key, pollingInterval)
+					}
+
 					return false
 				}
 

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -47,22 +47,22 @@ func (c *controller) bindingAdd(obj interface{}) {
 	c.bindingQueue.Add(key)
 }
 
-func (c *controller) reconcileBindingKey(key string) error {
+func (c *controller) reconcileBindingKey(key string) (bool, error) {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
-		return err
+		return false, err
 	}
 	binding, err := c.bindingLister.Bindings(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
 		glog.Infof("Not doing work for Binding %v because it has been deleted", key)
-		return nil
+		return false, nil
 	}
 	if err != nil {
 		glog.Infof("Unable to retrieve Binding %v from store: %v", key, err)
-		return err
+		return false, err
 	}
 
-	return c.reconcileBinding(binding)
+	return false, c.reconcileBinding(binding)
 }
 
 func (c *controller) bindingUpdate(oldObj, newObj interface{}) {

--- a/pkg/controller/controller_broker.go
+++ b/pkg/controller/controller_broker.go
@@ -152,18 +152,18 @@ func shouldReconcileBroker(broker *v1alpha1.Broker, now time.Time, relistInterva
 	return true
 }
 
-func (c *controller) reconcileBrokerKey(key string) error {
+func (c *controller) reconcileBrokerKey(key string) (bool, error) {
 	broker, err := c.brokerLister.Get(key)
 	if errors.IsNotFound(err) {
 		glog.Infof("Not doing work for Broker %v because it has been deleted", key)
-		return nil
+		return false, nil
 	}
 	if err != nil {
 		glog.Infof("Unable to retrieve Broker %v from store: %v", key, err)
-		return err
+		return false, err
 	}
 
-	return c.reconcileBroker(broker)
+	return false, c.reconcileBroker(broker)
 }
 
 // reconcileBroker is the control-loop that reconciles a Broker. An

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -485,14 +485,6 @@ func (c *controller) reconcileInstance(instance *v1alpha1.Instance) error {
 		c.updateInstanceStatus(toUpdate)
 
 		c.recorder.Eventf(instance, api.EventTypeNormal, successProvisionReason, successProvisionMessage)
-
-		key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(instance)
-		if err != nil {
-			glog.Errorf("Couldn't create a key for object %+v: %v", instance, err)
-			return fmt.Errorf("Couldn't create a key for object %+v: %v", instance, err)
-		}
-
-		c.instanceQueue.Add(key)
 	}
 	return nil
 }

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -68,7 +68,7 @@ func (c *controller) reconcileInstanceKey(key string) (bool, error) {
 
 	// Check if we need to poll on this instance.
 	// Have to re-retrieve instance as it might have changed during reconciliation.
-	instance, err = c.instanceLister.Instances(namespace).Get(name)
+	instance, err = c.serviceCatalogClient.Instances(instance.Namespace).Get(name, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return false, nil
 	}

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -46,54 +46,6 @@ func (c *controller) instanceAdd(obj interface{}) {
 	c.instanceQueue.Add(key)
 }
 
-// Async operations on instances have a somewhat convoluted flow in order to
-// ensure that only a single goroutine works on an instance at any given time.
-// The flow is:
-//
-// 1.  When the controller wants to begin polling the state of an operation on
-//     an instance, it calls its beginPollingInstance method (or
-//     calls continuePollingInstance, an alias of that method)
-// 2.  begin/continuePollingInstance do a rate-limited add to the polling queue
-// 3.  the pollingQueue calls requeueInstanceForPoll, which adds the instance's
-//     key to the instance work queue
-// 4.  the worker servicing the instance polling queue forgets the instances key,
-//     requiring the controller to call continuePollingInstance if additional
-//     work is needed.
-// 5.  the instance work queue is the single work queue that actually services
-//     instances by calling reconcileInstance
-
-// requeueInstanceForPoll adds the given instance key to the controller's work
-// queue for instances.  It is used to trigger polling for the status of an
-// async operation on and instance and is called by the worker servicing the
-// instance polling queue.  After requeueInstanceForPoll exits, the worker
-// forgets the key from the polling queue, so the controller must call
-// continuePollingInstance if the instance requires additional polling.
-func (c *controller) requeueInstanceForPoll(key string) error {
-	c.instanceQueue.Add(key)
-
-	return nil
-}
-
-// beginPollingInstance does a rate-limited add of the key for the given
-// instance to the controller's instance polling queue.
-func (c *controller) beginPollingInstance(instance *v1alpha1.Instance) error {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(instance)
-	if err != nil {
-		glog.Errorf("Couldn't create a key for object %+v: %v", instance, err)
-		return fmt.Errorf("Couldn't create a key for object %+v: %v", instance, err)
-	}
-
-	c.pollingQueue.AddRateLimited(key)
-
-	return nil
-}
-
-// continuePollingInstance does a rate-limited add of the key for the given
-// instance to the controller's instance polling queue.
-func (c *controller) continuePollingInstance(instance *v1alpha1.Instance) error {
-	return c.beginPollingInstance(instance)
-}
-
 func (c *controller) reconcileInstanceKey(key string) error {
 	// For namespace-scoped resources, SplitMetaNamespaceKey splits the key
 	// i.e. "namespace/name" into two separate strings
@@ -246,11 +198,6 @@ func (c *controller) reconcileInstanceDelete(instance *v1alpha1.Instance) error 
 				asyncDeprovisioningMessage,
 			)
 			err := c.updateInstanceStatus(toUpdate)
-			if err != nil {
-				return err
-			}
-
-			err = c.beginPollingInstance(instance)
 			if err != nil {
 				return err
 			}
@@ -511,9 +458,13 @@ func (c *controller) reconcileInstance(instance *v1alpha1.Instance) error {
 
 		c.recorder.Eventf(instance, api.EventTypeNormal, asyncProvisioningReason, asyncProvisioningMessage)
 
-		if err := c.beginPollingInstance(instance); err != nil {
-			return err
+		// Actually, start polling this Service Instance by adding it into the polling queue
+		key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(instance)
+		if err != nil {
+			glog.Errorf("Couldn't create a key for object %+v: %v", instance, err)
+			return fmt.Errorf("Couldn't create a key for object %+v: %v", instance, err)
 		}
+		c.pollingQueue.Add(key)
 	} else {
 		glog.V(5).Infof("Successfully provisioned Instance %v/%v of ServiceClass %v at Broker %v: response: %+v", instance.Namespace, instance.Name, serviceClass.Name, brokerName, response)
 
@@ -650,11 +601,6 @@ func (c *controller) pollInstance(serviceClass *v1alpha1.ServiceClass, servicePl
 				reason,
 				message,
 			)
-		}
-
-		err = c.continuePollingInstance(instance)
-		if err != nil {
-			return err
 		}
 		return fmt.Errorf("last operation not completed (still in progress) for %v/%v", instance.Namespace, instance.Name)
 	case osb.StateSucceeded:

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -579,25 +580,19 @@ func TestReconcileInstanceAsynchronous(t *testing.T) {
 	updatedInstance := assertUpdateStatus(t, actions[0], instance)
 	assertInstanceReadyFalse(t, updatedInstance)
 
-	// Since polling is rate-limited, it is not possible to check whether the
-	// instance is in the polling queue.
-	//
-	// TODO: add a way to peek into rate-limited adds that are still pending,
-	// then uncomment.
-
-	// if testController.pollingQueue.Len() != 1 {
-	// 	t.Fatalf("Expected the asynchronous instance to end up in the polling queue")
-	// }
-	// item, _ := testController.pollingQueue.Get()
-	// if item == nil {
-	// 	t.Fatalf("Did not get back a key from polling queue")
-	// }
-	// actualKey := item.(string)
-	// expectedKey := fmt.Sprintf("%s/%s", instance.Namespace, instance.Name)
-	// if actualKey != expectedKey {
-	// 	t.Fatalf("got key as %q expected %q", actualKey, expectedKey)
-	// }
-
+	// The item should've been added to the pollingQueue for later processing
+	if testController.pollingQueue.Len() != 1 {
+		t.Fatalf("Expected the asynchronous instance to end up in the polling queue")
+	}
+	item, _ := testController.pollingQueue.Get()
+	if item == nil {
+		t.Fatalf("Did not get back a key from polling queue")
+	}
+	actualKey := item.(string)
+	expectedKey := fmt.Sprintf("%s/%s", instance.Namespace, instance.Name)
+	if actualKey != expectedKey {
+		t.Fatalf("got key as %q expected %q", actualKey, expectedKey)
+	}
 	assertAsyncOpInProgressTrue(t, updatedInstance)
 	assertInstanceLastOperation(t, updatedInstance, testOperation)
 	assertInstanceDashboardURL(t, updatedInstance, testDashboardURL)
@@ -656,24 +651,19 @@ func TestReconcileInstanceAsynchronousNoOperation(t *testing.T) {
 	updatedInstance := assertUpdateStatus(t, actions[0], instance)
 	assertInstanceReadyFalse(t, updatedInstance)
 
-	// Since polling is rate-limited, it is not possible to check whether the
-	// instance is in the polling queue.
-	//
-	// TODO: add a way to peek into rate-limited adds that are still pending,
-	// then uncomment.
-
-	// if testController.pollingQueue.Len() != 1 {
-	// 	t.Fatalf("Expected the asynchronous instance to end up in the polling queue")
-	// }
-	// item, _ := testController.pollingQueue.Get()
-	// if item == nil {
-	// 	t.Fatalf("Did not get back a key from polling queue")
-	// }
-	// key := item.(string)
-	// expectedKey := fmt.Sprintf("%s/%s", instance.Namespace, instance.Name)
-	// if key != expectedKey {
-	// 	t.Fatalf("got key as %q expected %q", key, expectedKey)
-	// }
+	// The item should've been added to the pollingQueue for later processing
+	if testController.pollingQueue.Len() != 1 {
+		t.Fatalf("Expected the asynchronous instance to end up in the polling queue")
+	}
+	item, _ := testController.pollingQueue.Get()
+	if item == nil {
+		t.Fatalf("Did not get back a key from polling queue")
+	}
+	key := item.(string)
+	expectedKey := fmt.Sprintf("%s/%s", instance.Namespace, instance.Name)
+	if key != expectedKey {
+		t.Fatalf("got key as %q expected %q", key, expectedKey)
+	}
 	assertAsyncOpInProgressTrue(t, updatedInstance)
 	assertInstanceLastOperation(t, updatedInstance, "")
 }

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -755,22 +755,10 @@ func TestReconcileInstanceDeleteAsynchronous(t *testing.T) {
 		return true, instance, nil
 	})
 
-	if testController.pollingQueue.Len() != 0 {
-		t.Fatalf("Expected the polling queue to be empty")
-	}
-
 	err := testController.reconcileInstance(instance)
 	if err != nil {
 		t.Fatalf("This should not fail")
 	}
-
-	// The item should've been added to the pollingQueue for later processing
-
-	// TODO: add a way to peek into rate-limited adds that are still pending,
-	// then uncomment.
-	// if testController.pollingQueue.Len() != 1 {
-	// 	t.Fatalf("Expected the asynchronous instance to end up in the polling queue")
-	// }
 
 	brokerActions := fakeBrokerClient.Actions()
 	assertNumberOfBrokerActions(t, brokerActions, 1)

--- a/pkg/controller/controller_serviceclass.go
+++ b/pkg/controller/controller_serviceclass.go
@@ -34,18 +34,18 @@ func (c *controller) serviceClassAdd(obj interface{}) {
 	c.serviceClassQueue.Add(key)
 }
 
-func (c *controller) reconcileServiceClassKey(key string) error {
+func (c *controller) reconcileServiceClassKey(key string) (bool, error) {
 	serviceClass, err := c.serviceClassLister.Get(key)
 	if errors.IsNotFound(err) {
 		glog.Infof("Not doing work for ServiceClass %v because it has been deleted", key)
-		return nil
+		return false, nil
 	}
 	if err != nil {
 		glog.Errorf("Unable to retrieve ServiceClass %v from store: %v", key, err)
-		return err
+		return false, err
 	}
 
-	return c.reconcileServiceClass(serviceClass)
+	return false, c.reconcileServiceClass(serviceClass)
 }
 
 func (c *controller) reconcileServiceClass(serviceClass *v1alpha1.ServiceClass) error {


### PR DESCRIPTION
@pmorie and I discussed, and we ended up coming to the conclusion that it'd be best to merge the two queues for instance reconciliation. The logic for the current implementation was seen as difficult to follow and contains a bug that did not allow for the decaying rate of polling to function properly. 

In this model, there is a separate worker function that handles reconciliation for instances. It takes a reconciliation function that passes back a parameter telling the controller whether that instance should be polled. Polling in this model is a static interval (default set to 30 seconds).