### PR TITLE
Re-enable the href checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,9 +237,8 @@ verify: .init .generate_files verify-client-gen
 	@bash -c '[ "`cat .out`" == "" ] || (cat .out ; false)'
 	@rm .out
 	@#
-	#disabled because of so many flakes during PR verifications
-	#@echo Running href checker:
-	#@$(DOCKER_CMD) verify-links.sh .
+	@echo Running href checker:
+	@$(DOCKER_CMD) verify-links.sh -t .
 	@echo Running errexit checker:
 	@$(DOCKER_CMD) build/verify-errexit.sh
 


### PR DESCRIPTION
It will now check the href 5 times before reporting an error.

You'll need to delete .scBuildImage to see this take effect, otherwise the old href check won't be part of the docker build image.

Closes: #1227

Signed-off-by: Doug Davis <dug@us.ibm.com>