### PR TITLE
Wait for test-broker Service endpoint to be available

### DIFF
--- a/test/e2e/broker.go
+++ b/test/e2e/broker.go
@@ -52,6 +52,9 @@ var _ = framework.ServiceCatalogDescribe("ServiceBroker", func() {
 		By("Creating a user broker service")
 		_, err = f.KubeClientSet.CoreV1().Services(f.Namespace.Name).Create(NewUPSBrokerService(brokerName))
 		Expect(err).NotTo(HaveOccurred())
+		By("Waiting for service endpoint")
+		err = framework.WaitForEndpoint(f.KubeClientSet, f.Namespace.Name, brokerName)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {

--- a/test/e2e/walkthrough.go
+++ b/test/e2e/walkthrough.go
@@ -46,6 +46,10 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 		By("Creating a ups-broker service")
 		_, err = f.KubeClientSet.CoreV1().Services(f.Namespace.Name).Create(NewUPSBrokerService(upsbrokername))
 		Expect(err).NotTo(HaveOccurred(), "failed to create upsbroker service")
+
+		By("Waiting for service endpoint")
+		err = framework.WaitForEndpoint(f.KubeClientSet, f.Namespace.Name, upsbrokername)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
E2E fails under OpenShift Origin as the broker service is not ready when we create the ServiceBroker and the initial GetCatalog times out.  Adding a poll that waits for the service endpoint addresses the issue.