### PR TITLE
Removing the helm install command

### DIFF
--- a/contrib/svc-cat-apiserver-aggregation-tls-setup.sh
+++ b/contrib/svc-cat-apiserver-aggregation-tls-setup.sh
@@ -16,8 +16,6 @@
 
 set -o errexit
 
-HELM_SCRIPT=helm-install.sh
-
 export HELM_RELEASE_NAME=${HELM_RELEASE_NAME:-catalog}
 export SVCCAT_NAMESPACE=${SVCCAT_NAMESPACE:-catalog}
 SVCCAT_SERVICE_NAME=${HELM_RELEASE_NAME}-catalog-apiserver

--- a/contrib/svc-cat-apiserver-aggregation-tls-setup.sh
+++ b/contrib/svc-cat-apiserver-aggregation-tls-setup.sh
@@ -63,16 +63,3 @@ echo '{"CN":"'${SVCCAT_SERVICE_NAME}'","hosts":['${ALT_NAMES}'],"key":{"algo":"r
 export SC_SERVING_CA=${SVCCAT_CA_CERT}
 export SC_SERVING_CERT=apiserver.pem
 export SC_SERVING_KEY=apiserver-key.pem
-
-cat <<EOF > $HELM_SCRIPT
-#!/bin/bash
-helm install charts/catalog \\
-  --name ${HELM_RELEASE_NAME} \\
-  --namespace ${SVCCAT_NAMESPACE} \\
-  --set apiserver.auth.enabled=true \\
-  --set useAggregator=true \\
-  --set apiserver.tls.ca=$(base64 --wrap 0 ${SC_SERVING_CA}) \\
-  --set apiserver.tls.cert=$(base64 --wrap 0 ${SC_SERVING_CERT}) \\
-  --set apiserver.tls.key=$(base64 --wrap 0 ${SC_SERVING_KEY})
-EOF
-chmod +x $HELM_SCRIPT


### PR DESCRIPTION
This command is unneeded, since it’s already in the [1.7 install instructions](https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/install-1.7.md#step-2---install-the-helm-chart).

Additionally, this helm command won’t work with BSD `base64` installations (i.e. on Mac OS X). The install instructions explain what to do differently on Mac