### PR TITLE
statically compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ endif
 BASEIMAGE?=gcr.io/google-containers/debian-base-$(ARCH):0.2
 
 GO_BUILD       = env CGO_ENABLED=0 GOOS=$(PLATFORM) GOARCH=$(ARCH) \
-                  go build -i $(GOFLAGS) \
-                  -ldflags '-d -s -w -X $(SC_PKG)/pkg.VERSION=$(VERSION) $(BUILD_LDFLAGS)'
+                  go build -i $(GOFLAGS) -a -tags netgo -installsuffix netgo \
+                  -ldflags '-s -w -X $(SC_PKG)/pkg.VERSION=$(VERSION) $(BUILD_LDFLAGS)'
 
 BASE_PATH      = $(ROOT:/src/github.com/kubernetes-incubator/service-catalog/=)
 export GOPATH  = $(BASE_PATH):$(ROOT)/vendor

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,10 @@ endif
 # TODO: Consider using busybox instead of debian
 BASEIMAGE?=gcr.io/google-containers/debian-base-$(ARCH):0.2
 
-GO_BUILD       = env GOOS=$(PLATFORM) GOARCH=$(ARCH) go build -i $(GOFLAGS) \
-                   -ldflags "-X $(SC_PKG)/pkg.VERSION=$(VERSION) $(BUILD_LDFLAGS)"
+GO_BUILD       = env CGO_ENABLED=0 GOOS=$(PLATFORM) GOARCH=$(ARCH) \
+                  go build -i $(GOFLAGS) \
+                  -ldflags '-d -s -w -X $(SC_PKG)/pkg.VERSION=$(VERSION) $(BUILD_LDFLAGS)'
+
 BASE_PATH      = $(ROOT:/src/github.com/kubernetes-incubator/service-catalog/=)
 export GOPATH  = $(BASE_PATH):$(ROOT)/vendor
 


### PR DESCRIPTION
Turned some debugger stuff off because I'm not sure anyone in the history of golang has ever tried to attach a debugger more than once.

going to want it for plugins.