### PR TITLE
instance deletion lifecycle enhancements

### DIFF
--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - {{ .Values.apiserver.audit.logPath }}
         {{- end}}
         - --admission-control
-        - "KubernetesNamespaceLifecycle,DefaultServicePlan"
+        - "KubernetesNamespaceLifecycle,DefaultServicePlan,ServiceInstanceCredentialsLifecycle"
         - --secure-port
         - "8443"
         - --storage-type

--- a/cmd/apiserver/app/plugins.go
+++ b/cmd/apiserver/app/plugins.go
@@ -22,5 +22,6 @@ package app
 import (
 	// Admission policies
 	_ "github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/namespace/lifecycle"
+	_ "github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/serviceinstancecredentials/lifecycle"
 	_ "github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/serviceplan/defaultserviceplan"
 )

--- a/cmd/apiserver/app/server/server.go
+++ b/cmd/apiserver/app/server/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/pkg"
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
 	"github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/namespace/lifecycle"
+	siclifecycle "github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/serviceinstancecredentials/lifecycle"
 	"github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/serviceplan/defaultserviceplan"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -137,4 +138,5 @@ func NewCommandServer(
 func registerAllAdmissionPlugins(plugins *admission.Plugins) {
 	lifecycle.Register(plugins)
 	defaultserviceplan.Register(plugins)
+	siclifecycle.Register(plugins)
 }

--- a/plugin/pkg/admission/serviceinstancecredentials/lifecycle/admission.go
+++ b/plugin/pkg/admission/serviceinstancecredentials/lifecycle/admission.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/golang/glog"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	informers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/internalversion"
+	internalversion "github.com/kubernetes-incubator/service-catalog/pkg/client/listers_generated/servicecatalog/internalversion"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/admission"
+
+	scadmission "github.com/kubernetes-incubator/service-catalog/pkg/apiserver/admission"
+)
+
+const (
+	// PluginName is name of admission plug-in
+	PluginName = "ServiceInstanceCredentialsLifecycle"
+)
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(io.Reader) (admission.Interface, error) {
+		return NewCredentialsBlocker()
+	})
+}
+
+// enforceNoNewCredentialsForDeletedInstance is an implementation of admission.Interface.
+// If creating new ServiceInstanceCredentials or updating an existing
+// set of credentials, fail the operation if the ServiceInstance is
+// marked for deletion
+type enforceNoNewCredentialsForDeletedInstance struct {
+	*admission.Handler
+	instanceLister internalversion.ServiceInstanceLister
+}
+
+var _ = scadmission.WantsInternalServiceCatalogInformerFactory(&enforceNoNewCredentialsForDeletedInstance{})
+
+func (b *enforceNoNewCredentialsForDeletedInstance) Admit(a admission.Attributes) error {
+
+	// we need to wait for our caches to warm
+	if !b.WaitForReady() {
+		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
+	}
+
+	// We only care about credentials
+	if a.GetResource().Group != servicecatalog.GroupName || a.GetResource().GroupResource() != servicecatalog.Resource("serviceinstancecredentials") {
+		return nil
+	}
+
+	// We don't want to deal with any sub resources
+	if a.GetSubresource() != "" {
+		return nil
+	}
+
+	credentials, ok := a.GetObject().(*servicecatalog.ServiceInstanceCredential)
+	if !ok {
+		return apierrors.NewBadRequest("Resource was marked with kind ServiceInstanceCredentials but was unable to be converted")
+	}
+
+	instanceRef := credentials.Spec.ServiceInstanceRef
+	instance, err := b.instanceLister.ServiceInstances(credentials.Namespace).Get(instanceRef.Name)
+
+	// block the credentials operation if the ServiceInstance is being deleted
+	if err == nil && instance.DeletionTimestamp != nil {
+		warning := fmt.Sprintf("ServiceInstanceCredentials %s/%s references an instance that is being deleted: %s/%s",
+			credentials.Namespace,
+			credentials.Name,
+			credentials.Namespace,
+			instanceRef.Name)
+		glog.Info(warning, err)
+		return admission.NewForbidden(a, fmt.Errorf(warning))
+	}
+
+	return nil
+}
+
+func (b *enforceNoNewCredentialsForDeletedInstance) SetInternalServiceCatalogInformerFactory(f informers.SharedInformerFactory) {
+	instanceInformer := f.Servicecatalog().InternalVersion().ServiceInstances()
+	b.instanceLister = instanceInformer.Lister()
+	b.SetReadyFunc(instanceInformer.Informer().HasSynced)
+}
+
+func (b *enforceNoNewCredentialsForDeletedInstance) Validate() error {
+	if b.instanceLister == nil {
+		return fmt.Errorf("missing instanceLister")
+	}
+	return nil
+}
+
+// NewCredentialsBlocker creates a new admission control handler that
+// blocks creation of a ServiceInstanceCredential if the instance
+// is being deleted
+func NewCredentialsBlocker() (admission.Interface, error) {
+	return &enforceNoNewCredentialsForDeletedInstance{
+		Handler: admission.NewHandler(admission.Create),
+	}, nil
+}

--- a/plugin/pkg/admission/serviceinstancecredentials/lifecycle/admission_test.go
+++ b/plugin/pkg/admission/serviceinstancecredentials/lifecycle/admission_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/client-go/pkg/api/v1"
+	core "k8s.io/client-go/testing"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	scadmission "github.com/kubernetes-incubator/service-catalog/pkg/apiserver/admission"
+	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/internalclientset"
+	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/internalclientset/fake"
+	informers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/internalversion"
+)
+
+// newHandlerForTest returns a configured handler for testing.
+func newHandlerForTest(internalClient internalclientset.Interface) (admission.Interface, informers.SharedInformerFactory, error) {
+	f := informers.NewSharedInformerFactory(internalClient, 5*time.Minute)
+	handler, err := NewCredentialsBlocker()
+	if err != nil {
+		return nil, f, err
+	}
+	pluginInitializer := scadmission.NewPluginInitializer(internalClient, f, nil, nil)
+	pluginInitializer.Initialize(handler)
+	err = admission.Validate(handler)
+	return handler, f, err
+}
+
+// newServiceInstance returns a new Service Instance for unit tests
+func newServiceInstance() servicecatalog.ServiceInstance {
+	return servicecatalog.ServiceInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "test-ns"},
+	}
+}
+
+// newServiceInstanceCredential returns a new Service Instance Credential that
+// references the "test-instance" service instance.
+func newServiceInstanceCredential() servicecatalog.ServiceInstanceCredential {
+	return servicecatalog.ServiceInstanceCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cred",
+			Namespace: "test-ns",
+		},
+		Spec: servicecatalog.ServiceInstanceCredentialSpec{
+			ServiceInstanceRef: v1.LocalObjectReference{
+				Name: "test-instance",
+			},
+			SecretName: "test-secret",
+		},
+	}
+}
+
+// TestBlockNewCredentialsForDeletedInstance validates the admission controller will
+// block creation of a Service Instance Credential that is referencing a
+// Service Instance which is marked for deletion
+func TestBlockNewCredentialsForDeletedInstance(t *testing.T) {
+	fakeClient := &fake.Clientset{}
+	handler, informerFactory, err := newHandlerForTest(fakeClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+
+	instance := newServiceInstance()
+	instance.DeletionTimestamp = &metav1.Time{}
+	scList := &servicecatalog.ServiceInstanceList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "1",
+		}}
+	scList.Items = append(scList.Items, instance)
+	fakeClient.AddReactor("list", "serviceinstances", func(action core.Action) (bool, runtime.Object, error) {
+		return true, scList, nil
+	})
+
+	credential := newServiceInstanceCredential()
+
+	informerFactory.Start(wait.NeverStop)
+
+	err = handler.Admit(admission.NewAttributesRecord(&credential, nil, servicecatalog.Kind("ServiceInstanceCredentials").WithVersion("version"),
+		"test-ns", "test-cred", servicecatalog.Resource("serviceinstancecredentials").WithVersion("version"), "", admission.Create, nil))
+	if err == nil {
+		t.Errorf("Unexpected error: %v", err.Error())
+	} else {
+		if err.Error() != "serviceinstancecredentials.servicecatalog.k8s.io \"test-cred\" is forbidden: ServiceInstanceCredentials test-ns/test-cred references an instance that is being deleted: test-ns/test-instance" {
+			t.Fatalf("admission controller blocked the request but not with expected error, expected a forbidden error, got %q", err.Error())
+		}
+	}
+}
+
+// TestAllowNewCredentialsForNonDeletedInstance validates the admission controller will not block
+// creation of a Service Instance Credential if the instance is not
+// marked for deletion
+func TestAllowNewCredentialsForNonDeletedInstance(t *testing.T) {
+	fakeClient := &fake.Clientset{}
+	handler, informerFactory, err := newHandlerForTest(fakeClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+	informerFactory.Start(wait.NeverStop)
+
+	credential := newServiceInstanceCredential()
+	err = handler.Admit(admission.NewAttributesRecord(&credential, nil, servicecatalog.Kind("ServiceInstanceCredentials").WithVersion("version"),
+		"test-ns", "test-cred", servicecatalog.Resource("serviceinstancecredentials").WithVersion("version"), "", admission.Create, nil))
+	if err != nil {
+		t.Errorf("Error, admission controller should not block this test")
+	}
+}


### PR DESCRIPTION
for #820  Determine how to handle deprovision requests to an instance with bindings
Not ready for merge, but I'd like initial review.

*  During instance reconciliation, if there are bindings for the given instance, don't do the delete, we must wait for all associated bindings to be removed first.

*  Added new admission controller that will prevent new service credentials from being created if the service instance is in the process of being deleted.


need to have unit test added for admission controller