### PR TITLE
Fix HTTP verbs supported by servicebrokers/status

### DIFF
--- a/pkg/registry/servicecatalog/binding/storage.go
+++ b/pkg/registry/servicecatalog/binding/storage.go
@@ -148,7 +148,9 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage, error) {
 	return &store, &StatusREST{&statusStore}, nil
 }
 
-// StatusREST defines the REST operations for the status subresource.
+// StatusREST defines the REST operations for the status subresource via
+// implementation of various rest interfaces.  It supports the http verbs GET,
+// PATCH, and PUT.
 type StatusREST struct {
 	store *registry.Store
 }

--- a/pkg/registry/servicecatalog/instance/storage.go
+++ b/pkg/registry/servicecatalog/instance/storage.go
@@ -147,7 +147,9 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 	return &store, &StatusREST{&statusStore}
 }
 
-// StatusREST defines the REST operations for the status subresource.
+// StatusREST defines the REST operations for the status subresource via
+// implementation of various rest interfaces.  It supports the http verbs GET,
+// PATCH, and PUT.
 type StatusREST struct {
 	store *registry.Store
 }


### PR DESCRIPTION
Part of fix for #1293 

You can test this as follows:

```console
$ kubectl proxy --port 8081 &

$ curl 127.0.0.1:8080/apis/servicecatalog.k8s.io/v1alpha1
```
