### PR TITLE
broker resource secret authorization checking

### DIFF
--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - {{ .Values.apiserver.audit.logPath }}
         {{- end}}
         - --admission-control
-        - "KubernetesNamespaceLifecycle,DefaultServicePlan,ServiceInstanceCredentialsLifecycle,ServicePlanChangeValidator"
+        - "KubernetesNamespaceLifecycle,DefaultServicePlan,ServiceInstanceCredentialsLifecycle,ServicePlanChangeValidator,BrokerAuthSarCheck"
         - --secure-port
         - "8443"
         - --storage-type

--- a/cmd/apiserver/app/plugins.go
+++ b/cmd/apiserver/app/plugins.go
@@ -20,7 +20,8 @@ package app
 // This should probably be part of some configuration fed into the build for a
 // given binary target.
 import (
-	// Admission policies
+	// Admission controllers
+	_ "github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/broker/authsarcheck"
 	_ "github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/namespace/lifecycle"
 	_ "github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/serviceinstancecredentials/lifecycle"
 	_ "github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/serviceplan/changevalidator"

--- a/cmd/apiserver/app/server/server.go
+++ b/cmd/apiserver/app/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/service-catalog/pkg"
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	"github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/broker/authsarcheck"
 	"github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/namespace/lifecycle"
 	siclifecycle "github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/serviceinstancecredentials/lifecycle"
 	"github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/serviceplan/changevalidator"
@@ -141,4 +142,5 @@ func registerAllAdmissionPlugins(plugins *admission.Plugins) {
 	defaultserviceplan.Register(plugins)
 	siclifecycle.Register(plugins)
 	changevalidator.Register(plugins)
+	authsarcheck.Register(plugins)
 }

--- a/plugin/pkg/admission/broker/authsarcheck/admission.go
+++ b/plugin/pkg/admission/broker/authsarcheck/admission.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authsarcheck
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/golang/glog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/admission"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	authorizationapi "k8s.io/client-go/pkg/apis/authorization/v1"
+
+	scadmission "github.com/kubernetes-incubator/service-catalog/pkg/apiserver/admission"
+)
+
+const (
+	pluginName = "BrokerAuthSarCheck"
+)
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(pluginName, func(io.Reader) (admission.Interface, error) {
+		return NewSARCheck()
+	})
+}
+
+// sarcheck is an implementation of admission.Interface.
+// It enforces the creator of a broker has proper access to the auth credentials
+type sarcheck struct {
+	*admission.Handler
+	client kubeclientset.Interface
+}
+
+var _ = scadmission.WantsKubeClientSet(&sarcheck{})
+
+func convertToSARExtra(extra map[string][]string) map[string]authorizationapi.ExtraValue {
+	if extra == nil {
+		return nil
+	}
+
+	ret := map[string]authorizationapi.ExtraValue{}
+	for k, v := range extra {
+		ret[k] = authorizationapi.ExtraValue(v)
+	}
+
+	return ret
+}
+
+func (s *sarcheck) Admit(a admission.Attributes) error {
+	// need to wait for our caches to warm
+	if !s.WaitForReady() {
+		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
+	}
+	// only care about brokers
+	if a.GetResource().Group != servicecatalog.GroupName || a.GetResource().GroupResource() != servicecatalog.Resource("servicebrokers") {
+		return nil
+	}
+	serviceBroker, ok := a.GetObject().(*servicecatalog.ServiceBroker)
+	if !ok {
+		return errors.NewBadRequest("Resource was marked with kind ServiceBroker, but was unable to be converted")
+	}
+	glog.V(5).Infof("Retrieved serviceBroker %v", serviceBroker)
+
+	if serviceBroker.Spec.AuthInfo == nil {
+		// no auth secret to check
+		return nil
+	}
+
+	var secretRef *v1.ObjectReference
+	if serviceBroker.Spec.AuthInfo.Basic != nil {
+		secretRef = serviceBroker.Spec.AuthInfo.Basic.SecretRef
+	} else if serviceBroker.Spec.AuthInfo.Bearer != nil {
+		secretRef = serviceBroker.Spec.AuthInfo.Bearer.SecretRef
+	} else if serviceBroker.Spec.AuthInfo.BasicAuthSecret != nil {
+		// TODO: this field is deprecated, remove in v1beta1
+		secretRef = serviceBroker.Spec.AuthInfo.BasicAuthSecret
+	}
+	userInfo := a.GetUserInfo()
+
+	sar := &authorizationapi.SubjectAccessReview{
+		Spec: authorizationapi.SubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationapi.ResourceAttributes{
+				Namespace: secretRef.Namespace,
+				Verb:      "get",
+				Group:     v1.SchemeGroupVersion.Group,
+				Version:   v1.SchemeGroupVersion.Version,
+				Resource:  v1.ResourceSecrets.String(),
+				Name:      secretRef.Name,
+			},
+			User:   userInfo.GetName(),
+			Groups: userInfo.GetGroups(),
+			Extra:  convertToSARExtra(userInfo.GetExtra()),
+			// TODO: uncomment after rebase onto Kubernetes 1.8.
+			// See https://github.com/kubernetes/kubernetes/pull/49677
+			//UID:    userInfo.GetUID(),
+		},
+	}
+	sar, err := s.client.Authorization().SubjectAccessReviews().Create(sar)
+	if err != nil {
+		return err
+	}
+
+	if !sar.Status.Allowed {
+		return admission.NewForbidden(a, fmt.Errorf("broker forbidden access to auth secret (%s): Reason: %s, EvaluationError: %s", secretRef.Name, sar.Status.Reason, sar.Status.EvaluationError))
+	}
+	return nil
+}
+
+// NewSARCheck creates a new subject access review check admission control handler
+func NewSARCheck() (admission.Interface, error) {
+	return &sarcheck{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}, nil
+}
+
+func (s *sarcheck) SetKubeClientSet(client kubeclientset.Interface) {
+	s.client = client
+}
+
+func (s *sarcheck) Validate() error {
+	if s.client == nil {
+		return fmt.Errorf("missing client")
+	}
+	return nil
+}

--- a/plugin/pkg/admission/broker/authsarcheck/admission_test.go
+++ b/plugin/pkg/admission/broker/authsarcheck/admission_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authsarcheck
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+
+	kubeinformers "k8s.io/client-go/informers"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/pkg/api/v1"
+	authorizationapi "k8s.io/client-go/pkg/apis/authorization/v1"
+	core "k8s.io/client-go/testing"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	scadmission "github.com/kubernetes-incubator/service-catalog/pkg/apiserver/admission"
+)
+
+// newHandlerForTest returns a configured handler for testing.
+func newHandlerForTest(kubeClient kubeclientset.Interface) (admission.Interface, kubeinformers.SharedInformerFactory, error) {
+	kf := kubeinformers.NewSharedInformerFactory(kubeClient, 5*time.Minute)
+	handler, err := NewSARCheck()
+	if err != nil {
+		return nil, kf, err
+	}
+	pluginInitializer := scadmission.NewPluginInitializer(nil, nil, kubeClient, kf)
+	pluginInitializer.Initialize(handler)
+	err = admission.Validate(handler)
+	return handler, kf, err
+}
+
+// newMockKubeClientForTest creates a mock kubernetes client that is configured
+// to allow any SAR creations.
+func newMockKubeClientForTest(userInfo *user.DefaultInfo) *kubefake.Clientset {
+	mockClient := &kubefake.Clientset{}
+	allowed := true
+	if userInfo.GetName() == "system:serviceaccount:test-ns:forbidden" {
+		allowed = false
+	}
+	mockClient.AddReactor("create", "subjectaccessreviews", func(action core.Action) (bool, runtime.Object, error) {
+		mysar := &authorizationapi.SubjectAccessReview{
+			Status: authorizationapi.SubjectAccessReviewStatus{
+				Allowed: allowed,
+				Reason:  "seemed friendly enough",
+			},
+		}
+		return true, mysar, nil
+	})
+	return mockClient
+}
+
+// TestAdmissionBroker tests Admit to ensure that the result from the SAR check
+// is properly checked.
+func TestAdmissionBroker(t *testing.T) {
+	// Anonymous struct fields:
+	// name: short description of the testing
+	// broker: a fake broker object
+	// allowed: flag for whether or not the broker should be admitted
+	cases := []struct {
+		name     string
+		broker   *servicecatalog.ServiceBroker
+		userInfo *user.DefaultInfo
+		allowed  bool
+	}{
+		{
+			name: "broker with no auth",
+			broker: &servicecatalog.ServiceBroker{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-broker",
+				},
+				Spec: servicecatalog.ServiceBrokerSpec{
+					URL: "http://example.com",
+				},
+			},
+			userInfo: &user.DefaultInfo{
+				Name:   "system:serviceaccount:test-ns:catalog",
+				Groups: []string{"system:serviceaccount", "system:serviceaccounts:test-ns"},
+			},
+			allowed: true,
+		},
+		{
+			name: "broker with basic auth, user authenticated",
+			broker: &servicecatalog.ServiceBroker{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-broker",
+				},
+				Spec: servicecatalog.ServiceBrokerSpec{
+					URL: "http://example.com",
+					AuthInfo: &servicecatalog.ServiceBrokerAuthInfo{
+						Basic: &servicecatalog.BasicAuthConfig{
+							SecretRef: &v1.ObjectReference{
+								Namespace: "test-ns",
+								Name:      "test-secret",
+							},
+						},
+					},
+				},
+			},
+			userInfo: &user.DefaultInfo{
+				Name:   "system:serviceaccount:test-ns:catalog",
+				Groups: []string{"system:serviceaccount", "system:serviceaccounts:test-ns"},
+			},
+			allowed: true,
+		},
+		{
+			name: "broker with basic auth, user authenticated (deprecated authinfo field)",
+			broker: &servicecatalog.ServiceBroker{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-broker",
+				},
+				Spec: servicecatalog.ServiceBrokerSpec{
+					URL: "http://example.com",
+					AuthInfo: &servicecatalog.ServiceBrokerAuthInfo{
+						BasicAuthSecret: &v1.ObjectReference{
+							Namespace: "test-ns",
+							Name:      "test-secret",
+						},
+					},
+				},
+			},
+			userInfo: &user.DefaultInfo{
+				Name:   "system:serviceaccount:test-ns:catalog",
+				Groups: []string{"system:serviceaccount", "system:serviceaccounts:test-ns"},
+			},
+			allowed: true,
+		},
+		{
+			name: "broker with bearer token, user authenticated",
+			broker: &servicecatalog.ServiceBroker{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-broker",
+				},
+				Spec: servicecatalog.ServiceBrokerSpec{
+					URL: "http://example.com",
+					AuthInfo: &servicecatalog.ServiceBrokerAuthInfo{
+						Bearer: &servicecatalog.BearerTokenAuthConfig{
+							SecretRef: &v1.ObjectReference{
+								Namespace: "test-ns",
+								Name:      "test-secret",
+							},
+						},
+					},
+				},
+			},
+			userInfo: &user.DefaultInfo{
+				Name:   "system:serviceaccount:test-ns:catalog",
+				Groups: []string{"system:serviceaccount", "system:serviceaccounts:test-ns"},
+			},
+			allowed: true,
+		},
+		{
+			name: "broker with bearer token, unauthenticated user",
+			broker: &servicecatalog.ServiceBroker{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-broker",
+				},
+				Spec: servicecatalog.ServiceBrokerSpec{
+					URL: "http://example.com",
+					AuthInfo: &servicecatalog.ServiceBrokerAuthInfo{
+						Bearer: &servicecatalog.BearerTokenAuthConfig{
+							SecretRef: &v1.ObjectReference{
+								Namespace: "test-ns",
+								Name:      "test-secret",
+							},
+						},
+					},
+				},
+			},
+			userInfo: &user.DefaultInfo{
+				Name:   "system:serviceaccount:test-ns:forbidden",
+				Groups: []string{"system:serviceaccount", "system:serviceaccounts:test-ns"},
+			},
+			allowed: false,
+		},
+	}
+
+	for _, tc := range cases {
+		mockKubeClient := newMockKubeClientForTest(tc.userInfo)
+		handler, kubeInformerFactory, err := newHandlerForTest(mockKubeClient)
+		if err != nil {
+			t.Errorf("unexpected error initializing handler: %v", err)
+		}
+		kubeInformerFactory.Start(wait.NeverStop)
+
+		err = handler.Admit(admission.NewAttributesRecord(tc.broker, nil, servicecatalog.Kind("ServiceBroker").WithVersion("version"), tc.broker.Namespace, tc.broker.Name, servicecatalog.Resource("servicebrokers").WithVersion("version"), "", admission.Create, tc.userInfo))
+		if err != nil && tc.allowed || err == nil && !tc.allowed {
+			t.Errorf("Create test '%s' reports: Unexpected error returned from admission handler: %v", tc.name, err)
+		}
+	}
+}


### PR DESCRIPTION
See #1167; ensures that the creator of a `ServiceBroker` resource is allowed to GET any secret that holds auth credentials for that broker.