### PR TITLE
Add note advising users on content of contrib/pkg

### DIFF
--- a/contrib/pkg/README.md
+++ b/contrib/pkg/README.md
@@ -1,0 +1,11 @@
+## Test Broker Code
+
+These packages contain code which is used to build a broker used to test the
+service-catalog project.  These packages are **NOT** intended to represent a
+fully up-to-date version of the API. The client library used by the service-
+catalog is [here](https://github.com/pmorie/go-open-service-broker-client).
+
+These packages are also **NOT** intended to represent a framework or library
+that should be used to create new brokers or used as a client to talk to
+brokers.
+


### PR DESCRIPTION
We've had a couple people in the community try to use this code to build new brokers - which isn't a goal.

This PR adds a note about it.