### PR TITLE
Add warning to Parameters field doc about sensitive information

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -411,13 +411,17 @@ type ServiceInstanceSpec struct {
 	// This is set by the controller based on ExternalServicePlanName
 	ServicePlanRef *v1.ObjectReference
 
-	// Parameters is a set of the parameters to be
-	// passed to the underlying broker.
-	// The inline YAML/JSON payload to be translated into equivalent
-	// JSON object.
-	// If a top-level parameter name exists in multiples sources among
-	// `Parameters` and `ParametersFrom` fields, it is
-	// considered to be a user error in the specification
+	// Parameters is a set of the parameters to be passed to the underlying
+	// broker. The inline YAML/JSON payload to be translated into equivalent
+	// JSON object. If a top-level parameter name exists in multiples sources
+	// among `Parameters` and `ParametersFrom` fields, it is considered to be
+	// a user error in the specification
+	//
+	// The Parameters field is NOT secret or secured in any way and should
+	// NEVER be used to hold sensitive information. To set parameters that
+	// contain secret information, you should ALWAYS store that information
+	// in a Secret and use the ParametersFrom field.
+	//
 	// +optional
 	Parameters *runtime.RawExtension
 
@@ -556,13 +560,17 @@ type ServiceInstanceCredentialSpec struct {
 	// Immutable.
 	ServiceInstanceRef v1.LocalObjectReference
 
-	// Parameters is a set of the parameters to be
-	// passed to the underlying broker.
-	// The inline YAML/JSON payload to be translated into equivalent
-	// JSON object.
-	// If a top-level parameter name exists in multiples sources among
-	// `Parameters` and `ParametersFrom` fields, it is
-	// considered to be a user error in the specification
+	// Parameters is a set of the parameters to be passed to the underlying
+	// broker. The inline YAML/JSON payload to be translated into equivalent
+	// JSON object. If a top-level parameter name exists in multiples sources
+	// among `Parameters` and `ParametersFrom` fields, it is considered to be
+	// a user error in the specification.
+	//
+	// The Parameters field is NOT secret or secured in any way and should
+	// NEVER be used to hold sensitive information. To set parameters that
+	// contain secret information, you should ALWAYS store that information
+	// in a Secret and use the ParametersFrom field.
+	//
 	// +optional
 	Parameters *runtime.RawExtension
 

--- a/pkg/apis/servicecatalog/v1alpha1/types.go
+++ b/pkg/apis/servicecatalog/v1alpha1/types.go
@@ -410,13 +410,17 @@ type ServiceInstanceSpec struct {
 	// This is set by the controller based on ExternalServicePlanName
 	ServicePlanRef *v1.ObjectReference `json:"servicePlanRef,omitempty"`
 
-	// Parameters is a set of the parameters to be
-	// passed to the underlying broker.
-	// The inline YAML/JSON payload to be translated into equivalent
-	// JSON object.
-	// If a top-level parameter name exists in multiples sources among
-	// `Parameters` and `ParametersFrom` fields, it is
-	// considered to be a user error in the specification
+	// Parameters is a set of the parameters to be passed to the underlying
+	// broker. The inline YAML/JSON payload to be translated into equivalent
+	// JSON object. If a top-level parameter name exists in multiples sources
+	// among `Parameters` and `ParametersFrom` fields, it is considered to be
+	// a user error in the specification.
+	//
+	// The Parameters field is NOT secret or secured in any way and should
+	// NEVER be used to hold sensitive information. To set parameters that
+	// contain secret information, you should ALWAYS store that information
+	// in a Secret and use the ParametersFrom field.
+	//
 	// +optional
 	Parameters *runtime.RawExtension `json:"parameters,omitempty"`
 
@@ -555,20 +559,24 @@ type ServiceInstanceCredentialSpec struct {
 	// Immutable.
 	ServiceInstanceRef v1.LocalObjectReference `json:"instanceRef"`
 
-	// Parameters is a set of the parameters to be
-	// passed to the underlying broker.
-	// The inline YAML/JSON payload to be translated into equivalent
-	// JSON object.
-	// If a top-level parameter name exists in multiples sources among
-	// `Parameters` and `ParametersFrom` fields, it is
-	// considered to be a user error in the specification
+	// Parameters is a set of the parameters to be passed to the underlying
+	// broker. The inline YAML/JSON payload to be translated into equivalent
+	// JSON object. If a top-level parameter name exists in multiples sources
+	// among `Parameters` and `ParametersFrom` fields, it is considered to be
+	// a user error in the specification.
+	//
+	// The Parameters field is NOT secret or secured in any way and should
+	// NEVER be used to hold sensitive information. To set parameters that
+	// contain secret information, you should ALWAYS store that information
+	// in a Secret and use the ParametersFrom field.
+	//
 	// +optional
 	Parameters *runtime.RawExtension `json:"parameters,omitempty"`
 
 	// List of sources to populate parameters.
 	// If a top-level parameter name exists in multiples sources among
 	// `Parameters` and `ParametersFrom` fields, it is
-	// considered to be a user error in the specification
+	// considered to be a user error in the specification.
 	// +optional
 	ParametersFrom []ParametersFromSource `json:"parametersFrom,omitempty"`
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -757,13 +757,13 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 						},
 						"parameters": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Parameters is a set of the parameters to be passed to the underlying broker. The inline YAML/JSON payload to be translated into equivalent JSON object. If a top-level parameter name exists in multiples sources among `Parameters` and `ParametersFrom` fields, it is considered to be a user error in the specification",
+								Description: "Parameters is a set of the parameters to be passed to the underlying broker. The inline YAML/JSON payload to be translated into equivalent JSON object. If a top-level parameter name exists in multiples sources among `Parameters` and `ParametersFrom` fields, it is considered to be a user error in the specification.\n\nThe Parameters field is NOT secret or secured in any way and should NEVER be used to hold sensitive information. To set parameters that contain secret information, you should ALWAYS store that information in a Secret and use the ParametersFrom field.",
 								Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 							},
 						},
 						"parametersFrom": {
 							SchemaProps: spec.SchemaProps{
-								Description: "List of sources to populate parameters. If a top-level parameter name exists in multiples sources among `Parameters` and `ParametersFrom` fields, it is considered to be a user error in the specification",
+								Description: "List of sources to populate parameters. If a top-level parameter name exists in multiples sources among `Parameters` and `ParametersFrom` fields, it is considered to be a user error in the specification.",
 								Type:        []string{"array"},
 								Items: &spec.SchemaOrArray{
 									Schema: &spec.Schema{
@@ -921,7 +921,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 						},
 						"parameters": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Parameters is a set of the parameters to be passed to the underlying broker. The inline YAML/JSON payload to be translated into equivalent JSON object. If a top-level parameter name exists in multiples sources among `Parameters` and `ParametersFrom` fields, it is considered to be a user error in the specification",
+								Description: "Parameters is a set of the parameters to be passed to the underlying broker. The inline YAML/JSON payload to be translated into equivalent JSON object. If a top-level parameter name exists in multiples sources among `Parameters` and `ParametersFrom` fields, it is considered to be a user error in the specification.\n\nThe Parameters field is NOT secret or secured in any way and should NEVER be used to hold sensitive information. To set parameters that contain secret information, you should ALWAYS store that information in a Secret and use the ParametersFrom field.",
 								Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 							},
 						},


### PR DESCRIPTION
It came up today that users were not sufficiently warned about the implications of setting parameters inline; this PR adds guidance to always use secrets to hold sensitive parameters.