### PR TITLE
Keep consistentcy between charts/catalog/README and README

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -2,7 +2,7 @@
 
 Service Catalog is a Kubernetes Incubator project that provides a
 Kubernetes-native workflow for integrating with 
-[Open Service Brokers](https://www.openservicebrokerapi.org/) 
+[Open Service Brokers](https://www.openservicebrokerapi.org/)
 to provision and bind to application dependencies like databases, object
 storage, message-oriented middleware, and more.
 

--- a/pkg/brokerapi/broker_client.go
+++ b/pkg/brokerapi/broker_client.go
@@ -20,8 +20,8 @@ package brokerapi
 // retrieval, service instance management, and service binding management.
 //
 // The broker client defines functions for the catalog, instance and binding APIs for the
-// open service broker API (https://www.openservicebrokerapi.org/, based on the cloud foundry
-// service broker API: https://docs.cloudfoundry.org/services/api.html).
+// Open Service Broker API (https://www.openservicebrokerapi.org/, based on the Cloud Foundry
+// Service Broker API: https://docs.cloudfoundry.org/services/api.html).
 //
 // Each function accepts and returns parameters that are unique to this package. For example,
 // the catalog API function, GetCatalog, returns a *brokerapi.Catalog data type. Most callers


### PR DESCRIPTION
Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>

1. According to  #1188,  it doesn't work fine by https. 
   modify URL from https to http
2. Keep consistentcy between charts/catalog/README and README