### PR TITLE
e2e explicit plan check

### DIFF
--- a/test/e2e/walkthrough.go
+++ b/test/e2e/walkthrough.go
@@ -74,7 +74,7 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("Run walkthrough-example ", func() {
+	It("Runs through the walkthrough", func() {
 		var (
 			brokerName                     = upsbrokername
 			serviceclassName               = "user-provided-service"
@@ -129,6 +129,10 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 		By("Waiting for ClusterServiceClass to be ready")
 		err = util.WaitForClusterServiceClassToExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), serviceclassID)
 		Expect(err).NotTo(HaveOccurred(), "failed to wait serviceclass to be ready")
+
+		By("Waiting for ClusterServicePlan to be ready")
+		err = util.WaitForClusterServicePlanToExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), serviceplanID)
+		Expect(err).ShouldNot(HaveOccurred(), "serviceplan never became ready")
 
 		// Provisioning a ServiceInstance and binding to it
 		By("Creating a namespace")

--- a/test/e2e/walkthrough.go
+++ b/test/e2e/walkthrough.go
@@ -132,7 +132,7 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 
 		By("Waiting for ClusterServicePlan to be ready")
 		err = util.WaitForClusterServicePlanToExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), serviceplanID)
-		Expect(err).ShouldNot(HaveOccurred(), "serviceplan never became ready")
+		Ω(err).ShouldNot(HaveOccurred(), "serviceplan never became ready")
 
 		// Provisioning a ServiceInstance and binding to it
 		By("Creating a namespace")

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -98,10 +98,10 @@ func WaitForClusterServiceClassToExist(client v1beta1servicecatalog.Servicecatal
 	)
 }
 
-// WaitForClusterServiceClassToExist waits for the ClusterServiceClass with the given name
+// WaitForClusterServicePlanToExist waits for the ServicePlan with the given name
 // to exist.
 func WaitForClusterServicePlanToExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {
-	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
+	err := wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
 			glog.V(5).Infof("Waiting for ClusterServicePlan %v to exist", name)
 			_, err := client.ClusterServicePlans().Get(name, metav1.GetOptions{})

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -101,7 +101,7 @@ func WaitForClusterServiceClassToExist(client v1beta1servicecatalog.Servicecatal
 // WaitForClusterServicePlanToExist waits for the ServicePlan with the given name
 // to exist.
 func WaitForClusterServicePlanToExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {
-	err := wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
+	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
 			glog.V(5).Infof("Waiting for ClusterServicePlan %v to exist", name)
 			_, err := client.ClusterServicePlans().Get(name, metav1.GetOptions{})

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -98,8 +98,8 @@ func WaitForClusterServiceClassToExist(client v1beta1servicecatalog.Servicecatal
 	)
 }
 
-// WaitForClusterServicePlanToExist waits for the ServicePlan with the given name
-// to exist.
+// WaitForClusterServicePlanToExist waits for the ClusterServicePlan
+// with the given name to exist.
 func WaitForClusterServicePlanToExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {


### PR DESCRIPTION
This PR is not outdated or obsolete. `WaitForClusterServicePlanToExist` was implemented a second time in the period between now and submission, but it was never used in the e2e tests.