### PR TITLE
explicitly always prefer latest OSBAPI Version

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -50,7 +50,7 @@ const (
 	defaultLeaderElectionNamespace      = "kube-system"
 )
 
-var defaultOSBAPIPreferredVersion = osb.Version2_12().HeaderValue()
+var defaultOSBAPIPreferredVersion = osb.LatestAPIVersion().HeaderValue()
 
 // NewControllerManagerServer creates a new ControllerManagerServer with a
 // default config.

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -26,7 +26,8 @@ import (
 // +nonNamespaced=true
 
 // Broker represents an entity that provides ServiceClasses for use in the
-// service catalog.
+// service catalog. Broker is backed by an OSBAPI v2 broker supporting the
+// latest minor version of the v2 major version.
 type Broker struct {
 	metav1.TypeMeta
 	metav1.ObjectMeta

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1006,7 +1006,7 @@ func newTestController(t *testing.T, config fakeosb.FakeClientConfiguration) (
 		serviceCatalogSharedInformers.Bindings(),
 		brokerClFunc,
 		24*time.Hour,
-		osb.Version2_12().HeaderValue(),
+		osb.LatestAPIVersion().HeaderValue(),
 		fakeRecorder,
 	)
 	if err != nil {
@@ -1057,7 +1057,7 @@ func newTestControllerWithBrokerServer(
 		serviceCatalogSharedInformers.Bindings(),
 		osb.NewClient,
 		24*time.Hour,
-		osb.Version2_12().HeaderValue(),
+		osb.LatestAPIVersion().HeaderValue(),
 		fakeRecorder,
 	)
 	if err != nil {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -800,7 +800,7 @@ func newTestController(t *testing.T, config fakeosb.FakeClientConfiguration) (
 		serviceCatalogSharedInformers.Bindings(),
 		brokerClFunc,
 		24*time.Hour,
-		osb.Version2_12().HeaderValue(),
+		osb.LatestAPIVersion().HeaderValue(),
 		fakeRecorder,
 	)
 	t.Log("controller start")


### PR DESCRIPTION
 - resolves #982 

As agreed in 2017-08-15 meeting.