### PR TITLE
remove TPRs from Jenkins e2e pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,15 +118,6 @@ node {
             --create-artifacts
       """
 
-      sh """${env.ROOT}/contrib/jenkins/test_walkthrough.sh \
-            --registry gcr.io/${test_project}/catalog/ \
-            --version ${version} \
-            --with-tpr \
-            --cleanup \
-            --fix-auth \
-            --create-artifacts
-      """
-
       ansiColor('xterm-darker-gray') {
         // Run the e2e test framework
         sh """${env.ROOT}/contrib/jenkins/run_e2e.sh \


### PR DESCRIPTION
As discussed on Slack. Since TPRs are deprecated, our support for them is no longer a priority, and they should be removed from the e2e test flow. Once CRD support is ready, it can be added in at that time.