### PR TITLE
admission controller blocks Instance plan changes when Class specifies not updatable

### DIFF
--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - {{ .Values.apiserver.audit.logPath }}
         {{- end}}
         - --admission-control
-        - "KubernetesNamespaceLifecycle,DefaultServicePlan,ServiceInstanceCredentialsLifecycle"
+        - "KubernetesNamespaceLifecycle,DefaultServicePlan,ServiceInstanceCredentialsLifecycle,ServicePlanChangeValidator"
         - --secure-port
         - "8443"
         - --storage-type

--- a/cmd/apiserver/app/plugins.go
+++ b/cmd/apiserver/app/plugins.go
@@ -23,5 +23,6 @@ import (
 	// Admission policies
 	_ "github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/namespace/lifecycle"
 	_ "github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/serviceinstancecredentials/lifecycle"
+	_ "github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/serviceplan/changevalidator"
 	_ "github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/serviceplan/defaultserviceplan"
 )

--- a/cmd/apiserver/app/server/server.go
+++ b/cmd/apiserver/app/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
 	"github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/namespace/lifecycle"
 	siclifecycle "github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/serviceinstancecredentials/lifecycle"
+	"github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/serviceplan/changevalidator"
 	"github.com/kubernetes-incubator/service-catalog/plugin/pkg/admission/serviceplan/defaultserviceplan"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -139,4 +140,5 @@ func registerAllAdmissionPlugins(plugins *admission.Plugins) {
 	lifecycle.Register(plugins)
 	defaultserviceplan.Register(plugins)
 	siclifecycle.Register(plugins)
+	changevalidator.Register(plugins)
 }

--- a/plugin/pkg/admission/serviceplan/changevalidator/admission.go
+++ b/plugin/pkg/admission/serviceplan/changevalidator/admission.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package changevalidator
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/golang/glog"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/admission"
+
+	informers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/internalversion"
+	internalversion "github.com/kubernetes-incubator/service-catalog/pkg/client/listers_generated/servicecatalog/internalversion"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	scadmission "github.com/kubernetes-incubator/service-catalog/pkg/apiserver/admission"
+)
+
+const (
+	// PluginName is name of admission plug-in
+	PluginName = "ServicePlanChangeValidator"
+)
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(io.Reader) (admission.Interface, error) {
+		return NewDenyPlanChangeIfNotUpdatable()
+	})
+}
+
+// denyPlanChangeIfNotUpdatable is an implementation of admission.Interface.
+// It checks if the Service Instance is being updated with a Service Plan and
+// blocks the operation if the Service Class is set to PlanUpdatable=false
+type denyPlanChangeIfNotUpdatable struct {
+	*admission.Handler
+	scLister       internalversion.ServiceClassLister
+	instanceLister internalversion.ServiceInstanceLister
+}
+
+var _ = scadmission.WantsInternalServiceCatalogInformerFactory(&denyPlanChangeIfNotUpdatable{})
+
+func (d *denyPlanChangeIfNotUpdatable) Admit(a admission.Attributes) error {
+	// we need to wait for our caches to warm
+	if !d.WaitForReady() {
+		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
+	}
+
+	// We only care about service Instances
+	if a.GetResource().Group != servicecatalog.GroupName || a.GetResource().GroupResource() != servicecatalog.Resource("serviceinstances") {
+		return nil
+	}
+	instance, ok := a.GetObject().(*servicecatalog.ServiceInstance)
+	if !ok {
+		return apierrors.NewBadRequest("Resource was marked with kind Instance but was unable to be converted")
+	}
+
+	sc, err := d.scLister.Get(instance.Spec.ServiceClassName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			glog.V(5).Infof("Could not locate service class %v, can not determine if UpdateablePlan.", instance.Spec.ServiceClassName)
+			return nil
+		}
+		glog.Error(err)
+		return admission.NewForbidden(a, err)
+	}
+
+	if sc.PlanUpdatable {
+		return nil
+	}
+
+	if instance.Spec.PlanName != "" {
+		lister := d.instanceLister.ServiceInstances(instance.Namespace)
+		origInstance, err := lister.Get(instance.Name)
+		if err != nil {
+			glog.Errorf("Error locating instance %v/%v", instance.Namespace, instance.Name)
+			return err
+		}
+		if instance.Spec.PlanName != origInstance.Spec.PlanName {
+			glog.V(4).Infof("update Service Instance %v/%v request specified Plan Name %v while original instance had %v", instance.Namespace, instance.Name, instance.Spec.PlanName, origInstance.Spec.PlanName)
+			msg := fmt.Sprintf("The Service Class %v does not allow plan changes.", sc.Name)
+			glog.Error(msg)
+			return admission.NewForbidden(a, errors.New(msg))
+		}
+	}
+
+	return nil
+}
+
+// NewDenyPlanChangeIfNotUpdatable creates a new admission control handler that
+// blocks updates to an instance service plan if the instance has
+// PlanUpdatable=false
+// specified Service Class
+func NewDenyPlanChangeIfNotUpdatable() (admission.Interface, error) {
+	return &denyPlanChangeIfNotUpdatable{
+		Handler: admission.NewHandler(admission.Update),
+	}, nil
+}
+
+func (d *denyPlanChangeIfNotUpdatable) SetInternalServiceCatalogInformerFactory(f informers.SharedInformerFactory) {
+	scInformer := f.Servicecatalog().InternalVersion().ServiceClasses()
+	instanceInformer := f.Servicecatalog().InternalVersion().ServiceInstances()
+	d.instanceLister = instanceInformer.Lister()
+	d.scLister = scInformer.Lister()
+	d.SetReadyFunc(scInformer.Informer().HasSynced)
+}
+
+func (d *denyPlanChangeIfNotUpdatable) Validate() error {
+	if d.scLister == nil {
+		return errors.New("missing service class lister")
+	}
+	if d.instanceLister == nil {
+		return errors.New("missing instance lister")
+	}
+	return nil
+}

--- a/plugin/pkg/admission/serviceplan/changevalidator/admission_test.go
+++ b/plugin/pkg/admission/serviceplan/changevalidator/admission_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package changevalidator
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/admission"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	scadmission "github.com/kubernetes-incubator/service-catalog/pkg/apiserver/admission"
+	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/internalclientset"
+	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/internalclientset/fake"
+	informers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/internalversion"
+	core "k8s.io/client-go/testing"
+)
+
+// newHandlerForTest returns a configured handler for testing.
+func newHandlerForTest(internalClient internalclientset.Interface) (admission.Interface, informers.SharedInformerFactory, error) {
+	f := informers.NewSharedInformerFactory(internalClient, 5*time.Minute)
+	handler, err := NewDenyPlanChangeIfNotUpdatable()
+	if err != nil {
+		return nil, f, err
+	}
+	pluginInitializer := scadmission.NewPluginInitializer(internalClient, f, nil, nil)
+	pluginInitializer.Initialize(handler)
+	err = admission.Validate(handler)
+	return handler, f, err
+}
+
+// newFakeServiceCatalogClientForTest creates a fake clientset that returns a
+// ServiceClassList with the given ServiceClass as the single list item.
+func newFakeServiceCatalogClientForTest(sc *servicecatalog.ServiceClass) *fake.Clientset {
+	fakeClient := &fake.Clientset{}
+
+	scList := &servicecatalog.ServiceClassList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "1",
+		}}
+	scList.Items = append(scList.Items, *sc)
+
+	fakeClient.AddReactor("list", "serviceclasses", func(action core.Action) (bool, runtime.Object, error) {
+		return true, scList, nil
+	})
+	return fakeClient
+}
+
+// newServiceInstance returns a new instance for the specified namespace.
+func newServiceInstance(namespace string, serviceClassName string, planName string) servicecatalog.ServiceInstance {
+	instance := servicecatalog.ServiceInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "instance", Namespace: namespace},
+	}
+	instance.Spec.ServiceClassName = serviceClassName
+	instance.Spec.PlanName = planName
+	return instance
+}
+
+// newServiceClass returns a new instance with the specified plan and
+// UpdateablePlan attribute
+func newServiceClass(name string, plan string, updateablePlan bool) *servicecatalog.ServiceClass {
+	sc := &servicecatalog.ServiceClass{ObjectMeta: metav1.ObjectMeta{Name: name}, PlanUpdatable: updateablePlan}
+	sc.Plans = append(sc.Plans, servicecatalog.ServicePlan{Name: plan})
+	return sc
+}
+
+// setupInstanceLister creates a Service Instance and sets up a Instance Lister that
+// retuns the instance
+func setupInstanceLister(fakeClient *fake.Clientset) {
+	instance := newServiceInstance("dummy", "foo", "original-plan-name")
+	scList := &servicecatalog.ServiceInstanceList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "1",
+		}}
+	scList.Items = append(scList.Items, instance)
+
+	fakeClient.AddReactor("list", "serviceinstances", func(action core.Action) (bool, runtime.Object, error) {
+		return true, scList, nil
+	})
+}
+
+// TestServicePlanChangeBlockedByUpdateablePlanSetting tests that the
+// Admission Controller will block a request to update an Instance's
+// Service Plan
+func TestServicePlanChangeBlockedByUpdateablePlanSetting(t *testing.T) {
+	sc := newServiceClass("foo", "bar", false)
+	fakeClient := newFakeServiceCatalogClientForTest(sc)
+	handler, informerFactory, err := newHandlerForTest(fakeClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+	setupInstanceLister(fakeClient)
+	instance := newServiceInstance("dummy", "foo", "new-plan")
+	informerFactory.Start(wait.NeverStop)
+	err = handler.Admit(admission.NewAttributesRecord(&instance, nil, servicecatalog.Kind("ServiceInstance").WithVersion("version"), instance.Namespace, instance.Name, servicecatalog.Resource("serviceinstances").WithVersion("version"), "", admission.Update, nil))
+	if err != nil {
+		if !strings.Contains(err.Error(), "The Service Class foo does not allow plan changes.") {
+			t.Errorf("unexpected error %q returned from admission handler.", err.Error())
+		}
+	} else {
+		t.Error("This should have been an error")
+	}
+}
+
+// TestServicePlanChangePermittedByUpdateablePlanSetting tests the
+// Admission Controller verifying it allows an instance change to the
+// plan name if the service class has specified PlanUpdatable=true
+func TestServicePlanChangePermittedByUpdateablePlanSetting(t *testing.T) {
+	sc := newServiceClass("foo", "bar", true)
+	fakeClient := newFakeServiceCatalogClientForTest(sc)
+	handler, informerFactory, err := newHandlerForTest(fakeClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+
+	setupInstanceLister(fakeClient)
+
+	instance := newServiceInstance("dummy", "foo", "new-plan")
+	informerFactory.Start(wait.NeverStop)
+	err = handler.Admit(admission.NewAttributesRecord(&instance, nil, servicecatalog.Kind("ServiceInstance").WithVersion("version"), instance.Namespace, instance.Name, servicecatalog.Resource("serviceinstances").WithVersion("version"), "", admission.Update, nil))
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err.Error())
+	}
+}


### PR DESCRIPTION
New admission controller invoked on Instance updates.  This validates that if the instance plan has been changed that the service class has been configured with PlanUpdatable=true.  If not, the controller returns a 403.

I realize we'll have to make changes when #1106 lands

fixes #869 