### PR TITLE
fix rate-limiting for polling queue

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -172,6 +172,8 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
 // If reconciler returns an error, requeue the item up to maxRetries before giving up.
 // It enforces that the reconciler is never invoked concurrently with the same key.
+// If forgetAfterSuccess is true, it will cause the queue to forget the item should reconciliation
+// have no error.
 func worker(queue workqueue.RateLimitingInterface, resourceType string, maxRetries int, forgetAfterSuccess bool, reconciler func(key string) error) func() {
 	return func() {
 		exit := false

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -152,11 +152,11 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 	glog.Info("Starting service-catalog controller")
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(worker(c.brokerQueue, "ServiceBroker", maxRetries, c.reconcileServiceBrokerKey), time.Second, stopCh)
-		go wait.Until(worker(c.serviceClassQueue, "ServiceClass", maxRetries, c.reconcileServiceClassKey), time.Second, stopCh)
-		go wait.Until(worker(c.instanceQueue, "ServiceInstance", maxRetries, c.reconcileServiceInstanceKey), time.Second, stopCh)
-		go wait.Until(worker(c.bindingQueue, "ServiceInstanceCredential", maxRetries, c.reconcileServiceInstanceCredentialKey), time.Second, stopCh)
-		go wait.Until(worker(c.pollingQueue, "Poller", maxRetries, c.requeueServiceInstanceForPoll), time.Second, stopCh)
+		go wait.Until(worker(c.brokerQueue, "ServiceBroker", maxRetries, true, c.reconcileServiceBrokerKey), time.Second, stopCh)
+		go wait.Until(worker(c.serviceClassQueue, "ServiceClass", maxRetries, true, c.reconcileServiceClassKey), time.Second, stopCh)
+		go wait.Until(worker(c.instanceQueue, "ServiceInstance", maxRetries, true, c.reconcileServiceInstanceKey), time.Second, stopCh)
+		go wait.Until(worker(c.bindingQueue, "ServiceInstanceCredential", maxRetries, true, c.reconcileServiceInstanceCredentialKey), time.Second, stopCh)
+		go wait.Until(worker(c.pollingQueue, "Poller", maxRetries, false, c.requeueServiceInstanceForPoll), time.Second, stopCh)
 	}
 
 	<-stopCh
@@ -172,7 +172,7 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
 // If reconciler returns an error, requeue the item up to maxRetries before giving up.
 // It enforces that the reconciler is never invoked concurrently with the same key.
-func worker(queue workqueue.RateLimitingInterface, resourceType string, maxRetries int, reconciler func(key string) error) func() {
+func worker(queue workqueue.RateLimitingInterface, resourceType string, maxRetries int, forgetAfterSuccess bool, reconciler func(key string) error) func() {
 	return func() {
 		exit := false
 		for !exit {
@@ -185,7 +185,9 @@ func worker(queue workqueue.RateLimitingInterface, resourceType string, maxRetri
 
 				err := reconciler(key.(string))
 				if err == nil {
-					queue.Forget(key)
+					if forgetAfterSuccess {
+						queue.Forget(key)
+					}
 					return false
 				}
 

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -45,8 +45,9 @@ func (c *controller) instanceAdd(obj interface{}) {
 }
 
 func (c *controller) instanceUpdate(oldObj, newObj interface{}) {
-	// A polling instance will be added to the polling queue by the reconciler.
-	// We only need to take care of non-polling instances here.
+	// Instances with ongoing asynchronous operations will be manually added
+	// to the polling queue by the reconciler. They should be ignored here in
+	// order to enforce polling rate-limiting.
 	instance := newObj.(*v1alpha1.ServiceInstance)
 	if !instance.Status.AsyncOpInProgress {
 		c.instanceAdd(newObj)
@@ -77,6 +78,8 @@ func (c *controller) instanceDelete(obj interface{}) {
 //     work is needed.
 // 5.  the instance work queue is the single work queue that actually services
 //     instances by calling reconcileServiceInstance
+// 6.  when an asynchronous operation is completed, the controller calls
+//     finishPollingServiceInstance to forget the instance from the polling queue
 
 // requeueServiceInstanceForPoll adds the given instance key to the controller's work
 // queue for instances.  It is used to trigger polling for the status of an

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -40,10 +40,26 @@ func (c *controller) instanceAdd(obj interface{}) {
 		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
 		return
 	}
-	// TODO(vaikas): If the obj (which really is an ServiceInstance right?) has
-	// AsyncOpInProgress flag set, just add it directly to c.pollingQueue
-	// here? Why shouldn't we??
+
 	c.instanceQueue.Add(key)
+}
+
+func (c *controller) instanceUpdate(oldObj, newObj interface{}) {
+	// A polling instance will be added to the polling queue by the reconciler.
+	// We only need to take care of non-polling instances here.
+	instance := newObj.(*v1alpha1.ServiceInstance)
+	if !instance.Status.AsyncOpInProgress {
+		c.instanceAdd(newObj)
+	}
+}
+
+func (c *controller) instanceDelete(obj interface{}) {
+	instance, ok := obj.(*v1alpha1.ServiceInstance)
+	if instance == nil || !ok {
+		return
+	}
+
+	glog.V(4).Infof("Received delete event for ServiceInstance %v/%v; no further processing will occur", instance.Namespace, instance.Name)
 }
 
 // Async operations on instances have a somewhat convoluted flow in order to
@@ -94,6 +110,20 @@ func (c *controller) continuePollingServiceInstance(instance *v1alpha1.ServiceIn
 	return c.beginPollingServiceInstance(instance)
 }
 
+// finishPollingServiceInstance removes the instance's key from the controller's instance
+// polling queue.
+func (c *controller) finishPollingServiceInstance(instance *v1alpha1.ServiceInstance) error {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(instance)
+	if err != nil {
+		glog.Errorf("Couldn't create a key for object %+v: %v", instance, err)
+		return fmt.Errorf("Couldn't create a key for object %+v: %v", instance, err)
+	}
+
+	c.pollingQueue.Forget(key)
+
+	return nil
+}
+
 func (c *controller) reconcileServiceInstanceKey(key string) error {
 	// For namespace-scoped resources, SplitMetaNamespaceKey splits the key
 	// i.e. "namespace/name" into two separate strings
@@ -112,10 +142,6 @@ func (c *controller) reconcileServiceInstanceKey(key string) error {
 	}
 
 	return c.reconcileServiceInstance(instance)
-}
-
-func (c *controller) instanceUpdate(oldObj, newObj interface{}) {
-	c.instanceAdd(newObj)
 }
 
 // reconcileServiceInstanceDelete is responsible for handling any instance whose
@@ -697,6 +723,11 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 				successProvisionMessage,
 			)
 		}
+
+		err = c.finishPollingServiceInstance(instance)
+		if err != nil {
+			return err
+		}
 	case osb.StateFailed:
 		description := ""
 		if response.Description != nil {
@@ -727,6 +758,11 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 			msg,
 		)
 		c.recorder.Event(instance, api.EventTypeWarning, errorDeprovisionCalledReason, s)
+
+		err = c.finishPollingServiceInstance(instance)
+		if err != nil {
+			return err
+		}
 	default:
 		glog.Warningf("Got invalid state in LastOperationResponse: %q", response.State)
 		return fmt.Errorf("Got invalid state in LastOperationResponse: %q", response.State)
@@ -874,13 +910,4 @@ func (c *controller) updateServiceInstanceFinalizers(
 		glog.Errorf("Error updating %v: %v", logContext, err)
 	}
 	return err
-}
-
-func (c *controller) instanceDelete(obj interface{}) {
-	instance, ok := obj.(*v1alpha1.ServiceInstance)
-	if instance == nil || !ok {
-		return
-	}
-
-	glog.V(4).Infof("Received delete event for ServiceInstance %v/%v; no further processing will occur", instance.Namespace, instance.Name)
 }


### PR DESCRIPTION
Fixes a couple bugs causing rate-limiting to not work on the polling queue.

1) Currently, under normal worker logic, the polling queue forgets the item every time it gets back a non-error response, which caused rate-limiting to always reset. Added a boolean argument to the worker function that specifies whether this behavior should occur or not.

2) Currently, any update to an instance's status will trigger `instanceUpdate(oldObj, newObj)`, which directly adds to the instance queue. This causes polling status updates to immediately trigger a repoll, bypassing the polling queue's rate-limiting.

Unfortunately, this behavior is pretty much impossible to test in the current form. There's no way to step through the worker logic to verify the state of the world; if it's started, it will incessantly chew through all queue items. The worker logic should ideally be refactored to allow for a more testable state, but not as part of this PR.

Fortunately, I noticed that although `queue.AddRateLimited(key)` causes no immediate change in length of the queue that makes the addition hard to test for, it *does* increment `queue.NumRequeues(key)`. This allows me to bring back the polling queue length tests that were commented out.