### PR TITLE
Use feature gates in controller-manager

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/componentconfig"
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
@@ -99,4 +100,6 @@ func (s *ControllerManagerServer) AddFlags(fs *pflag.FlagSet) {
 	leaderelection.BindFlags(&s.LeaderElection, fs)
 	fs.StringVar(&s.LeaderElectionNamespace, "leader-election-namespace", s.LeaderElectionNamespace, "Namespace to use for leader election lock")
 	fs.DurationVar(&s.ReconciliationRetryDuration, "reconciliation-retry-duration", s.ReconciliationRetryDuration, "The maximum amount of time to retry reconciliations on a resource before failing")
+
+	utilfeature.DefaultFeatureGate.AddFlag(fs)
 }


### PR DESCRIPTION
The feature gates flags are used included api-server but not in controller-manager. This PR adds them to controller-manager. This is needed for originating identity to work since it is the controller-manager that adds the originating identity information to the OSB requests.