### PR TITLE
clean before building a specific arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,6 +326,8 @@ images: user-broker-image controller-manager-image apiserver-image
 
 images-all: $(addprefix arch-image-,$(ALL_ARCH))
 arch-image-%:
+	$(MAKE) clean-bin
+	$(MAKE) ARCH=$* build
 	$(MAKE) ARCH=$* images
 
 define build-and-tag # (service, image, mutable_image, prefix)


### PR DESCRIPTION
 - make gets tricked by the existence of the binaries, and the build is
   very happy to just copy whatever binary exists at the time. All
   existing non-amd64 builds contain amd64 binaries.


Before:
```
# docker create --name apippc apiserver-ppc64le:canary
5283819ad20bb4bd27aec1604851b7ae399c50ef089458c31bb85197f33599c0
# docker cp apippc:/opt/services/apiserver ./apiserverppc
# file apiserverppc
apiserverppc: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, not stripped
```
After:
```
# docker create --name apippc apiserver-ppc64le:canary
a7527b0df8b35f5f95882004c6888f1d02d6dfd24d945334cb66ed95f33d9a26
# docker cp apippc:/opt/services/apiserver ./apiserverppc
# file apiserverppc
apiserverppc: ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), statically linked, not stripped
```

no PPC make IBM unhappy. (I imagine anyway) Certainly makes the QA team unhappy.