### PR TITLE
correct osbapi service definition

### DIFF
--- a/pkg/brokerapi/service.go
+++ b/pkg/brokerapi/service.go
@@ -18,16 +18,17 @@ package brokerapi
 
 // Service represents a service (of which there may be many variants-- "plans")
 // offered by a service broker
+//
+// https://github.com/openservicebrokerapi/servicebroker/blob/v2.12/spec.md#service-objects
 type Service struct {
-	Name           string   `json:"name"`
-	ID             string   `json:"id"`
-	Description    string   `json:"description"`
-	Bindable       bool     `json:"bindable"`
-	PlanUpdateable bool     `json:"plan_updateable, omitempty"`
-	Tags           []string `json:"tags, omitempty"`
-	Requires       []string `json:"requires, omitempty"`
-
-	Metadata        interface{}   `json:"metadata, omitempty"`
-	Plans           []ServicePlan `json:"plans"`
+	Name            string        `json:"name"`
+	ID              string        `json:"id"`
+	Description     string        `json:"description"`
+	Tags            []string      `json:"tags,omitempty"`
+	Requires        []string      `json:"requires,omitempty"`
+	Bindable        bool          `json:"bindable"`
+	Metadata        interface{}   `json:"metadata,omitempty"`
 	DashboardClient interface{}   `json:"dashboard_client"`
+	PlanUpdateable  bool          `json:"plan_updateable,omitempty"`
+	Plans           []ServicePlan `json:"plans"`
 }

--- a/pkg/brokerapi/service_binding.go
+++ b/pkg/brokerapi/service_binding.go
@@ -25,7 +25,7 @@ type ServiceBinding struct {
 	PrivateKey        string                 `json:"private_key"`
 	ServiceInstanceID string                 `json:"service_instance_id"`
 	BindResource      map[string]interface{} `json:"bind_resource,omitempty"`
-	Parameters        map[string]interface{} `json:"parameters, omitempty"`
+	Parameters        map[string]interface{} `json:"parameters,omitempty"`
 }
 
 // BindingRequest represents a request to bind to a service instance
@@ -40,7 +40,6 @@ type BindingRequest struct {
 // CreateServiceBindingResponse represents a response to a service binding
 // request
 type CreateServiceBindingResponse struct {
-	// SyslogDrainURL string      `json:"syslog_drain_url, omitempty"`
 	Credentials Credential `json:"credentials"`
 }
 

--- a/pkg/brokerapi/service_instance.go
+++ b/pkg/brokerapi/service_instance.go
@@ -20,15 +20,15 @@ package brokerapi
 type ServiceInstance struct {
 	ID               string `json:"id"`
 	DashboardURL     string `json:"dashboard_url"`
-	InternalID       string `json:"internal_id, omitempty"`
+	InternalID       string `json:"internal_id,omitempty"`
 	ServiceID        string `json:"service_id"`
 	PlanID           string `json:"plan_id"`
 	OrganizationGUID string `json:"organization_guid"`
 	SpaceGUID        string `json:"space_guid"`
 
-	LastOperation *LastOperationResponse `json:"last_operation, omitempty"`
+	LastOperation *LastOperationResponse `json:"last_operation,omitempty"`
 
-	Parameters map[string]interface{} `json:"parameters, omitempty"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
 }
 
 // CreateServiceInstanceRequest represents a request to a broker to provision an
@@ -59,8 +59,8 @@ type ContextProfile struct {
 // CreateServiceInstanceResponse represents the response from a broker after a
 // request to provision an instance of a service
 type CreateServiceInstanceResponse struct {
-	DashboardURL string `json:"dashboard_url, omitempty"`
-	Operation    string `json:"operation, omitempty"`
+	DashboardURL string `json:"dashboard_url,omitempty"`
+	Operation    string `json:"operation,omitempty"`
 }
 
 // DeleteServiceInstanceRequest represents a request to a broker to deprovision an


### PR DESCRIPTION
 - Space before omitempty was semantically significant. Optional fields
   were being sent as "null"
 - Add documentation link to the v2.12 tag description of the Service.
 - Rearrange fields to match the documentation order.
 - remove extra newline