### PR TITLE
Write helm command to file for api aggregation

### DIFF
--- a/test/e2e/instance.go
+++ b/test/e2e/instance.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// how long to wait for an instance to be deleted.
-	instanceDeleteTimeout = 30 * time.Second
+	instanceDeleteTimeout = 60 * time.Second
 )
 
 func newTestInstance(name, serviceClassName, planName string) *v1alpha1.Instance {


### PR DESCRIPTION
Since we're already writing out all the certificates, might as well write out
the helm command with the arguments already filled out too. This is clearly an
optional commit, but while testing this I used the script helper several times.