### PR TITLE
add instance orphan mitigation

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -453,6 +453,10 @@ type ServiceInstanceStatus struct {
 	// against this ServiceInstance in progress.
 	AsyncOpInProgress bool
 
+	// OrphanMitigationInProgress is set to true if there is an ongoing orphan
+	// mitigation operation against this ServiceInstance in progress.
+	OrphanMitigationInProgress bool
+
 	// LastOperation is the string that the broker may have returned when
 	// an async operation started, it should be sent back to the broker
 	// on poll requests as a query param.

--- a/pkg/apis/servicecatalog/v1alpha1/types.generated.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.generated.go
@@ -7393,18 +7393,18 @@ func (x *ServiceInstanceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep2 := !z.EncBinary()
 			yy2arr2 := z.EncBasicHandle().StructToArray
-			var yyq2 [7]bool
+			var yyq2 [8]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
-			yyq2[2] = x.LastOperation != nil
-			yyq2[3] = x.DashboardURL != nil
-			yyq2[4] = x.CurrentOperation != ""
-			yyq2[6] = x.OperationStartTime != nil
+			yyq2[3] = x.LastOperation != nil
+			yyq2[4] = x.DashboardURL != nil
+			yyq2[5] = x.CurrentOperation != ""
+			yyq2[7] = x.OperationStartTime != nil
 			var yynn2 int
 			if yyr2 || yy2arr2 {
-				r.EncodeArrayStart(7)
+				r.EncodeArrayStart(8)
 			} else {
-				yynn2 = 3
+				yynn2 = 4
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
@@ -7461,46 +7461,49 @@ func (x *ServiceInstanceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[2] {
+				yym10 := z.EncBinary()
+				_ = yym10
+				if false {
+				} else {
+					r.EncodeBool(bool(x.OrphanMitigationInProgress))
+				}
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapKey1234)
+				r.EncodeString(codecSelferC_UTF81234, string("orphanMitigationInProgress"))
+				z.EncSendContainerState(codecSelfer_containerMapValue1234)
+				yym11 := z.EncBinary()
+				_ = yym11
+				if false {
+				} else {
+					r.EncodeBool(bool(x.OrphanMitigationInProgress))
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[3] {
 					if x.LastOperation == nil {
 						r.EncodeNil()
 					} else {
-						yy10 := *x.LastOperation
-						yym11 := z.EncBinary()
-						_ = yym11
+						yy13 := *x.LastOperation
+						yym14 := z.EncBinary()
+						_ = yym14
 						if false {
 						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy10))
+							r.EncodeString(codecSelferC_UTF81234, string(yy13))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2[2] {
+				if yyq2[3] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("lastOperation"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.LastOperation == nil {
 						r.EncodeNil()
 					} else {
-						yy12 := *x.LastOperation
-						yym13 := z.EncBinary()
-						_ = yym13
-						if false {
-						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy12))
-						}
-					}
-				}
-			}
-			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[3] {
-					if x.DashboardURL == nil {
-						r.EncodeNil()
-					} else {
-						yy15 := *x.DashboardURL
+						yy15 := *x.LastOperation
 						yym16 := z.EncBinary()
 						_ = yym16
 						if false {
@@ -7508,36 +7511,52 @@ func (x *ServiceInstanceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 							r.EncodeString(codecSelferC_UTF81234, string(yy15))
 						}
 					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
+				if yyq2[4] {
+					if x.DashboardURL == nil {
+						r.EncodeNil()
+					} else {
+						yy18 := *x.DashboardURL
+						yym19 := z.EncBinary()
+						_ = yym19
+						if false {
+						} else {
+							r.EncodeString(codecSelferC_UTF81234, string(yy18))
+						}
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2[3] {
+				if yyq2[4] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("dashboardURL"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.DashboardURL == nil {
 						r.EncodeNil()
 					} else {
-						yy17 := *x.DashboardURL
-						yym18 := z.EncBinary()
-						_ = yym18
+						yy20 := *x.DashboardURL
+						yym21 := z.EncBinary()
+						_ = yym21
 						if false {
 						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy17))
+							r.EncodeString(codecSelferC_UTF81234, string(yy20))
 						}
 					}
 				}
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[4] {
+				if yyq2[5] {
 					x.CurrentOperation.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2[4] {
+				if yyq2[5] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("currentOperation"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
@@ -7546,8 +7565,8 @@ func (x *ServiceInstanceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				yym23 := z.EncBinary()
-				_ = yym23
+				yym26 := z.EncBinary()
+				_ = yym26
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ReconciledGeneration))
@@ -7556,8 +7575,8 @@ func (x *ServiceInstanceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 				z.EncSendContainerState(codecSelfer_containerMapKey1234)
 				r.EncodeString(codecSelferC_UTF81234, string("reconciledGeneration"))
 				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				yym24 := z.EncBinary()
-				_ = yym24
+				yym27 := z.EncBinary()
+				_ = yym27
 				if false {
 				} else {
 					r.EncodeInt(int64(x.ReconciledGeneration))
@@ -7565,17 +7584,17 @@ func (x *ServiceInstanceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if yyq2[6] {
+				if yyq2[7] {
 					if x.OperationStartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym26 := z.EncBinary()
-						_ = yym26
+						yym29 := z.EncBinary()
+						_ = yym29
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.OperationStartTime) {
-						} else if yym26 {
+						} else if yym29 {
 							z.EncBinaryMarshal(x.OperationStartTime)
-						} else if !yym26 && z.IsJSONHandle() {
+						} else if !yym29 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.OperationStartTime)
 						} else {
 							z.EncFallback(x.OperationStartTime)
@@ -7585,20 +7604,20 @@ func (x *ServiceInstanceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2[6] {
+				if yyq2[7] {
 					z.EncSendContainerState(codecSelfer_containerMapKey1234)
 					r.EncodeString(codecSelferC_UTF81234, string("operationStartTime"))
 					z.EncSendContainerState(codecSelfer_containerMapValue1234)
 					if x.OperationStartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym27 := z.EncBinary()
-						_ = yym27
+						yym30 := z.EncBinary()
+						_ = yym30
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.OperationStartTime) {
-						} else if yym27 {
+						} else if yym30 {
 							z.EncBinaryMarshal(x.OperationStartTime)
-						} else if !yym27 && z.IsJSONHandle() {
+						} else if !yym30 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.OperationStartTime)
 						} else {
 							z.EncFallback(x.OperationStartTime)
@@ -7691,6 +7710,18 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 					*((*bool)(yyv6)) = r.DecodeBool()
 				}
 			}
+		case "orphanMitigationInProgress":
+			if r.TryDecodeAsNil() {
+				x.OrphanMitigationInProgress = false
+			} else {
+				yyv8 := &x.OrphanMitigationInProgress
+				yym9 := z.DecBinary()
+				_ = yym9
+				if false {
+				} else {
+					*((*bool)(yyv8)) = r.DecodeBool()
+				}
+			}
 		case "lastOperation":
 			if r.TryDecodeAsNil() {
 				if x.LastOperation != nil {
@@ -7700,8 +7731,8 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				if x.LastOperation == nil {
 					x.LastOperation = new(string)
 				}
-				yym9 := z.DecBinary()
-				_ = yym9
+				yym11 := z.DecBinary()
+				_ = yym11
 				if false {
 				} else {
 					*((*string)(x.LastOperation)) = r.DecodeString()
@@ -7716,8 +7747,8 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				if x.DashboardURL == nil {
 					x.DashboardURL = new(string)
 				}
-				yym11 := z.DecBinary()
-				_ = yym11
+				yym13 := z.DecBinary()
+				_ = yym13
 				if false {
 				} else {
 					*((*string)(x.DashboardURL)) = r.DecodeString()
@@ -7727,19 +7758,19 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.CurrentOperation = ""
 			} else {
-				yyv12 := &x.CurrentOperation
-				yyv12.CodecDecodeSelf(d)
+				yyv14 := &x.CurrentOperation
+				yyv14.CodecDecodeSelf(d)
 			}
 		case "reconciledGeneration":
 			if r.TryDecodeAsNil() {
 				x.ReconciledGeneration = 0
 			} else {
-				yyv13 := &x.ReconciledGeneration
-				yym14 := z.DecBinary()
-				_ = yym14
+				yyv15 := &x.ReconciledGeneration
+				yym16 := z.DecBinary()
+				_ = yym16
 				if false {
 				} else {
-					*((*int64)(yyv13)) = int64(r.DecodeInt(64))
+					*((*int64)(yyv15)) = int64(r.DecodeInt(64))
 				}
 			}
 		case "operationStartTime":
@@ -7751,13 +7782,13 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				if x.OperationStartTime == nil {
 					x.OperationStartTime = new(pkg1_v1.Time)
 				}
-				yym16 := z.DecBinary()
-				_ = yym16
+				yym18 := z.DecBinary()
+				_ = yym18
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.OperationStartTime) {
-				} else if yym16 {
+				} else if yym18 {
 					z.DecBinaryUnmarshal(x.OperationStartTime)
-				} else if !yym16 && z.IsJSONHandle() {
+				} else if !yym18 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.OperationStartTime)
 				} else {
 					z.DecFallback(x.OperationStartTime, false)
@@ -7774,16 +7805,16 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj17 int
-	var yyb17 bool
-	var yyhl17 bool = l >= 0
-	yyj17++
-	if yyhl17 {
-		yyb17 = yyj17 > l
+	var yyj19 int
+	var yyb19 bool
+	var yyhl19 bool = l >= 0
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb17 = r.CheckBreak()
+		yyb19 = r.CheckBreak()
 	}
-	if yyb17 {
+	if yyb19 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7791,21 +7822,21 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv18 := &x.Conditions
-		yym19 := z.DecBinary()
-		_ = yym19
+		yyv20 := &x.Conditions
+		yym21 := z.DecBinary()
+		_ = yym21
 		if false {
 		} else {
-			h.decSliceServiceInstanceCondition((*[]ServiceInstanceCondition)(yyv18), d)
+			h.decSliceServiceInstanceCondition((*[]ServiceInstanceCondition)(yyv20), d)
 		}
 	}
-	yyj17++
-	if yyhl17 {
-		yyb17 = yyj17 > l
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb17 = r.CheckBreak()
+		yyb19 = r.CheckBreak()
 	}
-	if yyb17 {
+	if yyb19 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7813,21 +7844,43 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.AsyncOpInProgress = false
 	} else {
-		yyv20 := &x.AsyncOpInProgress
-		yym21 := z.DecBinary()
-		_ = yym21
+		yyv22 := &x.AsyncOpInProgress
+		yym23 := z.DecBinary()
+		_ = yym23
 		if false {
 		} else {
-			*((*bool)(yyv20)) = r.DecodeBool()
+			*((*bool)(yyv22)) = r.DecodeBool()
 		}
 	}
-	yyj17++
-	if yyhl17 {
-		yyb17 = yyj17 > l
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb17 = r.CheckBreak()
+		yyb19 = r.CheckBreak()
 	}
-	if yyb17 {
+	if yyb19 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem1234)
+	if r.TryDecodeAsNil() {
+		x.OrphanMitigationInProgress = false
+	} else {
+		yyv24 := &x.OrphanMitigationInProgress
+		yym25 := z.DecBinary()
+		_ = yym25
+		if false {
+		} else {
+			*((*bool)(yyv24)) = r.DecodeBool()
+		}
+	}
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
+	} else {
+		yyb19 = r.CheckBreak()
+	}
+	if yyb19 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7840,20 +7893,20 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if x.LastOperation == nil {
 			x.LastOperation = new(string)
 		}
-		yym23 := z.DecBinary()
-		_ = yym23
+		yym27 := z.DecBinary()
+		_ = yym27
 		if false {
 		} else {
 			*((*string)(x.LastOperation)) = r.DecodeString()
 		}
 	}
-	yyj17++
-	if yyhl17 {
-		yyb17 = yyj17 > l
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb17 = r.CheckBreak()
+		yyb19 = r.CheckBreak()
 	}
-	if yyb17 {
+	if yyb19 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7866,20 +7919,20 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if x.DashboardURL == nil {
 			x.DashboardURL = new(string)
 		}
-		yym25 := z.DecBinary()
-		_ = yym25
+		yym29 := z.DecBinary()
+		_ = yym29
 		if false {
 		} else {
 			*((*string)(x.DashboardURL)) = r.DecodeString()
 		}
 	}
-	yyj17++
-	if yyhl17 {
-		yyb17 = yyj17 > l
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb17 = r.CheckBreak()
+		yyb19 = r.CheckBreak()
 	}
-	if yyb17 {
+	if yyb19 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7887,16 +7940,16 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.CurrentOperation = ""
 	} else {
-		yyv26 := &x.CurrentOperation
-		yyv26.CodecDecodeSelf(d)
+		yyv30 := &x.CurrentOperation
+		yyv30.CodecDecodeSelf(d)
 	}
-	yyj17++
-	if yyhl17 {
-		yyb17 = yyj17 > l
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb17 = r.CheckBreak()
+		yyb19 = r.CheckBreak()
 	}
-	if yyb17 {
+	if yyb19 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7904,21 +7957,21 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	if r.TryDecodeAsNil() {
 		x.ReconciledGeneration = 0
 	} else {
-		yyv27 := &x.ReconciledGeneration
-		yym28 := z.DecBinary()
-		_ = yym28
+		yyv31 := &x.ReconciledGeneration
+		yym32 := z.DecBinary()
+		_ = yym32
 		if false {
 		} else {
-			*((*int64)(yyv27)) = int64(r.DecodeInt(64))
+			*((*int64)(yyv31)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj17++
-	if yyhl17 {
-		yyb17 = yyj17 > l
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb17 = r.CheckBreak()
+		yyb19 = r.CheckBreak()
 	}
-	if yyb17 {
+	if yyb19 {
 		z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 		return
 	}
@@ -7931,30 +7984,30 @@ func (x *ServiceInstanceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 		if x.OperationStartTime == nil {
 			x.OperationStartTime = new(pkg1_v1.Time)
 		}
-		yym30 := z.DecBinary()
-		_ = yym30
+		yym34 := z.DecBinary()
+		_ = yym34
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.OperationStartTime) {
-		} else if yym30 {
+		} else if yym34 {
 			z.DecBinaryUnmarshal(x.OperationStartTime)
-		} else if !yym30 && z.IsJSONHandle() {
+		} else if !yym34 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.OperationStartTime)
 		} else {
 			z.DecFallback(x.OperationStartTime, false)
 		}
 	}
 	for {
-		yyj17++
-		if yyhl17 {
-			yyb17 = yyj17 > l
+		yyj19++
+		if yyhl19 {
+			yyb19 = yyj19 > l
 		} else {
-			yyb17 = r.CheckBreak()
+			yyb19 = r.CheckBreak()
 		}
-		if yyb17 {
+		if yyb19 {
 			break
 		}
 		z.DecSendContainerState(codecSelfer_containerArrayElem1234)
-		z.DecStructFieldNotFound(yyj17-1, "")
+		z.DecStructFieldNotFound(yyj19-1, "")
 	}
 	z.DecSendContainerState(codecSelfer_containerArrayEnd1234)
 }

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -452,6 +452,10 @@ type ServiceInstanceStatus struct {
 	// against this Service Instance in progress.
 	AsyncOpInProgress bool `json:"asyncOpInProgress"`
 
+	// OrphanMitigationInProgress is set to true if there is an ongoing orphan
+	// mitigation operation against this ServiceInstance in progress.
+	OrphanMitigationInProgress bool `json:"orphanMitigationInProgress"`
+
 	// LastOperation is the string that the broker may have returned when
 	// an async operation started, it should be sent back to the broker
 	// on poll requests as a query param.

--- a/pkg/apis/servicecatalog/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1alpha1/zz_generated.conversion.go
@@ -703,6 +703,7 @@ func Convert_servicecatalog_ServiceInstanceSpec_To_v1alpha1_ServiceInstanceSpec(
 func autoConvert_v1alpha1_ServiceInstanceStatus_To_servicecatalog_ServiceInstanceStatus(in *ServiceInstanceStatus, out *servicecatalog.ServiceInstanceStatus, s conversion.Scope) error {
 	out.Conditions = *(*[]servicecatalog.ServiceInstanceCondition)(unsafe.Pointer(&in.Conditions))
 	out.AsyncOpInProgress = in.AsyncOpInProgress
+	out.OrphanMitigationInProgress = in.OrphanMitigationInProgress
 	out.LastOperation = (*string)(unsafe.Pointer(in.LastOperation))
 	out.DashboardURL = (*string)(unsafe.Pointer(in.DashboardURL))
 	out.CurrentOperation = servicecatalog.ServiceInstanceOperation(in.CurrentOperation)
@@ -723,6 +724,7 @@ func autoConvert_servicecatalog_ServiceInstanceStatus_To_v1alpha1_ServiceInstanc
 		out.Conditions = *(*[]ServiceInstanceCondition)(unsafe.Pointer(&in.Conditions))
 	}
 	out.AsyncOpInProgress = in.AsyncOpInProgress
+	out.OrphanMitigationInProgress = in.OrphanMitigationInProgress
 	out.LastOperation = (*string)(unsafe.Pointer(in.LastOperation))
 	out.DashboardURL = (*string)(unsafe.Pointer(in.DashboardURL))
 	out.CurrentOperation = ServiceInstanceOperation(in.CurrentOperation)

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -18,6 +18,8 @@ package controller
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/golang/glog"
@@ -151,11 +153,9 @@ func (c *controller) reconcileServiceInstanceKey(key string) error {
 
 // reconcileServiceInstanceDelete is responsible for handling any instance whose
 // deletion timestamp is set.
-//
-// TODO: may change when orphan mitigation is implemented.
 func (c *controller) reconcileServiceInstanceDelete(instance *v1alpha1.ServiceInstance) error {
 	// nothing to do...
-	if instance.DeletionTimestamp == nil {
+	if instance.DeletionTimestamp == nil && !instance.Status.OrphanMitigationInProgress {
 		return nil
 	}
 
@@ -204,13 +204,15 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1alpha1.ServiceIn
 		return nil
 	}
 
-	// If there is no op in progress, and the instance was never provisioned,
-	// we can just delete. this can happen if the service class name
-	// referenced never existed.
-	//
-	// TODO: the above logic changes slightly once we handle orphan
-	// mitigation.
-	if !instance.Status.AsyncOpInProgress && instance.Status.ReconciledGeneration == 0 {
+	// If there is no op in progress, and the instance either was never
+	// provisioned or was already deprovisioned due to orphan mitigation,
+	// we can just clear the finalizer and delete. One possible  scenario
+	// is if  the service class name referenced never existed.
+	if !instance.Status.AsyncOpInProgress &&
+		!instance.Status.OrphanMitigationInProgress &&
+		(isServiceInstanceFailed(instance) || instance.Status.ReconciledGeneration == 0) {
+
+		glog.V(5).Infof("Clearing catalog finalizer from ServiceInstance %v/%v", instance.Namespace, instance.Name)
 		clone, err := api.Scheme.DeepCopy(instance)
 		if err != nil {
 			return err
@@ -241,8 +243,6 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1alpha1.ServiceIn
 	}
 	toUpdate := clone.(*v1alpha1.ServiceInstance)
 
-	glog.V(4).Infof("Finalizing ServiceInstance %v/%v", instance.Namespace, instance.Name)
-
 	request := &osb.DeprovisionRequest{
 		InstanceID:        instance.Spec.ExternalID,
 		ServiceID:         serviceClass.Spec.ExternalID,
@@ -271,21 +271,6 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1alpha1.ServiceIn
 			return err
 		}
 		request.OriginatingIdentity = originatingIdentity
-	}
-
-	// If the instance is failed, just clear the finalizer
-	if isServiceInstanceFailed(instance) {
-		glog.V(5).Infof("Clearing catalog finalizer from ServiceInstance %v/%v", instance.Namespace, instance.Name)
-
-		// Clear the finalizer
-		finalizers.Delete(v1alpha1.FinalizerServiceCatalog)
-		toUpdate.Finalizers = finalizers.List()
-
-		if _, err = c.updateServiceInstanceStatus(toUpdate); err != nil {
-			return err
-		}
-
-		return nil
 	}
 
 	// it is arguable we should perform an extract-method refactor on this
@@ -323,13 +308,20 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1alpha1.ServiceIn
 				v1alpha1.ConditionUnknown,
 				errorDeprovisionCalledReason,
 				"Deprovision call failed. "+s)
-			setServiceInstanceCondition(
-				toUpdate,
-				v1alpha1.ServiceInstanceConditionFailed,
-				v1alpha1.ConditionTrue,
-				errorDeprovisionCalledReason,
-				s,
-			)
+
+			if !instance.Status.OrphanMitigationInProgress {
+				// Do not overwrite 'Failed' message if deprovisioning due to orphan
+				// mitigation in order to prevent loss of original reason for the
+				// orphan.
+				setServiceInstanceCondition(
+					toUpdate,
+					v1alpha1.ServiceInstanceConditionFailed,
+					v1alpha1.ConditionTrue,
+					errorDeprovisionCalledReason,
+					s,
+				)
+			}
+
 			c.clearServiceInstanceCurrentOperation(toUpdate)
 			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 				return err
@@ -359,11 +351,15 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1alpha1.ServiceIn
 			s := fmt.Sprintf(`Stopping reconciliation retries on ServiceInstance "%v/%v" because too much time has elapsed`, instance.Namespace, instance.Name)
 			glog.Info(s)
 			c.recorder.Event(instance, api.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
-			setServiceInstanceCondition(toUpdate,
-				v1alpha1.ServiceInstanceConditionFailed,
-				v1alpha1.ConditionTrue,
-				errorReconciliationRetryTimeoutReason,
-				s)
+
+			if !instance.Status.OrphanMitigationInProgress {
+				setServiceInstanceCondition(toUpdate,
+					v1alpha1.ServiceInstanceConditionFailed,
+					v1alpha1.ConditionTrue,
+					errorReconciliationRetryTimeoutReason,
+					s)
+			}
+
 			c.clearServiceInstanceCurrentOperation(toUpdate)
 			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 				return err
@@ -422,9 +418,11 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1alpha1.ServiceIn
 		successDeprovisionMessage,
 	)
 
-	// Clear the finalizer
-	finalizers.Delete(v1alpha1.FinalizerServiceCatalog)
-	toUpdate.Finalizers = finalizers.List()
+	if instance.DeletionTimestamp != nil {
+		// Clear the finalizer for normal instance deletions
+		finalizers.Delete(v1alpha1.FinalizerServiceCatalog)
+		toUpdate.Finalizers = finalizers.List()
+	}
 
 	if _, err = c.updateServiceInstanceStatus(toUpdate); err != nil {
 		return err
@@ -452,24 +450,25 @@ func isServiceInstanceFailed(instance *v1alpha1.ServiceInstance) bool {
 // error is returned to indicate that the instance has not been fully
 // processed and should be resubmitted at a later time.
 func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance) error {
+	if instance.Status.AsyncOpInProgress {
+		return c.pollServiceInstanceInternal(instance)
+	}
+
+	if instance.ObjectMeta.DeletionTimestamp != nil || instance.Status.OrphanMitigationInProgress {
+		return c.reconcileServiceInstanceDelete(instance)
+	}
+
 	// Currently, we only set a failure condition if the initial provision
 	// call fails, so if that condition is set, we only need to remove the
 	// finalizer from the instance. We will need to reevaluate this logic as
 	// we make any changes to capture permanent failure in new cases.
-	//
-	// TODO: this will change once we fully implement orphan mitigation, see:
-	// https://github.com/kubernetes-incubator/service-catalog/issues/988
-	if isServiceInstanceFailed(instance) && instance.ObjectMeta.DeletionTimestamp == nil {
+	if isServiceInstanceFailed(instance) {
 		glog.V(4).Infof(
 			"Not processing event for ServiceInstance %v/%v because status showed that it has failed",
 			instance.Namespace,
 			instance.Name,
 		)
 		return nil
-	}
-
-	if instance.Status.AsyncOpInProgress {
-		return c.pollServiceInstanceInternal(instance)
 	}
 
 	// If there's no async op in progress, determine whether there is a new
@@ -489,22 +488,16 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 	// communicating with the broker.  In the future the same logic will
 	// result in an instance that requires update being processed by the
 	// controller.
-	if instance.DeletionTimestamp == nil {
-		if instance.Status.ReconciledGeneration == instance.Generation {
-			glog.V(4).Infof(
-				"Not processing event for ServiceInstance %v/%v because reconciled generation showed there is no work to do",
-				instance.Namespace,
-				instance.Name,
-			)
-			return nil
-		}
+	if instance.Status.ReconciledGeneration == instance.Generation {
+		glog.V(4).Infof(
+			"Not processing event for ServiceInstance %v/%v because reconciled generation showed there is no work to do",
+			instance.Namespace,
+			instance.Name,
+		)
+		return nil
 	}
 
 	glog.V(4).Infof("Processing ServiceInstance %v/%v", instance.Namespace, instance.Name)
-
-	if instance.ObjectMeta.DeletionTimestamp != nil {
-		return c.reconcileServiceInstanceDelete(instance)
-	}
 
 	glog.V(4).Infof("Adding/Updating ServiceInstance %v/%v", instance.Namespace, instance.Name)
 
@@ -638,16 +631,48 @@ func (c *controller) reconcileServiceInstance(instance *v1alpha1.ServiceInstance
 				v1alpha1.ConditionFalse,
 				errorProvisionCallFailedReason,
 				"ServiceBroker returned a failure for provision call; operation will not be retried: "+s)
+
+			if shouldStartOrphanMitigation(httpErr.StatusCode) {
+				setServiceInstanceStartOrphanMitigation(toUpdate)
+
+				if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+					return err
+				}
+
+				return httpErr
+			}
+
 			c.clearServiceInstanceCurrentOperation(toUpdate)
+
 			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 				return err
 			}
+
 			return nil
 		}
 
 		s := fmt.Sprintf("Error provisioning ServiceInstance \"%s/%s\" of ServiceClass %q at ServiceBroker %q: %s", instance.Namespace, instance.Name, serviceClass.Spec.ExternalName, brokerName, err)
 		glog.Warning(s)
 		c.recorder.Event(instance, api.EventTypeWarning, errorErrorCallingProvisionReason, s)
+
+		urlErr, ok := err.(*url.Error)
+		if ok && urlErr.Timeout() {
+			// Communication to the broker timed out. Treat as terminal failure and
+			// begin orphan mitigation.
+			setServiceInstanceCondition(
+				toUpdate,
+				v1alpha1.ServiceInstanceConditionReady,
+				v1alpha1.ConditionFalse,
+				errorErrorCallingProvisionReason,
+				"Communication with ServiceBroker timed out; operation will not be retried: "+s)
+			setServiceInstanceStartOrphanMitigation(toUpdate)
+
+			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+				return err
+			}
+
+			return err
+		}
 
 		setServiceInstanceCondition(
 			toUpdate,
@@ -749,11 +774,17 @@ func (c *controller) pollServiceInstanceInternal(instance *v1alpha1.ServiceInsta
 }
 
 func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, servicePlan *v1alpha1.ServicePlan, brokerName string, brokerClient osb.Client, instance *v1alpha1.ServiceInstance) error {
-	// There are some conditions that are different if we're
-	// deleting, this is more readable than checking the
-	// timestamps in various places.
+	// There are three possible operations that require polling:
+	// 1) Normal asynchronous provision
+	// 2) Normal asynchronous deprovision
+	// 3) Deprovisioning as part of orphan mitigation
+	//
+	// There are some conditions that are different depending on which
+	// operation we're polling for. This is more readable than checking the
+	// status in various places.
+	mitigatingOrphan := instance.Status.OrphanMitigationInProgress
 	deleting := false
-	if instance.Status.CurrentOperation == v1alpha1.ServiceInstanceOperationDeprovision {
+	if instance.Status.CurrentOperation == v1alpha1.ServiceInstanceOperationDeprovision || mitigatingOrphan {
 		deleting = true
 	}
 
@@ -768,13 +799,21 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 		s := fmt.Sprintf(`Stopping reconciliation retries on ServiceInstance "%v/%v" because the operation start time is not set`, instance.Namespace, instance.Name)
 		glog.Info(s)
 		c.recorder.Event(instance, api.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
-		setServiceInstanceCondition(toUpdate,
-			v1alpha1.ServiceInstanceConditionFailed,
-			v1alpha1.ConditionTrue,
-			errorReconciliationRetryTimeoutReason,
-			s)
-		toUpdate.Status.OperationStartTime = nil
-		toUpdate.Status.ReconciledGeneration = toUpdate.Generation
+
+		if !mitigatingOrphan {
+			setServiceInstanceCondition(toUpdate,
+				v1alpha1.ServiceInstanceConditionFailed,
+				v1alpha1.ConditionTrue,
+				errorReconciliationRetryTimeoutReason,
+				s)
+		}
+
+		if deleting {
+			c.clearServiceInstanceCurrentOperation(toUpdate)
+		} else {
+			setServiceInstanceStartOrphanMitigation(toUpdate)
+		}
+
 		if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 			return err
 		}
@@ -840,10 +879,12 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 				successDeprovisionMessage,
 			)
 
-			// Clear the finalizer
-			if finalizers := sets.NewString(toUpdate.Finalizers...); finalizers.Has(v1alpha1.FinalizerServiceCatalog) {
-				finalizers.Delete(v1alpha1.FinalizerServiceCatalog)
-				toUpdate.Finalizers = finalizers.List()
+			if !mitigatingOrphan {
+				// Clear the finalizer
+				if finalizers := sets.NewString(toUpdate.Finalizers...); finalizers.Has(v1alpha1.FinalizerServiceCatalog) {
+					finalizers.Delete(v1alpha1.FinalizerServiceCatalog)
+					toUpdate.Finalizers = finalizers.List()
+				}
 			}
 
 			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
@@ -883,12 +924,21 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 			s := fmt.Sprintf(`Stopping reconciliation retries on ServiceInstance "%v/%v" because too much time has elapsed`, instance.Namespace, instance.Name)
 			glog.Info(s)
 			c.recorder.Event(instance, api.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
-			setServiceInstanceCondition(toUpdate,
-				v1alpha1.ServiceInstanceConditionFailed,
-				v1alpha1.ConditionTrue,
-				errorReconciliationRetryTimeoutReason,
-				s)
-			c.clearServiceInstanceCurrentOperation(toUpdate)
+
+			if !mitigatingOrphan {
+				setServiceInstanceCondition(toUpdate,
+					v1alpha1.ServiceInstanceConditionFailed,
+					v1alpha1.ConditionTrue,
+					errorReconciliationRetryTimeoutReason,
+					s)
+			}
+
+			if deleting {
+				c.clearServiceInstanceCurrentOperation(toUpdate)
+			} else {
+				setServiceInstanceStartOrphanMitigation(toUpdate)
+			}
+
 			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 				return err
 			}
@@ -948,12 +998,21 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 			s := fmt.Sprintf(`Stopping reconciliation retries on ServiceInstance "%v/%v" because too much time has elapsed`, instance.Namespace, instance.Name)
 			glog.Info(s)
 			c.recorder.Event(instance, api.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
-			setServiceInstanceCondition(toUpdate,
-				v1alpha1.ServiceInstanceConditionFailed,
-				v1alpha1.ConditionTrue,
-				errorReconciliationRetryTimeoutReason,
-				s)
-			c.clearServiceInstanceCurrentOperation(toUpdate)
+
+			if !mitigatingOrphan {
+				setServiceInstanceCondition(toUpdate,
+					v1alpha1.ServiceInstanceConditionFailed,
+					v1alpha1.ConditionTrue,
+					errorReconciliationRetryTimeoutReason,
+					s)
+			}
+
+			if deleting {
+				c.clearServiceInstanceCurrentOperation(toUpdate)
+			} else {
+				setServiceInstanceStartOrphanMitigation(toUpdate)
+			}
+
 			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 				return err
 			}
@@ -993,10 +1052,12 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 				successDeprovisionMessage,
 			)
 
-			// Clear the finalizer
-			if finalizers := sets.NewString(toUpdate.Finalizers...); finalizers.Has(v1alpha1.FinalizerServiceCatalog) {
-				finalizers.Delete(v1alpha1.FinalizerServiceCatalog)
-				toUpdate.Finalizers = finalizers.List()
+			if !mitigatingOrphan {
+				// Clear the finalizer
+				if finalizers := sets.NewString(toUpdate.Finalizers...); finalizers.Has(v1alpha1.FinalizerServiceCatalog) {
+					finalizers.Delete(v1alpha1.FinalizerServiceCatalog)
+					toUpdate.Finalizers = finalizers.List()
+				}
 			}
 
 			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
@@ -1052,13 +1113,17 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 			reason,
 			msg,
 		)
-		setServiceInstanceCondition(
-			toUpdate,
-			v1alpha1.ServiceInstanceConditionFailed,
-			v1alpha1.ConditionTrue,
-			reason,
-			msg,
-		)
+
+		if !mitigatingOrphan {
+			setServiceInstanceCondition(
+				toUpdate,
+				v1alpha1.ServiceInstanceConditionFailed,
+				v1alpha1.ConditionTrue,
+				reason,
+				msg,
+			)
+		}
+
 		if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 			return err
 		}
@@ -1078,12 +1143,21 @@ func (c *controller) pollServiceInstance(serviceClass *v1alpha1.ServiceClass, se
 			s := fmt.Sprintf(`Stopping reconciliation retries on ServiceInstance "%v/%v" because too much time has elapsed`, instance.Namespace, instance.Name)
 			glog.Info(s)
 			c.recorder.Event(instance, api.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
-			setServiceInstanceCondition(toUpdate,
-				v1alpha1.ServiceInstanceConditionFailed,
-				v1alpha1.ConditionTrue,
-				errorReconciliationRetryTimeoutReason,
-				s)
-			c.clearServiceInstanceCurrentOperation(toUpdate)
+
+			if !mitigatingOrphan {
+				setServiceInstanceCondition(toUpdate,
+					v1alpha1.ServiceInstanceConditionFailed,
+					v1alpha1.ConditionTrue,
+					errorReconciliationRetryTimeoutReason,
+					s)
+			}
+
+			if deleting {
+				c.clearServiceInstanceCurrentOperation(toUpdate)
+			} else {
+				setServiceInstanceStartOrphanMitigation(toUpdate)
+			}
+
 			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
 				return err
 			}
@@ -1235,6 +1309,27 @@ func (c *controller) clearServiceInstanceCurrentOperation(toUpdate *v1alpha1.Ser
 	toUpdate.Status.CurrentOperation = ""
 	toUpdate.Status.OperationStartTime = nil
 	toUpdate.Status.AsyncOpInProgress = false
+	toUpdate.Status.OrphanMitigationInProgress = false
 	toUpdate.Status.LastOperation = nil
 	toUpdate.Status.ReconciledGeneration = toUpdate.Generation
+}
+
+// setServiceInstanceStartOrphanMitigation sets the fields of the instance's
+// Status to indicate that orphan mitigation is starting. The Status is *not*
+// recorded in the registry.
+func setServiceInstanceStartOrphanMitigation(toUpdate *v1alpha1.ServiceInstance) {
+	toUpdate.Status.OperationStartTime = nil
+	toUpdate.Status.AsyncOpInProgress = false
+	toUpdate.Status.OrphanMitigationInProgress = true
+}
+
+// shouldStartOrphanMitigation returns whether an error with the given status
+// code indicates that orphan migitation should start.
+func shouldStartOrphanMitigation(statusCode int) bool {
+	is2XX := (statusCode >= 200 && statusCode < 300)
+	is5XX := (statusCode >= 500 && statusCode < 600)
+
+	return (is2XX && statusCode != http.StatusOK) ||
+		statusCode == http.StatusRequestTimeout ||
+		is5XX
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1579,23 +1579,23 @@ func assertAsyncOpInProgressFalse(t *testing.T, obj runtime.Object) {
 	}
 }
 
-func assertOrphanMitigationInProgressTrue(t *testing.T, obj runtime.Object) {
-	testOrphanMitigationInProgress(t, "" /* name */, fatalf, obj, true)
+func assertServiceInstanceOrphanMitigationInProgressTrue(t *testing.T, obj runtime.Object) {
+	testServiceInstanceOrphanMitigationInProgress(t, "" /* name */, fatalf, obj, true)
 }
 
-func assertOrphanMitigationInProgressFalse(t *testing.T, obj runtime.Object) {
-	testOrphanMitigationInProgress(t, "" /* name */, fatalf, obj, false)
+func assertServiceInstanceOrphanMitigationInProgressFalse(t *testing.T, obj runtime.Object) {
+	testServiceInstanceOrphanMitigationInProgress(t, "" /* name */, fatalf, obj, false)
 }
 
-func expectOrphanMitigationInProgressTrue(t *testing.T, name string, obj runtime.Object) bool {
-	return testOrphanMitigationInProgress(t, name, fatalf, obj, true)
+func expectServiceInstanceOrphanMitigationInProgressTrue(t *testing.T, name string, obj runtime.Object) bool {
+	return testServiceInstanceOrphanMitigationInProgress(t, name, fatalf, obj, true)
 }
 
-func expectOrphanMitigationInProgressFalse(t *testing.T, name string, obj runtime.Object) bool {
-	return testOrphanMitigationInProgress(t, name, fatalf, obj, false)
+func expectServiceInstanceOrphanMitigationInProgressFalse(t *testing.T, name string, obj runtime.Object) bool {
+	return testServiceInstanceOrphanMitigationInProgress(t, name, fatalf, obj, false)
 }
 
-func testOrphanMitigationInProgress(t *testing.T, name string, f failfFunc, obj runtime.Object, expected bool) bool {
+func testServiceInstanceOrphanMitigationInProgress(t *testing.T, name string, f failfFunc, obj runtime.Object, expected bool) bool {
 	logContext := ""
 	if len(name) > 0 {
 		logContext = name + ": "
@@ -1647,7 +1647,7 @@ func assertServiceInstanceErrorBeforeRequest(t *testing.T, obj runtime.Object, r
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertServiceInstanceReconciliationNotComplete(t, obj)
 	assertAsyncOpInProgressFalse(t, obj)
-	assertOrphanMitigationInProgressFalse(t, obj)
+	assertServiceInstanceOrphanMitigationInProgressFalse(t, obj)
 }
 
 func assertServiceInstanceOperationInProgress(t *testing.T, obj runtime.Object, operation v1alpha1.ServiceInstanceOperation) {
@@ -1663,7 +1663,7 @@ func assertServiceInstanceOperationInProgress(t *testing.T, obj runtime.Object, 
 	assertServiceInstanceOperationStartTimeSet(t, obj, true)
 	assertServiceInstanceReconciliationNotComplete(t, obj)
 	assertAsyncOpInProgressFalse(t, obj)
-	assertOrphanMitigationInProgressFalse(t, obj)
+	assertServiceInstanceOrphanMitigationInProgressFalse(t, obj)
 }
 
 func assertServiceInstanceOperationSuccess(t *testing.T, obj runtime.Object, operation v1alpha1.ServiceInstanceOperation) {
@@ -1684,7 +1684,7 @@ func assertServiceInstanceOperationSuccess(t *testing.T, obj runtime.Object, ope
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertServiceInstanceReconciliationComplete(t, obj)
 	assertAsyncOpInProgressFalse(t, obj)
-	assertOrphanMitigationInProgressFalse(t, obj)
+	assertServiceInstanceOrphanMitigationInProgressFalse(t, obj)
 	if operation == v1alpha1.ServiceInstanceOperationDeprovision {
 		assertEmptyFinalizers(t, obj)
 	}
@@ -1702,6 +1702,19 @@ func assertServiceInstanceRequestFailingError(t *testing.T, obj runtime.Object, 
 	assertServiceInstanceCondition(t, obj, v1alpha1.ServiceInstanceConditionFailed, v1alpha1.ConditionTrue, failureReason)
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertAsyncOpInProgressFalse(t, obj)
+}
+
+func assertServiceInstanceRequestFailingErrorNoOrphanMitigation(t *testing.T, obj runtime.Object, operation v1alpha1.ServiceInstanceOperation, readyReason string, failureReason string) {
+	assertServiceInstanceRequestFailingError(t, obj, operation, readyReason, failureReason)
+	assertServiceInstanceCurrentOperationClear(t, obj)
+	assertServiceInstanceReconciliationComplete(t, obj)
+	assertServiceInstanceOrphanMitigationInProgressFalse(t, obj)
+}
+
+func assertServiceInstanceRequestFailingErrorStartOrphanMitigation(t *testing.T, obj runtime.Object, operation v1alpha1.ServiceInstanceOperation, readyReason string, failureReason string) {
+	assertServiceInstanceRequestFailingError(t, obj, operation, readyReason, failureReason)
+	assertServiceInstanceCurrentOperation(t, obj, v1alpha1.ServiceInstanceOperationProvision)
+	assertServiceInstanceOrphanMitigationInProgressTrue(t, obj)
 }
 
 func assertServiceInstanceRequestRetriableError(t *testing.T, obj runtime.Object, operation v1alpha1.ServiceInstanceOperation, reason string) {

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -983,6 +983,13 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 								Format:      "",
 							},
 						},
+						"orphanMitigationInProgress": {
+							SchemaProps: spec.SchemaProps{
+								Description: "OrphanMitigationInProgress is set to true if there is an ongoing orphan mitigation operation against this ServiceInstance in progress.",
+								Type:        []string{"boolean"},
+								Format:      "",
+							},
+						},
 						"lastOperation": {
 							SchemaProps: spec.SchemaProps{
 								Description: "LastOperation is the string that the broker may have returned when an async operation started, it should be sent back to the broker on poll requests as a query param.",
@@ -1018,7 +1025,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 					},
-					Required: []string{"conditions", "asyncOpInProgress", "reconciledGeneration"},
+					Required: []string{"conditions", "asyncOpInProgress", "orphanMitigationInProgress", "reconciledGeneration"},
 				},
 			},
 			Dependencies: []string{


### PR DESCRIPTION
Implementation of instance orphan mitigation. #988 

When an instance provision request hits one of the states described [here](https://github.com/openservicebrokerapi/servicebroker/blob/v2.12/spec.md#orphans) or the controller hits the retry limit on an ongoing async operation, set the instance as Failed, do not update `ReconciledGeneration`, set its `OrphanMitigationInProgress` status attribute, and requeue it.

When the reconciler gets to it, it will attempt a deprovision. When the deprovision attempt ends (whether success or failure), unset `OrphanMitigationInProgress` and update `ReconciledGeneration`. Updates on the deprovision attempt are written to the Ready condition as usual.

If the orphan mitigation attempt ends in failure, the controller will not record that in the Failed condition in order to preserve the information as to why the instance originally failed. The final state of the orphan mitigation attempt, whether success or failure, is captured in the Ready condition.

While orphan mitigation is occurring, the instance is still considered in the "Provisioning" operation state. This seemed natural to me, as it's really a cleanup operation at the end of the provisioning logic, and once it's done, `ReconciledGeneration` is updated and that operation ends.