### PR TITLE
Removing errexit from TLS setup script

### DIFF
--- a/contrib/svc-cat-apiserver-aggregation-tls-setup.sh
+++ b/contrib/svc-cat-apiserver-aggregation-tls-setup.sh
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o errexit
 
 export HELM_RELEASE_NAME=${HELM_RELEASE_NAME:-catalog}
 export SVCCAT_NAMESPACE=${SVCCAT_NAMESPACE:-catalog}


### PR DESCRIPTION
Since this script is being sourced, it causes any errors in future commands to terminate the terminal session. In the future, I'd like to remove this script and replace it with a helm plugin or similar. For now, this fix makes the install experience a bit smoother.

cc/ @nilebox @jpeeler @MHBauer 