### PR TITLE
Add option to helm charts for enabling OriginatingIdentity feature

### DIFF
--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -58,6 +58,10 @@ spec:
         {{- if not .Values.apiserver.auth.enabled }}
         - --disable-auth
         {{- end }}
+        {{- if .Values.originatingIdentityEnabled }}
+        - --feature-gates
+        - OriginatingIdentity=true
+        {{- end }}
         ports:
         - containerPort: 8443
         volumeMounts:

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -66,6 +66,10 @@ spec:
         - --broker-relist-interval
         - {{ .Values.controllerManager.brokerRelistInterval }}
         {{- end }}
+        {{- if .Values.originatingIdentityEnabled }}
+        - --feature-gates
+        - OriginatingIdentity=true
+        {{- end }}
         ports:
         - containerPort: 8080
         volumeMounts:

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -97,3 +97,5 @@ controllerManager:
   serviceAccount: service-catalog-controller-manager
   # Controls whether the API server's TLS verification should be skipped.
   apiserverSkipVerify: true
+# Whether the OriginatingIdentity alpha feature should be enabled
+originatingIdentityEnabled: false


### PR DESCRIPTION
Add the `originatingIdentityEnabled` value to the catalog helm chart. When the value is set to true, the OriginatingIdentity feature will be enabled for the API Server and the Controller Manager.