### PR TITLE
add non-default image installation guide to walkthrough

### DIFF
--- a/docs/install-1.6.md
+++ b/docs/install-1.6.md
@@ -79,6 +79,10 @@ newly-installed executable.
 
 # Step 2 - Installing the Service Catalog
 
+It is recommended to deploy the service catalog with your local copy of the repo
+at the latest tagged version. Should it be in any other state, see the
+Troubleshooting section [here](#non-default-image-installation).
+
 The service catalog is packaged as a Helm chart located in the
 [charts/catalog](../charts/catalog) directory in this repository, and supports a
 wide variety of customizations which are detailed in that directory's
@@ -165,3 +169,38 @@ kubectl config set-context service-catalog --cluster=service-catalog
 Note: Your cloud provider may require firewall rules to allow your traffic get in.
 Please refer to the [Troubleshooting](./walkthrough-1.6.md#troubleshooting) 
 section of the walkthrough document for details.
+
+## Troubleshooting
+
+### Non-default image installation
+
+The service catalog installation will by default use images of the controller
+and apiserver built at the latest tagged version. Should you be using a
+different state of the repo (for instance, the latest commit in the `master`
+branch), there may be conflicts with these images and the latest chart and
+walkthrough files. During installation, you may specify the images of the
+controller and apiserver to use. To do so, set your `REGISTRY` and `VERSION`
+environment variables to the appropriate container registry and image tag
+respectively and add the following flags to your `helm install` command:
+
+```console
+--set apiserver.image=${REGISTRY}apiserver:${VERSION} \
+--set controllerManager.image=${REGISTRY}controller-manager:${VERSION}
+```
+
+The `quay.io/kubernetes-service-catalog/` container registry stores images built
+from recent `master` commits. To use these images, set `REGISTRY` to point to
+this registry and `VERSION` to the abbreviated SHA of that commit via the
+following:
+
+```console
+REGISTRY=quay.io/kubernetes-service-catalog/
+VERSION=$(git describe --always --abbrev=7)
+```
+
+Note that there is a lag between when a commit is made and the images are built,
+so the latest commit to `master` may not yet be available. If the most
+up-to-date image is not yet available, or you would like to use a build with
+local changes, please take a look at the build documentation
+[here](https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/devguide.md#building).
+

--- a/docs/install-1.7.md
+++ b/docs/install-1.7.md
@@ -127,6 +127,10 @@ source ../../contrib/svc-cat-apiserver-aggregation-tls-setup.sh
 
 # Step 2 - Install the Helm Chart
 
+It is recommended to deploy the service catalog with your local copy of the repo
+at the latest tagged version. Should it be in any other state, see the
+Troubleshooting section [here](#non-default-image-installation).
+
 Use helm to install the Service Catalog, associating it with the
 configured name ${HELM_NAME}, and into the specified namespace." This
 command also enables authentication and aggregation and provides the
@@ -157,3 +161,38 @@ helm install ../../charts/catalog \
         --set apiserver.tls.cert=$(base64 ${SC_SERVING_CERT}) \
         --set apiserver.tls.key=$(base64 ${SC_SERVING_KEY})
 ```
+
+# Troubleshooting
+
+## Non-default image installation
+
+The service catalog installation will by default use images of the controller
+and apiserver built at the latest tagged version. Should you be using a
+different state of the repo (for instance, the latest commit in the `master`
+branch), there may be conflicts with these images and the latest chart and
+walkthrough files. During installation, you may specify the images of the
+controller and apiserver to use. To do so, set your `REGISTRY` and `VERSION`
+environment variables to the appropriate container registry and image tag
+respectively and add the following flags to your `helm install` command:
+
+```console
+--set apiserver.image=${REGISTRY}apiserver:${VERSION} \
+--set controllerManager.image=${REGISTRY}controller-manager:${VERSION}
+```
+
+The `quay.io/kubernetes-service-catalog/` container registry stores images built
+from recent `master` commits. To use these images, set `REGISTRY` to point to
+this registry and `VERSION` to the abbreviated SHA of that commit via the
+following:
+
+```console
+REGISTRY=quay.io/kubernetes-service-catalog/
+VERSION=$(git describe --always --abbrev=7)
+```
+
+Note that there is a lag between when a commit is made and the images are built,
+so the latest commit to `master` may not yet be available. If the most
+up-to-date image is not yet available, or you would like to use a build with
+local changes, please take a look at the build documentation
+[here](https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/devguide.md#building).
+


### PR DESCRIPTION
I see quite often people posting in the Slack channel asking for help with mysterious installation issues. Most of these seem to be people trying to deploy service catalog with the latest master commit checked out. However, the default installation uses images built at the latest tagged version, which has caused conflicts for a non-trivial amount of people.

This PR clarifies this situation in the docs and adds installation instructions for those who want to build off the latest master images.