### PR TITLE
do the clean before building an arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,4 +397,6 @@ endif
 
 release-push: $(addprefix release-push-,$(ALL_ARCH))
 release-push-%:
+	$(MAKE) clean-bin
+	$(MAKE) ARCH=$* build
 	$(MAKE) ARCH=$* push


### PR DESCRIPTION
 - I did not realize we do not call the build-images command
 - we call push relase directly, which implicitly builds each individual image

follow up to #1168