### PR TITLE
#1149 - block concurrent updates to ServiceInstance and ServiceInstanceCredential

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -57,6 +57,7 @@ type ServiceBrokerSpec struct {
 	// This is strongly discouraged.  You should use the CABundle instead.
 	// +optional
 	InsecureSkipTLSVerify bool
+
 	// CABundle is a PEM encoded CA bundle which will be used to validate a Broker's serving certificate.
 	// +optional
 	CABundle []byte
@@ -446,6 +447,10 @@ type ServiceInstanceStatus struct {
 	// the service instance.
 	DashboardURL *string
 
+	// CurrentOperation is the operation the Controller is currently performing
+	// on the ServiceInstance.
+	CurrentOperation ServiceInstanceOperation
+
 	// ReconciledGeneration is the 'Generation' of the serviceInstanceSpec that
 	// was last processed by the controller. The reconciled generation is updated
 	// even if the controller failed to process the spec.
@@ -487,6 +492,22 @@ const (
 	// ServiceInstanceConditionFailed represents information about a final failure
 	// that should not be retried.
 	ServiceInstanceConditionFailed ServiceInstanceConditionType = "Failed"
+)
+
+// ServiceInstanceOperation represents a type of operation the controller can
+// be performing for a service instance in the OSB API.
+type ServiceInstanceOperation string
+
+const (
+	// ServiceInstanceOperationProvision indicates that the ServiceInstance is
+	// being Provisioned.
+	ServiceInstanceOperationProvision ServiceInstanceOperation = "Provision"
+	// ServiceInstanceOperationUpdate indicates that the ServiceInstance is
+	// being Updated.
+	ServiceInstanceOperationUpdate ServiceInstanceOperation = "Update"
+	// ServiceInstanceOperationDeprovision indicates that the ServiceInstance is
+	// being Deprovisioned.
+	ServiceInstanceOperationDeprovision ServiceInstanceOperation = "Deprovision"
 )
 
 // ServiceInstanceCredentialList is a list of ServiceInstanceCredentials.
@@ -560,6 +581,10 @@ type ServiceInstanceCredentialSpec struct {
 type ServiceInstanceCredentialStatus struct {
 	Conditions []ServiceInstanceCredentialCondition
 
+	// CurrentOperation is the operation the Controller is currently performing
+	// on the ServiceInstanceCredential.
+	CurrentOperation ServiceInstanceCredentialOperation
+
 	// ReconciledGeneration is the 'Generation' of the
 	// serviceInstanceCredentialSpec that was last processed by the controller.
 	// The reconciled generation is updated even if the controller failed to
@@ -601,6 +626,19 @@ const (
 	// ServiceInstanceCredentialConditionFailed represents a ServiceInstanceCredentialCondition that has failed
 	// completely and should not be retried.
 	ServiceInstanceCredentialConditionFailed ServiceInstanceCredentialConditionType = "Failed"
+)
+
+// ServiceInstanceCredentialOperation represents a type of operation
+// the controller can be performing for a binding in the OSB API.
+type ServiceInstanceCredentialOperation string
+
+const (
+	// ServiceInstanceCredentialOperationBind indicates that the
+	// ServiceInstanceCredential is being bound.
+	ServiceInstanceCredentialOperationBind ServiceInstanceCredentialOperation = "Bind"
+	// ServiceInstanceCredentialOperationUnbind indicates that the
+	// ServiceInstanceCredential is being unbound.
+	ServiceInstanceCredentialOperationUnbind ServiceInstanceCredentialOperation = "Unbind"
 )
 
 // These are internal finalizer values to service catalog, must be qualified name.

--- a/pkg/apis/servicecatalog/v1alpha1/types.generated.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.generated.go
@@ -7274,15 +7274,16 @@ func (x *ServiceInstanceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep2 := !z.EncBinary()
 			yy2arr2 := z.EncBasicHandle().StructToArray
-			var yyq2 [6]bool
+			var yyq2 [7]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
 			yyq2[2] = x.LastOperation != nil
 			yyq2[3] = x.DashboardURL != nil
-			yyq2[5] = x.OperationStartTime != nil
+			yyq2[4] = x.CurrentOperation != ""
+			yyq2[6] = x.OperationStartTime != nil
 			var yynn2 int
 			if yyr2 || yy2arr2 {
-				r.EncodeArrayStart(6)
+				r.EncodeArrayStart(7)
 			} else {
 				yynn2 = 3
 				for _, b := range yyq2 {
@@ -7411,8 +7412,23 @@ func (x *ServiceInstanceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym20 := z.EncBinary()
-				_ = yym20
+				if yyq2[4] {
+					x.CurrentOperation.CodecEncodeSelf(e)
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[4] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("currentOperation"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					x.CurrentOperation.CodecEncodeSelf(e)
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym23 := z.EncBinary()
+				_ = yym23
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ReconciledGeneration))
@@ -7421,8 +7437,8 @@ func (x *ServiceInstanceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("reconciledGeneration"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym21 := z.EncBinary()
-				_ = yym21
+				yym24 := z.EncBinary()
+				_ = yym24
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ReconciledGeneration))
@@ -7430,17 +7446,17 @@ func (x *ServiceInstanceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[5] {
+				if yyq2[6] {
 					if x.OperationStartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym23 := z.EncBinary()
-						_ = yym23
+						yym26 := z.EncBinary()
+						_ = yym26
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.OperationStartTime) {
-						} else if yym23 {
+						} else if yym26 {
 							z.EncBinaryMarshal(x.OperationStartTime)
-						} else if !yym23 && z.IsJSONHandle() {
+						} else if !yym26 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.OperationStartTime)
 						} else {
 							z.EncFallback(x.OperationStartTime)
@@ -7450,20 +7466,20 @@ func (x *ServiceInstanceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2[5] {
+				if yyq2[6] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("operationStartTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.OperationStartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym24 := z.EncBinary()
-						_ = yym24
+						yym27 := z.EncBinary()
+						_ = yym27
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.OperationStartTime) {
-						} else if yym24 {
+						} else if yym27 {
 							z.EncBinaryMarshal(x.OperationStartTime)
-						} else if !yym24 && z.IsJSONHandle() {
+						} else if !yym27 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.OperationStartTime)
 						} else {
 							z.EncFallback(x.OperationStartTime)
@@ -7588,16 +7604,23 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 					*((*string)(x.DashboardURL)) = r.DecodeString()
 				}
 			}
+		case "currentOperation":
+			if r.TryDecodeAsNil() {
+				x.CurrentOperation = ""
+			} else {
+				yyv12 := &x.CurrentOperation
+				yyv12.CodecDecodeSelf(d)
+			}
 		case "reconciledGeneration":
 			if r.TryDecodeAsNil() {
 				x.ReconciledGeneration = 0
 			} else {
-				yyv12 := &x.ReconciledGeneration
-				yym13 := z.DecBinary()
-				_ = yym13
+				yyv13 := &x.ReconciledGeneration
+				yym14 := z.DecBinary()
+				_ = yym14
 				if false {
 				} else {
-					*((*int64)(yyv12)) = int64(r.DecodeInt(64))
+					*((*int64)(yyv13)) = int64(r.DecodeInt(64))
 				}
 			}
 		case "operationStartTime":
@@ -7609,13 +7632,13 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				if x.OperationStartTime == nil {
 					x.OperationStartTime = new(pkg1_v1.Time)
 				}
-				yym15 := z.DecBinary()
-				_ = yym15
+				yym16 := z.DecBinary()
+				_ = yym16
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.OperationStartTime) {
-				} else if yym15 {
+				} else if yym16 {
 					z.DecBinaryUnmarshal(x.OperationStartTime)
-				} else if !yym15 && z.IsJSONHandle() {
+				} else if !yym16 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.OperationStartTime)
 				} else {
 					z.DecFallback(x.OperationStartTime, false)
@@ -7632,16 +7655,16 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj16 int
-	var yyb16 bool
-	var yyhl16 bool = l >= 0
-	yyj16++
-	if yyhl16 {
-		yyb16 = yyj16 > l
+	var yyj17 int
+	var yyb17 bool
+	var yyhl17 bool = l >= 0
+	yyj17++
+	if yyhl17 {
+		yyb17 = yyj17 > l
 	} else {
-		yyb16 = r.CheckBreak()
+		yyb17 = r.CheckBreak()
 	}
-	if yyb16 {
+	if yyb17 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7649,21 +7672,21 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv17 := &x.Conditions
-		yym18 := z.DecBinary()
-		_ = yym18
+		yyv18 := &x.Conditions
+		yym19 := z.DecBinary()
+		_ = yym19
 		if false {
 		} else {
-			h.decSliceServiceInstanceCondition((*[]ServiceInstanceCondition)(yyv17), d)
+			h.decSliceServiceInstanceCondition((*[]ServiceInstanceCondition)(yyv18), d)
 		}
 	}
-	yyj16++
-	if yyhl16 {
-		yyb16 = yyj16 > l
+	yyj17++
+	if yyhl17 {
+		yyb17 = yyj17 > l
 	} else {
-		yyb16 = r.CheckBreak()
+		yyb17 = r.CheckBreak()
 	}
-	if yyb16 {
+	if yyb17 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7671,21 +7694,21 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.AsyncOpInProgress = false
 	} else {
-		yyv19 := &x.AsyncOpInProgress
-		yym20 := z.DecBinary()
-		_ = yym20
+		yyv20 := &x.AsyncOpInProgress
+		yym21 := z.DecBinary()
+		_ = yym21
 		if false {
 		} else {
-			*((*bool)(yyv19)) = r.DecodeBool()
+			*((*bool)(yyv20)) = r.DecodeBool()
 		}
 	}
-	yyj16++
-	if yyhl16 {
-		yyb16 = yyj16 > l
+	yyj17++
+	if yyhl17 {
+		yyb17 = yyj17 > l
 	} else {
-		yyb16 = r.CheckBreak()
+		yyb17 = r.CheckBreak()
 	}
-	if yyb16 {
+	if yyb17 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7698,20 +7721,20 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if x.LastOperation == nil {
 			x.LastOperation = new(string)
 		}
-		yym22 := z.DecBinary()
-		_ = yym22
+		yym23 := z.DecBinary()
+		_ = yym23
 		if false {
 		} else {
 			*((*string)(x.LastOperation)) = r.DecodeString()
 		}
 	}
-	yyj16++
-	if yyhl16 {
-		yyb16 = yyj16 > l
+	yyj17++
+	if yyhl17 {
+		yyb17 = yyj17 > l
 	} else {
-		yyb16 = r.CheckBreak()
+		yyb17 = r.CheckBreak()
 	}
-	if yyb16 {
+	if yyb17 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7724,20 +7747,37 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if x.DashboardURL == nil {
 			x.DashboardURL = new(string)
 		}
-		yym24 := z.DecBinary()
-		_ = yym24
+		yym25 := z.DecBinary()
+		_ = yym25
 		if false {
 		} else {
 			*((*string)(x.DashboardURL)) = r.DecodeString()
 		}
 	}
-	yyj16++
-	if yyhl16 {
-		yyb16 = yyj16 > l
+	yyj17++
+	if yyhl17 {
+		yyb17 = yyj17 > l
 	} else {
-		yyb16 = r.CheckBreak()
+		yyb17 = r.CheckBreak()
 	}
-	if yyb16 {
+	if yyb17 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.CurrentOperation = ""
+	} else {
+		yyv26 := &x.CurrentOperation
+		yyv26.CodecDecodeSelf(d)
+	}
+	yyj17++
+	if yyhl17 {
+		yyb17 = yyj17 > l
+	} else {
+		yyb17 = r.CheckBreak()
+	}
+	if yyb17 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7745,21 +7785,21 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.ReconciledGeneration = 0
 	} else {
-		yyv25 := &x.ReconciledGeneration
-		yym26 := z.DecBinary()
-		_ = yym26
+		yyv27 := &x.ReconciledGeneration
+		yym28 := z.DecBinary()
+		_ = yym28
 		if false {
 		} else {
-			*((*int64)(yyv25)) = int64(r.DecodeInt(64))
+			*((*int64)(yyv27)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj16++
-	if yyhl16 {
-		yyb16 = yyj16 > l
+	yyj17++
+	if yyhl17 {
+		yyb17 = yyj17 > l
 	} else {
-		yyb16 = r.CheckBreak()
+		yyb17 = r.CheckBreak()
 	}
-	if yyb16 {
+	if yyb17 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7772,30 +7812,30 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if x.OperationStartTime == nil {
 			x.OperationStartTime = new(pkg1_v1.Time)
 		}
-		yym28 := z.DecBinary()
-		_ = yym28
+		yym30 := z.DecBinary()
+		_ = yym30
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.OperationStartTime) {
-		} else if yym28 {
+		} else if yym30 {
 			z.DecBinaryUnmarshal(x.OperationStartTime)
-		} else if !yym28 && z.IsJSONHandle() {
+		} else if !yym30 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.OperationStartTime)
 		} else {
 			z.DecFallback(x.OperationStartTime, false)
 		}
 	}
 	for {
-		yyj16++
-		if yyhl16 {
-			yyb16 = yyj16 > l
+		yyj17++
+		if yyhl17 {
+			yyb17 = yyj17 > l
 		} else {
-			yyb16 = r.CheckBreak()
+			yyb17 = r.CheckBreak()
 		}
-		if yyb16 {
+		if yyb17 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj16-1, "")
+		z.DecStructFieldNotFound(yyj17-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -8182,6 +8222,32 @@ func (x ServiceInstanceConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
 }
 
 func (x *ServiceInstanceConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1 := z.DecBinary()
+	_ = yym1
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		*((*string)(x)) = r.DecodeString()
+	}
+}
+
+func (x ServiceInstanceOperation) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	yym1 := z.EncBinary()
+	_ = yym1
+	if false {
+	} else if z.HasExtensions() && z.EncExt(x) {
+	} else {
+		r.EncodeString(codecSelferC_UTF81234, string(x))
+	}
+}
+
+func (x *ServiceInstanceOperation) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -9427,13 +9493,14 @@ func (x *ServiceInstanceCredentialStatus) CodecEncodeSelf(e *codec1978.Encoder) 
 		} else {
 			yysep2 := !z.EncBinary()
 			yy2arr2 := z.EncBasicHandle().StructToArray
-			var yyq2 [3]bool
+			var yyq2 [4]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[2] = x.OperationStartTime != nil
+			yyq2[1] = x.CurrentOperation != ""
+			yyq2[3] = x.OperationStartTime != nil
 			var yynn2 int
 			if yyr2 || yy2arr2 {
-				r.EncodeArrayStart(3)
+				r.EncodeArrayStart(4)
 			} else {
 				yynn2 = 2
 				for _, b := range yyq2 {
@@ -9473,8 +9540,23 @@ func (x *ServiceInstanceCredentialStatus) CodecEncodeSelf(e *codec1978.Encoder) 
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym7 := z.EncBinary()
-				_ = yym7
+				if yyq2[1] {
+					x.CurrentOperation.CodecEncodeSelf(e)
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2[1] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("currentOperation"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					x.CurrentOperation.CodecEncodeSelf(e)
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				yym10 := z.EncBinary()
+				_ = yym10
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ReconciledGeneration))
@@ -9483,8 +9565,8 @@ func (x *ServiceInstanceCredentialStatus) CodecEncodeSelf(e *codec1978.Encoder) 
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("reconciledGeneration"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym8 := z.EncBinary()
-				_ = yym8
+				yym11 := z.EncBinary()
+				_ = yym11
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ReconciledGeneration))
@@ -9492,17 +9574,17 @@ func (x *ServiceInstanceCredentialStatus) CodecEncodeSelf(e *codec1978.Encoder) 
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[2] {
+				if yyq2[3] {
 					if x.OperationStartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym10 := z.EncBinary()
-						_ = yym10
+						yym13 := z.EncBinary()
+						_ = yym13
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.OperationStartTime) {
-						} else if yym10 {
+						} else if yym13 {
 							z.EncBinaryMarshal(x.OperationStartTime)
-						} else if !yym10 && z.IsJSONHandle() {
+						} else if !yym13 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.OperationStartTime)
 						} else {
 							z.EncFallback(x.OperationStartTime)
@@ -9512,20 +9594,20 @@ func (x *ServiceInstanceCredentialStatus) CodecEncodeSelf(e *codec1978.Encoder) 
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2[2] {
+				if yyq2[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("operationStartTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.OperationStartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym11 := z.EncBinary()
-						_ = yym11
+						yym14 := z.EncBinary()
+						_ = yym14
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.OperationStartTime) {
-						} else if yym11 {
+						} else if yym14 {
 							z.EncBinaryMarshal(x.OperationStartTime)
-						} else if !yym11 && z.IsJSONHandle() {
+						} else if !yym14 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.OperationStartTime)
 						} else {
 							z.EncFallback(x.OperationStartTime)
@@ -9606,16 +9688,23 @@ func (x *ServiceInstanceCredentialStatus) codecDecodeSelfFromMap(l int, d *codec
 					h.decSliceServiceInstanceCredentialCondition((*[]ServiceInstanceCredentialCondition)(yyv4), d)
 				}
 			}
+		case "currentOperation":
+			if r.TryDecodeAsNil() {
+				x.CurrentOperation = ""
+			} else {
+				yyv6 := &x.CurrentOperation
+				yyv6.CodecDecodeSelf(d)
+			}
 		case "reconciledGeneration":
 			if r.TryDecodeAsNil() {
 				x.ReconciledGeneration = 0
 			} else {
-				yyv6 := &x.ReconciledGeneration
-				yym7 := z.DecBinary()
-				_ = yym7
+				yyv7 := &x.ReconciledGeneration
+				yym8 := z.DecBinary()
+				_ = yym8
 				if false {
 				} else {
-					*((*int64)(yyv6)) = int64(r.DecodeInt(64))
+					*((*int64)(yyv7)) = int64(r.DecodeInt(64))
 				}
 			}
 		case "operationStartTime":
@@ -9627,13 +9716,13 @@ func (x *ServiceInstanceCredentialStatus) codecDecodeSelfFromMap(l int, d *codec
 				if x.OperationStartTime == nil {
 					x.OperationStartTime = new(pkg1_v1.Time)
 				}
-				yym9 := z.DecBinary()
-				_ = yym9
+				yym10 := z.DecBinary()
+				_ = yym10
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.OperationStartTime) {
-				} else if yym9 {
+				} else if yym10 {
 					z.DecBinaryUnmarshal(x.OperationStartTime)
-				} else if !yym9 && z.IsJSONHandle() {
+				} else if !yym10 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.OperationStartTime)
 				} else {
 					z.DecFallback(x.OperationStartTime, false)
@@ -9650,16 +9739,16 @@ func (x *ServiceInstanceCredentialStatus) codecDecodeSelfFromArray(l int, d *cod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj10 int
-	var yyb10 bool
-	var yyhl10 bool = l >= 0
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	var yyj11 int
+	var yyb11 bool
+	var yyhl11 bool = l >= 0
+	yyj11++
+	if yyhl11 {
+		yyb11 = yyj11 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb11 = r.CheckBreak()
 	}
-	if yyb10 {
+	if yyb11 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9667,21 +9756,38 @@ func (x *ServiceInstanceCredentialStatus) codecDecodeSelfFromArray(l int, d *cod
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv11 := &x.Conditions
-		yym12 := z.DecBinary()
-		_ = yym12
+		yyv12 := &x.Conditions
+		yym13 := z.DecBinary()
+		_ = yym13
 		if false {
 		} else {
-			h.decSliceServiceInstanceCredentialCondition((*[]ServiceInstanceCredentialCondition)(yyv11), d)
+			h.decSliceServiceInstanceCredentialCondition((*[]ServiceInstanceCredentialCondition)(yyv12), d)
 		}
 	}
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	yyj11++
+	if yyhl11 {
+		yyb11 = yyj11 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb11 = r.CheckBreak()
 	}
-	if yyb10 {
+	if yyb11 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.CurrentOperation = ""
+	} else {
+		yyv14 := &x.CurrentOperation
+		yyv14.CodecDecodeSelf(d)
+	}
+	yyj11++
+	if yyhl11 {
+		yyb11 = yyj11 > l
+	} else {
+		yyb11 = r.CheckBreak()
+	}
+	if yyb11 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9689,21 +9795,21 @@ func (x *ServiceInstanceCredentialStatus) codecDecodeSelfFromArray(l int, d *cod
 	if r.TryDecodeAsNil() {
 		x.ReconciledGeneration = 0
 	} else {
-		yyv13 := &x.ReconciledGeneration
-		yym14 := z.DecBinary()
-		_ = yym14
+		yyv15 := &x.ReconciledGeneration
+		yym16 := z.DecBinary()
+		_ = yym16
 		if false {
 		} else {
-			*((*int64)(yyv13)) = int64(r.DecodeInt(64))
+			*((*int64)(yyv15)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	yyj11++
+	if yyhl11 {
+		yyb11 = yyj11 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb11 = r.CheckBreak()
 	}
-	if yyb10 {
+	if yyb11 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -9716,30 +9822,30 @@ func (x *ServiceInstanceCredentialStatus) codecDecodeSelfFromArray(l int, d *cod
 		if x.OperationStartTime == nil {
 			x.OperationStartTime = new(pkg1_v1.Time)
 		}
-		yym16 := z.DecBinary()
-		_ = yym16
+		yym18 := z.DecBinary()
+		_ = yym18
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.OperationStartTime) {
-		} else if yym16 {
+		} else if yym18 {
 			z.DecBinaryUnmarshal(x.OperationStartTime)
-		} else if !yym16 && z.IsJSONHandle() {
+		} else if !yym18 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.OperationStartTime)
 		} else {
 			z.DecFallback(x.OperationStartTime, false)
 		}
 	}
 	for {
-		yyj10++
-		if yyhl10 {
-			yyb10 = yyj10 > l
+		yyj11++
+		if yyhl11 {
+			yyb11 = yyj11 > l
 		} else {
-			yyb10 = r.CheckBreak()
+			yyb11 = r.CheckBreak()
 		}
-		if yyb10 {
+		if yyb11 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj10-1, "")
+		z.DecStructFieldNotFound(yyj11-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }
@@ -10126,6 +10232,32 @@ func (x ServiceInstanceCredentialConditionType) CodecEncodeSelf(e *codec1978.Enc
 }
 
 func (x *ServiceInstanceCredentialConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym1 := z.DecBinary()
+	_ = yym1
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		*((*string)(x)) = r.DecodeString()
+	}
+}
+
+func (x ServiceInstanceCredentialOperation) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	yym1 := z.EncBinary()
+	_ = yym1
+	if false {
+	} else if z.HasExtensions() && z.EncExt(x) {
+	} else {
+		r.EncodeString(codecSelferC_UTF81234, string(x))
+	}
+}
+
+func (x *ServiceInstanceCredentialOperation) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -11057,7 +11189,7 @@ func (x codecSelfer1234) decSliceServiceInstance(v *[]ServiceInstance, d *codec1
 
 			yyrg1 := len(yyv1) > 0
 			yyv21 := yyv1
-			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 416)
+			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 432)
 			if yyrt1 {
 				if yyrl1 <= cap(yyv1) {
 					yyv1 = yyv1[:yyrl1]
@@ -11657,7 +11789,7 @@ func (x codecSelfer1234) decSliceServiceInstanceCredential(v *[]ServiceInstanceC
 
 			yyrg1 := len(yyv1) > 0
 			yyv21 := yyv1
-			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 392)
+			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 408)
 			if yyrt1 {
 				if yyrl1 <= cap(yyv1) {
 					yyv1 = yyv1[:yyrl1]

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -57,6 +57,7 @@ type ServiceBrokerSpec struct {
 	// This is strongly discouraged.  You should use the CABundle instead.
 	// +optional
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
+
 	// CABundle is a PEM encoded CA bundle which will be used to validate a Broker's serving certificate.
 	// +optional
 	CABundle []byte `json:"caBundle,omitempty"`
@@ -450,6 +451,10 @@ type ServiceInstanceStatus struct {
 	// the service instance.
 	DashboardURL *string `json:"dashboardURL,omitempty"`
 
+	// CurrentOperation is the operation the Controller is currently performing
+	// on the ServiceInstance.
+	CurrentOperation ServiceInstanceOperation `json:"currentOperation,omitempty"`
+
 	// ReconciledGeneration is the 'Generation' of the serviceInstanceSpec that
 	// was last processed by the controller. The reconciled generation is updated
 	// even if the controller failed to process the spec.
@@ -491,6 +496,22 @@ const (
 	// ServiceInstanceConditionFailed represents information about a final failure
 	// that should not be retried.
 	ServiceInstanceConditionFailed ServiceInstanceConditionType = "Failed"
+)
+
+// ServiceInstanceOperation represents a type of operation the controller can
+// be performing for a service instance in the OSB API.
+type ServiceInstanceOperation string
+
+const (
+	// ServiceInstanceOperationProvision indicates that the ServiceInstance is
+	// being Provisioned.
+	ServiceInstanceOperationProvision ServiceInstanceOperation = "Provision"
+	// ServiceInstanceOperationUpdate indicates that the ServiceInstance is
+	// being Updated.
+	ServiceInstanceOperationUpdate ServiceInstanceOperation = "Update"
+	// ServiceInstanceOperationDeprovision indicates that the ServiceInstance is
+	// being Deprovisioned.
+	ServiceInstanceOperationDeprovision ServiceInstanceOperation = "Deprovision"
 )
 
 // ServiceInstanceCredentialList is a list of ServiceInstanceCredentials.
@@ -564,6 +585,10 @@ type ServiceInstanceCredentialSpec struct {
 type ServiceInstanceCredentialStatus struct {
 	Conditions []ServiceInstanceCredentialCondition `json:"conditions"`
 
+	// CurrentOperation is the operation the Controller is currently performing
+	// on the ServiceInstanceCredential.
+	CurrentOperation ServiceInstanceCredentialOperation `json:"currentOperation,omitempty"`
+
 	// ReconciledGeneration is the 'Generation' of the
 	// serviceInstanceCredentialSpec that was last processed by the controller.
 	// The reconciled generation is updated even if the controller failed to
@@ -605,6 +630,19 @@ const (
 	// ServiceInstanceCredentialConditionFailed represents a ServiceInstanceCredentialCondition that has failed
 	// completely and should not be retried.
 	ServiceInstanceCredentialConditionFailed ServiceInstanceCredentialConditionType = "Failed"
+)
+
+// ServiceInstanceCredentialOperation represents a type of operation
+// the controller can be performing for a binding in the OSB API.
+type ServiceInstanceCredentialOperation string
+
+const (
+	// ServiceInstanceCredentialOperationBind indicates that the
+	// ServiceInstanceCredential is being bound.
+	ServiceInstanceCredentialOperationBind ServiceInstanceCredentialOperation = "Bind"
+	// ServiceInstanceCredentialOperationUnbind indicates that the
+	// ServiceInstanceCredential is being unbound.
+	ServiceInstanceCredentialOperationUnbind ServiceInstanceCredentialOperation = "Unbind"
 )
 
 // These are external finalizer values to service catalog, must be qualified name.

--- a/pkg/apis/servicecatalog/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1alpha1/zz_generated.conversion.go
@@ -612,6 +612,7 @@ func Convert_servicecatalog_ServiceInstanceCredentialSpec_To_v1alpha1_ServiceIns
 
 func autoConvert_v1alpha1_ServiceInstanceCredentialStatus_To_servicecatalog_ServiceInstanceCredentialStatus(in *ServiceInstanceCredentialStatus, out *servicecatalog.ServiceInstanceCredentialStatus, s conversion.Scope) error {
 	out.Conditions = *(*[]servicecatalog.ServiceInstanceCredentialCondition)(unsafe.Pointer(&in.Conditions))
+	out.CurrentOperation = servicecatalog.ServiceInstanceCredentialOperation(in.CurrentOperation)
 	out.ReconciledGeneration = in.ReconciledGeneration
 	out.OperationStartTime = (*meta_v1.Time)(unsafe.Pointer(in.OperationStartTime))
 	return nil
@@ -628,6 +629,7 @@ func autoConvert_servicecatalog_ServiceInstanceCredentialStatus_To_v1alpha1_Serv
 	} else {
 		out.Conditions = *(*[]ServiceInstanceCredentialCondition)(unsafe.Pointer(&in.Conditions))
 	}
+	out.CurrentOperation = ServiceInstanceCredentialOperation(in.CurrentOperation)
 	out.ReconciledGeneration = in.ReconciledGeneration
 	out.OperationStartTime = (*meta_v1.Time)(unsafe.Pointer(in.OperationStartTime))
 	return nil
@@ -699,6 +701,7 @@ func autoConvert_v1alpha1_ServiceInstanceStatus_To_servicecatalog_ServiceInstanc
 	out.AsyncOpInProgress = in.AsyncOpInProgress
 	out.LastOperation = (*string)(unsafe.Pointer(in.LastOperation))
 	out.DashboardURL = (*string)(unsafe.Pointer(in.DashboardURL))
+	out.CurrentOperation = servicecatalog.ServiceInstanceOperation(in.CurrentOperation)
 	out.ReconciledGeneration = in.ReconciledGeneration
 	out.OperationStartTime = (*meta_v1.Time)(unsafe.Pointer(in.OperationStartTime))
 	return nil
@@ -718,6 +721,7 @@ func autoConvert_servicecatalog_ServiceInstanceStatus_To_v1alpha1_ServiceInstanc
 	out.AsyncOpInProgress = in.AsyncOpInProgress
 	out.LastOperation = (*string)(unsafe.Pointer(in.LastOperation))
 	out.DashboardURL = (*string)(unsafe.Pointer(in.DashboardURL))
+	out.CurrentOperation = ServiceInstanceOperation(in.CurrentOperation)
 	out.ReconciledGeneration = in.ReconciledGeneration
 	out.OperationStartTime = (*meta_v1.Time)(unsafe.Pointer(in.OperationStartTime))
 	return nil

--- a/pkg/apis/servicecatalog/validation/instance.go
+++ b/pkg/apis/servicecatalog/validation/instance.go
@@ -105,12 +105,13 @@ func validateServiceInstanceStatus(spec *sc.ServiceInstanceStatus, fldPath *fiel
 	return errors
 }
 
-// internalValidateServiceInstanceUpdateAllowed ensures there is not an asynchronous
-// operation ongoing with the instance before allowing an update to go through.
+// internalValidateServiceInstanceUpdateAllowed ensures there is not a
+// pending update on-going with the spec of the instance before allowing an update
+// to the spec to go through.
 func internalValidateServiceInstanceUpdateAllowed(new *sc.ServiceInstance, old *sc.ServiceInstance) field.ErrorList {
 	errors := field.ErrorList{}
-	if old.Status.AsyncOpInProgress {
-		errors = append(errors, field.Forbidden(field.NewPath("spec"), "Another operation for this service instance is in progress"))
+	if old.Generation != new.Generation && old.Status.ReconciledGeneration != old.Generation {
+		errors = append(errors, field.Forbidden(field.NewPath("spec"), "Another update for this service instance is in progress"))
 	}
 	return errors
 }

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -75,7 +75,7 @@ func TestReconcileServiceInstanceCredentialNonExistingServiceInstance(t *testing
 		t.Fatalf("Unexpected verb on actions[0]; expected %v, got %v", e, a)
 	}
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
-	assertServiceInstanceCredentialReadyFalse(t, updatedServiceInstanceCredential, errorNonexistentServiceInstanceReason)
+	assertServiceInstanceCredentialErrorBeforeRequest(t, updatedServiceInstanceCredential, errorNonexistentServiceInstanceReason)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -129,7 +129,7 @@ func TestReconcileServiceInstanceCredentialNonExistingServiceClass(t *testing.T)
 
 	// There should only be one action that says it failed because no such service class.
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
-	assertServiceInstanceCredentialReadyFalse(t, updatedServiceInstanceCredential, errorNonexistentServiceClassMessage)
+	assertServiceInstanceCredentialErrorBeforeRequest(t, updatedServiceInstanceCredential, errorNonexistentServiceClassMessage)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -197,9 +197,13 @@ func TestReconcileServiceInstanceCredentialWithSecretConflict(t *testing.T) {
 	})
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	assertNumberOfActions(t, actions, 2)
+
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding).(*v1alpha1.ServiceInstanceCredential)
-	assertServiceInstanceCredentialReadyFalse(t, updatedServiceInstanceCredential)
+	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
+
+	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding).(*v1alpha1.ServiceInstanceCredential)
+	assertServiceInstanceCredentialReqeustRetriableError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorInjectingBindResultReason)
 
 	kubeActions := fakeKubeClient.Actions()
 	assertNumberOfActions(t, kubeActions, 2)
@@ -293,9 +297,13 @@ func TestReconcileServiceInstanceCredentialWithParameters(t *testing.T) {
 	})
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	assertNumberOfActions(t, actions, 2)
+
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding).(*v1alpha1.ServiceInstanceCredential)
-	assertServiceInstanceCredentialReadyTrue(t, updatedServiceInstanceCredential)
+	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
+
+	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding).(*v1alpha1.ServiceInstanceCredential)
+	assertServiceInstanceCredentialOperationSuccess(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
 
 	kubeActions := fakeKubeClient.Actions()
 	assertNumberOfActions(t, kubeActions, 3)
@@ -383,7 +391,7 @@ func TestReconcileServiceInstanceCredentialNonbindableServiceClass(t *testing.T)
 
 	// There should only be one action that says binding was created
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
-	assertServiceInstanceCredentialReadyFalse(t, updatedServiceInstanceCredential, errorNonbindableServiceClassReason)
+	assertServiceInstanceCredentialErrorBeforeRequest(t, updatedServiceInstanceCredential, errorNonbindableServiceClassReason)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -460,9 +468,13 @@ func TestReconcileServiceInstanceCredentialNonbindableServiceClassBindablePlan(t
 	})
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	assertNumberOfActions(t, actions, 2)
+
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
-	assertServiceInstanceCredentialReadyTrue(t, updatedServiceInstanceCredential)
+	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
+
+	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding)
+	assertServiceInstanceCredentialOperationSuccess(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
 
 	kubeActions := fakeKubeClient.Actions()
 	assertNumberOfActions(t, kubeActions, 3)
@@ -538,7 +550,7 @@ func TestReconcileServiceInstanceCredentialBindableServiceClassNonbindablePlan(t
 
 	// There should only be one action that says binding was created
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
-	assertServiceInstanceCredentialReadyFalse(t, updatedServiceInstanceCredential, errorNonbindableServiceClassReason)
+	assertServiceInstanceCredentialErrorBeforeRequest(t, updatedServiceInstanceCredential, errorNonbindableServiceClassReason)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -594,7 +606,7 @@ func TestReconcileServiceInstanceCredentialFailsWithServiceInstanceAsyncOngoing(
 
 	// There should only be one action that says binding was created
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
-	assertServiceInstanceCredentialReadyFalse(t, updatedServiceInstanceCredential)
+	assertServiceInstanceCredentialErrorBeforeRequest(t, updatedServiceInstanceCredential, errorWithOngoingAsyncOperation)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -647,7 +659,7 @@ func TestReconcileServiceInstanceCredentialServiceInstanceNotReady(t *testing.T)
 
 	// There should only be one action that says binding was created
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
-	assertServiceInstanceCredentialReadyFalse(t, updatedServiceInstanceCredential)
+	assertServiceInstanceCredentialErrorBeforeRequest(t, updatedServiceInstanceCredential, errorServiceInstanceNotReadyReason)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -692,11 +704,11 @@ func TestReconcileServiceInstanceCredentialNamespaceError(t *testing.T) {
 	brokerActions := fakeServiceBrokerClient.Actions()
 	assertNumberOfServiceBrokerActions(t, brokerActions, 0)
 
-	// TODO missing the action
 	actions := fakeCatalogClient.Actions()
 	assertNumberOfActions(t, actions, 1)
+
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
-	assertServiceInstanceCredentialReadyFalse(t, updatedServiceInstanceCredential)
+	assertServiceInstanceCredentialErrorBeforeRequest(t, updatedServiceInstanceCredential, errorFindingNamespaceServiceInstanceReason)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -725,12 +737,15 @@ func TestReconcileServiceInstanceCredentialDelete(t *testing.T) {
 			Namespace:         testNamespace,
 			DeletionTimestamp: &metav1.Time{},
 			Finalizers:        []string{v1alpha1.FinalizerServiceCatalog},
-			Generation:        1,
+			Generation:        2,
 		},
 		Spec: v1alpha1.ServiceInstanceCredentialSpec{
 			ServiceInstanceRef: v1.LocalObjectReference{Name: testServiceInstanceName},
 			ExternalID:         bindingGUID,
 			SecretName:         testServiceInstanceCredentialSecretName,
+		},
+		Status: v1alpha1.ServiceInstanceCredentialStatus{
+			ReconciledGeneration: 1,
 		},
 	}
 
@@ -766,19 +781,16 @@ func TestReconcileServiceInstanceCredentialDelete(t *testing.T) {
 	}
 
 	actions := fakeCatalogClient.Actions()
-	// The three actions should be:
-	// 0. Updating the ready condition
-	// 1. Get against the binding in question
-	// 2. Removing the finalizer
-	assertNumberOfActions(t, actions, 3)
+	// The actions should be:
+	// 0. Updating the current operation
+	// 1. Updating the ready condition
+	assertNumberOfActions(t, actions, 2)
 
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
-	assertServiceInstanceCredentialReadyFalse(t, updatedServiceInstanceCredential)
+	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationUnbind)
 
-	assertGet(t, actions[1], binding)
-
-	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[2], binding)
-	assertEmptyFinalizers(t, updatedServiceInstanceCredential)
+	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding)
+	assertServiceInstanceCredentialOperationSuccess(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationUnbind)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -943,7 +955,7 @@ func TestReconcileServiceInstanceCredentialDeleteFailedServiceInstanceCredential
 	binding.ObjectMeta.DeletionTimestamp = &metav1.Time{}
 	binding.ObjectMeta.Finalizers = []string{v1alpha1.FinalizerServiceCatalog}
 
-	binding.ObjectMeta.Generation = 1
+	binding.ObjectMeta.Generation = 2
 	binding.Status.ReconciledGeneration = 1
 
 	fakeCatalogClient.AddReactor("get", "serviceinstancecredentials", func(action clientgotesting.Action) (bool, runtime.Object, error) {
@@ -978,19 +990,16 @@ func TestReconcileServiceInstanceCredentialDeleteFailedServiceInstanceCredential
 	}
 
 	actions := fakeCatalogClient.Actions()
-	// The three actions should be:
-	// 0. Updating the ready condition
-	// 1. Get against the binding in question
-	// 2. Removing the finalizer
-	assertNumberOfActions(t, actions, 3)
+	// The four actions should be:
+	// 0. Updating the current operation
+	// 1. Updating the ready condition
+	assertNumberOfActions(t, actions, 2)
 
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
-	assertServiceInstanceCredentialReadyFalse(t, updatedServiceInstanceCredential)
+	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationUnbind)
 
-	assertGet(t, actions[1], binding)
-
-	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[2], binding)
-	assertEmptyFinalizers(t, updatedServiceInstanceCredential)
+	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding)
+	assertServiceInstanceCredentialOperationSuccess(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationUnbind)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -1004,7 +1013,7 @@ func TestReconcileServiceInstanceCredentialDeleteFailedServiceInstanceCredential
 // TestReconcileBindingWithBrokerError tests reconcileBinding to ensure a
 // binding request response that contains a broker error fails as expected.
 func TestReconcileServiceInstanceCredentialWithServiceBrokerError(t *testing.T) {
-	_, _, _, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
+	_, fakeCatalogClient, _, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
 		BindReaction: &fakeosb.BindReaction{
 			Response: &osb.BindResponse{
 				Credentials: map[string]interface{}{
@@ -1039,6 +1048,15 @@ func TestReconcileServiceInstanceCredentialWithServiceBrokerError(t *testing.T) 
 		t.Fatal("reconcileServiceInstanceCredential should have returned an error")
 	}
 
+	actions := fakeCatalogClient.Actions()
+	assertNumberOfActions(t, actions, 2)
+
+	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
+	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
+
+	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding)
+	assertServiceInstanceCredentialReqeustRetriableError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorBindCallReason)
+
 	events := getRecordedEvents(testController)
 	expectedEvent := api.EventTypeWarning + " " + errorBindCallReason + " " + `Error creating ServiceInstanceCredential "test-binding/test-ns" for ServiceInstance "test-ns/test-instance" of ServiceClass "test-serviceclass" at ServiceBroker "test-broker": Unexpected action`
 	if 1 != len(events) {
@@ -1052,7 +1070,7 @@ func TestReconcileServiceInstanceCredentialWithServiceBrokerError(t *testing.T) 
 // TestReconcileBindingWithBrokerHTTPError tests reconcileBindings to ensure a
 // binding request response that contains a broker HTTP error fails as expected.
 func TestReconcileServiceInstanceCredentialWithServiceBrokerHTTPError(t *testing.T) {
-	_, _, _, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
+	_, fakeCatalogClient, _, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
 		BindReaction: &fakeosb.BindReaction{
 			Response: &osb.BindResponse{
 				Credentials: map[string]interface{}{
@@ -1086,6 +1104,15 @@ func TestReconcileServiceInstanceCredentialWithServiceBrokerHTTPError(t *testing
 	if err != nil {
 		t.Fatal("reconcileServiceInstanceCredential should not have returned an error")
 	}
+
+	actions := fakeCatalogClient.Actions()
+	assertNumberOfActions(t, actions, 2)
+
+	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
+	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
+
+	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding)
+	assertServiceInstanceCredentialReqeustFailingError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorBindCallReason, "ServiceInstanceCredentialReturnedFailure")
 
 	events := getRecordedEvents(testController)
 	expectedEvent := api.EventTypeWarning + " " + errorBindCallReason + " " + `Error creating ServiceInstanceCredential "test-binding/test-ns" for ServiceInstance "test-ns/test-instance" of ServiceClass "test-serviceclass" at ServiceBroker "test-broker", Status: 422; ErrorMessage: AsyncRequired; Description: This service plan requires client support for asynchronous service operations.; ResponseError: <nil>`
@@ -1155,7 +1182,13 @@ func TestReconcileServiceInstanceCredentialWithServiceInstanceCredentialCallFail
 	}
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	assertNumberOfActions(t, actions, 2)
+
+	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
+	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
+
+	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding)
+	assertServiceInstanceCredentialReqeustRetriableError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorBindCallReason)
 
 	brokerActions := fakeServiceBrokerClient.Actions()
 	assertNumberOfServiceBrokerActions(t, brokerActions, 1)
@@ -1213,17 +1246,13 @@ func TestReconcileServiceInstanceCredentialWithServiceInstanceCredentialFailure(
 	}
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	assertNumberOfActions(t, actions, 2)
 
-	updatedObject := assertUpdateStatus(t, actions[0], binding)
-	assertServiceInstanceCredentialReadyFalse(t, updatedObject)
-	updatedServiceInstanceCredential, ok := updatedObject.(*v1alpha1.ServiceInstanceCredential)
-	if !ok {
-		t.Fatal("Couldn't convert to v1alpha1.ServiceInstanceCredential")
-	}
-	if num := len(updatedServiceInstanceCredential.Status.Conditions); num != 2 {
-		t.Fatalf("Expected two conditions, got %v", num)
-	}
+	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
+	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
+
+	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding)
+	assertServiceInstanceCredentialReqeustFailingError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorBindCallReason, "ServiceInstanceCredentialReturnedFailure")
 
 	brokerActions := fakeServiceBrokerClient.Actions()
 	assertNumberOfServiceBrokerActions(t, brokerActions, 1)
@@ -1438,13 +1467,13 @@ func TestReconcileUnbindingWithServiceBrokerError(t *testing.T) {
 	}
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	assertNumberOfActions(t, actions, 2)
 
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
-	assertServiceInstanceCredentialReadyFalse(t, updatedServiceInstanceCredential)
+	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationUnbind)
 
-	assertServiceInstanceCredentialReconciledGeneration(t, updatedServiceInstanceCredential, 0)
-	assertServiceInstanceCredentialOperationStartTimeSet(t, updatedServiceInstanceCredential, true)
+	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding)
+	assertServiceInstanceCredentialReqeustRetriableError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationUnbind, errorUnbindCallReason)
 
 	events := getRecordedEvents(testController)
 	expectedEvent := api.EventTypeWarning + " " + errorUnbindCallReason + " " + `Error unbinding ServiceInstanceCredential "test-binding/test-ns" for ServiceInstance "test-ns/test-instance" of ServiceClass "test-serviceclass" at ServiceBroker "test-broker": Unexpected action`
@@ -1496,11 +1525,13 @@ func TestReconcileUnbindingWithServiceBrokerHTTPError(t *testing.T) {
 	}
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	assertNumberOfActions(t, actions, 2)
+
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
-	assertServiceInstanceCredentialReadyFalse(t, updatedServiceInstanceCredential)
-	assertServiceInstanceCredentialCondition(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialConditionFailed, v1alpha1.ConditionTrue)
-	assertServiceInstanceCredentialOperationStartTimeSet(t, updatedServiceInstanceCredential, false)
+	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationUnbind)
+
+	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding)
+	assertServiceInstanceCredentialReqeustFailingError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationUnbind, errorUnbindCallReason, errorUnbindCallReason)
 
 	events := getRecordedEvents(testController)
 	expectedEvent := api.EventTypeWarning + " " + errorUnbindCallReason + " " + `Error unbinding ServiceInstanceCredential "test-binding/test-ns" for ServiceInstance "test-ns/test-instance" of ServiceClass "test-serviceclass" at ServiceBroker "test-broker": Status: 410; ErrorMessage: <nil>; Description: <nil>; ResponseError: <nil>`
@@ -1634,6 +1665,7 @@ func TestReconcileBindingSuccessOnFinalRetry(t *testing.T) {
 	sharedInformers.ServiceInstances().Informer().GetStore().Add(getTestServiceInstanceWithStatus(v1alpha1.ConditionTrue))
 
 	binding := getTestServiceInstanceCredential()
+	binding.Status.CurrentOperation = v1alpha1.ServiceInstanceCredentialOperationBind
 	startTime := metav1.NewTime(time.Now().Add(-7 * 24 * time.Hour))
 	binding.Status.OperationStartTime = &startTime
 
@@ -1656,9 +1688,9 @@ func TestReconcileBindingSuccessOnFinalRetry(t *testing.T) {
 
 	actions := fakeCatalogClient.Actions()
 	assertNumberOfActions(t, actions, 1)
+
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding).(*v1alpha1.ServiceInstanceCredential)
-	assertServiceInstanceCredentialReadyTrue(t, updatedServiceInstanceCredential)
-	assertServiceInstanceCredentialOperationStartTimeSet(t, updatedServiceInstanceCredential, false)
+	assertServiceInstanceCredentialOperationSuccess(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -1690,6 +1722,7 @@ func TestReconcileBindingFailureOnFinalRetry(t *testing.T) {
 	sharedInformers.ServiceInstances().Informer().GetStore().Add(getTestServiceInstanceWithStatus(v1alpha1.ConditionTrue))
 
 	binding := getTestServiceInstanceCredential()
+	binding.Status.CurrentOperation = v1alpha1.ServiceInstanceCredentialOperationBind
 	startTime := metav1.NewTime(time.Now().Add(-7 * 24 * time.Hour))
 	binding.Status.OperationStartTime = &startTime
 
@@ -1699,10 +1732,9 @@ func TestReconcileBindingFailureOnFinalRetry(t *testing.T) {
 
 	actions := fakeCatalogClient.Actions()
 	assertNumberOfActions(t, actions, 1)
+
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding).(*v1alpha1.ServiceInstanceCredential)
-	assertServiceInstanceCredentialReadyFalse(t, updatedServiceInstanceCredential)
-	assertServiceInstanceCredentialCondition(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialConditionFailed, v1alpha1.ConditionTrue, errorReconciliationRetryTimeoutReason)
-	assertServiceInstanceCredentialOperationStartTimeSet(t, updatedServiceInstanceCredential, false)
+	assertServiceInstanceCredentialReqeustFailingError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorBindCallReason, errorReconciliationRetryTimeoutReason)
 
 	expectedEventPrefixes := []string{
 		api.EventTypeWarning + " " + errorBindCallReason,
@@ -1745,6 +1777,7 @@ func TestReconcileBindingWithSecretConflictFailedAfterFinalRetry(t *testing.T) {
 	sharedInformers.ServicePlans().Informer().GetStore().Add(getTestServicePlan())
 	sharedInformers.ServiceInstances().Informer().GetStore().Add(getTestServiceInstanceWithStatus(v1alpha1.ConditionTrue))
 
+	startTime := metav1.NewTime(time.Now().Add(-7 * 24 * time.Hour))
 	binding := &v1alpha1.ServiceInstanceCredential{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       testServiceInstanceCredentialName,
@@ -1756,9 +1789,11 @@ func TestReconcileBindingWithSecretConflictFailedAfterFinalRetry(t *testing.T) {
 			ExternalID:         bindingGUID,
 			SecretName:         testServiceInstanceCredentialSecretName,
 		},
+		Status: v1alpha1.ServiceInstanceCredentialStatus{
+			CurrentOperation:   v1alpha1.ServiceInstanceCredentialOperationBind,
+			OperationStartTime: &startTime,
+		},
 	}
-	startTime := metav1.NewTime(time.Now().Add(-7 * 24 * time.Hour))
-	binding.Status.OperationStartTime = &startTime
 
 	if err := testController.reconcileServiceInstanceCredential(binding); err != nil {
 		t.Fatalf("reconciliation should complete since the retry duration has elapsed: %v", err)
@@ -1781,8 +1816,7 @@ func TestReconcileBindingWithSecretConflictFailedAfterFinalRetry(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding).(*v1alpha1.ServiceInstanceCredential)
-	assertServiceInstanceCredentialReadyFalse(t, updatedServiceInstanceCredential)
-	assertServiceInstanceCredentialCondition(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialConditionFailed, v1alpha1.ConditionTrue)
+	assertServiceInstanceCredentialReqeustFailingError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorInjectingBindResultReason, errorReconciliationRetryTimeoutReason)
 
 	kubeActions := fakeKubeClient.Actions()
 	assertNumberOfActions(t, kubeActions, 2)
@@ -1808,4 +1842,46 @@ func TestReconcileBindingWithSecretConflictFailedAfterFinalRetry(t *testing.T) {
 			t.Fatalf("Received unexpected event:\n  expected prefix: %v\n  got: %v", e, a)
 		}
 	}
+}
+
+// TestReconcileServiceInstanceCrednetialWithStatusUpdateError verifies that the
+// reconciler returns an error when there is a conflict updating the status of
+// the resource. This is an otherwise successful scenario where the update to set
+// the in-progress operation fails.
+func TestReconcileServiceInstanceCredentialWithStatusUpdateError(t *testing.T) {
+	fakeKubeClient, fakeCatalogClient, fakeServiceBrokerClient, testController, sharedInformers := newTestController(t, noFakeActions())
+
+	addGetNamespaceReaction(fakeKubeClient)
+	addGetSecretNotFoundReaction(fakeKubeClient)
+
+	sharedInformers.ServiceBrokers().Informer().GetStore().Add(getTestServiceBroker())
+	sharedInformers.ServiceClasses().Informer().GetStore().Add(getTestServiceClass())
+	sharedInformers.ServicePlans().Informer().GetStore().Add(getTestServicePlan())
+	sharedInformers.ServiceInstances().Informer().GetStore().Add(getTestServiceInstanceWithStatus(v1alpha1.ConditionTrue))
+
+	binding := getTestServiceInstanceCredential()
+
+	fakeCatalogClient.AddReactor("update", "serviceinstancecredentials", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("update error")
+	})
+
+	err := testController.reconcileServiceInstanceCredential(binding)
+	if err == nil {
+		t.Fatalf("expected error from but got none")
+	}
+	if e, a := "update error", err.Error(); e != a {
+		t.Fatalf("unexpected error returned: expected %q, got %q", e, a)
+	}
+
+	brokerActions := fakeServiceBrokerClient.Actions()
+	assertNumberOfServiceBrokerActions(t, brokerActions, 0)
+
+	actions := fakeCatalogClient.Actions()
+	assertNumberOfActions(t, actions, 1)
+
+	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding)
+	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
+
+	events := getRecordedEvents(testController)
+	assertNumEvents(t, events, 0)
 }

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -203,7 +203,7 @@ func TestReconcileServiceInstanceCredentialWithSecretConflict(t *testing.T) {
 	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
 
 	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding).(*v1alpha1.ServiceInstanceCredential)
-	assertServiceInstanceCredentialReqeustRetriableError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorInjectingBindResultReason)
+	assertServiceInstanceCredentialRequestRetriableError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorInjectingBindResultReason)
 
 	kubeActions := fakeKubeClient.Actions()
 	assertNumberOfActions(t, kubeActions, 2)
@@ -1055,7 +1055,7 @@ func TestReconcileServiceInstanceCredentialWithServiceBrokerError(t *testing.T) 
 	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
 
 	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding)
-	assertServiceInstanceCredentialReqeustRetriableError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorBindCallReason)
+	assertServiceInstanceCredentialRequestRetriableError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorBindCallReason)
 
 	events := getRecordedEvents(testController)
 	expectedEvent := api.EventTypeWarning + " " + errorBindCallReason + " " + `Error creating ServiceInstanceCredential "test-binding/test-ns" for ServiceInstance "test-ns/test-instance" of ServiceClass "test-serviceclass" at ServiceBroker "test-broker": Unexpected action`
@@ -1112,7 +1112,7 @@ func TestReconcileServiceInstanceCredentialWithServiceBrokerHTTPError(t *testing
 	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
 
 	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding)
-	assertServiceInstanceCredentialReqeustFailingError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorBindCallReason, "ServiceInstanceCredentialReturnedFailure")
+	assertServiceInstanceCredentialRequestFailingError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorBindCallReason, "ServiceInstanceCredentialReturnedFailure")
 
 	events := getRecordedEvents(testController)
 	expectedEvent := api.EventTypeWarning + " " + errorBindCallReason + " " + `Error creating ServiceInstanceCredential "test-binding/test-ns" for ServiceInstance "test-ns/test-instance" of ServiceClass "test-serviceclass" at ServiceBroker "test-broker", Status: 422; ErrorMessage: AsyncRequired; Description: This service plan requires client support for asynchronous service operations.; ResponseError: <nil>`
@@ -1188,7 +1188,7 @@ func TestReconcileServiceInstanceCredentialWithServiceInstanceCredentialCallFail
 	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
 
 	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding)
-	assertServiceInstanceCredentialReqeustRetriableError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorBindCallReason)
+	assertServiceInstanceCredentialRequestRetriableError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorBindCallReason)
 
 	brokerActions := fakeServiceBrokerClient.Actions()
 	assertNumberOfServiceBrokerActions(t, brokerActions, 1)
@@ -1252,7 +1252,7 @@ func TestReconcileServiceInstanceCredentialWithServiceInstanceCredentialFailure(
 	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind)
 
 	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding)
-	assertServiceInstanceCredentialReqeustFailingError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorBindCallReason, "ServiceInstanceCredentialReturnedFailure")
+	assertServiceInstanceCredentialRequestFailingError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorBindCallReason, "ServiceInstanceCredentialReturnedFailure")
 
 	brokerActions := fakeServiceBrokerClient.Actions()
 	assertNumberOfServiceBrokerActions(t, brokerActions, 1)
@@ -1473,7 +1473,7 @@ func TestReconcileUnbindingWithServiceBrokerError(t *testing.T) {
 	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationUnbind)
 
 	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding)
-	assertServiceInstanceCredentialReqeustRetriableError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationUnbind, errorUnbindCallReason)
+	assertServiceInstanceCredentialRequestRetriableError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationUnbind, errorUnbindCallReason)
 
 	events := getRecordedEvents(testController)
 	expectedEvent := api.EventTypeWarning + " " + errorUnbindCallReason + " " + `Error unbinding ServiceInstanceCredential "test-binding/test-ns" for ServiceInstance "test-ns/test-instance" of ServiceClass "test-serviceclass" at ServiceBroker "test-broker": Unexpected action`
@@ -1531,7 +1531,7 @@ func TestReconcileUnbindingWithServiceBrokerHTTPError(t *testing.T) {
 	assertServiceInstanceCredentialOperationInProgress(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationUnbind)
 
 	updatedServiceInstanceCredential = assertUpdateStatus(t, actions[1], binding)
-	assertServiceInstanceCredentialReqeustFailingError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationUnbind, errorUnbindCallReason, errorUnbindCallReason)
+	assertServiceInstanceCredentialRequestFailingError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationUnbind, errorUnbindCallReason, errorUnbindCallReason)
 
 	events := getRecordedEvents(testController)
 	expectedEvent := api.EventTypeWarning + " " + errorUnbindCallReason + " " + `Error unbinding ServiceInstanceCredential "test-binding/test-ns" for ServiceInstance "test-ns/test-instance" of ServiceClass "test-serviceclass" at ServiceBroker "test-broker": Status: 410; ErrorMessage: <nil>; Description: <nil>; ResponseError: <nil>`
@@ -1734,7 +1734,7 @@ func TestReconcileBindingFailureOnFinalRetry(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding).(*v1alpha1.ServiceInstanceCredential)
-	assertServiceInstanceCredentialReqeustFailingError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorBindCallReason, errorReconciliationRetryTimeoutReason)
+	assertServiceInstanceCredentialRequestFailingError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorBindCallReason, errorReconciliationRetryTimeoutReason)
 
 	expectedEventPrefixes := []string{
 		api.EventTypeWarning + " " + errorBindCallReason,
@@ -1816,7 +1816,7 @@ func TestReconcileBindingWithSecretConflictFailedAfterFinalRetry(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstanceCredential := assertUpdateStatus(t, actions[0], binding).(*v1alpha1.ServiceInstanceCredential)
-	assertServiceInstanceCredentialReqeustFailingError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorInjectingBindResultReason, errorReconciliationRetryTimeoutReason)
+	assertServiceInstanceCredentialRequestFailingError(t, updatedServiceInstanceCredential, v1alpha1.ServiceInstanceCredentialOperationBind, errorInjectingBindResultReason, errorReconciliationRetryTimeoutReason)
 
 	kubeActions := fakeKubeClient.Actions()
 	assertNumberOfActions(t, kubeActions, 2)

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -183,6 +183,7 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1alpha1.ServiceIn
 				instance.Namespace,
 				instance.Name)
 			glog.Warning(s)
+			c.recorder.Event(instance, api.EventTypeWarning, errorDeprovisionBlockedByCredentialsReason, s)
 
 			setServiceInstanceCondition(
 				toUpdate,
@@ -190,8 +191,9 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1alpha1.ServiceIn
 				v1alpha1.ConditionFalse,
 				errorDeprovisionBlockedByCredentialsReason,
 				"Delete instance failed. "+s)
-			c.updateServiceInstanceStatus(toUpdate)
-			c.recorder.Event(instance, api.EventTypeWarning, errorDeprovisionBlockedByCredentialsReason, s)
+			if _, err = c.updateServiceInstanceStatus(toUpdate); err != nil {
+				return err
+			}
 			return nil
 		}
 	}
@@ -209,9 +211,18 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1alpha1.ServiceIn
 	// TODO: the above logic changes slightly once we handle orphan
 	// mitigation.
 	if !instance.Status.AsyncOpInProgress && instance.Status.ReconciledGeneration == 0 {
-		finalizers.Delete(finalizerToken)
+		clone, err := api.Scheme.DeepCopy(instance)
+		if err != nil {
+			return err
+		}
+		toUpdate := clone.(*v1alpha1.ServiceInstance)
 		// Clear the finalizer
-		return c.updateServiceInstanceFinalizers(instance, finalizers.List())
+		finalizers.Delete(finalizerToken)
+		toUpdate.Finalizers = finalizers.List()
+		if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+			return err
+		}
+		return nil
 	}
 
 	// All updates not having a DeletingTimestamp will have been handled above
@@ -244,6 +255,7 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1alpha1.ServiceIn
 		if err != nil {
 			s := fmt.Sprintf(`Error building originating identity headers for deprovisioning ServiceInstance "%v/%v": %v`, instance.Namespace, instance.Name, err)
 			glog.Warning(s)
+			c.recorder.Event(instance, api.EventTypeWarning, errorWithOriginatingIdentity, s)
 
 			setServiceInstanceCondition(
 				toUpdate,
@@ -252,58 +264,47 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1alpha1.ServiceIn
 				errorWithOriginatingIdentity,
 				s,
 			)
-			c.updateServiceInstanceStatus(toUpdate)
+			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+				return err
+			}
 
-			c.recorder.Event(instance, api.EventTypeWarning, errorWithOriginatingIdentity, s)
 			return err
 		}
 		request.OriginatingIdentity = originatingIdentity
 	}
 
-	// If the instance is not failed, deprovision it at the broker.
-	if !isServiceInstanceFailed(instance) {
-		// it is arguable we should perform an extract-method refactor on this
-		// code block
+	// If the instance is failed, just clear the finalizer
+	if isServiceInstanceFailed(instance) {
+		glog.V(5).Infof("Clearing catalog finalizer from ServiceInstance %v/%v", instance.Namespace, instance.Name)
 
-		now := metav1.Now()
+		// Clear the finalizer
+		finalizers.Delete(v1alpha1.FinalizerServiceCatalog)
+		toUpdate.Finalizers = finalizers.List()
 
-		glog.V(4).Infof("Deprovisioning ServiceInstance %v/%v of ServiceClass %v at ServiceBroker %v", instance.Namespace, instance.Name, serviceClass.Name, brokerName)
-		response, err := brokerClient.DeprovisionInstance(request)
+		if _, err = c.updateServiceInstanceStatus(toUpdate); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// it is arguable we should perform an extract-method refactor on this
+	// code block
+
+	if toUpdate.Status.CurrentOperation == "" {
+		toUpdate, err = c.recordStartOfServiceInstanceOperation(toUpdate, v1alpha1.ServiceInstanceOperationDeprovision)
 		if err != nil {
-			httpErr, isError := osb.IsHTTPError(err)
-			if isError {
-				s := fmt.Sprintf(
-					"Error deprovisioning ServiceInstance \"%s/%s\" of ServiceClass %q at ServiceBroker %q with status code %d: ErrorMessage: %v, Description: %v",
-					instance.Namespace,
-					instance.Name,
-					serviceClass.Name,
-					brokerName,
-					httpErr.StatusCode,
-					httpErr.ErrorMessage,
-					httpErr.Description,
-				)
-				glog.Warning(s)
+			// There has been an update to the instance. Start reconciliation
+			// over with a fresh view of the instance.
+			return err
+		}
+	}
 
-				setServiceInstanceCondition(
-					toUpdate,
-					v1alpha1.ServiceInstanceConditionReady,
-					v1alpha1.ConditionUnknown,
-					errorDeprovisionCalledReason,
-					"Deprovision call failed. "+s)
-				setServiceInstanceCondition(
-					toUpdate,
-					v1alpha1.ServiceInstanceConditionFailed,
-					v1alpha1.ConditionTrue,
-					errorDeprovisionCalledReason,
-					s,
-				)
-				c.updateServiceInstanceStatus(toUpdate)
-				c.recorder.Event(instance, api.EventTypeWarning, errorDeprovisionCalledReason, s)
-
-				// Return nil so that the reconciler does not retry the deprovision
-				return nil
-			}
-
+	glog.V(4).Infof("Deprovisioning ServiceInstance %v/%v of ServiceClass %v at ServiceBroker %v", instance.Namespace, instance.Name, serviceClass.Name, brokerName)
+	response, err := brokerClient.DeprovisionInstance(request)
+	if err != nil {
+		httpErr, isError := osb.IsHTTPError(err)
+		if isError {
 			s := fmt.Sprintf(
 				"Error deprovisioning ServiceInstance \"%s/%s\" of ServiceClass %q at ServiceBroker %q with status code %d: ErrorMessage: %v, Description: %v",
 				instance.Namespace,
@@ -315,6 +316,7 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1alpha1.ServiceIn
 				httpErr.Description,
 			)
 			glog.Warning(s)
+			c.recorder.Event(instance, api.EventTypeWarning, errorDeprovisionCalledReason, s)
 
 			setServiceInstanceCondition(
 				toUpdate,
@@ -322,90 +324,118 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1alpha1.ServiceIn
 				v1alpha1.ConditionUnknown,
 				errorDeprovisionCalledReason,
 				"Deprovision call failed. "+s)
-
-			c.recorder.Event(instance, api.EventTypeWarning, errorDeprovisionCalledReason, s)
-
-			if instance.Status.OperationStartTime == nil {
-				toUpdate.Status.OperationStartTime = &now
-			} else if !time.Now().Before(instance.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
-				s := fmt.Sprintf(`Stopping reconciliation retries on ServiceInstance "%v/%v" because too much time has elapsed`, instance.Namespace, instance.Name)
-				glog.Info(s)
-				c.recorder.Event(instance, api.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
-				setServiceInstanceCondition(toUpdate,
-					v1alpha1.ServiceInstanceConditionFailed,
-					v1alpha1.ConditionTrue,
-					errorReconciliationRetryTimeoutReason,
-					s)
-				toUpdate.Status.OperationStartTime = nil
-				c.updateServiceInstanceStatus(toUpdate)
-				return nil
-			}
-
-			c.updateServiceInstanceStatus(toUpdate)
-			return err
-		}
-
-		if response.Async {
-			glog.V(5).Infof("Received asynchronous de-provisioning response for ServiceInstance %v/%v of ServiceClass %v at ServiceBroker %v: response: %+v", instance.Namespace, instance.Name, serviceClass.Name, brokerName, response)
-			if response.OperationKey != nil && *response.OperationKey != "" {
-				key := string(*response.OperationKey)
-				toUpdate.Status.LastOperation = &key
-			}
-
-			toUpdate.Status.OperationStartTime = &now
-
-			// Tag this instance as having an ongoing async operation so we can enforce
-			// no other operations against it can start.
-			toUpdate.Status.AsyncOpInProgress = true
-
 			setServiceInstanceCondition(
 				toUpdate,
-				v1alpha1.ServiceInstanceConditionReady,
-				v1alpha1.ConditionFalse,
-				asyncDeprovisioningReason,
-				asyncDeprovisioningMessage,
+				v1alpha1.ServiceInstanceConditionFailed,
+				v1alpha1.ConditionTrue,
+				errorDeprovisionCalledReason,
+				s,
 			)
-			err := c.updateServiceInstanceStatus(toUpdate)
-			if err != nil {
+			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 				return err
 			}
-
-			err = c.beginPollingServiceInstance(instance)
-			if err != nil {
-				return err
-			}
-
-			c.recorder.Eventf(instance, api.EventTypeNormal, asyncDeprovisioningReason, asyncDeprovisioningMessage)
-
 			return nil
 		}
 
-		glog.V(5).Infof("Deprovision call to broker succeeded for ServiceInstance %v/%v, finalizing", instance.Namespace, instance.Name)
+		s := fmt.Sprintf(
+			"Error deprovisioning ServiceInstance \"%s/%s\" of ServiceClass %q at ServiceBroker %q with status code %d: ErrorMessage: %v, Description: %v",
+			instance.Namespace,
+			instance.Name,
+			serviceClass.Name,
+			brokerName,
+			httpErr.StatusCode,
+			httpErr.ErrorMessage,
+			httpErr.Description,
+		)
+		glog.Warning(s)
+		c.recorder.Event(instance, api.EventTypeWarning, errorDeprovisionCalledReason, s)
 
-		toUpdate.Status.OperationStartTime = nil
+		setServiceInstanceCondition(
+			toUpdate,
+			v1alpha1.ServiceInstanceConditionReady,
+			v1alpha1.ConditionUnknown,
+			errorDeprovisionCalledReason,
+			"Deprovision call failed. "+s)
+
+		if !time.Now().Before(toUpdate.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
+			s := fmt.Sprintf(`Stopping reconciliation retries on ServiceInstance "%v/%v" because too much time has elapsed`, instance.Namespace, instance.Name)
+			glog.Info(s)
+			c.recorder.Event(instance, api.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
+			setServiceInstanceCondition(toUpdate,
+				v1alpha1.ServiceInstanceConditionFailed,
+				v1alpha1.ConditionTrue,
+				errorReconciliationRetryTimeoutReason,
+				s)
+			c.clearServiceInstanceCurrentOperation(toUpdate)
+			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+			return err
+		}
+		return err
+	}
+
+	if response.Async {
+		glog.V(5).Infof("Received asynchronous de-provisioning response for ServiceInstance %v/%v of ServiceClass %v at ServiceBroker %v: response: %+v", instance.Namespace, instance.Name, serviceClass.Name, brokerName, response)
+
+		if response.OperationKey != nil && *response.OperationKey != "" {
+			key := string(*response.OperationKey)
+			toUpdate.Status.LastOperation = &key
+		}
+
+		// Tag this instance as having an ongoing async operation so we can enforce
+		// no other operations against it can start.
+		toUpdate.Status.AsyncOpInProgress = true
 
 		setServiceInstanceCondition(
 			toUpdate,
 			v1alpha1.ServiceInstanceConditionReady,
 			v1alpha1.ConditionFalse,
-			successDeprovisionReason,
-			successDeprovisionMessage,
+			asyncDeprovisioningReason,
+			asyncDeprovisioningMessage,
 		)
-		err = c.updateServiceInstanceStatus(toUpdate)
+		if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+			return err
+		}
+
+		err = c.beginPollingServiceInstance(instance)
 		if err != nil {
 			return err
 		}
 
-		c.recorder.Event(instance, api.EventTypeNormal, successDeprovisionReason, successDeprovisionMessage)
-		glog.V(5).Infof("Successfully deprovisioned ServiceInstance %v/%v of ServiceClass %v at ServiceBroker %v", instance.Namespace, instance.Name, serviceClass.Name, brokerName)
-		// In the success case, fall through to clearing the finalizer.
+		c.recorder.Eventf(instance, api.EventTypeNormal, asyncDeprovisioningReason, asyncDeprovisioningMessage)
+
+		return nil
 	}
 
-	glog.V(5).Infof("Clearing catalog finalizer from ServiceInstance %v/%v", instance.Namespace, instance.Name)
+	glog.V(5).Infof("Deprovision call to broker succeeded for ServiceInstance %v/%v, finalizing", instance.Namespace, instance.Name)
+
+	c.clearServiceInstanceCurrentOperation(toUpdate)
+
+	setServiceInstanceCondition(
+		toUpdate,
+		v1alpha1.ServiceInstanceConditionReady,
+		v1alpha1.ConditionFalse,
+		successDeprovisionReason,
+		successDeprovisionMessage,
+	)
 
 	// Clear the finalizer
 	finalizers.Delete(v1alpha1.FinalizerServiceCatalog)
-	return c.updateServiceInstanceFinalizers(instance, finalizers.List())
+	toUpdate.Finalizers = finalizers.List()
+
+	if _, err = c.updateServiceInstanceStatus(toUpdate); err != nil {
+		return err
+	}
+
+	c.recorder.Event(instance, api.EventTypeNormal, successDeprovisionReason, successDeprovisionMessage)
+	glog.V(5).Infof("Successfully deprovisioned ServiceInstance %v/%v of ServiceClass %v at ServiceBroker %v", instance.Namespace, instance.Name, serviceClass.Name, brokerName)
+
+	return nil
 }
 
 // isServiceInstanceFailed returns whether the instance has a failed condition with
@@ -421,7 +451,7 @@ func isServiceInstanceFailed(instance *v1alpha1.ServiceInstance) bool {
 }
 
 // reconcileServiceInstance is the control-loop for reconciling Instances. An
-// error is returned to indicate that the binding has not been fully
+// error is returned to indicate that the instance has not been fully
 // processed and should be resubmitted at a later time.
 func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance) error {
 	// Currently, we only set a failure condition if the initial provision
@@ -499,6 +529,7 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 		if err != nil {
 			s := fmt.Sprintf("Failed to prepare ServiceInstance parameters\n%s\n %s", instance.Spec.Parameters, err)
 			glog.Warning(s)
+			c.recorder.Event(instance, api.EventTypeWarning, errorWithParameters, s)
 
 			setServiceInstanceCondition(
 				toUpdate,
@@ -507,9 +538,10 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 				errorWithParameters,
 				s,
 			)
-			c.updateServiceInstanceStatus(toUpdate)
+			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+				return err
+			}
 
-			c.recorder.Event(instance, api.EventTypeWarning, errorWithParameters, s)
 			return err
 		}
 	}
@@ -518,6 +550,7 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 	if err != nil {
 		s := fmt.Sprintf("Failed to get namespace %q during instance create: %s", instance.Namespace, err)
 		glog.Info(s)
+		c.recorder.Event(instance, api.EventTypeWarning, errorFindingNamespaceServiceInstanceReason, s)
 
 		setServiceInstanceCondition(
 			toUpdate,
@@ -526,9 +559,10 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 			errorFindingNamespaceServiceInstanceReason,
 			"Error finding namespace for instance. "+s,
 		)
-		c.updateServiceInstanceStatus(toUpdate)
+		if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+			return err
+		}
 
-		c.recorder.Event(instance, api.EventTypeWarning, errorFindingNamespaceServiceInstanceReason, s)
 		return err
 	}
 
@@ -554,6 +588,7 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 		if err != nil {
 			s := fmt.Sprintf(`Error building originating identity headers for provisioning ServiceInstance "%v/%v": %v`, instance.Namespace, instance.Name, err)
 			glog.Warning(s)
+			c.recorder.Event(instance, api.EventTypeWarning, errorWithOriginatingIdentity, s)
 
 			setServiceInstanceCondition(
 				toUpdate,
@@ -562,15 +597,23 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 				errorWithOriginatingIdentity,
 				s,
 			)
-			c.updateServiceInstanceStatus(toUpdate)
+			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+				return err
+			}
 
-			c.recorder.Event(instance, api.EventTypeWarning, errorWithOriginatingIdentity, s)
 			return err
 		}
 		request.OriginatingIdentity = originatingIdentity
 	}
 
-	now := metav1.Now()
+	if toUpdate.Status.CurrentOperation == "" {
+		toUpdate, err = c.recordStartOfServiceInstanceOperation(toUpdate, v1alpha1.ServiceInstanceOperationProvision)
+		if err != nil {
+			// There has been an update to the instance. Start reconciliation
+			// over with a fresh view of the instance.
+			return err
+		}
+	}
 
 	glog.V(4).Infof("Provisioning a new ServiceInstance %v/%v of ServiceClass %v at ServiceBroker %v", instance.Namespace, instance.Name, serviceClass.Name, brokerName)
 	response, err := brokerClient.ProvisionInstance(request)
@@ -583,6 +626,7 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 			// should not be retried; set the Failed condition.
 			s := fmt.Sprintf("Error provisioning ServiceInstance \"%s/%s\" of ServiceClass %q at ServiceBroker %q: %s", instance.Namespace, instance.Name, serviceClass.Name, brokerName, httpErr)
 			glog.Warning(s)
+			c.recorder.Event(instance, api.EventTypeWarning, errorProvisionCallFailedReason, s)
 
 			setServiceInstanceCondition(
 				toUpdate,
@@ -596,19 +640,16 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 				v1alpha1.ConditionFalse,
 				errorProvisionCallFailedReason,
 				"ServiceBroker returned a failure for provision call; operation will not be retried: "+s)
-			toUpdate.Status.OperationStartTime = nil
-			toUpdate.Status.ReconciledGeneration = toUpdate.Generation
-			err := c.updateServiceInstanceStatus(toUpdate)
-			if err != nil {
+			c.clearServiceInstanceCurrentOperation(toUpdate)
+			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 				return err
 			}
-
-			c.recorder.Event(instance, api.EventTypeWarning, errorProvisionCallFailedReason, s)
 			return nil
 		}
 
 		s := fmt.Sprintf("Error provisioning ServiceInstance \"%s/%s\" of ServiceClass %q at ServiceBroker %q: %s", instance.Namespace, instance.Name, serviceClass.Name, brokerName, err)
 		glog.Warning(s)
+		c.recorder.Event(instance, api.EventTypeWarning, errorErrorCallingProvisionReason, s)
 
 		setServiceInstanceCondition(
 			toUpdate,
@@ -616,11 +657,8 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 			v1alpha1.ConditionFalse,
 			errorErrorCallingProvisionReason,
 			"Provision call failed and will be retried: "+s)
-		c.recorder.Event(instance, api.EventTypeWarning, errorErrorCallingProvisionReason, s)
 
-		if instance.Status.OperationStartTime == nil {
-			toUpdate.Status.OperationStartTime = &now
-		} else if !time.Now().Before(instance.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
+		if !time.Now().Before(toUpdate.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
 			s := fmt.Sprintf(`Stopping reconciliation retries on ServiceInstance "%v/%v" because too much time has elapsed`, instance.Namespace, instance.Name)
 			glog.Info(s)
 			c.recorder.Event(instance, api.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
@@ -629,13 +667,16 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 				v1alpha1.ConditionTrue,
 				errorReconciliationRetryTimeoutReason,
 				s)
-			toUpdate.Status.OperationStartTime = nil
-			toUpdate.Status.ReconciledGeneration = toUpdate.Generation
-			c.updateServiceInstanceStatus(toUpdate)
+			c.clearServiceInstanceCurrentOperation(toUpdate)
+			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+				return err
+			}
 			return nil
 		}
 
-		c.updateServiceInstanceStatus(toUpdate)
+		if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+			return err
+		}
 
 		return err
 	}
@@ -652,6 +693,7 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 	// passed back to the broker during polling of last_operation.
 	if response.Async {
 		glog.V(5).Infof("Received asynchronous provisioning response for ServiceInstance %v/%v of ServiceClass %v at ServiceBroker %v: response: %+v", instance.Namespace, instance.Name, serviceClass.Name, brokerName, response)
+
 		if response.OperationKey != nil && *response.OperationKey != "" {
 			key := string(*response.OperationKey)
 			toUpdate.Status.LastOperation = &key
@@ -661,8 +703,6 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 		// no other operations against it can start.
 		toUpdate.Status.AsyncOpInProgress = true
 
-		toUpdate.Status.OperationStartTime = &now
-
 		setServiceInstanceCondition(
 			toUpdate,
 			v1alpha1.ServiceInstanceConditionReady,
@@ -670,21 +710,19 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 			asyncProvisioningReason,
 			asyncProvisioningMessage,
 		)
-		c.updateServiceInstanceStatus(toUpdate)
-
-		c.recorder.Eventf(instance, api.EventTypeNormal, asyncProvisioningReason, asyncProvisioningMessage)
+		if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+			return err
+		}
 
 		if err := c.beginPollingServiceInstance(instance); err != nil {
 			return err
 		}
+
+		c.recorder.Eventf(instance, api.EventTypeNormal, asyncProvisioningReason, asyncProvisioningMessage)
 	} else {
 		glog.V(5).Infof("Successfully provisioned ServiceInstance %v/%v of ServiceClass %v at ServiceBroker %v: response: %+v", instance.Namespace, instance.Name, serviceClass.Name, brokerName, response)
 
-		toUpdate.Status.OperationStartTime = nil
-
-		// Create/Update for Instance has completed successfully, so set
-		// Status.ReconciledGeneration to the Generation used.
-		toUpdate.Status.ReconciledGeneration = toUpdate.Generation
+		c.clearServiceInstanceCurrentOperation(toUpdate)
 
 		// TODO: process response
 		setServiceInstanceCondition(
@@ -694,7 +732,9 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 			successProvisionReason,
 			successProvisionMessage,
 		)
-		c.updateServiceInstanceStatus(toUpdate)
+		if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+			return err
+		}
 
 		c.recorder.Eventf(instance, api.EventTypeNormal, successProvisionReason, successProvisionMessage)
 	}
@@ -716,7 +756,7 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 	// deleting, this is more readable than checking the
 	// timestamps in various places.
 	deleting := false
-	if instance.DeletionTimestamp != nil {
+	if instance.Status.CurrentOperation == v1alpha1.ServiceInstanceOperationDeprovision {
 		deleting = true
 	}
 
@@ -738,7 +778,7 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 			s)
 		toUpdate.Status.OperationStartTime = nil
 		toUpdate.Status.ReconciledGeneration = toUpdate.Generation
-		if err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+		if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 			return err
 		}
 		return c.finishPollingServiceInstance(instance)
@@ -759,8 +799,21 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 		if err != nil {
 			s := fmt.Sprintf(`Error building originating identity headers for polling last operation of ServiceInstance "%v/%v": %v`, instance.Namespace, instance.Name, err)
 			glog.Warning(s)
-
 			c.recorder.Event(instance, api.EventTypeWarning, errorWithOriginatingIdentity, s)
+
+			clone, cloneErr := api.Scheme.DeepCopy(instance)
+			if cloneErr != nil {
+				return cloneErr
+			}
+			toUpdate := clone.(*v1alpha1.ServiceInstance)
+			setServiceInstanceCondition(toUpdate,
+				v1alpha1.ServiceInstanceConditionReady,
+				v1alpha1.ConditionFalse,
+				errorWithOriginatingIdentity,
+				s)
+			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+				return err
+			}
 			return err
 		}
 		request.OriginatingIdentity = originatingIdentity
@@ -780,9 +833,9 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 			}
 			toUpdate := clone.(*v1alpha1.ServiceInstance)
 
-			toUpdate.Status.AsyncOpInProgress = false
-			toUpdate.Status.OperationStartTime = nil
-			c.updateServiceInstanceCondition(
+			c.clearServiceInstanceCurrentOperation(toUpdate)
+
+			setServiceInstanceCondition(
 				toUpdate,
 				v1alpha1.ServiceInstanceConditionReady,
 				v1alpha1.ConditionFalse,
@@ -793,17 +846,17 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 			// Clear the finalizer
 			if finalizers := sets.NewString(toUpdate.Finalizers...); finalizers.Has(v1alpha1.FinalizerServiceCatalog) {
 				finalizers.Delete(v1alpha1.FinalizerServiceCatalog)
-				c.updateServiceInstanceFinalizers(toUpdate, finalizers.List())
+				toUpdate.Finalizers = finalizers.List()
+			}
+
+			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+				return err
 			}
 
 			c.recorder.Event(instance, api.EventTypeNormal, successDeprovisionReason, successDeprovisionMessage)
 			glog.V(5).Infof("Successfully deprovisioned ServiceInstance %v/%v of ServiceClass %v at ServiceBroker %v", instance.Namespace, instance.Name, serviceClass.Name, brokerName)
 
-			err = c.finishPollingServiceInstance(instance)
-			if err != nil {
-				return err
-			}
-			return nil
+			return c.finishPollingServiceInstance(instance)
 		}
 
 		// We got some kind of error from the broker.  While polling last
@@ -839,9 +892,8 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 				v1alpha1.ConditionTrue,
 				errorReconciliationRetryTimeoutReason,
 				s)
-			toUpdate.Status.OperationStartTime = nil
-			toUpdate.Status.ReconciledGeneration = toUpdate.Generation
-			if err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+			c.clearServiceInstanceCurrentOperation(toUpdate)
+			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 				return err
 			}
 			return c.finishPollingServiceInstance(instance)
@@ -854,6 +906,8 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 
 	switch response.State {
 	case osb.StateInProgress:
+		var toUpdate *v1alpha1.ServiceInstance
+
 		// if the description is non-nil, then update the instance condition with it
 		if response.Description != nil {
 			// The way the worker keeps on requeueing is by returning an error, so
@@ -862,7 +916,7 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 			if err != nil {
 				return err
 			}
-			toUpdate := clone.(*v1alpha1.ServiceInstance)
+			toUpdate = clone.(*v1alpha1.ServiceInstance)
 			toUpdate.Status.AsyncOpInProgress = true
 
 			var message string
@@ -878,7 +932,7 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 			if response.Description != nil {
 				message = fmt.Sprintf("%s (%s)", message, *response.Description)
 			}
-			c.updateServiceInstanceCondition(
+			setServiceInstanceCondition(
 				toUpdate,
 				v1alpha1.ServiceInstanceConditionReady,
 				v1alpha1.ConditionFalse,
@@ -888,11 +942,13 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 		}
 
 		if !time.Now().Before(instance.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
-			clone, err := api.Scheme.DeepCopy(instance)
-			if err != nil {
-				return err
+			if toUpdate == nil {
+				clone, err := api.Scheme.DeepCopy(instance)
+				if err != nil {
+					return err
+				}
+				toUpdate = clone.(*v1alpha1.ServiceInstance)
 			}
-			toUpdate := clone.(*v1alpha1.ServiceInstance)
 			s := fmt.Sprintf(`Stopping reconciliation retries on ServiceInstance "%v/%v" because too much time has elapsed`, instance.Namespace, instance.Name)
 			glog.Info(s)
 			c.recorder.Event(instance, api.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
@@ -901,14 +957,18 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 				v1alpha1.ConditionTrue,
 				errorReconciliationRetryTimeoutReason,
 				s)
-			toUpdate.Status.AsyncOpInProgress = false
-			toUpdate.Status.OperationStartTime = nil
-			toUpdate.Status.ReconciledGeneration = toUpdate.Generation
-			if err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+			c.clearServiceInstanceCurrentOperation(toUpdate)
+			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 				return err
 			}
 
 			return c.finishPollingServiceInstance(instance)
+		}
+
+		if toUpdate != nil {
+			if _, err = c.updateServiceInstanceStatus(toUpdate); err != nil {
+				return err
+			}
 		}
 
 		err = c.continuePollingServiceInstance(instance)
@@ -924,42 +984,47 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 			return err
 		}
 		toUpdate := clone.(*v1alpha1.ServiceInstance)
-		toUpdate.Status.AsyncOpInProgress = false
-		toUpdate.Status.OperationStartTime = nil
+		c.clearServiceInstanceCurrentOperation(toUpdate)
 
 		// If we were asynchronously deleting a Service Instance, finish
 		// the finalizers.
 		if deleting {
-			err := c.updateServiceInstanceCondition(
+			setServiceInstanceCondition(
 				toUpdate,
 				v1alpha1.ServiceInstanceConditionReady,
 				v1alpha1.ConditionFalse,
 				successDeprovisionReason,
 				successDeprovisionMessage,
 			)
-			if err != nil {
-				return err
-			}
 
 			// Clear the finalizer
 			if finalizers := sets.NewString(toUpdate.Finalizers...); finalizers.Has(v1alpha1.FinalizerServiceCatalog) {
 				finalizers.Delete(v1alpha1.FinalizerServiceCatalog)
-				c.updateServiceInstanceFinalizers(toUpdate, finalizers.List())
+				toUpdate.Finalizers = finalizers.List()
 			}
+
+			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+				return err
+			}
+
 			c.recorder.Event(instance, api.EventTypeNormal, successDeprovisionReason, successDeprovisionMessage)
+
 			glog.V(5).Infof("Successfully deprovisioned ServiceInstance %v/%v of ServiceClass %v at ServiceBroker %v", instance.Namespace, instance.Name, serviceClass.Name, brokerName)
 		} else {
 			// Create/Update for InstanceCredential has completed successfully,
 			// so set Status.ReconciledGeneration to the Generation used.
 			toUpdate.Status.ReconciledGeneration = toUpdate.Generation
 
-			c.updateServiceInstanceCondition(
+			setServiceInstanceCondition(
 				toUpdate,
 				v1alpha1.ServiceInstanceConditionReady,
 				v1alpha1.ConditionTrue,
 				successProvisionReason,
 				successProvisionMessage,
 			)
+			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+				return err
+			}
 		}
 
 		err = c.finishPollingServiceInstance(instance)
@@ -972,15 +1037,14 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 			description = *response.Description
 		}
 		s := fmt.Sprintf("Error deprovisioning ServiceInstance \"%s/%s\" of ServiceClass %q at ServiceBroker %q: %q", instance.Namespace, instance.Name, serviceClass.Name, brokerName, description)
+		c.recorder.Event(instance, api.EventTypeWarning, errorDeprovisionCalledReason, s)
 
 		clone, err := api.Scheme.DeepCopy(instance)
 		if err != nil {
 			return err
 		}
 		toUpdate := clone.(*v1alpha1.ServiceInstance)
-		toUpdate.Status.AsyncOpInProgress = false
-		toUpdate.Status.OperationStartTime = nil
-		toUpdate.Status.ReconciledGeneration = toUpdate.Generation
+		c.clearServiceInstanceCurrentOperation(toUpdate)
 
 		readyCond := v1alpha1.ConditionFalse
 		reason := errorProvisionCallFailedReason
@@ -1004,10 +1068,9 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 			reason,
 			msg,
 		)
-		if err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+		if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 			return err
 		}
-		c.recorder.Event(instance, api.EventTypeWarning, errorDeprovisionCalledReason, s)
 
 		err = c.finishPollingServiceInstance(instance)
 		if err != nil {
@@ -1029,9 +1092,8 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 				v1alpha1.ConditionTrue,
 				errorReconciliationRetryTimeoutReason,
 				s)
-			toUpdate.Status.OperationStartTime = nil
-			toUpdate.Status.ReconciledGeneration = toUpdate.Generation
-			if err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+			c.clearServiceInstanceCurrentOperation(toUpdate)
+			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 				return err
 			}
 			return c.finishPollingServiceInstance(instance)
@@ -1105,14 +1167,14 @@ func setServiceInstanceConditionInternal(toUpdate *v1alpha1.ServiceInstance,
 //
 // Note: objects coming from informers should never be mutated; the instance
 // passed to this method should always be a deep copy.
-func (c *controller) updateServiceInstanceStatus(toUpdate *v1alpha1.ServiceInstance) error {
+func (c *controller) updateServiceInstanceStatus(toUpdate *v1alpha1.ServiceInstance) (*v1alpha1.ServiceInstance, error) {
 	glog.V(4).Infof("Updating status for ServiceInstance %v/%v", toUpdate.Namespace, toUpdate.Name)
-	_, err := c.serviceCatalogClient.ServiceInstances(toUpdate.Namespace).UpdateStatus(toUpdate)
+	updatedInstance, err := c.serviceCatalogClient.ServiceInstances(toUpdate.Namespace).UpdateStatus(toUpdate)
 	if err != nil {
 		glog.Errorf("Failed to update status for ServiceInstance %v/%v: %v", toUpdate.Namespace, toUpdate.Name, err)
 	}
 
-	return err
+	return updatedInstance, err
 }
 
 // updateServiceInstanceCondition updates the given condition for the given Instance
@@ -1141,34 +1203,47 @@ func (c *controller) updateServiceInstanceCondition(
 	return err
 }
 
-// updateServiceInstanceFinalizers updates the given finalizers for the given ServiceInstanceCredential.
-func (c *controller) updateServiceInstanceFinalizers(
-	instance *v1alpha1.ServiceInstance,
-	finalizers []string) error {
-
-	// Get the latest version of the instance so that we can avoid conflicts
-	// (since we have probably just updated the status of the instance and are
-	// now removing the last finalizer).
-	instance, err := c.serviceCatalogClient.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-	if err != nil {
-		glog.Errorf("Error getting ServiceInstance %v/%v to finalize: %v", instance.Namespace, instance.Name, err)
+// recordStartOfServiceInstanceOperation updates the instance to indicate that
+// there is a current operation being performed. The Status of the instance
+// is recorded in the registry.
+// params:
+// toUpdate - a modifiable copy of the instance in the registry to update
+// operation - operation that is being performed on the instance
+// returns:
+// 1 - a modifiable copy of the updated instance in the registry; or toUpdate
+//     if there was an error
+// 2 - any error that occurred
+func (c *controller) recordStartOfServiceInstanceOperation(toUpdate *v1alpha1.ServiceInstance, operation v1alpha1.ServiceInstanceOperation) (*v1alpha1.ServiceInstance, error) {
+	toUpdate.Status.CurrentOperation = operation
+	now := metav1.Now()
+	toUpdate.Status.OperationStartTime = &now
+	reason := ""
+	message := ""
+	switch operation {
+	case v1alpha1.ServiceInstanceOperationProvision:
+		reason = provisioningInFlightReason
+		message = provisioningInFlightMessage
+	case v1alpha1.ServiceInstanceOperationDeprovision:
+		reason = deprovisioningInFlightReason
+		message = deprovisioningInFlightMessage
 	}
+	setServiceInstanceCondition(
+		toUpdate,
+		v1alpha1.ServiceInstanceConditionReady,
+		v1alpha1.ConditionFalse,
+		reason,
+		message,
+	)
+	return c.updateServiceInstanceStatus(toUpdate)
+}
 
-	clone, err := api.Scheme.DeepCopy(instance)
-	if err != nil {
-		return err
-	}
-	toUpdate := clone.(*v1alpha1.ServiceInstance)
-
-	toUpdate.Finalizers = finalizers
-
-	logContext := fmt.Sprintf("finalizers for ServiceInstance %v/%v to %v",
-		instance.Namespace, instance.Name, finalizers)
-
-	glog.V(4).Infof("Updating %v", logContext)
-	_, err = c.serviceCatalogClient.ServiceInstances(instance.Namespace).UpdateStatus(toUpdate)
-	if err != nil {
-		glog.Errorf("Error updating %v: %v", logContext, err)
-	}
-	return err
+// clearServiceInstanceCurrentOperation sets the fields of the instance's Status
+// to indicate that there is no current operation being performed. The Status
+// is *not* recorded in the registry.
+func (c *controller) clearServiceInstanceCurrentOperation(toUpdate *v1alpha1.ServiceInstance) {
+	toUpdate.Status.CurrentOperation = ""
+	toUpdate.Status.OperationStartTime = nil
+	toUpdate.Status.AsyncOpInProgress = false
+	toUpdate.Status.LastOperation = nil
+	toUpdate.Status.ReconciledGeneration = toUpdate.Generation
 }

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -331,6 +331,7 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1alpha1.ServiceIn
 				errorDeprovisionCalledReason,
 				s,
 			)
+			c.clearServiceInstanceCurrentOperation(toUpdate)
 			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 				return err
 			}
@@ -1011,10 +1012,6 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 
 			glog.V(5).Infof("Successfully deprovisioned ServiceInstance %v/%v of ServiceClass %v at ServiceBroker %v", instance.Namespace, instance.Name, serviceClass.Name, brokerName)
 		} else {
-			// Create/Update for InstanceCredential has completed successfully,
-			// so set Status.ReconciledGeneration to the Generation used.
-			toUpdate.Status.ReconciledGeneration = toUpdate.Generation
-
 			setServiceInstanceCondition(
 				toUpdate,
 				v1alpha1.ServiceInstanceConditionReady,

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -404,7 +404,7 @@ func TestReconcileServiceInstanceWithProvisionCallFailure(t *testing.T) {
 	assertServiceInstanceOperationInProgress(t, updatedServiceInstance, v1alpha1.ServiceInstanceOperationProvision)
 
 	updatedServiceInstance = assertUpdateStatus(t, actions[1], instance)
-	assertServiceInstanceReqeustRetriableError(t, updatedServiceInstance, v1alpha1.ServiceInstanceOperationProvision, errorErrorCallingProvisionReason)
+	assertServiceInstanceRequestRetriableError(t, updatedServiceInstance, v1alpha1.ServiceInstanceOperationProvision, errorErrorCallingProvisionReason)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -467,7 +467,7 @@ func TestReconcileServiceInstanceWithProvisionFailure(t *testing.T) {
 	assertServiceInstanceOperationInProgress(t, updatedServiceInstance, v1alpha1.ServiceInstanceOperationProvision)
 
 	updatedServiceInstance = assertUpdateStatus(t, actions[1], instance)
-	assertServiceInstanceReqeustFailingError(t, updatedServiceInstance, v1alpha1.ServiceInstanceOperationProvision, errorProvisionCallFailedReason, "ServiceBrokerReturnedFailure")
+	assertServiceInstanceRequestFailingError(t, updatedServiceInstance, v1alpha1.ServiceInstanceOperationProvision, errorProvisionCallFailedReason, "ServiceBrokerReturnedFailure")
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -1259,7 +1259,7 @@ func TestPollServiceInstanceFailureProvisioningWithOperation(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceReqeustFailingError(t, updatedServiceInstance, v1alpha1.ServiceInstanceOperationProvision, errorProvisionCallFailedReason, errorProvisionCallFailedReason)
+	assertServiceInstanceRequestFailingError(t, updatedServiceInstance, v1alpha1.ServiceInstanceOperationProvision, errorProvisionCallFailedReason, errorProvisionCallFailedReason)
 }
 
 // TestPollServiceInstanceInProgressDeprovisioningWithOperationNoFinalizer tests
@@ -1432,7 +1432,7 @@ func TestPollServiceInstanceFailureDeprovisioningWithOperation(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceReqeustFailingError(t, updatedServiceInstance, v1alpha1.ServiceInstanceOperationDeprovision, errorDeprovisionCalledReason, errorDeprovisionCalledReason)
+	assertServiceInstanceRequestFailingError(t, updatedServiceInstance, v1alpha1.ServiceInstanceOperationDeprovision, errorDeprovisionCalledReason, errorDeprovisionCalledReason)
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
@@ -1735,7 +1735,7 @@ func TestReconcileServiceInstanceFailureOnFinalRetry(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceReqeustFailingError(t, updatedServiceInstance, v1alpha1.ServiceInstanceOperationProvision, errorErrorCallingProvisionReason, errorReconciliationRetryTimeoutReason)
+	assertServiceInstanceRequestFailingError(t, updatedServiceInstance, v1alpha1.ServiceInstanceOperationProvision, errorErrorCallingProvisionReason, errorReconciliationRetryTimeoutReason)
 
 	expectedEventPrefixes := []string{
 		api.EventTypeWarning + " " + errorErrorCallingProvisionReason,
@@ -1854,7 +1854,7 @@ func TestPollServiceInstanceFailureOnFinalRetry(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceReqeustFailingError(t, updatedServiceInstance, v1alpha1.ServiceInstanceOperationProvision, asyncProvisioningReason, errorReconciliationRetryTimeoutReason)
+	assertServiceInstanceRequestFailingError(t, updatedServiceInstance, v1alpha1.ServiceInstanceOperationProvision, asyncProvisioningReason, errorReconciliationRetryTimeoutReason)
 	assertServiceInstanceConditionHasLastOperationDescription(t, updatedServiceInstance, v1alpha1.ServiceInstanceOperationProvision, lastOperationDescription)
 
 	// verify no kube resources created.

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1583,7 +1583,7 @@ func assertServiceInstanceOperationSuccess(t *testing.T, obj runtime.Object, ope
 	}
 }
 
-func assertServiceInstanceReqeustFailingError(t *testing.T, obj runtime.Object, operation v1alpha1.ServiceInstanceOperation, readyReason string, failureReason string) {
+func assertServiceInstanceRequestFailingError(t *testing.T, obj runtime.Object, operation v1alpha1.ServiceInstanceOperation, readyReason string, failureReason string) {
 	var readyStatus v1alpha1.ConditionStatus
 	switch operation {
 	case v1alpha1.ServiceInstanceOperationProvision:
@@ -1599,7 +1599,7 @@ func assertServiceInstanceReqeustFailingError(t *testing.T, obj runtime.Object, 
 	assertAsyncOpInProgressFalse(t, obj)
 }
 
-func assertServiceInstanceReqeustRetriableError(t *testing.T, obj runtime.Object, operation v1alpha1.ServiceInstanceOperation, reason string) {
+func assertServiceInstanceRequestRetriableError(t *testing.T, obj runtime.Object, operation v1alpha1.ServiceInstanceOperation, reason string) {
 	var readyStatus v1alpha1.ConditionStatus
 	switch operation {
 	case v1alpha1.ServiceInstanceOperationProvision:
@@ -1787,7 +1787,7 @@ func assertServiceInstanceCredentialOperationSuccess(t *testing.T, obj runtime.O
 	}
 }
 
-func assertServiceInstanceCredentialReqeustFailingError(t *testing.T, obj runtime.Object, operation v1alpha1.ServiceInstanceCredentialOperation, readyReason string, failureReason string) {
+func assertServiceInstanceCredentialRequestFailingError(t *testing.T, obj runtime.Object, operation v1alpha1.ServiceInstanceCredentialOperation, readyReason string, failureReason string) {
 	var readyStatus v1alpha1.ConditionStatus
 	switch operation {
 	case v1alpha1.ServiceInstanceCredentialOperationBind:
@@ -1802,7 +1802,7 @@ func assertServiceInstanceCredentialReqeustFailingError(t *testing.T, obj runtim
 	assertServiceInstanceCredentialReconciliationComplete(t, obj)
 }
 
-func assertServiceInstanceCredentialReqeustRetriableError(t *testing.T, obj runtime.Object, operation v1alpha1.ServiceInstanceCredentialOperation, reason string) {
+func assertServiceInstanceCredentialRequestRetriableError(t *testing.T, obj runtime.Object, operation v1alpha1.ServiceInstanceCredentialOperation, reason string) {
 	var readyStatus v1alpha1.ConditionStatus
 	switch operation {
 	case v1alpha1.ServiceInstanceCredentialOperationBind:

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -818,6 +818,13 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 								},
 							},
 						},
+						"currentOperation": {
+							SchemaProps: spec.SchemaProps{
+								Description: "CurrentOperation is the operation the Controller is currently performing on the ServiceInstanceCredential.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 						"reconciledGeneration": {
 							SchemaProps: spec.SchemaProps{
 								Description: "ReconciledGeneration is the 'Generation' of the serviceInstanceCredentialSpec that was last processed by the controller. The reconciled generation is updated even if the controller failed to process the spec.",
@@ -974,6 +981,13 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 						"dashboardURL": {
 							SchemaProps: spec.SchemaProps{
 								Description: "DashboardURL is the URL of a web-based management user interface for the service instance.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
+						"currentOperation": {
+							SchemaProps: spec.SchemaProps{
+								Description: "CurrentOperation is the operation the Controller is currently performing on the ServiceInstance.",
 								Type:        []string{"string"},
 								Format:      "",
 							},

--- a/test/fake/clientset.go
+++ b/test/fake/clientset.go
@@ -26,7 +26,7 @@ import (
 
 // Clientset is a wrapper around the generated fake clientset that clones the
 // ServiceInstance and ServiceInstanceCredential objects being passed to
-// UpdateStatus. This is a workaround until the generated fake clientset does it
+// UpdateStatus. This is a workaround until the generated fake clientset does its
 // own copying.
 type Clientset struct {
 	*servicecatalogclientset.Clientset

--- a/test/fake/clientset.go
+++ b/test/fake/clientset.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"k8s.io/client-go/discovery"
+
+	clientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
+	servicecatalogclientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/fake"
+	servicecatalogv1alpha1 "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1alpha1"
+)
+
+// Clientset is a wrapper around the generated fake clientset that clones the
+// ServiceInstance and ServiceInstanceCredential objects being passed to
+// UpdateStatus. This is a workaround until the generated fake clientset does it
+// own copying.
+type Clientset struct {
+	*servicecatalogclientset.Clientset
+}
+
+func (c *Clientset) Discovery() discovery.DiscoveryInterface {
+	return c.Clientset.Discovery()
+}
+
+var _ clientset.Interface = &Clientset{}
+
+func (c *Clientset) ServicecatalogV1alpha1() servicecatalogv1alpha1.ServicecatalogV1alpha1Interface {
+	return &ServicecatalogV1alpha1{c.Clientset.ServicecatalogV1alpha1()}
+}
+
+func (c *Clientset) Servicecatalog() servicecatalogv1alpha1.ServicecatalogV1alpha1Interface {
+	return &ServicecatalogV1alpha1{c.Clientset.ServicecatalogV1alpha1()}
+}

--- a/test/fake/clientset_test.go
+++ b/test/fake/clientset_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"testing"
+
+	clientgotesting "k8s.io/client-go/testing"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	servicecatalogclientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/fake"
+)
+
+func TestClientsetStoresServiceInstanceClone(t *testing.T) {
+	clientset := Clientset{&servicecatalogclientset.Clientset{}}
+	instance := &v1alpha1.ServiceInstance{}
+	instance.Name = "test-instance"
+	returnedInstance, err := clientset.ServicecatalogV1alpha1().ServiceInstances("test-namespace").UpdateStatus(instance)
+	if err != nil {
+		t.Fatalf("unexpected error from UpdateStatus: %v", err)
+	}
+
+	actions := clientset.Actions()
+	if e, a := 1, len(actions); e != a {
+		t.Fatalf("unexpected number of actions: expected %v, got %v", e, a)
+	}
+	action := actions[0]
+
+	updateAction, ok := actions[0].(clientgotesting.UpdateAction)
+	if !ok {
+		t.Fatalf("unexpected action type; failed to convert action %+v to UpdateAction", action)
+	}
+
+	storedObject := updateAction.GetObject()
+	storedInstance, ok := storedObject.(*v1alpha1.ServiceInstance)
+	if !ok {
+		t.Fatalf("unexpected object in action; failed to convert action object %+v to ServiceInstance", storedObject)
+	}
+
+	if e, a := instance, storedInstance; e == a {
+		t.Fatalf("expected stored instance to not be the same object as original instance: original = %v, stored = %v", e, a)
+	}
+	if e, a := returnedInstance, storedInstance; e == a {
+		t.Fatalf("expected stored instance to not be the same object as returned instance, returned = %v, stored = %v", e, a)
+	}
+	if e, a := instance.Name, storedInstance.Name; e != a {
+		t.Fatalf("unexpected name: expected %v, got %v", e, a)
+	}
+}
+
+func TestClientsetStoresServiceInstanceCredentialClone(t *testing.T) {
+	clientset := Clientset{&servicecatalogclientset.Clientset{}}
+	binding := &v1alpha1.ServiceInstanceCredential{}
+	binding.Name = "test-instance"
+	returnedBinding, err := clientset.ServicecatalogV1alpha1().ServiceInstanceCredentials("test-namespace").UpdateStatus(binding)
+	if err != nil {
+		t.Fatalf("unexpected error from UpdateStatus: %v", err)
+	}
+
+	actions := clientset.Actions()
+	if e, a := 1, len(actions); e != a {
+		t.Fatalf("unexpected number of actions: expected %v, got %v", e, a)
+	}
+	action := actions[0]
+
+	updateAction, ok := actions[0].(clientgotesting.UpdateAction)
+	if !ok {
+		t.Fatalf("unexpected action type; failed to convert action %+v to UpdateAction", action)
+	}
+
+	storedObject := updateAction.GetObject()
+	storedBinding, ok := storedObject.(*v1alpha1.ServiceInstanceCredential)
+	if !ok {
+		t.Fatalf("unexpected object in action; failed to convert action object %+v to ServiceInstanceCredential", storedObject)
+	}
+
+	if e, a := binding, storedBinding; e == a {
+		t.Fatalf("expected stored instance to not be the same object as original binding: original = %v, stored = %v", e, a)
+	}
+	if e, a := returnedBinding, storedBinding; e == a {
+		t.Fatalf("expected stored instance to not be the same object as returned binding, returned = %v, stored = %v", e, a)
+	}
+	if e, a := binding.Name, storedBinding.Name; e != a {
+		t.Fatalf("unexpected name: expected %v, got %v", e, a)
+	}
+}

--- a/test/fake/servicecatalog.go
+++ b/test/fake/servicecatalog.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	rest "k8s.io/client-go/rest"
+
+	servicecatalogv1alpha1 "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1alpha1"
+	v1alpha1 "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1alpha1"
+)
+
+// ServicecatalogV1alpha1 is a wrapper around the generated fake service catalog
+// that clones the ServiceInstance and ServiceInstanceCredential objects being
+// passed to UpdateStatus. This is a workaround until the generated fake clientset
+// does it own copying.
+type ServicecatalogV1alpha1 struct {
+	servicecatalogv1alpha1.ServicecatalogV1alpha1Interface
+}
+
+var _ servicecatalogv1alpha1.ServicecatalogV1alpha1Interface = &ServicecatalogV1alpha1{}
+
+func (c *ServicecatalogV1alpha1) ServiceBrokers() v1alpha1.ServiceBrokerInterface {
+	return c.ServicecatalogV1alpha1Interface.ServiceBrokers()
+}
+
+func (c *ServicecatalogV1alpha1) ServiceClasses() v1alpha1.ServiceClassInterface {
+	return c.ServicecatalogV1alpha1Interface.ServiceClasses()
+}
+
+func (c *ServicecatalogV1alpha1) ServiceInstances(namespace string) v1alpha1.ServiceInstanceInterface {
+	serviceInstances := c.ServicecatalogV1alpha1Interface.ServiceInstances(namespace)
+	return &ServiceInstances{serviceInstances}
+}
+
+func (c *ServicecatalogV1alpha1) ServiceInstanceCredentials(namespace string) v1alpha1.ServiceInstanceCredentialInterface {
+	serviceInstanceCredentials := c.ServicecatalogV1alpha1Interface.ServiceInstanceCredentials(namespace)
+	return &ServiceInstanceCredentials{serviceInstanceCredentials}
+}
+
+func (c *ServicecatalogV1alpha1) ServicePlans() v1alpha1.ServicePlanInterface {
+	return c.ServicecatalogV1alpha1Interface.ServicePlans()
+}
+
+func (c *ServicecatalogV1alpha1) RESTClient() rest.Interface {
+	return c.ServicecatalogV1alpha1Interface.RESTClient()
+}

--- a/test/fake/servicecatalog.go
+++ b/test/fake/servicecatalog.go
@@ -26,7 +26,7 @@ import (
 // ServicecatalogV1alpha1 is a wrapper around the generated fake service catalog
 // that clones the ServiceInstance and ServiceInstanceCredential objects being
 // passed to UpdateStatus. This is a workaround until the generated fake clientset
-// does it own copying.
+// does its own copying.
 type ServicecatalogV1alpha1 struct {
 	servicecatalogv1alpha1.ServicecatalogV1alpha1Interface
 }

--- a/test/fake/serviceinstancecredentials.go
+++ b/test/fake/serviceinstancecredentials.go
@@ -29,7 +29,7 @@ import (
 // ServiceInstanceCredentials is a wrapper around the generated fake
 // ServiceInstanceCredentials that clones the ServiceInstanceCredential objects
 // being passed to UpdateStatus. This is a workaround until the generated fake
-// clientset does it own copying.
+// clientset does its own copying.
 type ServiceInstanceCredentials struct {
 	v1alpha1typed.ServiceInstanceCredentialInterface
 }

--- a/test/fake/serviceinstancecredentials.go
+++ b/test/fake/serviceinstancecredentials.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+	watch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/pkg/api"
+
+	v1alpha1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	v1alpha1typed "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1alpha1"
+)
+
+// ServiceInstanceCredentials is a wrapper around the generated fake
+// ServiceInstanceCredentials that clones the ServiceInstanceCredential objects
+// being passed to UpdateStatus. This is a workaround until the generated fake
+// clientset does it own copying.
+type ServiceInstanceCredentials struct {
+	v1alpha1typed.ServiceInstanceCredentialInterface
+}
+
+func (c *ServiceInstanceCredentials) Create(serviceInstance *v1alpha1.ServiceInstanceCredential) (result *v1alpha1.ServiceInstanceCredential, err error) {
+	return c.ServiceInstanceCredentialInterface.Create(serviceInstance)
+}
+
+func (c *ServiceInstanceCredentials) Update(serviceInstance *v1alpha1.ServiceInstanceCredential) (result *v1alpha1.ServiceInstanceCredential, err error) {
+	return c.ServiceInstanceCredentialInterface.Update(serviceInstance)
+}
+
+func (c *ServiceInstanceCredentials) UpdateStatus(serviceInstance *v1alpha1.ServiceInstanceCredential) (*v1alpha1.ServiceInstanceCredential, error) {
+	clone, err := api.Scheme.DeepCopy(serviceInstance)
+	if err != nil {
+		return nil, err
+	}
+	instanceCopy := clone.(*v1alpha1.ServiceInstanceCredential)
+	_, err = c.ServiceInstanceCredentialInterface.UpdateStatus(instanceCopy)
+	return serviceInstance, err
+}
+
+func (c *ServiceInstanceCredentials) Delete(name string, options *v1.DeleteOptions) error {
+	return c.ServiceInstanceCredentialInterface.Delete(name, options)
+}
+
+func (c *ServiceInstanceCredentials) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	return c.ServiceInstanceCredentialInterface.DeleteCollection(options, listOptions)
+}
+
+func (c *ServiceInstanceCredentials) Get(name string, options v1.GetOptions) (result *v1alpha1.ServiceInstanceCredential, err error) {
+	return c.ServiceInstanceCredentialInterface.Get(name, options)
+}
+
+func (c *ServiceInstanceCredentials) List(opts v1.ListOptions) (result *v1alpha1.ServiceInstanceCredentialList, err error) {
+	return c.ServiceInstanceCredentialInterface.List(opts)
+}
+
+// Watch returns a watch.Interface that watches the requested serviceInstances.
+func (c *ServiceInstanceCredentials) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	return c.ServiceInstanceCredentialInterface.Watch(opts)
+}
+
+// Patch applies the patch and returns the patched serviceInstance.
+func (c *ServiceInstanceCredentials) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.ServiceInstanceCredential, err error) {
+	return c.ServiceInstanceCredentialInterface.Patch(name, pt, data, subresources...)
+}

--- a/test/fake/serviceinstances.go
+++ b/test/fake/serviceinstances.go
@@ -28,7 +28,7 @@ import (
 
 // ServiceInstances is a wrapper around the generated fake ServiceInstances
 // that clones the ServiceInstance objects being passed to UpdateStatus. This is a
-// workaround until the generated fake clientset does it own copying.
+// workaround until the generated fake clientset does its own copying.
 type ServiceInstances struct {
 	v1alpha1typed.ServiceInstanceInterface
 }

--- a/test/fake/serviceinstances.go
+++ b/test/fake/serviceinstances.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+	watch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/pkg/api"
+
+	v1alpha1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	v1alpha1typed "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1alpha1"
+)
+
+// ServiceInstances is a wrapper around the generated fake ServiceInstances
+// that clones the ServiceInstance objects being passed to UpdateStatus. This is a
+// workaround until the generated fake clientset does it own copying.
+type ServiceInstances struct {
+	v1alpha1typed.ServiceInstanceInterface
+}
+
+func (c *ServiceInstances) Create(serviceInstance *v1alpha1.ServiceInstance) (result *v1alpha1.ServiceInstance, err error) {
+	return c.ServiceInstanceInterface.Create(serviceInstance)
+}
+
+func (c *ServiceInstances) Update(serviceInstance *v1alpha1.ServiceInstance) (result *v1alpha1.ServiceInstance, err error) {
+	return c.ServiceInstanceInterface.Update(serviceInstance)
+}
+
+func (c *ServiceInstances) UpdateStatus(serviceInstance *v1alpha1.ServiceInstance) (*v1alpha1.ServiceInstance, error) {
+	clone, err := api.Scheme.DeepCopy(serviceInstance)
+	if err != nil {
+		return nil, err
+	}
+	instanceCopy := clone.(*v1alpha1.ServiceInstance)
+	_, err = c.ServiceInstanceInterface.UpdateStatus(instanceCopy)
+	return serviceInstance, err
+}
+
+func (c *ServiceInstances) Delete(name string, options *v1.DeleteOptions) error {
+	return c.ServiceInstanceInterface.Delete(name, options)
+}
+
+func (c *ServiceInstances) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	return c.ServiceInstanceInterface.DeleteCollection(options, listOptions)
+}
+
+func (c *ServiceInstances) Get(name string, options v1.GetOptions) (result *v1alpha1.ServiceInstance, err error) {
+	return c.ServiceInstanceInterface.Get(name, options)
+}
+
+func (c *ServiceInstances) List(opts v1.ListOptions) (result *v1alpha1.ServiceInstanceList, err error) {
+	return c.ServiceInstanceInterface.List(opts)
+}
+
+// Watch returns a watch.Interface that watches the requested serviceInstances.
+func (c *ServiceInstances) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	return c.ServiceInstanceInterface.Watch(opts)
+}
+
+// Patch applies the patch and returns the patched serviceInstance.
+func (c *ServiceInstances) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.ServiceInstance, err error) {
+	return c.ServiceInstanceInterface.Patch(name, pt, data, subresources...)
+}


### PR DESCRIPTION
Closes #1149 

* Adds CurrentOperation fields to ServiceInstanceStatus and ServiceInstanceCredentialStatus.
* Adds an admission controller that blocks update requests to ServiceInstance and ServiceInstanceCredential when the DeletionTimestamp is not nil (indicating a delete in progress) or when Generation does not match ReconciledGeneration (indicating an update in progress).
* Fails reconciliation when updating the status of the resource returns an error.

