### PR TITLE
workaround for TPR installation test

### DIFF
--- a/pkg/storage/tpr/install_types_test.go
+++ b/pkg/storage/tpr/install_types_test.go
@@ -144,7 +144,10 @@ func TestInstallTypesErrors(t *testing.T) {
 	}
 }
 
-//make sure we don't poll on resource that was failed on install
+//make sure we don't poll on resource that was failed on install.
+//
+// This test depends on the order of installation of the
+// thirdPartyResources
 func TestInstallTypesPolling(t *testing.T) {
 	getCallCount := 0
 	createCallCount := 0
@@ -165,7 +168,7 @@ func TestInstallTypesPolling(t *testing.T) {
 		func(action core.Action) (bool, runtime.Object, error) {
 			createCallCount++
 			name := action.(core.CreateAction).GetObject().(*v1beta1.ThirdPartyResource).Name
-			if name == serviceBrokerTPR.Name || name == serviceInstanceTPR.Name {
+			if name == serviceBrokerTPR.Name || name == serviceClassTPR.Name {
 				return true, nil, fmt.Errorf("Error creatingTPR : %v", name)
 			}
 			return true, nil, nil
@@ -178,7 +181,7 @@ func TestInstallTypesPolling(t *testing.T) {
 
 	for _, action := range getCallActions {
 		name := action.GetName()
-		if name == serviceBrokerTPR.Name || name == serviceInstanceTPR.Name {
+		if name == serviceBrokerTPR.Name || name == serviceClassTPR.Name {
 			t.Errorf("Failed to skip polling for resource that failed to install: %q", action)
 		}
 	}


### PR DESCRIPTION
 - this test has a race condition in it if we pretend that types
   are installed later.

For the order:
	serviceBrokerTPR,
	serviceClassTPR,
	servicePlanTPR,
	serviceInstanceTPR,
	serviceInstanceCredentialTPR,

 - If we were to pretend the last two fail to install, our get count may
   rack up faster than expected by the time we get to the last TPR. We
   may run out of increments and have a successful install when we are
   trained to have a failing create.
 - We are trying to have explicit TPR failures, so we can expect them at
   the end of the test.

 - Depending on the first two (in the list order) failing ensures that
   they will pass the first GET gate before any other GET calls have a
   chance to run.


I also tried the opposite of my suggestion (pretending on instance and instancecredential), and it failed every time.