### PR TITLE
Fix gofmt issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ $(BINDIR)/e2e.test: .init
 .PHONY: verify verify-client-gen
 verify: .init .generate_files verify-client-gen
 	@echo Running gofmt:
-	@$(DOCKER_CMD) gofmt -l -s $(TOP_TEST_DIRS) $(TOP_SRC_DIRS) &> .out || true
+	@$(DOCKER_CMD) gofmt -l -s $(TOP_TEST_DIRS) $(TOP_SRC_DIRS)>.out 2>&1||true
 	@bash -c '[ "`cat .out`" == "" ] || \
 	  (echo -e "\n*** Please 'gofmt' the following:" ; cat .out ; echo ; false)'
 	@rm .out


### PR DESCRIPTION
When running "make verify" I see this:
```
Running gofmt:
Running golint and go vet:
pkg/apis/servicecatalog/checksum/checksum_test.go
```

What's odd is that the file name is due to the gofmt not the golint.
But, the real issues are:
1) the `&>` in the Makefile isn't getting picked up
2) the gofmt issue

This PR replaces `&>` with `> .out 2>&1` and fixes the gofmt issue

Signed-off-by: Doug Davis <dug@us.ibm.com>