### PR TITLE
Splitting up the Walkthrough for 1.6 and 1.7 instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ contrib/build/*/tmp/*
 .pkg
 .kube
 .var
+docs/certs

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ _somewhere_ in a simple way:
     application configuration primitives in Kubernetes: Services, Secrets, and
     ConfigMaps.
 
+For more introduction, installation and self-guided demo instructions, please
+see the [introduction](./docs/introduction.md) doc.
+
 For more details about the design and features of this project see the
 [design](docs/design.md) doc.
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ _somewhere_ in a simple way:
     application configuration primitives in Kubernetes: Services, Secrets, and
     ConfigMaps.
 
-For more introduction, installation and self-guided demo instructions, please
-see the [introduction](./docs/introduction.md) doc.
+For more introduction, including installation and self-guided demo 
+instructions, please see the [introduction](./docs/introduction.md) doc.
 
 For more details about the design and features of this project see the
 [design](docs/design.md) doc.

--- a/contrib/examples/walkthrough/README.md
+++ b/contrib/examples/walkthrough/README.md
@@ -1,4 +1,6 @@
 ## Walkthrough Resources
 
-This directory contains API resources for use with the [demo
-walkthrough](../../../docs/walkthrough.md).
+This directory contains API resources for use with the demo walkthrough.
+
+Please see [the introduction document](../../../docs/introduction.md) for 
+instructions.

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -267,5 +267,5 @@ the Kubernetes cluster as third party resources.
 
 ## Demo walkthrough
 
-Check out the [walk-through](walkthrough.md) for a detailed guide of an example
-deployment.
+Check out the [introduction](./introduction.md) to get started with 
+installation and a self-guided demo.

--- a/docs/install-1.6.md
+++ b/docs/install-1.6.md
@@ -1,0 +1,165 @@
+# Installing Service Catalog on Clusters Running Kubernetes 1.6 (DEPRECATED)
+
+This document contains instructions for installing the Service Catalog onto
+Kubernetes clusters running version 1.6. Since Service Catalog
+only officially supports versions 1.7 and later, these instructions are 
+deprecated and may be removed at any time.
+
+If you are running a Kubernetes cluster running version 1.7 or later, please 
+see [install-1.7.md](./install-1.7.md).
+
+# Step 1 - Prerequisites
+
+## Starting Kubernetes with DNS
+
+You *must* have a Kubernetes cluster with cluster DNS enabled. We can't list
+instructions here for enabling cluster DNS for all Kubernetes cluster
+installations, but here are a few notes:
+
+* If you are using Google Container Engine or minikube, you likely have cluster
+DNS enabled already.
+* If you are using hack/local-up-cluster.sh, ensure the
+`KUBE_ENABLE_CLUSTER_DNS` environment variable is set as follows:
+
+```console
+hack/local-up-cluster.sh -O
+```
+
+## Helm
+
+You *must* use [Helm](http://helm.sh/) v2 or newer in the installation steps
+below.
+
+If you already have Helm v2 or newer, execute `helm init` (if you haven't
+already) to install Tiller (the server-side component of Helm), and you should
+be done with Helm setup.
+
+If you don't already have Helm v2, see the
+[installation instructions](https://github.com/kubernetes/helm/blob/master/docs/install.md).
+
+If your kubernetes cluster has
+[RBAC](https://kubernetes.io/docs/admin/authorization/rbac/) enabled, you must
+ensure that the tiller pod has `cluster-admin` access. By default, `helm init`
+installs the tiller pod into `kube-system` namespace, with tiller configured to
+use the `default` service account.
+
+```console
+kubectl create clusterrolebinding tiller-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
+```
+
+`cluster-admin` access is required in order for helm to work correctly in
+clusters with RBAC enabled.  If you used the `--tiller-namespace` or
+`--service-account` flags when running `helm init`, the `--serviceaccount` flag
+in the previous command needs to be adjusted to reference the appropriate
+namespace and ServiceAccount name.
+
+## A Recent `kubectl`
+
+As with Kubernetes itself, interaction with the service catalog system is
+achieved through the `kubectl` command line interface. Chances are high that
+you already have this installed, however, the service catalog *requires*
+`kubectl` version 1.6 or newer.
+
+To proceed, we must:
+
+- Download and install `kubectl` version 1.6 or newer.
+- Configure `kubectl` to communicate with the service catalog's API server.
+
+To install `kubectl` follow the [standard instructions](https://kubernetes.io/docs/tasks/kubectl/install/).
+
+For example, on a mac,
+```console
+curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl
+chmod +x ./kubectl
+```
+
+We'll assume hereafter that all `kubectl` commands are using this
+newly-installed executable.
+
+
+# Step 2 - Installing the Service Catalog
+
+The service catalog is packaged as a Helm chart located in the
+[charts/catalog](../charts/catalog) directory in this repository, and supports a
+wide variety of customizations which are detailed in that directory's
+[README.md](https://github.com/kubernetes-incubator/service-catalog/blob/master/charts/catalog/README.md).
+
+## The Service Catalog Data Store
+
+We'll be interacting with a variety of resources in the following steps. The
+service catalog API server needs to store all of these resources in a data
+store. The data store implementation in the API server is pluggable, and we
+currently support the following implementations:
+
+1. Etcd 3
+2. Third Party Resources (also, known as TPRs) - this is an _alpha_ feature 
+right now. It has known issues and may be removed at any time
+
+The first implementation requires that the API server has access to an Etcd 3 cluster, and the
+second only requires access to the Kubernetes API to store TPRs.
+
+Even if you store data in TPRs, you should still access data via the service catalog API. It is 
+possible to access data via the TPRs directly, but we don't recommend it.
+
+## Install
+
+To install the service catalog system with Etcd 3 as the backing data store:
+
+```console
+helm install charts/catalog --name catalog --namespace catalog
+```
+
+To install the service catalog system with TPRs as the backing data store:
+
+```console
+helm install charts/catalog --name catalog --namespace catalog --set apiserver.storage.type=tpr,apiserver.storage.tpr.globalNamespace=catalog
+```
+
+Regardless of which data store implementation you choose, the remainder of the steps in this
+walkthrough will stay the same.
+
+## API Server Authentication and Authorization
+
+Authentication and authorization are disabled in the Helm chart by default. To enable them, 
+set the `apiserver.auth.enabled` option on the Helm chart:
+
+```console
+helm install charts/catalog --name catalog --namespace catalog --set apiserver.auth.enabled=true
+```
+
+For more information about certificate setup, see the [documentation on
+authentication and authorization](./auth.md).
+
+
+## Do Overs
+
+If you make a mistake somewhere along the way in this walk-through and want to start over,
+check out the "Cleaning Up" section below. Follow those instructions before you start over.
+
+## Step 3 - Configuring `kubectl` to Talk to the API Server
+
+To configure `kubectl` to communicate with the service catalog API server, we'll have to
+get the IP address that points to the `Service` that sits in front of the API server pod(s).
+If you installed the catalog with one of the `helm install` commands above, then this service 
+will be called `catalog-catalog-apiserver`, and be in the `catalog` namespace. 
+
+### Notes on Getting the IP Address
+
+How you get this IP address is highly dependent on your Kubernetes installation method. Regardless
+of how you do it, do not use the Cluster IP of the `Service`. The `Service` is created as a
+`NodePort` in this walkthrough, so you'll likely need to use the IP address of the node or one of
+the nodes in your cluster.
+
+### Setting up a New `kubectl` Context
+
+When you determine the IP address of this service, set its value into the `SVC_CAT_API_SERVER_IP`
+environment variable and then run the following commands:
+
+```console
+kubectl config set-cluster service-catalog --server=https://$SVC_CAT_API_SERVER_IP:30443 --insecure-skip-tls-verify=true
+kubectl config set-context service-catalog --cluster=service-catalog
+```
+
+Note: Your cloud provider may require firewall rules to allow your traffic get in.
+Please refer to the [Troubleshooting](./walkthrough-1.6.md#troubleshooting) 
+section of the walkthrough document for details.

--- a/docs/install-1.6.md
+++ b/docs/install-1.6.md
@@ -6,7 +6,7 @@ only officially supports versions 1.7 and later, these instructions are
 deprecated and may be removed at any time.
 
 If you are running a Kubernetes cluster running version 1.7 or later, please 
-see [install-1.7.md](./install-1.7.md).
+see the [installation instructions for 1.7](./install-1.7.md).
 
 # Step 1 - Prerequisites
 

--- a/docs/install-1.6.md
+++ b/docs/install-1.6.md
@@ -134,9 +134,9 @@ authentication and authorization](./auth.md).
 ## Do Overs
 
 If you make a mistake somewhere along the way in this walk-through and want to 
-start over, check out the 
-[Final Cleanup](./walkthrough-1.6.md#Step-9---Final-Cleanup) section in the 
-walkthrough document. Follow those instructions before you start over.
+start over, check out the "Final Cleanup" section in the 
+[walkthrough document](./walkthrough-1.6.md). Follow those instructions before 
+you start over.
 
 ## Step 3 - Configuring `kubectl` to Talk to the API Server
 

--- a/docs/install-1.6.md
+++ b/docs/install-1.6.md
@@ -147,10 +147,10 @@ will be called `catalog-catalog-apiserver`, and be in the `catalog` namespace.
 
 ### Notes on Getting the IP Address
 
-How you get this IP address is highly dependent on your Kubernetes installation method. Regardless
-of how you do it, do not use the Cluster IP of the `Service`. The `Service` is created as a
-`NodePort` in this walkthrough, so you'll likely need to use the IP address of the node or one of
-the nodes in your cluster.
+How you get this IP address is highly dependent on your Kubernetes installation
+method. Regardless of how you do it, do not use the Cluster IP of the 
+`Service`. The `Service` is created as a `NodePort` in this walkthrough, you 
+will need to use the address of one of the nodes in your cluster.
 
 ### Setting up a New `kubectl` Context
 

--- a/docs/install-1.6.md
+++ b/docs/install-1.6.md
@@ -93,7 +93,7 @@ currently support the following implementations:
 
 1. Etcd 3
 2. Third Party Resources (also, known as TPRs) - this is an _alpha_ feature 
-right now. It has known issues and may be removed at any time
+right now. It has known issues and may be removed at any time.
 
 The first implementation requires that the API server has access to an Etcd 3 cluster, and the
 second only requires access to the Kubernetes API to store TPRs.

--- a/docs/install-1.6.md
+++ b/docs/install-1.6.md
@@ -133,8 +133,10 @@ authentication and authorization](./auth.md).
 
 ## Do Overs
 
-If you make a mistake somewhere along the way in this walk-through and want to start over,
-check out the "Cleaning Up" section below. Follow those instructions before you start over.
+If you make a mistake somewhere along the way in this walk-through and want to 
+start over, check out the 
+[Final Cleanup](./walkthrough-1.6.md#Step-9---Final-Cleanup) section in the 
+walkthrough document. Follow those instructions before you start over.
 
 ## Step 3 - Configuring `kubectl` to Talk to the API Server
 

--- a/docs/install-1.6.md
+++ b/docs/install-1.6.md
@@ -82,7 +82,7 @@ newly-installed executable.
 The service catalog is packaged as a Helm chart located in the
 [charts/catalog](../charts/catalog) directory in this repository, and supports a
 wide variety of customizations which are detailed in that directory's
-[README.md](https://github.com/kubernetes-incubator/service-catalog/blob/master/charts/catalog/README.md).
+[README.md](../charts/catalog/README.md).
 
 ## The Service Catalog Data Store
 

--- a/docs/install-1.6.md
+++ b/docs/install-1.6.md
@@ -158,7 +158,7 @@ When you determine the IP address of this service, set its value into the `SVC_C
 environment variable and then run the following commands:
 
 ```console
-kubectl config set-cluster service-catalog --server=https://$SVC_CAT_API_SERVER_IP:30443 --insecure-skip-tls-verify=true
+kubectl config set-cluster service-catalog --server=https://${SVC_CAT_API_SERVER_IP}:30443 --insecure-skip-tls-verify=true
 kubectl config set-context service-catalog --cluster=service-catalog
 ```
 

--- a/docs/install-1.6.md
+++ b/docs/install-1.6.md
@@ -22,7 +22,7 @@ DNS enabled already.
 `KUBE_ENABLE_CLUSTER_DNS` environment variable is set as follows:
 
 ```console
-hack/local-up-cluster.sh -O
+KUBE_ENABLE_CLUSTER_DNS=true hack/local-up-cluster.sh -O
 ```
 
 ## Helm

--- a/docs/install-1.7.md
+++ b/docs/install-1.7.md
@@ -37,7 +37,13 @@ cd certs
 We'll assume that you're operating from this `docs/certs` directory for the 
 remainder of this document.
 
-Next, create the certs:
+Next, install the `cfssl` toolchain (which the following script uses):
+
+```console
+go get -u github.com/cloudflare/cfssl/cmd/...
+```
+
+Finally, create the certs:
 
 ```console
 source ../../contrib/svc-cat-apiserver-aggregation-tls-setup.sh

--- a/docs/install-1.7.md
+++ b/docs/install-1.7.md
@@ -93,8 +93,8 @@ export SVCCAT_SERVICE_NAME=${HELM_RELEASE_NAME}-catalog-apiserver
 
 ## Create Our Own CA and Generate Keys
 
-The `APIService` resource expects a certificate bundle. We can create our own, or
-pull the one from kube core for reuse.
+The `APIService` resource expects a certificate bundle. We can create our own, 
+or pull the one core Kubernetes API server for reuse.
 
 The certificate bundle is made up of Certificate Authority, a Serving
 Certificate, and the Serving Private Key. 

--- a/docs/install-1.7.md
+++ b/docs/install-1.7.md
@@ -50,6 +50,7 @@ and certificates that we'll generate in the following steps:
 
 ```console
 mkdir certs
+cd certs
 ```
 
 ## Check That the API Aggregator is Enabled

--- a/docs/install-1.7.md
+++ b/docs/install-1.7.md
@@ -9,7 +9,7 @@ and go inside the cluster, and register themselves on demand to augment the
 externally facing API that kubernetes offers.
 
 Instead of requiring the end-user to access multiple API servers, the API 
-aggregation system allows many servers to run inside the cluster, and combines
+aggregation system allows many API servers to run inside the cluster, and combines
 all of their APIs into one externally facing API. 
 
 This system is very useful from an end-user's perspective, as it allows the 

--- a/docs/install-1.7.md
+++ b/docs/install-1.7.md
@@ -91,7 +91,11 @@ export SVCCAT_NAMESPACE=catalog
 export SVCCAT_SERVICE_NAME=${HELM_RELEASE_NAME}-catalog-apiserver
 ```
 
-## Create Our Own CA and Generate Keys
+## Get a Certificate Authority (CA) and Keys
+
+There are two options to get a CA and keys.
+
+### Option 1 - Create Our Own CA and Generate Keys
 
 The `APIService` resource expects a certificate bundle. We can create our own, 
 or pull the one core Kubernetes API server for reuse.
@@ -145,7 +149,7 @@ export SC_SERVING_CERT=apiserver.pem
 export SC_SERVING_KEY=apiserver-key.pem
 ```
 
-## Get the Appropriate TLS CA, Certificate and Key from Kubernetes
+### Options 2 - Get the Appropriate TLS CA, Certificate and Key from Kubernetes
 
 If you are in a cloud provider environment, you most likely do not
 have access to the appropriate keys.

--- a/docs/install-1.7.md
+++ b/docs/install-1.7.md
@@ -13,8 +13,8 @@ aggregation system allows many servers to run inside the cluster, and combines
 all of their APIs into one externally facing API. 
 
 This system is very useful from an end-user's perspective, as it allows the 
-client to use a single API point with familiar tooling, authentication and 
-authorization.
+client to use a single API point with familiar, consistent tooling, 
+authentication and authorization.
 
 The Service Catalog utilizes API aggregation to present its API. Read on
 to discover how to install it.

--- a/docs/install-1.7.md
+++ b/docs/install-1.7.md
@@ -16,187 +16,34 @@ This system is very useful from an end-user's perspective, as it allows the
 client to use a single API point with familiar, consistent tooling, 
 authentication and authorization.
 
-The Service Catalog utilizes API aggregation to present its API. Read on
-to discover how to install it.
+The Service Catalog utilizes API aggregation to present its API.
 
-# Step 1 - TLS Certificates
+# Step 1 - Generate TLS Certificates
 
-We need to provide a set of certificates to be provided as a
-certificate bundle to the `APIService` resource.
+We provide a script to do all of the steps needed to set up TLS certificates
+that the aggregation system uses. If you'd like to read how to do this setup
+manually, please see the 
+[manual API aggregation setup document](./manual-api-aggregation-setup.md).
 
-For development purposes, it is convenient to use the existing CA
-automatically set up by the kubernetes development environment. The
-[script in contrib](../contrib/svc-cat-apiserver-aggregation-tls-setup.sh)
-generates a fresh CA and certificate setup, without using any existing
-kubernetes infrastructure CAs or certificates. This script should be
-`source`ed to define all of the variables it contains in the current
-shell process.
+Otherwise, read on for automated instructions.
 
-For background on why we need to deal with certificates and CA's at all, you 
-may read the [the auth doc](auth.md) (this is not required, however).
-
-## Install `cfssl` Tools
-
-Before we continue, you'll need to install the `cfssl` tools:
-
-```console
-go get -u github.com/cloudflare/cfssl/cmd/...
-```
-
-## Create a Certificates Directory
-
-Please create a fresh directory called `certs` to hold the configuration
-and certificates that we'll generate in the following steps:
+First, create a directory in which certificates will be generated:
 
 ```console
 mkdir certs
 cd certs
 ```
 
-## Check That the API Aggregator is Enabled
+We'll assume that you're operating from this `docs/certs` directory for the 
+remainder of this document.
 
-Run the following:
-
-```console
-kubectl api-versions
-```
-
-This endpoint must list `apiregistration.k8s.io/v1beta1`. If it does not, your 
-Kubernetes installation is likely version 1.6 or previous. We recommend running
-1.7 or later, but if you decide to continue, please see the 
-[installation document for Kubernetes 1.6](./install-1.6.md).
-
-This `apiregistration.k8s.io/v1beta1` API Group will not show up if you are 
-connecting to the insecure port of the core API server, so be sure that your
-`kubectl` configuration file (often located at `~/.kube/config`) is pointing
-to an https endpoint.
-
-## Create Environment Variables
-
-The following environment variables will be used during the following steps.
-They will be passed to the certificate generation tools as well as the final
-`helm install` step.
-
-They are important to set, as the signed certificates will be bound to the 
-exact service name that is defined below as `SVCCAT_SERVICE_NAME`. 
-
-`SVCCAT_SERVICE_NAME` will be the exact DNS entry that the generated 
-certificate is bound to, so any deviation from the use of these defined 
-variables will result in a certificate that is useless for the purposes of 
-aggregation.
-
-```
-export HELM_RELEASE_NAME=catalog
-export SVCCAT_NAMESPACE=catalog
-export SVCCAT_SERVICE_NAME=${HELM_RELEASE_NAME}-catalog-apiserver
-```
-
-## Get a Certificate Authority (CA) and Keys
-
-There are two options to get a CA and keys.
-
-### Option 1 - Create Our Own CA and Generate Keys
-
-The `APIService` resource expects a certificate bundle. We can create our own, 
-or pull the one core Kubernetes API server for reuse.
-
-The certificate bundle is made up of Certificate Authority, a Serving
-Certificate, and the Serving Private Key. 
-
-Run the following to create a CA and generate keys:
+Next, create the certs:
 
 ```console
-export CA_NAME=ca
-
-export ALT_NAMES="\"${SVCCAT_SERVICE_NAME}.${SVCCAT_NAMESPACE}\",\"${SVCCAT_SERVICE_NAME}.${SVCCAT_NAMESPACE}.svc"\"
-
-export SVCCAT_CA_SETUP=svc-cat-ca.json
-cat >> ${SVCCAT_CA_SETUP} << EOF
-{
-    "hosts": [ ${ALT_NAMES} ],
-    "key": {
-        "algo": "rsa",
-        "size": 2048
-    },
-    "names": [
-        {
-            "C": "US",
-            "L": "san jose",
-            "O": "kube",
-            "OU": "WWW",
-            "ST": "California"
-        }
-    ]
-}
-EOF
-
-
-cfssl genkey --initca ${SVCCAT_CA_SETUP} | cfssljson -bare ${CA_NAME}
-# now the files 'ca.csr  ca-key.pem  ca.pem' exist
-
-export SVCCAT_CA_CERT=${CA_NAME}.pem
-export SVCCAT_CA_KEY=${CA_NAME}-key.pem
-
-export PURPOSE=server
-echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","'${PURPOSE}'"]}}}' > "${PURPOSE}-ca-config.json"
-
-echo '{"CN":"'${SVCCAT_SERVICE_NAME}'","hosts":['${ALT_NAMES}'],"key":{"algo":"rsa","size":2048}}' \
- | cfssl gencert -ca=${SVCCAT_CA_CERT} -ca-key=${SVCCAT_CA_KEY} -config=server-ca-config.json - \
- | cfssljson -bare apiserver
-
-export SC_SERVING_CA=${SVCCAT_CA_CERT}
-export SC_SERVING_CERT=apiserver.pem
-export SC_SERVING_KEY=apiserver-key.pem
+source ../../contrib/svc-cat-apiserver-aggregation-tls-setup.sh
 ```
 
-### Options 2 - Get the Appropriate TLS CA, Certificate and Key from Kubernetes
-
-If you are in a cloud provider environment, you most likely do not
-have access to the appropriate keys.
-
-The key we are looking for in an already running system is the
-`--root-ca-file` flag to the controller-manager.
-
-The following is an example based on a real kubernetes cluster. The
-various files may be named differently and in different locations.
-
-
-```
-export SERVING_NAME=server-ca
-export SERVINGCA_CERT=${SERVING_NAME}.crt
-export SERVINGCA_KEY=${SERVING_NAME}.key
-# a default location
-cp /var/run/kubernetes/${SERVINGCA_CERT} .
-cp /var/run/kubernetes/${SERVINGCA_KEY} .
-```
-
-## Create a cfssl Config File For a New Signing Key
-
-```
-export PURPOSE=server
-echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","'${PURPOSE}'"]}}}' > "${PURPOSE}-ca-config.json"
-```
-
-## Use the Existing Keys and the Config File to Generate the New Signing Certificate and Key
-
-```
-export NAME_SPACE=catalog
-export SERVICE_NAME=catalog-catalog-apiserver
-export ALT_NAMES="\"${SERVICE_NAME}.${NAME_SPACE}\",\"${SERVICE_NAME}.${NAME_SPACE}.svc"\"
-echo '{"CN":"'${SERVICE_NAME}'","hosts":['${ALT_NAMES}'],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=${SERVINGCA_CERT} -ca-key=${SERVINGCA_KEY} -config=server-ca-config.json - | cfssljson -bare apiserver
-```
-
-## Final Key Names
-
-These variables define the final names of the resulting keys.
-
-```
-export SC_SERVING_CA=${SERVINGCA_CERT}
-export SC_SERVING_CERT=apiserver.pem
-export SC_SERVING_KEY=apiserver-key.pem
-```
-
-# Step 2 - Install the Service Catalog Chart with Helm
+# Step 2 - Install the Helm Chart
 
 Use helm to install the Service Catalog, associating it with the
 configured name ${HELM_NAME}, and into the specified namespace." This
@@ -208,7 +55,7 @@ the versions of the `base64` command (Linux has GNU base64, Mac OS X has BSD
 base64). If you're installing from a Linux based machine, run this:
 
 ```
-helm install charts/catalog \
+helm install ../../charts/catalog \
     --name ${HELM_RELEASE_NAME} --namespace ${SVCCAT_NAMESPACE} \
     --set apiserver.auth.enabled=true \
         --set useAggregator=true \
@@ -220,38 +67,11 @@ helm install charts/catalog \
 If you're on a Mac OS X based machine, run this:
 
 ```
-helm install charts/catalog \
+helm install ../../charts/catalog \
     --name ${HELM_RELEASE_NAME} --namespace ${SVCCAT_NAMESPACE} \
     --set apiserver.auth.enabled=true \
         --set useAggregator=true \
         --set apiserver.tls.ca=$(base64 ${SC_SERVING_CA}) \
         --set apiserver.tls.cert=$(base64 ${SC_SERVING_CERT}) \
         --set apiserver.tls.key=$(base64 ${SC_SERVING_KEY})
-```
-
-`servicecatalog.k8s.io/v1alpha1` should show up under `kubectl
-api-versions` almost immediately, but kubectl will be slow to respond
-to other commands until the apiserver is fully running.
-
-If it doesn't show up the kubectl discovery cache is stale and needs
-to be deleted. It may be located in the `.kube` directory,
-approximately `~/.kube/cache/discovery/`.
-
-Now Service Catalog e2e tests should work with the same `kubeconfig` set
-for both the core APIServer access and the Service Catalog APIServer
-access.
-
-```
-export SERVICECATALOGCONFIG=~/.kube/config
-export KUBECONFIG=~/.kube/config
-make test-e2e
-```
-
-# Summary
-
-Before installing the helm chart, run the script in the `contrib` directory
-by `source`ing it. From the root of this repository, run this command:
-
-```shell
-source ./contrib/svc-cat-apiserver-aggregation-tls-setup.sh
 ```

--- a/docs/install-1.7.md
+++ b/docs/install-1.7.md
@@ -18,6 +18,82 @@ authentication and authorization.
 
 The Service Catalog utilizes API aggregation to present its API.
 
+# Prerequisites
+
+# Step 1 - Prerequisites
+
+## Starting Kubernetes with DNS
+
+You *must* have a Kubernetes cluster with cluster DNS enabled. We can't list
+instructions here for enabling cluster DNS for all Kubernetes cluster
+installations, but here are a few notes:
+
+* If you are using a cloud-based Kubernetes cluster or minikube, you likely 
+have cluster DNS enabled already.
+* If you are using `hack/local-up-cluster.sh`, ensure the
+`KUBE_ENABLE_CLUSTER_DNS` environment variable is set and then run the install
+script
+
+## Helm
+
+You *must* use [Helm](http://helm.sh/) v2 or newer in the installation steps
+below.
+
+If you already have Helm v2 or newer, execute `helm init` (if you haven't
+already) to install Tiller (the server-side component of Helm), and you should
+be done with Helm setup.
+
+If you don't already have Helm v2, see the
+[installation instructions](https://github.com/kubernetes/helm/blob/master/docs/install.md).
+
+## RBAC
+
+Your Kubernetes cluster must have RBAC enabled, and your Tiller pod needs to
+have `cluster-admin` access. If you are using Minikube, make sure to run
+your `minikube start` command with this flag:
+
+```console
+minikube start --extra-config=apiserver.Authorization.Mode=RBAC
+```
+
+AssumingBy default, `helm init` installs the Tiller pod into the `kube-system`
+namespace, with Tiller configured to use the `default` service account.
+
+Configure Tiller with `cluster-admin` access with the following command:
+
+```console
+kubectl create clusterrolebinding tiller-cluster-admin \
+    --clusterrole=cluster-admin \
+    --serviceaccount=kube-system:default
+```
+
+If you used the `--tiller-namespace` or `--service-account` flags when running 
+`helm init`, the `--serviceaccount` flag in the previous command needs to be 
+adjusted to reference the appropriate namespace and ServiceAccount name.
+
+## A Recent `kubectl`
+
+As with Kubernetes itself, interaction with the service catalog system is
+achieved through the `kubectl` command line interface. Chances are high that
+you already have this installed, however, the service catalog *requires*
+`kubectl` version 1.6 or newer.
+
+To proceed, we must:
+
+- Download and install `kubectl` version 1.6 or newer.
+- Configure `kubectl` to communicate with the service catalog's API server.
+
+To install `kubectl` follow the [standard instructions](https://kubernetes.io/docs/tasks/kubectl/install/).
+
+For example, on a mac,
+```console
+curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl
+chmod +x ./kubectl
+```
+
+We'll assume that all `kubectl` commands are using this newly-installed 
+executable.
+
 # Step 1 - Generate TLS Certificates
 
 We provide a script to do all of the steps needed to set up TLS certificates

--- a/docs/install-1.7.md
+++ b/docs/install-1.7.md
@@ -83,7 +83,7 @@ exact service name that is defined below as `SVCCAT_SERVICE_NAME`.
 `SVCCAT_SERVICE_NAME` will be the exact DNS entry that the generated 
 certificate is bound to, so any deviation from the use of these defined 
 variables will result in a certificate that is useless for the purposes of 
-aggregation. All of the DNS entries must match.
+aggregation.
 
 ```
 export HELM_RELEASE_NAME=catalog

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,65 @@
+# Service Catalog Introduction
+
+The Kubernetes Service Catalog provides a Kubernetes-native interface to one
+or more [Open Service Broker API](https://openservicebrokerapi.org/) compatible
+service brokers.
+
+# Concepts
+
+The service catalog API has five main concepts:
+
+- Open Service Broker API Server: A server that acts as a service broker and conforms to the 
+[Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md)
+specification. This software could be hosted within your own Kubernetes cluster
+or elsewhere.
+
+The remaining four concepts all map directly to new Kubernetes resource types
+that are provided by the service catalog API.
+
+- `ServiceBroker`: An in-cluster representation of a broker server. A resource of this
+type encapsulates connection details for that broker server. These are created
+and managed by cluster operators who wish to use that broker server to make new
+types of managed services available within their cluster.
+- `ServiceClass`: A *type* of managed service offered by a particular broker.
+Each time a new `ServiceBroker` resource is added to the cluster, the service catalog
+controller connects to the corresponding broker server to obtain a list of
+service offerings. A new `ServiceClass` resource will automatically be created
+for each.
+- `ServiceInstance`: A provisioned instance of a `ServiceClass`. These are created
+by cluster users who wish to make a new concrete _instance_ of some _type_ of
+managed service to make that available for use by one or more in-cluster
+applications. When a new `ServiceInstance` resource is created, the service catalog
+controller will connect to the appropriate broker server and instruct it to
+provision the service instance.
+- `ServiceInstanceCredential`: Access credential to a `ServiceInstance`. These
+are created by cluster users who wish for their applications to make use of a
+service `ServiceInstance`. Upon creation, the service catalog controller will
+create a Kubernetes `Secret` containing connection details and credentials for
+the service instance. Such `Secret`s can be mounted into pods as usual.
+
+These concepts and resources are the building blocks of the service catalog.
+
+# Installation
+
+Service Catalog installs into a Kubernetes cluster and runs behind the
+[Kubernetes API Aggregator](https://kubernetes.io/docs/concepts/api-extension/apiserver-aggregation/).
+
+The aggregator works best in Kubernetes versions 1.7 and above, so we only
+provide official support for Kubernetes 1.7 or higher. We do, however,
+provide instructions for versions 1.6 and lower. They are no longer 
+maintained and we do not recommend using them to run a production installation
+of Service Catalog.
+
+## Kubernetes 1.7 and Above
+
+- [Installation instructions](./install-1.7.md)
+- [Demo instructions](./walkthrough-1.7.md)
+
+## Kubernetes 1.6 (Deprecated)
+
+We recommend that you run Service Catalog on Kubernetes version 1.7 or higher.
+The 1.6 instructions are deprecated, not maintained and may be removed in the
+future.
+
+- [Installation instructions](./install-1.6.md)
+- [Demo instructions](./walkthrough-1.6.md)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -53,7 +53,7 @@ of Service Catalog.
 ## Kubernetes 1.7 and Above
 
 - [Installation instructions](./install-1.7.md)
-- [Demo instructions](./walkthrough-1.7.md)
+- [Demo instructions](./walkthrough-1.7.md) (this is a work in progress)
 
 ## Kubernetes 1.6 (Deprecated)
 

--- a/docs/manual-api-aggregation-setup.md
+++ b/docs/manual-api-aggregation-setup.md
@@ -1,0 +1,236 @@
+# Manual API Aggregation Setup
+
+This document describes how to manually set up artifacts that the helm chart
+for Service Catalog needs to integrate with the API aggregator.
+
+This repository provides a script to automatically set those artifacts up, and 
+we recommend that you use it. If you'd like to do so, please see the
+[install document](./install-1.7.md).
+
+# Step 1 - Create TLS Certificates
+
+We need to provide a set of certificates to be provided as a
+certificate bundle to the `APIService` resource.
+
+For development purposes, it is convenient to use the existing CA
+automatically set up by the kubernetes development environment. The
+[script in contrib](../contrib/svc-cat-apiserver-aggregation-tls-setup.sh)
+generates a fresh CA and certificate setup, without using any existing
+kubernetes infrastructure CAs or certificates. This script should be
+`source`ed to define all of the variables it contains in the current
+shell process.
+
+For background on why we need to deal with certificates and CA's at all, you 
+may read the [the auth doc](auth.md) (this is not required, however).
+
+## Install `cfssl` Tools
+
+Before we continue, you'll need to install the `cfssl` tools:
+
+```console
+go get -u github.com/cloudflare/cfssl/cmd/...
+```
+
+## Create a Certificates Directory
+
+Please create a fresh directory called `certs` to hold the configuration
+and certificates that we'll generate in the following steps:
+
+```console
+mkdir certs
+cd certs
+```
+
+## Check That the API Aggregator is Enabled
+
+Run the following:
+
+```console
+kubectl api-versions
+```
+
+This endpoint must list `apiregistration.k8s.io/v1beta1`. If it does not, your 
+Kubernetes installation is likely version 1.6 or previous. We recommend running
+1.7 or later, but if you decide to continue, please see the 
+[installation document for Kubernetes 1.6](./install-1.6.md).
+
+This `apiregistration.k8s.io/v1beta1` API Group will not show up if you are 
+connecting to the insecure port of the core API server, so be sure that your
+`kubectl` configuration file (often located at `~/.kube/config`) is pointing
+to an https endpoint.
+
+## Create Environment Variables
+
+The following environment variables will be used during the following steps.
+They will be passed to the certificate generation tools as well as the final
+`helm install` step.
+
+They are important to set, as the signed certificates will be bound to the 
+exact service name that is defined below as `SVCCAT_SERVICE_NAME`. 
+
+`SVCCAT_SERVICE_NAME` will be the exact DNS entry that the generated 
+certificate is bound to, so any deviation from the use of these defined 
+variables will result in a certificate that is useless for the purposes of 
+aggregation.
+
+```
+export HELM_RELEASE_NAME=catalog
+export SVCCAT_NAMESPACE=catalog
+export SVCCAT_SERVICE_NAME=${HELM_RELEASE_NAME}-catalog-apiserver
+```
+
+## Get a Certificate Authority (CA) and Keys
+
+There are two options to get a CA and keys.
+
+### Option 1 - Create Our Own CA and Generate Keys
+
+The `APIService` resource expects a certificate bundle. We can create our own, 
+or pull the one core Kubernetes API server for reuse.
+
+The certificate bundle is made up of Certificate Authority, a Serving
+Certificate, and the Serving Private Key. 
+
+Run the following to create a CA and generate keys:
+
+```console
+export CA_NAME=ca
+
+export ALT_NAMES="\"${SVCCAT_SERVICE_NAME}.${SVCCAT_NAMESPACE}\",\"${SVCCAT_SERVICE_NAME}.${SVCCAT_NAMESPACE}.svc"\"
+
+export SVCCAT_CA_SETUP=svc-cat-ca.json
+cat >> ${SVCCAT_CA_SETUP} << EOF
+{
+    "hosts": [ ${ALT_NAMES} ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "US",
+            "L": "san jose",
+            "O": "kube",
+            "OU": "WWW",
+            "ST": "California"
+        }
+    ]
+}
+EOF
+
+
+cfssl genkey --initca ${SVCCAT_CA_SETUP} | cfssljson -bare ${CA_NAME}
+# now the files 'ca.csr  ca-key.pem  ca.pem' exist
+
+export SVCCAT_CA_CERT=${CA_NAME}.pem
+export SVCCAT_CA_KEY=${CA_NAME}-key.pem
+
+export PURPOSE=server
+echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","'${PURPOSE}'"]}}}' > "${PURPOSE}-ca-config.json"
+
+echo '{"CN":"'${SVCCAT_SERVICE_NAME}'","hosts":['${ALT_NAMES}'],"key":{"algo":"rsa","size":2048}}' \
+ | cfssl gencert -ca=${SVCCAT_CA_CERT} -ca-key=${SVCCAT_CA_KEY} -config=server-ca-config.json - \
+ | cfssljson -bare apiserver
+
+export SC_SERVING_CA=${SVCCAT_CA_CERT}
+export SC_SERVING_CERT=apiserver.pem
+export SC_SERVING_KEY=apiserver-key.pem
+```
+
+### Options 2 - Get the Appropriate TLS CA, Certificate and Key from Kubernetes
+
+If you are in a cloud provider environment, you most likely do not
+have access to the appropriate keys.
+
+The key we are looking for in an already running system is the
+`--root-ca-file` flag to the controller-manager.
+
+The following is an example based on a real kubernetes cluster. The
+various files may be named differently and in different locations.
+
+
+```
+export SERVING_NAME=server-ca
+export SERVINGCA_CERT=${SERVING_NAME}.crt
+export SERVINGCA_KEY=${SERVING_NAME}.key
+# a default location
+cp /var/run/kubernetes/${SERVINGCA_CERT} .
+cp /var/run/kubernetes/${SERVINGCA_KEY} .
+```
+
+## Create a cfssl Config File For a New Signing Key
+
+```
+export PURPOSE=server
+echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","'${PURPOSE}'"]}}}' > "${PURPOSE}-ca-config.json"
+```
+
+## Use the Existing Keys and the Config File to Generate the New Signing Certificate and Key
+
+```
+export NAME_SPACE=catalog
+export SERVICE_NAME=catalog-catalog-apiserver
+export ALT_NAMES="\"${SERVICE_NAME}.${NAME_SPACE}\",\"${SERVICE_NAME}.${NAME_SPACE}.svc"\"
+echo '{"CN":"'${SERVICE_NAME}'","hosts":['${ALT_NAMES}'],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=${SERVINGCA_CERT} -ca-key=${SERVINGCA_KEY} -config=server-ca-config.json - | cfssljson -bare apiserver
+```
+
+## Final Key Names
+
+These variables define the final names of the resulting keys.
+
+```
+export SC_SERVING_CA=${SERVINGCA_CERT}
+export SC_SERVING_CERT=apiserver.pem
+export SC_SERVING_KEY=apiserver-key.pem
+```
+
+# Step 2 - Install the Service Catalog Chart with Helm
+
+Use helm to install the Service Catalog, associating it with the
+configured name ${HELM_NAME}, and into the specified namespace." This
+command also enables authentication and aggregation and provides the
+keys we just generated inline.
+
+The installation commands vary slightly between Linux and Mac OS X because of
+the versions of the `base64` command (Linux has GNU base64, Mac OS X has BSD 
+base64). If you're installing from a Linux based machine, run this:
+
+```
+helm install charts/catalog \
+    --name ${HELM_RELEASE_NAME} --namespace ${SVCCAT_NAMESPACE} \
+    --set apiserver.auth.enabled=true \
+        --set useAggregator=true \
+        --set apiserver.tls.ca=$(base64 --wrap 0 ${SC_SERVING_CA}) \
+        --set apiserver.tls.cert=$(base64 --wrap 0 ${SC_SERVING_CERT}) \
+        --set apiserver.tls.key=$(base64 --wrap 0 ${SC_SERVING_KEY})
+```
+
+If you're on a Mac OS X based machine, run this:
+
+```
+helm install charts/catalog \
+    --name ${HELM_RELEASE_NAME} --namespace ${SVCCAT_NAMESPACE} \
+    --set apiserver.auth.enabled=true \
+        --set useAggregator=true \
+        --set apiserver.tls.ca=$(base64 ${SC_SERVING_CA}) \
+        --set apiserver.tls.cert=$(base64 ${SC_SERVING_CERT}) \
+        --set apiserver.tls.key=$(base64 ${SC_SERVING_KEY})
+```
+
+`servicecatalog.k8s.io/v1alpha1` should show up under `kubectl
+api-versions` almost immediately, but kubectl will be slow to respond
+to other commands until the apiserver is fully running.
+
+If it doesn't show up the kubectl discovery cache is stale and needs
+to be deleted. It may be located in the `.kube` directory,
+approximately `~/.kube/cache/discovery/`.
+
+Now Service Catalog e2e tests should work with the same `kubeconfig` set
+for both the core APIServer access and the Service Catalog APIServer
+access.
+
+```
+export SERVICECATALOGCONFIG=~/.kube/config
+export KUBECONFIG=~/.kube/config
+make test-e2e
+```

--- a/docs/walkthrough-1.6.md
+++ b/docs/walkthrough-1.6.md
@@ -12,7 +12,8 @@ If you are running a Kubernetes cluster running version 1.7 or later, please
 see [walkthrough-1.7.md](./walkthrough-1.7.md).
 
 This document assumes that you've installed Service Catalog onto your cluster.
-If you haven't, please see [install-1.6.md](./install-1.6.md).
+If you haven't, please see the 
+[installation instructions for 1.6](./install-1.6.md).
 
 # Step 1 - Installing the UPS ServiceBroker
 

--- a/docs/walkthrough-1.6.md
+++ b/docs/walkthrough-1.6.md
@@ -1,4 +1,4 @@
-# Service Catalog Demonstration Walkthrough
+# Service Catalog Demonstration Walkthrough (DEPRECATED)
 
 This document outlines the basic features of the service catalog by walking
 through a short demo.

--- a/docs/walkthrough-1.7.md
+++ b/docs/walkthrough-1.7.md
@@ -1,0 +1,8 @@
+# Service Catalog Demonstration Walkthrough
+
+This document assumes that you've installed Service Catalog onto your cluster.
+If you haven't, please see [install-1.7.md](./install-1.7.md).
+
+This document is a work in progress. Instructions for the self-guided demo
+will be similar to those in the [1.6 walkthrough](./walkthrough-1.6.md),
+but note that the commands in that document will not work as-is.


### PR DESCRIPTION
As discussed, we will provide installation and walkthrough documents for both 1.6 (and prior) and 1.7 (and later) clusters. However, we will deprecate the 1.6 documents. I've done that here.

I've also split the walkthrough documents apart. For each Kubernetes version, I've provided an installation document and a walkthrough document.

Finally, I've moved the `docs/api-aggregation-setup.md` file into the installation guide for 1.7, and re-structured it to match the structure of the installation guide for 1.6.

__There is still work to follow-up on from this PR.__ This is a step in the right direction, and will improve on the current state of the world. @jboyd01 and I intend to move forward with follow-ups to further improve our install & walkthrough docs.

This patch replaces #1005 (which is now closed). I'd like to complete the 1.7 instructions (which are currently a TODO in this patch) in a follow-up.

cc/ @jboyd01, who is also interested in working on 1.7 install/walkthrough instructions.