### PR TITLE
Remove Alpha* prefix on all API fields for issue #1180

### DIFF
--- a/pkg/apis/servicecatalog/testing/fuzzer.go
+++ b/pkg/apis/servicecatalog/testing/fuzzer.go
@@ -236,9 +236,9 @@ func FuzzerFor(t *testing.T, version schema.GroupVersion, src rand.Source) *fuzz
 				return
 			}
 			sp.ExternalMetadata = metadata
-			sp.AlphaServiceInstanceCredentialCreateParameterSchema = metadata
-			sp.AlphaServiceInstanceCreateParameterSchema = metadata
-			sp.AlphaServiceInstanceUpdateParameterSchema = metadata
+			sp.ServiceInstanceCredentialCreateParameterSchema = metadata
+			sp.ServiceInstanceCreateParameterSchema = metadata
+			sp.ServiceInstanceUpdateParameterSchema = metadata
 		},
 	)
 	return f

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -223,16 +223,16 @@ type ServiceClass struct {
 	// attributes of the ServiceClass.  These are used in Cloud Foundry in a
 	// way similar to Kubernetes labels, but they currently have no special
 	// meaning in Kubernetes.
-	AlphaTags []string
+	Tags []string
 
 	// Currently, this field is ALPHA: it may change or disappear at any time
 	// and its data will not be migrated.
 	//
-	// AlphaRequires exposes a list of Cloud Foundry-specific 'permissions'
+	// Requires exposes a list of Cloud Foundry-specific 'permissions'
 	// that must be granted to an instance of this service within Cloud
 	// Foundry.  These 'permissions' have no meaning within Kubernetes and an
 	// ServiceInstance provisioned from this ServiceClass will not work correctly.
-	AlphaRequires []string
+	Requires []string
 }
 
 // ServicePlan represents a tier of a ServiceClass.
@@ -264,24 +264,24 @@ type ServicePlan struct {
 	// Currently, this field is ALPHA: it may change or disappear at any time
 	// and its data will not be migrated.
 	//
-	// AlphaServiceInstanceCreateParameterSchema is the schema for the parameters
+	// ServiceInstanceCreateParameterSchema is the schema for the parameters
 	// that may be supplied when provisioning a new ServiceInstance on this plan.
-	AlphaServiceInstanceCreateParameterSchema *runtime.RawExtension
+	ServiceInstanceCreateParameterSchema *runtime.RawExtension
 
 	// Currently, this field is ALPHA: it may change or disappear at any time
 	// and its data will not be migrated.
 	//
-	// AlphaServiceInstanceUpdateParameterSchema is the schema for the parameters
+	// ServiceInstanceUpdateParameterSchema is the schema for the parameters
 	// that may be updated once an ServiceInstance has been provisioned on this plan.
 	// This field only has meaning if the ServiceClass is PlanUpdatable.
-	AlphaServiceInstanceUpdateParameterSchema *runtime.RawExtension
+	ServiceInstanceUpdateParameterSchema *runtime.RawExtension
 
 	// Currently, this field is ALPHA: it may change or disappear at any time
 	// and its data will not be migrated.
 	//
-	// AlphaServiceInstanceCredentialCreateParameterSchema is the schema for the parameters that
+	// ServiceInstanceCredentialCreateParameterSchema is the schema for the parameters that
 	// may be supplied binding to an ServiceInstance on this plan.
-	AlphaServiceInstanceCredentialCreateParameterSchema *runtime.RawExtension
+	ServiceInstanceCredentialCreateParameterSchema *runtime.RawExtension
 }
 
 // ServiceInstanceList is a list of instances.

--- a/pkg/apis/servicecatalog/v1alpha1/types.generated.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.generated.go
@@ -2862,8 +2862,8 @@ func (x *ServiceClass) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2[0] = x.Kind != ""
 			yyq2[1] = x.APIVersion != ""
 			yyq2[2] = true
-			yyq2[10] = len(x.AlphaTags) != 0
-			yyq2[11] = len(x.AlphaRequires) != 0
+			yyq2[10] = len(x.Tags) != 0
+			yyq2[11] = len(x.Requires) != 0
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(12)
@@ -3114,14 +3114,14 @@ func (x *ServiceClass) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[10] {
-					if x.AlphaTags == nil {
+					if x.Tags == nil {
 						r.EncodeNil()
 					} else {
 						yym36 := z.EncBinary()
 						_ = yym36
 						if false {
 						} else {
-							z.F.EncSliceStringV(x.AlphaTags, false, e)
+							z.F.EncSliceStringV(x.Tags, false, e)
 						}
 					}
 				} else {
@@ -3130,16 +3130,16 @@ func (x *ServiceClass) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2[10] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("alphaTags"))
+					r.EncodeString(codecSelferC_UTF81234, string("tags"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.AlphaTags == nil {
+					if x.Tags == nil {
 						r.EncodeNil()
 					} else {
 						yym37 := z.EncBinary()
 						_ = yym37
 						if false {
 						} else {
-							z.F.EncSliceStringV(x.AlphaTags, false, e)
+							z.F.EncSliceStringV(x.Tags, false, e)
 						}
 					}
 				}
@@ -3147,14 +3147,14 @@ func (x *ServiceClass) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[11] {
-					if x.AlphaRequires == nil {
+					if x.Requires == nil {
 						r.EncodeNil()
 					} else {
 						yym39 := z.EncBinary()
 						_ = yym39
 						if false {
 						} else {
-							z.F.EncSliceStringV(x.AlphaRequires, false, e)
+							z.F.EncSliceStringV(x.Requires, false, e)
 						}
 					}
 				} else {
@@ -3163,16 +3163,16 @@ func (x *ServiceClass) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2[11] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("alphaRequires"))
+					r.EncodeString(codecSelferC_UTF81234, string("requires"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.AlphaRequires == nil {
+					if x.Requires == nil {
 						r.EncodeNil()
 					} else {
 						yym40 := z.EncBinary()
 						_ = yym40
 						if false {
 						} else {
-							z.F.EncSliceStringV(x.AlphaRequires, false, e)
+							z.F.EncSliceStringV(x.Requires, false, e)
 						}
 					}
 				}
@@ -3366,11 +3366,11 @@ func (x *ServiceClass) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					z.DecFallback(x.ExternalMetadata, false)
 				}
 			}
-		case "alphaTags":
+		case "tags":
 			if r.TryDecodeAsNil() {
-				x.AlphaTags = nil
+				x.Tags = nil
 			} else {
-				yyv24 := &x.AlphaTags
+				yyv24 := &x.Tags
 				yym25 := z.DecBinary()
 				_ = yym25
 				if false {
@@ -3378,11 +3378,11 @@ func (x *ServiceClass) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					z.F.DecSliceStringX(yyv24, false, d)
 				}
 			}
-		case "alphaRequires":
+		case "requires":
 			if r.TryDecodeAsNil() {
-				x.AlphaRequires = nil
+				x.Requires = nil
 			} else {
-				yyv26 := &x.AlphaRequires
+				yyv26 := &x.Requires
 				yym27 := z.DecBinary()
 				_ = yym27
 				if false {
@@ -3644,9 +3644,9 @@ func (x *ServiceClass) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.AlphaTags = nil
+		x.Tags = nil
 	} else {
-		yyv49 := &x.AlphaTags
+		yyv49 := &x.Tags
 		yym50 := z.DecBinary()
 		_ = yym50
 		if false {
@@ -3666,9 +3666,9 @@ func (x *ServiceClass) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		x.AlphaRequires = nil
+		x.Requires = nil
 	} else {
-		yyv51 := &x.AlphaRequires
+		yyv51 := &x.Requires
 		yym52 := z.DecBinary()
 		_ = yym52
 		if false {
@@ -3710,9 +3710,9 @@ func (x *ServicePlan) CodecEncodeSelf(e *codec1978.Encoder) {
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
 			yyq2[3] = x.Bindable != nil
-			yyq2[6] = x.AlphaServiceInstanceCreateParameterSchema != nil
-			yyq2[7] = x.AlphaServiceInstanceUpdateParameterSchema != nil
-			yyq2[8] = x.AlphaServiceInstanceCredentialCreateParameterSchema != nil
+			yyq2[6] = x.ServiceInstanceCreateParameterSchema != nil
+			yyq2[7] = x.ServiceInstanceUpdateParameterSchema != nil
+			yyq2[8] = x.ServiceInstanceCredentialCreateParameterSchema != nil
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(9)
@@ -3873,17 +3873,17 @@ func (x *ServicePlan) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[6] {
-					if x.AlphaServiceInstanceCreateParameterSchema == nil {
+					if x.ServiceInstanceCreateParameterSchema == nil {
 						r.EncodeNil()
 					} else {
 						yym24 := z.EncBinary()
 						_ = yym24
 						if false {
-						} else if z.HasExtensions() && z.EncExt(x.AlphaServiceInstanceCreateParameterSchema) {
+						} else if z.HasExtensions() && z.EncExt(x.ServiceInstanceCreateParameterSchema) {
 						} else if !yym24 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.AlphaServiceInstanceCreateParameterSchema)
+							z.EncJSONMarshal(x.ServiceInstanceCreateParameterSchema)
 						} else {
-							z.EncFallback(x.AlphaServiceInstanceCreateParameterSchema)
+							z.EncFallback(x.ServiceInstanceCreateParameterSchema)
 						}
 					}
 				} else {
@@ -3892,19 +3892,19 @@ func (x *ServicePlan) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2[6] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("alphaInstanceCreateParameterSchema"))
+					r.EncodeString(codecSelferC_UTF81234, string("instanceCreateParameterSchema"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.AlphaServiceInstanceCreateParameterSchema == nil {
+					if x.ServiceInstanceCreateParameterSchema == nil {
 						r.EncodeNil()
 					} else {
 						yym25 := z.EncBinary()
 						_ = yym25
 						if false {
-						} else if z.HasExtensions() && z.EncExt(x.AlphaServiceInstanceCreateParameterSchema) {
+						} else if z.HasExtensions() && z.EncExt(x.ServiceInstanceCreateParameterSchema) {
 						} else if !yym25 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.AlphaServiceInstanceCreateParameterSchema)
+							z.EncJSONMarshal(x.ServiceInstanceCreateParameterSchema)
 						} else {
-							z.EncFallback(x.AlphaServiceInstanceCreateParameterSchema)
+							z.EncFallback(x.ServiceInstanceCreateParameterSchema)
 						}
 					}
 				}
@@ -3912,17 +3912,17 @@ func (x *ServicePlan) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[7] {
-					if x.AlphaServiceInstanceUpdateParameterSchema == nil {
+					if x.ServiceInstanceUpdateParameterSchema == nil {
 						r.EncodeNil()
 					} else {
 						yym27 := z.EncBinary()
 						_ = yym27
 						if false {
-						} else if z.HasExtensions() && z.EncExt(x.AlphaServiceInstanceUpdateParameterSchema) {
+						} else if z.HasExtensions() && z.EncExt(x.ServiceInstanceUpdateParameterSchema) {
 						} else if !yym27 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.AlphaServiceInstanceUpdateParameterSchema)
+							z.EncJSONMarshal(x.ServiceInstanceUpdateParameterSchema)
 						} else {
-							z.EncFallback(x.AlphaServiceInstanceUpdateParameterSchema)
+							z.EncFallback(x.ServiceInstanceUpdateParameterSchema)
 						}
 					}
 				} else {
@@ -3931,19 +3931,19 @@ func (x *ServicePlan) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2[7] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("alphaInstanceUpdateParameterSchema"))
+					r.EncodeString(codecSelferC_UTF81234, string("instanceUpdateParameterSchema"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.AlphaServiceInstanceUpdateParameterSchema == nil {
+					if x.ServiceInstanceUpdateParameterSchema == nil {
 						r.EncodeNil()
 					} else {
 						yym28 := z.EncBinary()
 						_ = yym28
 						if false {
-						} else if z.HasExtensions() && z.EncExt(x.AlphaServiceInstanceUpdateParameterSchema) {
+						} else if z.HasExtensions() && z.EncExt(x.ServiceInstanceUpdateParameterSchema) {
 						} else if !yym28 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.AlphaServiceInstanceUpdateParameterSchema)
+							z.EncJSONMarshal(x.ServiceInstanceUpdateParameterSchema)
 						} else {
-							z.EncFallback(x.AlphaServiceInstanceUpdateParameterSchema)
+							z.EncFallback(x.ServiceInstanceUpdateParameterSchema)
 						}
 					}
 				}
@@ -3951,17 +3951,17 @@ func (x *ServicePlan) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
 				if yyq2[8] {
-					if x.AlphaServiceInstanceCredentialCreateParameterSchema == nil {
+					if x.ServiceInstanceCredentialCreateParameterSchema == nil {
 						r.EncodeNil()
 					} else {
 						yym30 := z.EncBinary()
 						_ = yym30
 						if false {
-						} else if z.HasExtensions() && z.EncExt(x.AlphaServiceInstanceCredentialCreateParameterSchema) {
+						} else if z.HasExtensions() && z.EncExt(x.ServiceInstanceCredentialCreateParameterSchema) {
 						} else if !yym30 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.AlphaServiceInstanceCredentialCreateParameterSchema)
+							z.EncJSONMarshal(x.ServiceInstanceCredentialCreateParameterSchema)
 						} else {
-							z.EncFallback(x.AlphaServiceInstanceCredentialCreateParameterSchema)
+							z.EncFallback(x.ServiceInstanceCredentialCreateParameterSchema)
 						}
 					}
 				} else {
@@ -3970,19 +3970,19 @@ func (x *ServicePlan) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2[8] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
-					r.EncodeString(codecSelferC_UTF81234, string("alphaServiceInstanceCredentialCreateParameterSchema"))
+					r.EncodeString(codecSelferC_UTF81234, string("serviceInstanceCredentialCreateParameterSchema"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
-					if x.AlphaServiceInstanceCredentialCreateParameterSchema == nil {
+					if x.ServiceInstanceCredentialCreateParameterSchema == nil {
 						r.EncodeNil()
 					} else {
 						yym31 := z.EncBinary()
 						_ = yym31
 						if false {
-						} else if z.HasExtensions() && z.EncExt(x.AlphaServiceInstanceCredentialCreateParameterSchema) {
+						} else if z.HasExtensions() && z.EncExt(x.ServiceInstanceCredentialCreateParameterSchema) {
 						} else if !yym31 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.AlphaServiceInstanceCredentialCreateParameterSchema)
+							z.EncJSONMarshal(x.ServiceInstanceCredentialCreateParameterSchema)
 						} else {
-							z.EncFallback(x.AlphaServiceInstanceCredentialCreateParameterSchema)
+							z.EncFallback(x.ServiceInstanceCredentialCreateParameterSchema)
 						}
 					}
 				}
@@ -4131,61 +4131,61 @@ func (x *ServicePlan) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					z.DecFallback(x.ExternalMetadata, false)
 				}
 			}
-		case "alphaInstanceCreateParameterSchema":
+		case "instanceCreateParameterSchema":
 			if r.TryDecodeAsNil() {
-				if x.AlphaServiceInstanceCreateParameterSchema != nil {
-					x.AlphaServiceInstanceCreateParameterSchema = nil
+				if x.ServiceInstanceCreateParameterSchema != nil {
+					x.ServiceInstanceCreateParameterSchema = nil
 				}
 			} else {
-				if x.AlphaServiceInstanceCreateParameterSchema == nil {
-					x.AlphaServiceInstanceCreateParameterSchema = new(pkg4_runtime.RawExtension)
+				if x.ServiceInstanceCreateParameterSchema == nil {
+					x.ServiceInstanceCreateParameterSchema = new(pkg4_runtime.RawExtension)
 				}
 				yym17 := z.DecBinary()
 				_ = yym17
 				if false {
-				} else if z.HasExtensions() && z.DecExt(x.AlphaServiceInstanceCreateParameterSchema) {
+				} else if z.HasExtensions() && z.DecExt(x.ServiceInstanceCreateParameterSchema) {
 				} else if !yym17 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(x.AlphaServiceInstanceCreateParameterSchema)
+					z.DecJSONUnmarshal(x.ServiceInstanceCreateParameterSchema)
 				} else {
-					z.DecFallback(x.AlphaServiceInstanceCreateParameterSchema, false)
+					z.DecFallback(x.ServiceInstanceCreateParameterSchema, false)
 				}
 			}
-		case "alphaInstanceUpdateParameterSchema":
+		case "instanceUpdateParameterSchema":
 			if r.TryDecodeAsNil() {
-				if x.AlphaServiceInstanceUpdateParameterSchema != nil {
-					x.AlphaServiceInstanceUpdateParameterSchema = nil
+				if x.ServiceInstanceUpdateParameterSchema != nil {
+					x.ServiceInstanceUpdateParameterSchema = nil
 				}
 			} else {
-				if x.AlphaServiceInstanceUpdateParameterSchema == nil {
-					x.AlphaServiceInstanceUpdateParameterSchema = new(pkg4_runtime.RawExtension)
+				if x.ServiceInstanceUpdateParameterSchema == nil {
+					x.ServiceInstanceUpdateParameterSchema = new(pkg4_runtime.RawExtension)
 				}
 				yym19 := z.DecBinary()
 				_ = yym19
 				if false {
-				} else if z.HasExtensions() && z.DecExt(x.AlphaServiceInstanceUpdateParameterSchema) {
+				} else if z.HasExtensions() && z.DecExt(x.ServiceInstanceUpdateParameterSchema) {
 				} else if !yym19 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(x.AlphaServiceInstanceUpdateParameterSchema)
+					z.DecJSONUnmarshal(x.ServiceInstanceUpdateParameterSchema)
 				} else {
-					z.DecFallback(x.AlphaServiceInstanceUpdateParameterSchema, false)
+					z.DecFallback(x.ServiceInstanceUpdateParameterSchema, false)
 				}
 			}
-		case "alphaServiceInstanceCredentialCreateParameterSchema":
+		case "serviceInstanceCredentialCreateParameterSchema":
 			if r.TryDecodeAsNil() {
-				if x.AlphaServiceInstanceCredentialCreateParameterSchema != nil {
-					x.AlphaServiceInstanceCredentialCreateParameterSchema = nil
+				if x.ServiceInstanceCredentialCreateParameterSchema != nil {
+					x.ServiceInstanceCredentialCreateParameterSchema = nil
 				}
 			} else {
-				if x.AlphaServiceInstanceCredentialCreateParameterSchema == nil {
-					x.AlphaServiceInstanceCredentialCreateParameterSchema = new(pkg4_runtime.RawExtension)
+				if x.ServiceInstanceCredentialCreateParameterSchema == nil {
+					x.ServiceInstanceCredentialCreateParameterSchema = new(pkg4_runtime.RawExtension)
 				}
 				yym21 := z.DecBinary()
 				_ = yym21
 				if false {
-				} else if z.HasExtensions() && z.DecExt(x.AlphaServiceInstanceCredentialCreateParameterSchema) {
+				} else if z.HasExtensions() && z.DecExt(x.ServiceInstanceCredentialCreateParameterSchema) {
 				} else if !yym21 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(x.AlphaServiceInstanceCredentialCreateParameterSchema)
+					z.DecJSONUnmarshal(x.ServiceInstanceCredentialCreateParameterSchema)
 				} else {
-					z.DecFallback(x.AlphaServiceInstanceCredentialCreateParameterSchema, false)
+					z.DecFallback(x.ServiceInstanceCredentialCreateParameterSchema, false)
 				}
 			}
 		default:
@@ -4357,21 +4357,21 @@ func (x *ServicePlan) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		if x.AlphaServiceInstanceCreateParameterSchema != nil {
-			x.AlphaServiceInstanceCreateParameterSchema = nil
+		if x.ServiceInstanceCreateParameterSchema != nil {
+			x.ServiceInstanceCreateParameterSchema = nil
 		}
 	} else {
-		if x.AlphaServiceInstanceCreateParameterSchema == nil {
-			x.AlphaServiceInstanceCreateParameterSchema = new(pkg4_runtime.RawExtension)
+		if x.ServiceInstanceCreateParameterSchema == nil {
+			x.ServiceInstanceCreateParameterSchema = new(pkg4_runtime.RawExtension)
 		}
 		yym36 := z.DecBinary()
 		_ = yym36
 		if false {
-		} else if z.HasExtensions() && z.DecExt(x.AlphaServiceInstanceCreateParameterSchema) {
+		} else if z.HasExtensions() && z.DecExt(x.ServiceInstanceCreateParameterSchema) {
 		} else if !yym36 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(x.AlphaServiceInstanceCreateParameterSchema)
+			z.DecJSONUnmarshal(x.ServiceInstanceCreateParameterSchema)
 		} else {
-			z.DecFallback(x.AlphaServiceInstanceCreateParameterSchema, false)
+			z.DecFallback(x.ServiceInstanceCreateParameterSchema, false)
 		}
 	}
 	yyj22++
@@ -4386,21 +4386,21 @@ func (x *ServicePlan) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		if x.AlphaServiceInstanceUpdateParameterSchema != nil {
-			x.AlphaServiceInstanceUpdateParameterSchema = nil
+		if x.ServiceInstanceUpdateParameterSchema != nil {
+			x.ServiceInstanceUpdateParameterSchema = nil
 		}
 	} else {
-		if x.AlphaServiceInstanceUpdateParameterSchema == nil {
-			x.AlphaServiceInstanceUpdateParameterSchema = new(pkg4_runtime.RawExtension)
+		if x.ServiceInstanceUpdateParameterSchema == nil {
+			x.ServiceInstanceUpdateParameterSchema = new(pkg4_runtime.RawExtension)
 		}
 		yym38 := z.DecBinary()
 		_ = yym38
 		if false {
-		} else if z.HasExtensions() && z.DecExt(x.AlphaServiceInstanceUpdateParameterSchema) {
+		} else if z.HasExtensions() && z.DecExt(x.ServiceInstanceUpdateParameterSchema) {
 		} else if !yym38 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(x.AlphaServiceInstanceUpdateParameterSchema)
+			z.DecJSONUnmarshal(x.ServiceInstanceUpdateParameterSchema)
 		} else {
-			z.DecFallback(x.AlphaServiceInstanceUpdateParameterSchema, false)
+			z.DecFallback(x.ServiceInstanceUpdateParameterSchema, false)
 		}
 	}
 	yyj22++
@@ -4415,21 +4415,21 @@ func (x *ServicePlan) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
 	if r.TryDecodeAsNil() {
-		if x.AlphaServiceInstanceCredentialCreateParameterSchema != nil {
-			x.AlphaServiceInstanceCredentialCreateParameterSchema = nil
+		if x.ServiceInstanceCredentialCreateParameterSchema != nil {
+			x.ServiceInstanceCredentialCreateParameterSchema = nil
 		}
 	} else {
-		if x.AlphaServiceInstanceCredentialCreateParameterSchema == nil {
-			x.AlphaServiceInstanceCredentialCreateParameterSchema = new(pkg4_runtime.RawExtension)
+		if x.ServiceInstanceCredentialCreateParameterSchema == nil {
+			x.ServiceInstanceCredentialCreateParameterSchema = new(pkg4_runtime.RawExtension)
 		}
 		yym40 := z.DecBinary()
 		_ = yym40
 		if false {
-		} else if z.HasExtensions() && z.DecExt(x.AlphaServiceInstanceCredentialCreateParameterSchema) {
+		} else if z.HasExtensions() && z.DecExt(x.ServiceInstanceCredentialCreateParameterSchema) {
 		} else if !yym40 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(x.AlphaServiceInstanceCredentialCreateParameterSchema)
+			z.DecJSONUnmarshal(x.ServiceInstanceCredentialCreateParameterSchema)
 		} else {
-			z.DecFallback(x.AlphaServiceInstanceCredentialCreateParameterSchema, false)
+			z.DecFallback(x.ServiceInstanceCredentialCreateParameterSchema, false)
 		}
 	}
 	for {

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -223,16 +223,16 @@ type ServiceClass struct {
 	// attributes of the ServiceClass.  These are used in Cloud Foundry in a
 	// way similar to Kubernetes labels, but they currently have no special
 	// meaning in Kubernetes.
-	AlphaTags []string `json:"alphaTags,omitempty"`
+	Tags []string `json:"tags,omitempty"`
 
 	// Currently, this field is ALPHA: it may change or disappear at any time
 	// and its data will not be migrated.
 	//
-	// AlphaRequires exposes a list of Cloud Foundry-specific 'permissions'
+	// Requires exposes a list of Cloud Foundry-specific 'permissions'
 	// that must be granted to an instance of this service within Cloud
 	// Foundry.  These 'permissions' have no meaning within Kubernetes and an
 	// ServiceInstance provisioned from this ServiceClass will not work correctly.
-	AlphaRequires []string `json:"alphaRequires,omitempty"`
+	Requires []string `json:"requires,omitempty"`
 }
 
 // ServicePlan represents a tier of a ServiceClass.
@@ -264,24 +264,24 @@ type ServicePlan struct {
 	// Currently, this field is ALPHA: it may change or disappear at any time
 	// and its data will not be migrated.
 	//
-	// AlphaServiceInstanceCreateParameterSchema is the schema for the parameters
+	// ServiceInstanceCreateParameterSchema is the schema for the parameters
 	// that may be supplied when provisioning a new ServiceInstance on this plan.
-	AlphaServiceInstanceCreateParameterSchema *runtime.RawExtension `json:"alphaInstanceCreateParameterSchema,omitempty"`
+	ServiceInstanceCreateParameterSchema *runtime.RawExtension `json:"instanceCreateParameterSchema,omitempty"`
 
 	// Currently, this field is ALPHA: it may change or disappear at any time
 	// and its data will not be migrated.
 	//
-	// AlphaServiceInstanceUpdateParameterSchema is the schema for the parameters
+	// ServiceInstanceUpdateParameterSchema is the schema for the parameters
 	// that may be updated once an ServiceInstance has been provisioned on this plan.
 	// This field only has meaning if the ServiceClass is PlanUpdatable.
-	AlphaServiceInstanceUpdateParameterSchema *runtime.RawExtension `json:"alphaInstanceUpdateParameterSchema,omitempty"`
+	ServiceInstanceUpdateParameterSchema *runtime.RawExtension `json:"instanceUpdateParameterSchema,omitempty"`
 
 	// Currently, this field is ALPHA: it may change or disappear at any time
 	// and its data will not be migrated.
 	//
-	// AlphaServiceInstanceCredentialCreateParameterSchema is the schema for the parameters that
+	// ServiceInstanceCredentialCreateParameterSchema is the schema for the parameters that
 	// may be supplied binding to an ServiceInstance on this plan.
-	AlphaServiceInstanceCredentialCreateParameterSchema *runtime.RawExtension `json:"alphaServiceInstanceCredentialCreateParameterSchema,omitempty"`
+	ServiceInstanceCredentialCreateParameterSchema *runtime.RawExtension `json:"serviceInstanceCredentialCreateParameterSchema,omitempty"`
 }
 
 // ServiceInstanceList is a list of instances.

--- a/pkg/apis/servicecatalog/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1alpha1/zz_generated.conversion.go
@@ -338,8 +338,8 @@ func autoConvert_v1alpha1_ServiceClass_To_servicecatalog_ServiceClass(in *Servic
 	out.PlanUpdatable = in.PlanUpdatable
 	out.ExternalID = in.ExternalID
 	out.ExternalMetadata = (*runtime.RawExtension)(unsafe.Pointer(in.ExternalMetadata))
-	out.AlphaTags = *(*[]string)(unsafe.Pointer(&in.AlphaTags))
-	out.AlphaRequires = *(*[]string)(unsafe.Pointer(&in.AlphaRequires))
+	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
+	out.Requires = *(*[]string)(unsafe.Pointer(&in.Requires))
 	return nil
 }
 
@@ -361,8 +361,8 @@ func autoConvert_servicecatalog_ServiceClass_To_v1alpha1_ServiceClass(in *servic
 	out.PlanUpdatable = in.PlanUpdatable
 	out.ExternalID = in.ExternalID
 	out.ExternalMetadata = (*runtime.RawExtension)(unsafe.Pointer(in.ExternalMetadata))
-	out.AlphaTags = *(*[]string)(unsafe.Pointer(&in.AlphaTags))
-	out.AlphaRequires = *(*[]string)(unsafe.Pointer(&in.AlphaRequires))
+	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
+	out.Requires = *(*[]string)(unsafe.Pointer(&in.Requires))
 	return nil
 }
 
@@ -690,9 +690,9 @@ func autoConvert_v1alpha1_ServicePlan_To_servicecatalog_ServicePlan(in *ServiceP
 	out.Bindable = (*bool)(unsafe.Pointer(in.Bindable))
 	out.Free = in.Free
 	out.ExternalMetadata = (*runtime.RawExtension)(unsafe.Pointer(in.ExternalMetadata))
-	out.AlphaServiceInstanceCreateParameterSchema = (*runtime.RawExtension)(unsafe.Pointer(in.AlphaServiceInstanceCreateParameterSchema))
-	out.AlphaServiceInstanceUpdateParameterSchema = (*runtime.RawExtension)(unsafe.Pointer(in.AlphaServiceInstanceUpdateParameterSchema))
-	out.AlphaServiceInstanceCredentialCreateParameterSchema = (*runtime.RawExtension)(unsafe.Pointer(in.AlphaServiceInstanceCredentialCreateParameterSchema))
+	out.ServiceInstanceCreateParameterSchema = (*runtime.RawExtension)(unsafe.Pointer(in.ServiceInstanceCreateParameterSchema))
+	out.ServiceInstanceUpdateParameterSchema = (*runtime.RawExtension)(unsafe.Pointer(in.ServiceInstanceUpdateParameterSchema))
+	out.ServiceInstanceCredentialCreateParameterSchema = (*runtime.RawExtension)(unsafe.Pointer(in.ServiceInstanceCredentialCreateParameterSchema))
 	return nil
 }
 
@@ -708,9 +708,9 @@ func autoConvert_servicecatalog_ServicePlan_To_v1alpha1_ServicePlan(in *servicec
 	out.Bindable = (*bool)(unsafe.Pointer(in.Bindable))
 	out.Free = in.Free
 	out.ExternalMetadata = (*runtime.RawExtension)(unsafe.Pointer(in.ExternalMetadata))
-	out.AlphaServiceInstanceCreateParameterSchema = (*runtime.RawExtension)(unsafe.Pointer(in.AlphaServiceInstanceCreateParameterSchema))
-	out.AlphaServiceInstanceUpdateParameterSchema = (*runtime.RawExtension)(unsafe.Pointer(in.AlphaServiceInstanceUpdateParameterSchema))
-	out.AlphaServiceInstanceCredentialCreateParameterSchema = (*runtime.RawExtension)(unsafe.Pointer(in.AlphaServiceInstanceCredentialCreateParameterSchema))
+	out.ServiceInstanceCreateParameterSchema = (*runtime.RawExtension)(unsafe.Pointer(in.ServiceInstanceCreateParameterSchema))
+	out.ServiceInstanceUpdateParameterSchema = (*runtime.RawExtension)(unsafe.Pointer(in.ServiceInstanceUpdateParameterSchema))
+	out.ServiceInstanceCredentialCreateParameterSchema = (*runtime.RawExtension)(unsafe.Pointer(in.ServiceInstanceCredentialCreateParameterSchema))
 	return nil
 }
 

--- a/pkg/apis/servicecatalog/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/v1alpha1/zz_generated.deepcopy.go
@@ -266,13 +266,13 @@ func DeepCopy_v1alpha1_ServiceClass(in interface{}, out interface{}, c *conversi
 				*out = newVal.(*runtime.RawExtension)
 			}
 		}
-		if in.AlphaTags != nil {
-			in, out := &in.AlphaTags, &out.AlphaTags
+		if in.Tags != nil {
+			in, out := &in.Tags, &out.Tags
 			*out = make([]string, len(*in))
 			copy(*out, *in)
 		}
-		if in.AlphaRequires != nil {
-			in, out := &in.AlphaRequires, &out.AlphaRequires
+		if in.Requires != nil {
+			in, out := &in.Requires, &out.Requires
 			*out = make([]string, len(*in))
 			copy(*out, *in)
 		}
@@ -532,24 +532,24 @@ func DeepCopy_v1alpha1_ServicePlan(in interface{}, out interface{}, c *conversio
 				*out = newVal.(*runtime.RawExtension)
 			}
 		}
-		if in.AlphaServiceInstanceCreateParameterSchema != nil {
-			in, out := &in.AlphaServiceInstanceCreateParameterSchema, &out.AlphaServiceInstanceCreateParameterSchema
+		if in.ServiceInstanceCreateParameterSchema != nil {
+			in, out := &in.ServiceInstanceCreateParameterSchema, &out.ServiceInstanceCreateParameterSchema
 			if newVal, err := c.DeepCopy(*in); err != nil {
 				return err
 			} else {
 				*out = newVal.(*runtime.RawExtension)
 			}
 		}
-		if in.AlphaServiceInstanceUpdateParameterSchema != nil {
-			in, out := &in.AlphaServiceInstanceUpdateParameterSchema, &out.AlphaServiceInstanceUpdateParameterSchema
+		if in.ServiceInstanceUpdateParameterSchema != nil {
+			in, out := &in.ServiceInstanceUpdateParameterSchema, &out.ServiceInstanceUpdateParameterSchema
 			if newVal, err := c.DeepCopy(*in); err != nil {
 				return err
 			} else {
 				*out = newVal.(*runtime.RawExtension)
 			}
 		}
-		if in.AlphaServiceInstanceCredentialCreateParameterSchema != nil {
-			in, out := &in.AlphaServiceInstanceCredentialCreateParameterSchema, &out.AlphaServiceInstanceCredentialCreateParameterSchema
+		if in.ServiceInstanceCredentialCreateParameterSchema != nil {
+			in, out := &in.ServiceInstanceCredentialCreateParameterSchema, &out.ServiceInstanceCredentialCreateParameterSchema
 			if newVal, err := c.DeepCopy(*in); err != nil {
 				return err
 			} else {

--- a/pkg/apis/servicecatalog/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/zz_generated.deepcopy.go
@@ -266,13 +266,13 @@ func DeepCopy_servicecatalog_ServiceClass(in interface{}, out interface{}, c *co
 				*out = newVal.(*runtime.RawExtension)
 			}
 		}
-		if in.AlphaTags != nil {
-			in, out := &in.AlphaTags, &out.AlphaTags
+		if in.Tags != nil {
+			in, out := &in.Tags, &out.Tags
 			*out = make([]string, len(*in))
 			copy(*out, *in)
 		}
-		if in.AlphaRequires != nil {
-			in, out := &in.AlphaRequires, &out.AlphaRequires
+		if in.Requires != nil {
+			in, out := &in.Requires, &out.Requires
 			*out = make([]string, len(*in))
 			copy(*out, *in)
 		}
@@ -532,24 +532,24 @@ func DeepCopy_servicecatalog_ServicePlan(in interface{}, out interface{}, c *con
 				*out = newVal.(*runtime.RawExtension)
 			}
 		}
-		if in.AlphaServiceInstanceCreateParameterSchema != nil {
-			in, out := &in.AlphaServiceInstanceCreateParameterSchema, &out.AlphaServiceInstanceCreateParameterSchema
+		if in.ServiceInstanceCreateParameterSchema != nil {
+			in, out := &in.ServiceInstanceCreateParameterSchema, &out.ServiceInstanceCreateParameterSchema
 			if newVal, err := c.DeepCopy(*in); err != nil {
 				return err
 			} else {
 				*out = newVal.(*runtime.RawExtension)
 			}
 		}
-		if in.AlphaServiceInstanceUpdateParameterSchema != nil {
-			in, out := &in.AlphaServiceInstanceUpdateParameterSchema, &out.AlphaServiceInstanceUpdateParameterSchema
+		if in.ServiceInstanceUpdateParameterSchema != nil {
+			in, out := &in.ServiceInstanceUpdateParameterSchema, &out.ServiceInstanceUpdateParameterSchema
 			if newVal, err := c.DeepCopy(*in); err != nil {
 				return err
 			} else {
 				*out = newVal.(*runtime.RawExtension)
 			}
 		}
-		if in.AlphaServiceInstanceCredentialCreateParameterSchema != nil {
-			in, out := &in.AlphaServiceInstanceCredentialCreateParameterSchema, &out.AlphaServiceInstanceCredentialCreateParameterSchema
+		if in.ServiceInstanceCredentialCreateParameterSchema != nil {
+			in, out := &in.ServiceInstanceCredentialCreateParameterSchema, &out.ServiceInstanceCredentialCreateParameterSchema
 			if newVal, err := c.DeepCopy(*in); err != nil {
 				return err
 			} else {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -452,9 +452,9 @@ func convertCatalog(in *osb.CatalogResponse) ([]*v1alpha1.ServiceClass, error) {
 			Plans:         plans,
 			PlanUpdatable: (svc.PlanUpdatable != nil && *svc.PlanUpdatable),
 			ExternalID:    svc.ID,
-			AlphaTags:     svc.Tags,
+			Tags:          svc.Tags,
 			Description:   svc.Description,
-			AlphaRequires: svc.Requires,
+			Requires:      svc.Requires,
 		}
 
 		if svc.Metadata != nil {
@@ -506,7 +506,7 @@ func convertServicePlans(plans []osb.Plan) ([]v1alpha1.ServicePlan, error) {
 						glog.Error(err)
 						return nil, err
 					}
-					ret[i].AlphaServiceInstanceCreateParameterSchema = &runtime.RawExtension{Raw: schema}
+					ret[i].ServiceInstanceCreateParameterSchema = &runtime.RawExtension{Raw: schema}
 				}
 				if instanceUpdateSchema := instanceSchemas.Update; instanceUpdateSchema != nil && instanceUpdateSchema.Parameters != nil {
 					schema, err := json.Marshal(instanceUpdateSchema.Parameters)
@@ -515,7 +515,7 @@ func convertServicePlans(plans []osb.Plan) ([]v1alpha1.ServicePlan, error) {
 						glog.Error(err)
 						return nil, err
 					}
-					ret[i].AlphaServiceInstanceUpdateParameterSchema = &runtime.RawExtension{Raw: schema}
+					ret[i].ServiceInstanceUpdateParameterSchema = &runtime.RawExtension{Raw: schema}
 				}
 			}
 			if bindingSchemas := schemas.ServiceBindings; bindingSchemas != nil {
@@ -526,7 +526,7 @@ func convertServicePlans(plans []osb.Plan) ([]v1alpha1.ServicePlan, error) {
 						glog.Error(err)
 						return nil, err
 					}
-					ret[i].AlphaServiceInstanceCredentialCreateParameterSchema = &runtime.RawExtension{Raw: schema}
+					ret[i].ServiceInstanceCredentialCreateParameterSchema = &runtime.RawExtension{Raw: schema}
 				}
 			}
 		}

--- a/pkg/controller/controller_broker.go
+++ b/pkg/controller/controller_broker.go
@@ -365,9 +365,9 @@ func (c *controller) reconcileServiceClassFromServiceBrokerCatalog(broker *v1alp
 	toUpdate.Bindable = serviceClass.Bindable
 	toUpdate.Plans = serviceClass.Plans
 	toUpdate.PlanUpdatable = serviceClass.PlanUpdatable
-	toUpdate.AlphaTags = serviceClass.AlphaTags
+	toUpdate.Tags = serviceClass.Tags
 	toUpdate.Description = serviceClass.Description
-	toUpdate.AlphaRequires = serviceClass.AlphaRequires
+	toUpdate.Requires = serviceClass.Requires
 
 	if _, err := c.serviceCatalogClient.ServiceClasses().Update(toUpdate); err != nil {
 		glog.Errorf("Error updating serviceClass %v from ServiceBroker %v: %v", serviceClass.Name, broker.Name, err)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -584,12 +584,12 @@ func TestCatalogConversionWithAlphaParameterSchemas(t *testing.T) {
 	}
 
 	plan := serviceClass.Plans[0]
-	if plan.AlphaServiceInstanceCreateParameterSchema == nil {
-		t.Fatalf("Expected plan.AlphaServiceInstanceCreateParameterSchema to be set, but was nil")
+	if plan.ServiceInstanceCreateParameterSchema == nil {
+		t.Fatalf("Expected plan.ServiceInstanceCreateParameterSchema to be set, but was nil")
 	}
 
 	cSchema := make(map[string]interface{})
-	if err := json.Unmarshal(plan.AlphaServiceInstanceCreateParameterSchema.Raw, &cSchema); err == nil {
+	if err := json.Unmarshal(plan.ServiceInstanceCreateParameterSchema.Raw, &cSchema); err == nil {
 		schema := make(map[string]interface{})
 		if err := json.Unmarshal([]byte(instanceParameterSchemaBytes), &schema); err != nil {
 			t.Fatalf("Error unmarshalling schema bytes: %v", err)
@@ -600,21 +600,21 @@ func TestCatalogConversionWithAlphaParameterSchemas(t *testing.T) {
 		}
 	}
 
-	if plan.AlphaServiceInstanceUpdateParameterSchema == nil {
-		t.Fatalf("Expected plan.AlphaServiceInstanceUpdateParameterSchema to be set, but was nil")
+	if plan.ServiceInstanceUpdateParameterSchema == nil {
+		t.Fatalf("Expected plan.ServiceInstanceUpdateParameterSchema to be set, but was nil")
 	}
 	m := make(map[string]string)
-	if err := json.Unmarshal(plan.AlphaServiceInstanceUpdateParameterSchema.Raw, &m); err == nil {
+	if err := json.Unmarshal(plan.ServiceInstanceUpdateParameterSchema.Raw, &m); err == nil {
 		if e, a := "zap", m["baz"]; e != a {
 			t.Fatalf("Unexpected value of alphaServiceInstanceUpdateParameterSchema; expected %v, got %v", e, a)
 		}
 	}
 
-	if plan.AlphaServiceInstanceCredentialCreateParameterSchema == nil {
-		t.Fatalf("Expected plan.AlphaServiceInstanceCredentialCreateParameterSchema to be set, but was nil")
+	if plan.ServiceInstanceCredentialCreateParameterSchema == nil {
+		t.Fatalf("Expected plan.ServiceInstanceCredentialCreateParameterSchema to be set, but was nil")
 	}
 	m = make(map[string]string)
-	if err := json.Unmarshal(plan.AlphaServiceInstanceCredentialCreateParameterSchema.Raw, &m); err == nil {
+	if err := json.Unmarshal(plan.ServiceInstanceCredentialCreateParameterSchema.Raw, &m); err == nil {
 		if e, a := "blu", m["zoo"]; e != a {
 			t.Fatalf("Unexpected value of alphaServiceInstanceCredentialCreateParameterSchema; expected %v, got %v", e, a)
 		}

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -412,7 +412,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 								Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 							},
 						},
-						"alphaTags": {
+						"tags": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Currently, this field is ALPHA: it may change or disappear at any time and its data will not be migrated.\n\nTags is a list of strings that represent different classification attributes of the ServiceClass.  These are used in Cloud Foundry in a way similar to Kubernetes labels, but they currently have no special meaning in Kubernetes.",
 								Type:        []string{"array"},
@@ -426,9 +426,9 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 								},
 							},
 						},
-						"alphaRequires": {
+						"requires": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Currently, this field is ALPHA: it may change or disappear at any time and its data will not be migrated.\n\nAlphaRequires exposes a list of Cloud Foundry-specific 'permissions' that must be granted to an instance of this service within Cloud Foundry.  These 'permissions' have no meaning within Kubernetes and an ServiceInstance provisioned from this ServiceClass will not work correctly.",
+								Description: "Currently, this field is ALPHA: it may change or disappear at any time and its data will not be migrated.\n\nRequires exposes a list of Cloud Foundry-specific 'permissions' that must be granted to an instance of this service within Cloud Foundry.  These 'permissions' have no meaning within Kubernetes and an ServiceInstance provisioned from this ServiceClass will not work correctly.",
 								Type:        []string{"array"},
 								Items: &spec.SchemaOrArray{
 									Schema: &spec.Schema{
@@ -493,7 +493,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 		"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1.ServiceInstance": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "ServiceInstance represents a provisioned instance of a ServiceClass.",
+					Description: "ServiceInstance represents a provisioned instance of a ServiceClass. Currently, the spec field cannot be changed once a ServiceInstance is created.  Spec changes submitted by users will be ignored.\n\nIn the future, this will be allowed and will represent the intention that the ServiceInstance should have the plan and/or parameters updated at the ServiceBroker.",
 					Properties: map[string]spec.Schema{
 						"kind": {
 							SchemaProps: spec.SchemaProps{
@@ -710,7 +710,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 		"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1.ServiceInstanceCredentialSpec": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "ServiceInstanceCredentialSpec represents the desired state of a ServiceInstanceCredential.",
+					Description: "ServiceInstanceCredentialSpec represents the desired state of a ServiceInstanceCredential.\n\nThe spec field cannot be changed after a ServiceInstanceCredential is created.  Changes submitted to the spec field will be ignored.",
 					Properties: map[string]spec.Schema{
 						"instanceRef": {
 							SchemaProps: spec.SchemaProps{
@@ -983,21 +983,21 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 								Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 							},
 						},
-						"alphaInstanceCreateParameterSchema": {
+						"instanceCreateParameterSchema": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Currently, this field is ALPHA: it may change or disappear at any time and its data will not be migrated.\n\nAlphaServiceInstanceCreateParameterSchema is the schema for the parameters that may be supplied when provisioning a new ServiceInstance on this plan.",
+								Description: "Currently, this field is ALPHA: it may change or disappear at any time and its data will not be migrated.\n\nServiceInstanceCreateParameterSchema is the schema for the parameters that may be supplied when provisioning a new ServiceInstance on this plan.",
 								Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 							},
 						},
-						"alphaInstanceUpdateParameterSchema": {
+						"instanceUpdateParameterSchema": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Currently, this field is ALPHA: it may change or disappear at any time and its data will not be migrated.\n\nAlphaServiceInstanceUpdateParameterSchema is the schema for the parameters that may be updated once an ServiceInstance has been provisioned on this plan. This field only has meaning if the ServiceClass is PlanUpdatable.",
+								Description: "Currently, this field is ALPHA: it may change or disappear at any time and its data will not be migrated.\n\nServiceInstanceUpdateParameterSchema is the schema for the parameters that may be updated once an ServiceInstance has been provisioned on this plan. This field only has meaning if the ServiceClass is PlanUpdatable.",
 								Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 							},
 						},
-						"alphaServiceInstanceCredentialCreateParameterSchema": {
+						"serviceInstanceCredentialCreateParameterSchema": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Currently, this field is ALPHA: it may change or disappear at any time and its data will not be migrated.\n\nAlphaServiceInstanceCredentialCreateParameterSchema is the schema for the parameters that may be supplied binding to an ServiceInstance on this plan.",
+								Description: "Currently, this field is ALPHA: it may change or disappear at any time and its data will not be migrated.\n\nServiceInstanceCredentialCreateParameterSchema is the schema for the parameters that may be supplied binding to an ServiceInstance on this plan.",
 								Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 							},
 						},


### PR DESCRIPTION
fixes #1180 

in Types.go remove Alpha from these names
AlphaParameterSchemas
AlphaRequires
AlphaServiceInstanceCreateParameterSchema
AlphaServiceInstanceCredentialCreateParameterSchema
AlphaServiceInstanceUpdateParameterSchema
AlphaTags

and fixup any other code references