### PR TITLE
Correctly handle presence of multiple plans with the same name

### DIFF
--- a/pkg/registry/servicecatalog/serviceplan/storage.go
+++ b/pkg/registry/servicecatalog/serviceplan/storage.go
@@ -89,7 +89,8 @@ func Match(label labels.Selector, field fields.Selector) storage.SelectionPredic
 
 // toSelectableFields returns a field set that represents the object for matching purposes.
 func toSelectableFields(servicePlan *servicecatalog.ServicePlan) fields.Set {
-	spSpecificFieldsSet := make(fields.Set, 2)
+	spSpecificFieldsSet := make(fields.Set, 3)
+	spSpecificFieldsSet["spec.serviceClassRef.name"] = servicePlan.Spec.ServiceClassRef.Name
 	spSpecificFieldsSet["spec.externalName"] = servicePlan.Spec.ExternalName
 	spSpecificFieldsSet["spec.externalID"] = servicePlan.Spec.ExternalID
 	return generic.AddObjectMetaFieldsSet(spSpecificFieldsSet, &servicePlan.ObjectMeta, true)


### PR DESCRIPTION
...when looking up the service plan for an instance.

Fixes #1292 