### PR TITLE
Split the travis Build into Verification and Build steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,14 @@ services:
 cache:
   directories:
   - .glide
-script:
-- make verify build test images
+jobs:
+  include:
+    - stage: Verify and Test
+      script: make verify test
+    - stage: Build and Make Image
+      script: make build images
+#script:
+#- make verify build test images
 deploy:
   provider: script
   script: scripts/deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,10 @@ cache:
   - .glide
 jobs:
   include:
-    - stage: Verify and Test
-      script: make verify test
-    - stage: Build and Make Image
-      script: make build images
-#script:
-#- make verify build test images
+    - stage: Verify and Build
+      script: make verify build
+    - stage: Test and Make Image
+      script: make test images
 deploy:
   provider: script
   script: scripts/deploy.sh


### PR DESCRIPTION
Split Travis CI to different stages so that its easy for users to understand what went wrong.