### PR TITLE
fix cleaning of build output for non-root users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,11 +288,11 @@ test-e2e: .generate_files $(BINDIR)/e2e.test
 clean: clean-bin clean-build-image clean-generated clean-coverage
 
 clean-bin:
-	rm -rf $(BINDIR)
+	$(DOCKER_CMD) rm -rf $(BINDIR)
 	rm -f .generate_exes
 
 clean-build-image:
-	rm -rf .pkg
+	$(DOCKER_CMD) rm -rf .pkg
 	rm -f .scBuildImage
 	docker rmi -f scbuildimage > /dev/null 2>&1 || true
 


### PR DESCRIPTION
The generated `.pkg` and `bin` folders are only deletable by root users, which causes `make clean` to fail for users without those permissions. Deleting from within docker sidesteps this.

This problem broke the v0.0.18 release's image deployment due to the addition of `$(MAKE) clean-bin` in #1179 , and should be dealt with ASAP.