### PR TITLE
Adds how to download Helm chart (charts/catalog)

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -12,6 +12,7 @@ For more information, [visit the project on github]
 ## Prerequisites
 
 - Kubernetes 1.6+ with Beta APIs enabled
+- `charts/catalog` already exists in your local machine
 
 ## Installing the Chart
 

--- a/docs/install-1.6.md
+++ b/docs/install-1.6.md
@@ -53,6 +53,14 @@ clusters with RBAC enabled.  If you used the `--tiller-namespace` or
 in the previous command needs to be adjusted to reference the appropriate
 namespace and ServiceAccount name.
 
+### Helm Charts
+
+You need to download the
+[charts/catalog](https://github.com/kubernetes-incubator/service-catalog/tree/master/charts/catalog)
+directory to your local machine. Please refer to
+[here](https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/devguide.md#2-clone-fork-to-local-storage) 
+for the guide.
+
 ## A Recent `kubectl`
 
 As with Kubernetes itself, interaction with the service catalog system is

--- a/docs/install-1.7.md
+++ b/docs/install-1.7.md
@@ -44,6 +44,14 @@ and you should be done with Helm setup.
 If you don't already have an appropriate Helm version, see the
 [Helm installation instructions](https://github.com/kubernetes/helm/blob/master/docs/install.md).
 
+### Helm Charts
+
+You need to download the
+[charts/catalog](https://github.com/kubernetes-incubator/service-catalog/tree/master/charts/catalog)
+directory to your local machine. Please refer to
+[here](https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/devguide.md#2-clone-fork-to-local-storage) 
+for the guide.
+
 ## RBAC
 
 Your Kubernetes cluster must have RBAC enabled, and your Tiller pod needs to


### PR DESCRIPTION
The guide is missing that `charts/catalog` needs to be in a local machine.

/release-note-none