### PR TITLE
Fix HTTP verbs supported by serviceinstances/status

### DIFF
--- a/pkg/registry/servicecatalog/instance/storage.go
+++ b/pkg/registry/servicecatalog/instance/storage.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -143,5 +144,27 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 	statusStore := store
 	statusStore.UpdateStrategy = instanceStatusUpdateStrategy
 
-	return &store, &statusStore
+	return &store, &StatusREST{&statusStore}
+}
+
+// StatusREST defines the REST operations for the status subresource.
+type StatusREST struct {
+	store *registry.Store
+}
+
+// New returns a new ServiceInstance
+func (r *StatusREST) New() runtime.Object {
+	return &servicecatalog.ServiceInstance{}
+}
+
+// Get retrieves the object from the storage. It is required to support Patch
+// and to implement the rest.Getter interface.
+func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	return r.store.Get(ctx, name, options)
+}
+
+// Update alters the status subset of an object and it
+// implements rest.Updater interface
+func (r *StatusREST) Update(ctx genericapirequest.Context, name string, objInfo rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo)
 }


### PR DESCRIPTION
Part of fix for #1293, similar to #1294

This PR is also including updating generated files that were missing from some previous PR, only substantive changes here are to pkg/registry/servicecatalog/instance/storage.go

