### PR TITLE
temporarily disabled verify-links.sh from the verify target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,8 +237,9 @@ verify: .init .generate_files verify-client-gen
 	@bash -c '[ "`cat .out`" == "" ] || (cat .out ; false)'
 	@rm .out
 	@#
-	@echo Running href checker:
-	@$(DOCKER_CMD) verify-links.sh .
+	#disabled because of so many flakes during PR verifications
+	#@echo Running href checker:
+	#@$(DOCKER_CMD) verify-links.sh .
 	@echo Running errexit checker:
 	@$(DOCKER_CMD) build/verify-errexit.sh
 


### PR DESCRIPTION
many PRs are failing during travis run:

Running repo-infra verify scripts
Running href checker:
./README.md: Can't load url: https://goreportcard.com/badge/github.com/kubernetes-incubator/service-catalog
make: *** [verify] Error 1
