### PR TITLE
rename test variables to be consistent

### DIFF
--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -56,7 +56,7 @@ func TestReconcileServiceBindingNonExistingServiceInstance(t *testing.T) {
 		},
 		Spec: v1beta1.ServiceBindingSpec{
 			ServiceInstanceRef: v1.LocalObjectReference{Name: "nothere"},
-			ExternalID:         bindingGUID,
+			ExternalID:         testServiceBindingGUID,
 		},
 	}
 
@@ -117,7 +117,7 @@ func TestReconcileServiceBindingUnresolvedClusterServiceClassReference(t *testin
 		},
 		Spec: v1beta1.ServiceBindingSpec{
 			ServiceInstanceRef: v1.LocalObjectReference{Name: testServiceInstanceName},
-			ExternalID:         bindingGUID,
+			ExternalID:         testServiceBindingGUID,
 		},
 	}
 
@@ -166,7 +166,7 @@ func TestReconcileServiceBindingUnresolvedClusterServicePlanReference(t *testing
 		},
 		Spec: v1beta1.ServiceBindingSpec{
 			ServiceInstanceRef: v1.LocalObjectReference{Name: testServiceInstanceName},
-			ExternalID:         bindingGUID,
+			ExternalID:         testServiceBindingGUID,
 		},
 	}
 
@@ -217,7 +217,7 @@ func TestReconcileServiceBindingNonExistingClusterServiceClass(t *testing.T) {
 		},
 		Spec: v1beta1.ServiceBindingSpec{
 			ServiceInstanceRef: v1.LocalObjectReference{Name: testServiceInstanceName},
-			ExternalID:         bindingGUID,
+			ExternalID:         testServiceBindingGUID,
 		},
 	}
 
@@ -294,13 +294,13 @@ func TestReconcileServiceBindingWithSecretConflict(t *testing.T) {
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertBind(t, brokerActions[0], &osb.BindRequest{
-		BindingID:  bindingGUID,
-		InstanceID: instanceGUID,
-		ServiceID:  serviceClassGUID,
-		PlanID:     planGUID,
-		AppGUID:    strPtr(testNsUID),
+		BindingID:  testServiceBindingGUID,
+		InstanceID: testServiceInstanceGUID,
+		ServiceID:  testServiceClassGUID,
+		PlanID:     testServicePlanGUID,
+		AppGUID:    strPtr(testNamespaceGUID),
 		BindResource: &osb.BindResource{
-			AppGUID: strPtr(testNsUID),
+			AppGUID: strPtr(testNamespaceGUID),
 		},
 	})
 
@@ -394,11 +394,11 @@ func TestReconcileServiceBindingWithParameters(t *testing.T) {
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertBind(t, brokerActions[0], &osb.BindRequest{
-		BindingID:  bindingGUID,
-		InstanceID: instanceGUID,
-		ServiceID:  serviceClassGUID,
-		PlanID:     planGUID,
-		AppGUID:    strPtr(testNsUID),
+		BindingID:  testServiceBindingGUID,
+		InstanceID: testServiceInstanceGUID,
+		ServiceID:  testServiceClassGUID,
+		PlanID:     testServicePlanGUID,
+		AppGUID:    strPtr(testNamespaceGUID),
 		Parameters: map[string]interface{}{
 			"args": []interface{}{
 				"first-arg",
@@ -407,7 +407,7 @@ func TestReconcileServiceBindingWithParameters(t *testing.T) {
 			"name": "test-param",
 		},
 		BindResource: &osb.BindResource{
-			AppGUID: strPtr(testNsUID),
+			AppGUID: strPtr(testNamespaceGUID),
 		},
 	})
 
@@ -503,7 +503,7 @@ func TestReconcileServiceBindingNonbindableClusterServiceClass(t *testing.T) {
 		},
 		Spec: v1beta1.ServiceBindingSpec{
 			ServiceInstanceRef: v1.LocalObjectReference{Name: testServiceInstanceName},
-			ExternalID:         bindingGUID,
+			ExternalID:         testServiceBindingGUID,
 		},
 	}
 
@@ -593,7 +593,7 @@ func TestReconcileServiceBindingNonbindableClusterServiceClassBindablePlan(t *te
 		PlanID:     planGUID,
 		AppGUID:    strPtr(testNsUID),
 		BindResource: &osb.BindResource{
-			AppGUID: strPtr(testNsUID),
+			AppGUID: strPtr(testNamespaceGUID),
 		},
 	})
 
@@ -665,7 +665,7 @@ func TestReconcileServiceBindingBindableClusterServiceClassNonbindablePlan(t *te
 		},
 		Spec: v1beta1.ServiceBindingSpec{
 			ServiceInstanceRef: v1.LocalObjectReference{Name: testServiceInstanceName},
-			ExternalID:         bindingGUID,
+			ExternalID:         testServiceBindingGUID,
 		},
 	}
 
@@ -713,7 +713,7 @@ func TestReconcileServiceBindingFailsWithServiceInstanceAsyncOngoing(t *testing.
 		},
 		Spec: v1beta1.ServiceBindingSpec{
 			ServiceInstanceRef: v1.LocalObjectReference{Name: testServiceInstanceName},
-			ExternalID:         bindingGUID,
+			ExternalID:         testServiceBindingGUID,
 		},
 	}
 
@@ -776,7 +776,7 @@ func TestReconcileServiceBindingServiceInstanceNotReady(t *testing.T) {
 		},
 		Spec: v1beta1.ServiceBindingSpec{
 			ServiceInstanceRef: v1.LocalObjectReference{Name: testServiceInstanceName},
-			ExternalID:         bindingGUID,
+			ExternalID:         testServiceBindingGUID,
 		},
 	}
 
@@ -827,7 +827,7 @@ func TestReconcileServiceBindingNamespaceError(t *testing.T) {
 		},
 		Spec: v1beta1.ServiceBindingSpec{
 			ServiceInstanceRef: v1.LocalObjectReference{Name: testServiceInstanceName},
-			ExternalID:         bindingGUID,
+			ExternalID:         testServiceBindingGUID,
 		},
 	}
 
@@ -898,10 +898,10 @@ func TestReconcileServiceBindingDelete(t *testing.T) {
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertUnbind(t, brokerActions[0], &osb.UnbindRequest{
-		BindingID:  bindingGUID,
-		InstanceID: instanceGUID,
-		ServiceID:  serviceClassGUID,
-		PlanID:     planGUID,
+		BindingID:  testServiceBindingGUID,
+		InstanceID: testServiceInstanceGUID,
+		ServiceID:  testServiceClassGUID,
+		PlanID:     testServicePlanGUID,
 	})
 
 	kubeActions := fakeKubeClient.Actions()
@@ -1110,10 +1110,10 @@ func TestReconcileServiceBindingDeleteFailedServiceBinding(t *testing.T) {
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertUnbind(t, brokerActions[0], &osb.UnbindRequest{
-		BindingID:  bindingGUID,
-		InstanceID: instanceGUID,
-		ServiceID:  serviceClassGUID,
-		PlanID:     planGUID,
+		BindingID:  testServiceBindingGUID,
+		InstanceID: testServiceInstanceGUID,
+		ServiceID:  testServiceClassGUID,
+		PlanID:     testServicePlanGUID,
 	})
 
 	// verify one kube action occurred
@@ -1341,10 +1341,10 @@ func TestReconcileServiceBindingWithServiceBindingCallFailure(t *testing.T) {
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertBind(t, brokerActions[0], &osb.BindRequest{
-		BindingID:  bindingGUID,
-		InstanceID: instanceGUID,
-		ServiceID:  serviceClassGUID,
-		PlanID:     planGUID,
+		BindingID:  testServiceBindingGUID,
+		InstanceID: testServiceInstanceGUID,
+		ServiceID:  testServiceClassGUID,
+		PlanID:     testServicePlanGUID,
 		AppGUID:    strPtr(""),
 		BindResource: &osb.BindResource{
 			AppGUID: strPtr(""),
@@ -1407,10 +1407,10 @@ func TestReconcileServiceBindingWithServiceBindingFailure(t *testing.T) {
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertBind(t, brokerActions[0], &osb.BindRequest{
-		BindingID:  bindingGUID,
-		InstanceID: instanceGUID,
-		ServiceID:  serviceClassGUID,
-		PlanID:     planGUID,
+		BindingID:  testServiceBindingGUID,
+		InstanceID: testServiceInstanceGUID,
+		ServiceID:  testServiceClassGUID,
+		PlanID:     testServicePlanGUID,
 		AppGUID:    strPtr(""),
 		BindResource: &osb.BindResource{
 			AppGUID: strPtr(""),
@@ -1837,13 +1837,13 @@ func TestReconcileBindingSuccessOnFinalRetry(t *testing.T) {
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertBind(t, brokerActions[0], &osb.BindRequest{
-		BindingID:  bindingGUID,
-		InstanceID: instanceGUID,
-		ServiceID:  serviceClassGUID,
-		PlanID:     planGUID,
-		AppGUID:    strPtr(testNsUID),
+		BindingID:  testServiceBindingGUID,
+		InstanceID: testServiceInstanceGUID,
+		ServiceID:  testServiceClassGUID,
+		PlanID:     testServicePlanGUID,
+		AppGUID:    strPtr(testNamespaceGUID),
 		BindResource: &osb.BindResource{
-			AppGUID: strPtr(testNsUID),
+			AppGUID: strPtr(testNamespaceGUID),
 		},
 	})
 
@@ -1965,13 +1965,13 @@ func TestReconcileBindingWithSecretConflictFailedAfterFinalRetry(t *testing.T) {
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertBind(t, brokerActions[0], &osb.BindRequest{
-		BindingID:  bindingGUID,
-		InstanceID: instanceGUID,
-		ServiceID:  serviceClassGUID,
-		PlanID:     planGUID,
-		AppGUID:    strPtr(testNsUID),
+		BindingID:  testServiceBindingGUID,
+		InstanceID: testServiceInstanceGUID,
+		ServiceID:  testServiceClassGUID,
+		PlanID:     testServicePlanGUID,
+		AppGUID:    strPtr(testNamespaceGUID),
 		BindResource: &osb.BindResource{
-			AppGUID: strPtr(testNsUID),
+			AppGUID: strPtr(testNamespaceGUID),
 		},
 	})
 
@@ -2134,17 +2134,17 @@ func TestReconcileServiceBindingWithSecretParameters(t *testing.T) {
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertBind(t, brokerActions[0], &osb.BindRequest{
-		BindingID:  bindingGUID,
-		InstanceID: instanceGUID,
-		ServiceID:  serviceClassGUID,
-		PlanID:     planGUID,
-		AppGUID:    strPtr(testNsUID),
+		BindingID:  testServiceBindingGUID,
+		InstanceID: testServiceInstanceGUID,
+		ServiceID:  testServiceClassGUID,
+		PlanID:     testServicePlanGUID,
+		AppGUID:    strPtr(testNamespaceGUID),
 		Parameters: map[string]interface{}{
 			"a": "1",
 			"b": "2",
 		},
 		BindResource: &osb.BindResource{
-			AppGUID: strPtr(testNsUID),
+			AppGUID: strPtr(testNamespaceGUID),
 		},
 	})
 

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -275,9 +275,9 @@ func TestReconcileServiceInstanceWithParameters(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
-		PlanID:            planGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testServiceClassGUID,
+		PlanID:            testServicePlanGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -377,9 +377,9 @@ func TestReconcileServiceInstanceResolvesReferences(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
-		PlanID:            planGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testServiceClassGUID,
+		PlanID:            testServicePlanGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -618,9 +618,9 @@ func TestReconcileServiceInstanceWithProvisionCallFailure(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
-		PlanID:            planGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testServiceClassGUID,
+		PlanID:            testServicePlanGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -682,9 +682,9 @@ func TestReconcileServiceInstanceWithProvisionFailure(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
-		PlanID:            planGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testServiceClassGUID,
+		PlanID:            testServicePlanGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -750,11 +750,11 @@ func TestReconcileServiceInstance(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
-		PlanID:            planGUID,
-		OrganizationGUID:  testNsUID,
-		SpaceGUID:         testNsUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testServiceClassGUID,
+		PlanID:            testServicePlanGUID,
+		OrganizationGUID:  testNamespaceGUID,
+		SpaceGUID:         testNamespaceGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -832,11 +832,11 @@ func TestReconcileServiceInstanceAsynchronous(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
-		PlanID:            planGUID,
-		OrganizationGUID:  testNsUID,
-		SpaceGUID:         testNsUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testServiceClassGUID,
+		PlanID:            testServicePlanGUID,
+		OrganizationGUID:  testNamespaceGUID,
+		SpaceGUID:         testNamespaceGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": testNamespace,
@@ -899,11 +899,11 @@ func TestReconcileServiceInstanceAsynchronousNoOperation(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
-		PlanID:            planGUID,
-		OrganizationGUID:  testNsUID,
-		SpaceGUID:         testNsUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testServiceClassGUID,
+		PlanID:            testServicePlanGUID,
+		OrganizationGUID:  testNamespaceGUID,
+		SpaceGUID:         testNamespaceGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -1012,9 +1012,9 @@ func TestReconcileServiceInstanceDelete(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertDeprovision(t, brokerActions[0], &osb.DeprovisionRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
-		PlanID:            planGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testServiceClassGUID,
+		PlanID:            testServicePlanGUID,
 	})
 
 	// Verify no core kube actions occurred
@@ -1113,9 +1113,9 @@ func TestReconcileServiceInstanceDeleteBlockedByCredentials(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertDeprovision(t, brokerActions[0], &osb.DeprovisionRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
-		PlanID:            planGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testServiceClassGUID,
+		PlanID:            testServicePlanGUID,
 	})
 
 	// Verify no core kube actions occurred
@@ -1192,9 +1192,9 @@ func TestReconcileServiceInstanceDeleteAsynchronous(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertDeprovision(t, brokerActions[0], &osb.DeprovisionRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
-		PlanID:            planGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testServiceClassGUID,
+		PlanID:            testServicePlanGUID,
 	})
 
 	// Verify no core kube actions occurred
@@ -1381,9 +1381,9 @@ func TestPollServiceInstanceInProgressProvisioningWithOperation(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
-		InstanceID:   instanceGUID,
-		ServiceID:    strPtr(serviceClassGUID),
-		PlanID:       strPtr(planGUID),
+		InstanceID:   testServiceInstanceGUID,
+		ServiceID:    strPtr(testServiceClassGUID),
+		PlanID:       strPtr(testServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1438,9 +1438,9 @@ func TestPollServiceInstanceSuccessProvisioningWithOperation(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
-		InstanceID:   instanceGUID,
-		ServiceID:    strPtr(serviceClassGUID),
-		PlanID:       strPtr(planGUID),
+		InstanceID:   testServiceInstanceGUID,
+		ServiceID:    strPtr(testServiceClassGUID),
+		PlanID:       strPtr(testServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1492,9 +1492,9 @@ func TestPollServiceInstanceFailureProvisioningWithOperation(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
-		InstanceID:   instanceGUID,
-		ServiceID:    strPtr(serviceClassGUID),
-		PlanID:       strPtr(planGUID),
+		InstanceID:   testServiceInstanceGUID,
+		ServiceID:    strPtr(testServiceClassGUID),
+		PlanID:       strPtr(testServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1554,9 +1554,9 @@ func TestPollServiceInstanceInProgressDeprovisioningWithOperationNoFinalizer(t *
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
-		InstanceID:   instanceGUID,
-		ServiceID:    strPtr(serviceClassGUID),
-		PlanID:       strPtr(planGUID),
+		InstanceID:   testServiceInstanceGUID,
+		ServiceID:    strPtr(testServiceClassGUID),
+		PlanID:       strPtr(testServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1611,9 +1611,9 @@ func TestPollServiceInstanceSuccessDeprovisioningWithOperationNoFinalizer(t *tes
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
-		InstanceID:   instanceGUID,
-		ServiceID:    strPtr(serviceClassGUID),
-		PlanID:       strPtr(planGUID),
+		InstanceID:   testServiceInstanceGUID,
+		ServiceID:    strPtr(testServiceClassGUID),
+		PlanID:       strPtr(testServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1672,9 +1672,9 @@ func TestPollServiceInstanceFailureDeprovisioningWithOperation(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
-		InstanceID:   instanceGUID,
-		ServiceID:    strPtr(serviceClassGUID),
-		PlanID:       strPtr(planGUID),
+		InstanceID:   testServiceInstanceGUID,
+		ServiceID:    strPtr(testServiceClassGUID),
+		PlanID:       strPtr(testServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1741,9 +1741,9 @@ func TestPollServiceInstanceStatusGoneDeprovisioningWithOperationNoFinalizer(t *
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
-		InstanceID:   instanceGUID,
-		ServiceID:    strPtr(serviceClassGUID),
-		PlanID:       strPtr(planGUID),
+		InstanceID:   testServiceInstanceGUID,
+		ServiceID:    strPtr(testServiceClassGUID),
+		PlanID:       strPtr(testServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1802,9 +1802,9 @@ func TestPollServiceInstanceClusterServiceBrokerError(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
-		InstanceID:   instanceGUID,
-		ServiceID:    strPtr(serviceClassGUID),
-		PlanID:       strPtr(planGUID),
+		InstanceID:   testServiceInstanceGUID,
+		ServiceID:    strPtr(testServiceClassGUID),
+		PlanID:       strPtr(testServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1865,9 +1865,9 @@ func TestPollServiceInstanceSuccessDeprovisioningWithOperationWithFinalizer(t *t
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
-		InstanceID:   instanceGUID,
-		ServiceID:    strPtr(serviceClassGUID),
-		PlanID:       strPtr(planGUID),
+		InstanceID:   testServiceInstanceGUID,
+		ServiceID:    strPtr(testServiceClassGUID),
+		PlanID:       strPtr(testServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1917,9 +1917,9 @@ func TestReconcileServiceInstanceSuccessOnFinalRetry(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
-		PlanID:            planGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testServiceClassGUID,
+		PlanID:            testServicePlanGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -1976,9 +1976,9 @@ func TestReconcileServiceInstanceFailureOnFinalRetry(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
-		PlanID:            planGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testServiceClassGUID,
+		PlanID:            testServicePlanGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -2059,9 +2059,9 @@ func TestPollServiceInstanceSuccessOnFinalRetry(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
-		InstanceID:   instanceGUID,
-		ServiceID:    strPtr(serviceClassGUID),
-		PlanID:       strPtr(planGUID),
+		InstanceID:   testServiceInstanceGUID,
+		ServiceID:    strPtr(testServiceClassGUID),
+		PlanID:       strPtr(testServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -2114,9 +2114,9 @@ func TestPollServiceInstanceFailureOnFinalRetry(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
-		InstanceID:   instanceGUID,
-		ServiceID:    strPtr(serviceClassGUID),
-		PlanID:       strPtr(planGUID),
+		InstanceID:   testServiceInstanceGUID,
+		ServiceID:    strPtr(testServiceClassGUID),
+		PlanID:       strPtr(testServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -3011,9 +3011,9 @@ func TestReconcileServiceInstanceWithSecretParameters(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
-		PlanID:            planGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testServiceClassGUID,
+		PlanID:            testServicePlanGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -64,7 +64,7 @@ func TestReconcileServiceInstanceNonExistentClusterServiceClass(t *testing.T) {
 				ExternalClusterServiceClassName: "nothere",
 				ExternalClusterServicePlanName:  "nothere",
 			},
-			ExternalID: instanceGUID,
+			ExternalID: testServiceInstanceGUID,
 		},
 	}
 
@@ -206,9 +206,9 @@ func TestReconcileServiceInstanceNonExistentClusterServicePlan(t *testing.T) {
 				ExternalClusterServicePlanName:  "nothere",
 			},
 			ClusterServiceClassRef: &corev1.ObjectReference{
-				Name: serviceClassGUID,
+				Name: testClusterServiceClassGUID,
 			},
-			ExternalID: instanceGUID,
+			ExternalID: testServiceInstanceGUID,
 		},
 	}
 
@@ -276,8 +276,8 @@ func TestReconcileServiceInstanceWithParameters(t *testing.T) {
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
 		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testServiceClassGUID,
-		PlanID:            testServicePlanGUID,
+		ServiceID:         testClusterServiceClassGUID,
+		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -378,8 +378,8 @@ func TestReconcileServiceInstanceResolvesReferences(t *testing.T) {
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
 		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testServiceClassGUID,
-		PlanID:            testServicePlanGUID,
+		ServiceID:         testClusterServiceClassGUID,
+		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -462,7 +462,7 @@ func TestReconcileServiceInstanceResolvesReferencesClusterServiceClassRefAlready
 
 	instance := getTestServiceInstance()
 	instance.Spec.ClusterServiceClassRef = &corev1.ObjectReference{
-		Name: serviceClassGUID,
+		Name: testClusterServiceClassGUID,
 	}
 
 	var scItems []v1beta1.ClusterServiceClass
@@ -485,9 +485,9 @@ func TestReconcileServiceInstanceResolvesReferencesClusterServiceClassRefAlready
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
-		PlanID:            planGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testClusterServiceClassGUID,
+		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -619,8 +619,8 @@ func TestReconcileServiceInstanceWithProvisionCallFailure(t *testing.T) {
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
 		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testServiceClassGUID,
-		PlanID:            testServicePlanGUID,
+		ServiceID:         testClusterServiceClassGUID,
+		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -683,8 +683,8 @@ func TestReconcileServiceInstanceWithProvisionFailure(t *testing.T) {
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
 		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testServiceClassGUID,
-		PlanID:            testServicePlanGUID,
+		ServiceID:         testClusterServiceClassGUID,
+		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -751,8 +751,8 @@ func TestReconcileServiceInstance(t *testing.T) {
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
 		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testServiceClassGUID,
-		PlanID:            testServicePlanGUID,
+		ServiceID:         testClusterServiceClassGUID,
+		PlanID:            testClusterServicePlanGUID,
 		OrganizationGUID:  testNamespaceGUID,
 		SpaceGUID:         testNamespaceGUID,
 		Context: map[string]interface{}{
@@ -833,8 +833,8 @@ func TestReconcileServiceInstanceAsynchronous(t *testing.T) {
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
 		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testServiceClassGUID,
-		PlanID:            testServicePlanGUID,
+		ServiceID:         testClusterServiceClassGUID,
+		PlanID:            testClusterServicePlanGUID,
 		OrganizationGUID:  testNamespaceGUID,
 		SpaceGUID:         testNamespaceGUID,
 		Context: map[string]interface{}{
@@ -900,8 +900,8 @@ func TestReconcileServiceInstanceAsynchronousNoOperation(t *testing.T) {
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
 		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testServiceClassGUID,
-		PlanID:            testServicePlanGUID,
+		ServiceID:         testClusterServiceClassGUID,
+		PlanID:            testClusterServicePlanGUID,
 		OrganizationGUID:  testNamespaceGUID,
 		SpaceGUID:         testNamespaceGUID,
 		Context: map[string]interface{}{
@@ -1013,8 +1013,8 @@ func TestReconcileServiceInstanceDelete(t *testing.T) {
 	assertDeprovision(t, brokerActions[0], &osb.DeprovisionRequest{
 		AcceptsIncomplete: true,
 		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testServiceClassGUID,
-		PlanID:            testServicePlanGUID,
+		ServiceID:         testClusterServiceClassGUID,
+		PlanID:            testClusterServicePlanGUID,
 	})
 
 	// Verify no core kube actions occurred
@@ -1114,8 +1114,8 @@ func TestReconcileServiceInstanceDeleteBlockedByCredentials(t *testing.T) {
 	assertDeprovision(t, brokerActions[0], &osb.DeprovisionRequest{
 		AcceptsIncomplete: true,
 		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testServiceClassGUID,
-		PlanID:            testServicePlanGUID,
+		ServiceID:         testClusterServiceClassGUID,
+		PlanID:            testClusterServicePlanGUID,
 	})
 
 	// Verify no core kube actions occurred
@@ -1193,8 +1193,8 @@ func TestReconcileServiceInstanceDeleteAsynchronous(t *testing.T) {
 	assertDeprovision(t, brokerActions[0], &osb.DeprovisionRequest{
 		AcceptsIncomplete: true,
 		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testServiceClassGUID,
-		PlanID:            testServicePlanGUID,
+		ServiceID:         testClusterServiceClassGUID,
+		PlanID:            testClusterServicePlanGUID,
 	})
 
 	// Verify no core kube actions occurred
@@ -1382,8 +1382,8 @@ func TestPollServiceInstanceInProgressProvisioningWithOperation(t *testing.T) {
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
 		InstanceID:   testServiceInstanceGUID,
-		ServiceID:    strPtr(testServiceClassGUID),
-		PlanID:       strPtr(testServicePlanGUID),
+		ServiceID:    strPtr(testClusterServiceClassGUID),
+		PlanID:       strPtr(testClusterServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1439,8 +1439,8 @@ func TestPollServiceInstanceSuccessProvisioningWithOperation(t *testing.T) {
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
 		InstanceID:   testServiceInstanceGUID,
-		ServiceID:    strPtr(testServiceClassGUID),
-		PlanID:       strPtr(testServicePlanGUID),
+		ServiceID:    strPtr(testClusterServiceClassGUID),
+		PlanID:       strPtr(testClusterServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1493,8 +1493,8 @@ func TestPollServiceInstanceFailureProvisioningWithOperation(t *testing.T) {
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
 		InstanceID:   testServiceInstanceGUID,
-		ServiceID:    strPtr(testServiceClassGUID),
-		PlanID:       strPtr(testServicePlanGUID),
+		ServiceID:    strPtr(testClusterServiceClassGUID),
+		PlanID:       strPtr(testClusterServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1555,8 +1555,8 @@ func TestPollServiceInstanceInProgressDeprovisioningWithOperationNoFinalizer(t *
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
 		InstanceID:   testServiceInstanceGUID,
-		ServiceID:    strPtr(testServiceClassGUID),
-		PlanID:       strPtr(testServicePlanGUID),
+		ServiceID:    strPtr(testClusterServiceClassGUID),
+		PlanID:       strPtr(testClusterServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1612,8 +1612,8 @@ func TestPollServiceInstanceSuccessDeprovisioningWithOperationNoFinalizer(t *tes
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
 		InstanceID:   testServiceInstanceGUID,
-		ServiceID:    strPtr(testServiceClassGUID),
-		PlanID:       strPtr(testServicePlanGUID),
+		ServiceID:    strPtr(testClusterServiceClassGUID),
+		PlanID:       strPtr(testClusterServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1673,8 +1673,8 @@ func TestPollServiceInstanceFailureDeprovisioningWithOperation(t *testing.T) {
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
 		InstanceID:   testServiceInstanceGUID,
-		ServiceID:    strPtr(testServiceClassGUID),
-		PlanID:       strPtr(testServicePlanGUID),
+		ServiceID:    strPtr(testClusterServiceClassGUID),
+		PlanID:       strPtr(testClusterServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1742,8 +1742,8 @@ func TestPollServiceInstanceStatusGoneDeprovisioningWithOperationNoFinalizer(t *
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
 		InstanceID:   testServiceInstanceGUID,
-		ServiceID:    strPtr(testServiceClassGUID),
-		PlanID:       strPtr(testServicePlanGUID),
+		ServiceID:    strPtr(testClusterServiceClassGUID),
+		PlanID:       strPtr(testClusterServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1803,8 +1803,8 @@ func TestPollServiceInstanceClusterServiceBrokerError(t *testing.T) {
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
 		InstanceID:   testServiceInstanceGUID,
-		ServiceID:    strPtr(testServiceClassGUID),
-		PlanID:       strPtr(testServicePlanGUID),
+		ServiceID:    strPtr(testClusterServiceClassGUID),
+		PlanID:       strPtr(testClusterServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1866,8 +1866,8 @@ func TestPollServiceInstanceSuccessDeprovisioningWithOperationWithFinalizer(t *t
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
 		InstanceID:   testServiceInstanceGUID,
-		ServiceID:    strPtr(testServiceClassGUID),
-		PlanID:       strPtr(testServicePlanGUID),
+		ServiceID:    strPtr(testClusterServiceClassGUID),
+		PlanID:       strPtr(testClusterServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -1918,8 +1918,8 @@ func TestReconcileServiceInstanceSuccessOnFinalRetry(t *testing.T) {
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
 		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testServiceClassGUID,
-		PlanID:            testServicePlanGUID,
+		ServiceID:         testClusterServiceClassGUID,
+		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -1977,8 +1977,8 @@ func TestReconcileServiceInstanceFailureOnFinalRetry(t *testing.T) {
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
 		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testServiceClassGUID,
-		PlanID:            testServicePlanGUID,
+		ServiceID:         testClusterServiceClassGUID,
+		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -2060,8 +2060,8 @@ func TestPollServiceInstanceSuccessOnFinalRetry(t *testing.T) {
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
 		InstanceID:   testServiceInstanceGUID,
-		ServiceID:    strPtr(testServiceClassGUID),
-		PlanID:       strPtr(testServicePlanGUID),
+		ServiceID:    strPtr(testClusterServiceClassGUID),
+		PlanID:       strPtr(testClusterServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -2115,8 +2115,8 @@ func TestPollServiceInstanceFailureOnFinalRetry(t *testing.T) {
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
 		InstanceID:   testServiceInstanceGUID,
-		ServiceID:    strPtr(testServiceClassGUID),
-		PlanID:       strPtr(testServicePlanGUID),
+		ServiceID:    strPtr(testClusterServiceClassGUID),
+		PlanID:       strPtr(testClusterServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -3012,8 +3012,8 @@ func TestReconcileServiceInstanceWithSecretParameters(t *testing.T) {
 	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
 		AcceptsIncomplete: true,
 		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testServiceClassGUID,
-		PlanID:            testServicePlanGUID,
+		ServiceID:         testClusterServiceClassGUID,
+		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
@@ -3216,8 +3216,8 @@ func TestReconcileServiceInstanceUpdateParameters(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	assertUpdateInstance(t, brokerActions[0], &osb.UpdateInstanceRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            nil, // no change to plan
 		Parameters: map[string]interface{}{
 			"args": map[string]interface{}{
@@ -3329,8 +3329,8 @@ func TestResolveReferencesNoClusterServicePlan(t *testing.T) {
 	if !ok {
 		t.Fatalf("couldn't convert to *v1beta1.ServiceInstance")
 	}
-	if updatedObject.Spec.ClusterServiceClassRef == nil || updatedObject.Spec.ClusterServiceClassRef.Name != serviceClassGUID {
-		t.Fatalf("ClusterServiceClassRef.Name was not set correctly, expected %q got: %+v", serviceClassGUID, updatedObject.Spec.ClusterServiceClassRef.Name)
+	if updatedObject.Spec.ClusterServiceClassRef == nil || updatedObject.Spec.ClusterServiceClassRef.Name != testClusterServiceClassGUID {
+		t.Fatalf("ClusterServiceClassRef.Name was not set correctly, expected %q got: %+v", testClusterServiceClassGUID, updatedObject.Spec.ClusterServiceClassRef.Name)
 	}
 	if updatedObject.Spec.ClusterServicePlanRef != nil {
 		t.Fatalf("ClusterServicePlanRef was unexpectedly set: %+v", updatedObject)
@@ -3409,11 +3409,11 @@ func TestReconcileServiceInstanceUpdatePlan(t *testing.T) {
 
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
-	expectedPlanID := planGUID
+	expectedPlanID := testClusterServicePlanGUID
 	assertUpdateInstance(t, brokerActions[0], &osb.UpdateInstanceRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
 		Parameters:        nil, // no change to parameters
 	})
@@ -3483,11 +3483,11 @@ func TestReconcileServiceInstanceWithUpdateCallFailure(t *testing.T) {
 
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
-	expectedPlanID := planGUID
+	expectedPlanID := testClusterServicePlanGUID
 	assertUpdateInstance(t, brokerActions[0], &osb.UpdateInstanceRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
 	})
 
@@ -3550,11 +3550,11 @@ func TestReconcileServiceInstanceWithUpdateFailure(t *testing.T) {
 
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
-	expectedPlanID := planGUID
+	expectedPlanID := testClusterServicePlanGUID
 	assertUpdateInstance(t, brokerActions[0], &osb.UpdateInstanceRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
 	})
 
@@ -3609,12 +3609,12 @@ func TestResolveReferencesWorks(t *testing.T) {
 		t.Fatalf("Should not have failed, but failed with: %q", err)
 	}
 
-	if updatedInstance.Spec.ClusterServiceClassRef == nil || updatedInstance.Spec.ClusterServiceClassRef.Name != serviceClassGUID {
-		t.Fatalf("Did not find expected ClusterServiceClassRef, expected %q got %+v", serviceClassGUID, updatedInstance.Spec.ClusterServiceClassRef)
+	if updatedInstance.Spec.ClusterServiceClassRef == nil || updatedInstance.Spec.ClusterServiceClassRef.Name != testClusterServiceClassGUID {
+		t.Fatalf("Did not find expected ClusterServiceClassRef, expected %q got %+v", testClusterServiceClassGUID, updatedInstance.Spec.ClusterServiceClassRef)
 	}
 
-	if updatedInstance.Spec.ClusterServicePlanRef == nil || updatedInstance.Spec.ClusterServicePlanRef.Name != planGUID {
-		t.Fatalf("Did not find expected ClusterServicePlanRef, expected %q got %+v", planGUID, updatedInstance.Spec.ClusterServicePlanRef.Name)
+	if updatedInstance.Spec.ClusterServicePlanRef == nil || updatedInstance.Spec.ClusterServicePlanRef.Name != testClusterServicePlanGUID {
+		t.Fatalf("Did not find expected ClusterServicePlanRef, expected %q got %+v", testClusterServicePlanGUID, updatedInstance.Spec.ClusterServicePlanRef.Name)
 	}
 
 	// We should get the following actions:
@@ -3641,10 +3641,10 @@ func TestResolveReferencesWorks(t *testing.T) {
 	if !ok {
 		t.Fatalf("couldn't convert to *v1beta1.ServiceInstance")
 	}
-	if updateObject.Spec.ClusterServiceClassRef == nil || updateObject.Spec.ClusterServiceClassRef.Name != serviceClassGUID {
+	if updateObject.Spec.ClusterServiceClassRef == nil || updateObject.Spec.ClusterServiceClassRef.Name != testClusterServiceClassGUID {
 		t.Fatalf("ClusterServiceClassRef was not resolved correctly during reconcile")
 	}
-	if updateObject.Spec.ClusterServicePlanRef == nil || updateObject.Spec.ClusterServicePlanRef.Name != planGUID {
+	if updateObject.Spec.ClusterServicePlanRef == nil || updateObject.Spec.ClusterServicePlanRef.Name != testClusterServicePlanGUID {
 		t.Fatalf("ClusterServicePlanRef was not resolved correctly during reconcile")
 	}
 
@@ -3691,8 +3691,8 @@ func TestResolveReferencesForPlanChange(t *testing.T) {
 		t.Fatalf("Should not have failed, but failed with: %q", err)
 	}
 
-	if updatedInstance.Spec.ClusterServiceClassRef == nil || updatedInstance.Spec.ClusterServiceClassRef.Name != serviceClassGUID {
-		t.Fatalf("Did not find expected ClusterServiceClassRef, expected %q got %+v", serviceClassGUID, updatedInstance.Spec.ClusterServiceClassRef)
+	if updatedInstance.Spec.ClusterServiceClassRef == nil || updatedInstance.Spec.ClusterServiceClassRef.Name != testClusterServiceClassGUID {
+		t.Fatalf("Did not find expected ClusterServiceClassRef, expected %q got %+v", testClusterServiceClassGUID, updatedInstance.Spec.ClusterServiceClassRef)
 	}
 
 	if updatedInstance.Spec.ClusterServicePlanRef == nil || updatedInstance.Spec.ClusterServicePlanRef.Name != newPlanID {
@@ -3716,7 +3716,7 @@ func TestResolveReferencesForPlanChange(t *testing.T) {
 	if !ok {
 		t.Fatalf("couldn't convert to *v1beta1.ServiceInstance")
 	}
-	if updateObject.Spec.ClusterServiceClassRef == nil || updateObject.Spec.ClusterServiceClassRef.Name != serviceClassGUID {
+	if updateObject.Spec.ClusterServiceClassRef == nil || updateObject.Spec.ClusterServiceClassRef.Name != testClusterServiceClassGUID {
 		t.Fatalf("ClusterServiceClassRef was not resolved correctly during reconcile")
 	}
 	if updateObject.Spec.ClusterServicePlanRef == nil || updateObject.Spec.ClusterServicePlanRef.Name != newPlanID {
@@ -3771,11 +3771,11 @@ func TestReconcileServiceInstanceUpdateAsynchronous(t *testing.T) {
 
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
-	expectedPlanID := planGUID
+	expectedPlanID := testClusterServicePlanGUID
 	assertUpdateInstance(t, brokerActions[0], &osb.UpdateInstanceRequest{
 		AcceptsIncomplete: true,
-		InstanceID:        instanceGUID,
-		ServiceID:         serviceClassGUID,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
 	})
 
@@ -3837,9 +3837,9 @@ func TestPollServiceInstanceAsyncInProgressUpdating(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
-		InstanceID:   instanceGUID,
-		ServiceID:    strPtr(serviceClassGUID),
-		PlanID:       strPtr(planGUID),
+		InstanceID:   testServiceInstanceGUID,
+		ServiceID:    strPtr(testClusterServiceClassGUID),
+		PlanID:       strPtr(testClusterServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -3894,9 +3894,9 @@ func TestPollServiceInstanceAsyncSuccessUpdating(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
-		InstanceID:   instanceGUID,
-		ServiceID:    strPtr(serviceClassGUID),
-		PlanID:       strPtr(planGUID),
+		InstanceID:   testServiceInstanceGUID,
+		ServiceID:    strPtr(testClusterServiceClassGUID),
+		PlanID:       strPtr(testClusterServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 
@@ -3948,9 +3948,9 @@ func TestPollServiceInstanceAsyncFailureUpdating(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
 	operationKey := osb.OperationKey(testOperation)
 	assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
-		InstanceID:   instanceGUID,
-		ServiceID:    strPtr(serviceClassGUID),
-		PlanID:       strPtr(planGUID),
+		InstanceID:   testServiceInstanceGUID,
+		ServiceID:    strPtr(testClusterServiceClassGUID),
+		PlanID:       strPtr(testClusterServicePlanGUID),
 		OperationKey: &operationKey,
 	})
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -59,29 +59,28 @@ import (
 // loops for the different catalog API resources.
 
 const (
-	serviceClassGUID                   = "SCGUID"
-	planGUID                           = "PGUID"
-	nonbindableClusterServiceClassGUID = "UNBINDABLE-SERVICE"
-	nonbindablePlanGUID                = "UNBINDABLE-PLAN"
-	instanceGUID                       = "IGUID"
-	bindingGUID                        = "BGUID"
+	testClusterServiceClassGUID            = "SCGUID"
+	testClusterServicePlanGUID             = "PGUID"
+	testNonbindableClusterServiceClassGUID = "UNBINDABLE-SERVICE"
+	testNonbindableClusterServicePlanGUID  = "UNBINDABLE-PLAN"
+	testServiceInstanceGUID                = "IGUID"
+	testServiceBindingGUID                 = "BGUID"
+	testNamespaceGUID                      = "test-ns-uid"
+	testRemovedClusterServiceClassGUID     = "REMOVED-SERVICE"
+	testRemovedClusterServicePlanGUID      = "REMOVED-PLAN"
 
-	removedClusterServiceClassGUID = "REMOVED-SERVICE"
-	removedClusterServicePlanGUID  = "REMOVED-PLAN"
-
-	testClusterServiceBrokerName           = "test-broker"
-	testClusterServiceClassName            = "test-serviceclass"
-	testRemovedClusterServiceClassName     = "removed-test-serviceclass"
-	testNonbindableClusterServiceClassName = "test-unbindable-serviceclass"
-	testClusterServicePlanName             = "test-plan"
-	testRemovedClusterServicePlanName      = "removed-test-plan"
-	testNonbindableClusterServicePlanName  = "test-unbindable-plan"
-	testServiceInstanceName                = "test-instance"
-	testServiceBindingName                 = "test-binding"
-	testNamespace                          = "test-ns"
-	testServiceBindingSecretName           = "test-secret"
-	testOperation                          = "test-operation"
-	testNsUID                              = "test-ns-uid"
+	testClusterServiceBrokerName            = "test-broker"
+	testClusterServiceClassName             = "test-serviceclass"
+	testClusterServicePlanName              = "test-plan"
+	testNonbindableClusterServiceClassName  = "test-unbindable-serviceclass"
+	testNonbindableClusterServicePlanName   = "test-unbindable-plan"
+	testRemovedClusterServiceClassName      = "removed-test-serviceclass"
+	testRemovedClusterServicePlanName       = "removed-test-plan"
+	testServiceInstanceName                 = "test-instance"
+	testServiceBindingSecretName            = "test-secret"
+	testNamespace                           = "test-ns"
+	testServiceInstanceCredentialSecretName = "test-secret"
+	testOperation                           = "test-operation"
 )
 
 var testDashboardURL = "http://dashboard"
@@ -482,13 +481,13 @@ func getTestCatalog() *osb.CatalogResponse {
 					{
 						Name:        testClusterServicePlanName,
 						Free:        truePtr(),
-						ID:          planGUID,
+						ID:          testServicePlanGUID,
 						Description: "a test plan",
 					},
 					{
 						Name:        testNonbindableClusterServicePlanName,
 						Free:        truePtr(),
-						ID:          nonbindablePlanGUID,
+						ID:          testNonbindableServicePlanGUID,
 						Description: "a test plan",
 						Bindable:    falsePtr(),
 					},
@@ -692,7 +691,7 @@ func getTestServiceBinding() *v1beta1.ServiceBinding {
 		},
 		Spec: v1beta1.ServiceBindingSpec{
 			ServiceInstanceRef: v1.LocalObjectReference{Name: testServiceInstanceName},
-			ExternalID:         bindingGUID,
+			ExternalID:         testServiceBindingGUID,
 		},
 	}
 }
@@ -2486,7 +2485,7 @@ func addGetNamespaceReaction(fakeKubeClient *clientgofake.Clientset) {
 	fakeKubeClient.AddReactor("get", "namespaces", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		return true, &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				UID: types.UID(testNsUID),
+				UID: types.UID(testNamespaceGUID),
 			},
 		}, nil
 	})

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -72,11 +72,13 @@ const (
 	testClusterServiceBrokerName            = "test-broker"
 	testClusterServiceClassName             = "test-serviceclass"
 	testClusterServicePlanName              = "test-plan"
+	testNonExistentClusterServiceClassName  = "nothere"
 	testNonbindableClusterServiceClassName  = "test-unbindable-serviceclass"
 	testNonbindableClusterServicePlanName   = "test-unbindable-plan"
 	testRemovedClusterServiceClassName      = "removed-test-serviceclass"
 	testRemovedClusterServicePlanName       = "removed-test-plan"
 	testServiceInstanceName                 = "test-instance"
+	testServiceBindingName                  = "test-binding"
 	testServiceBindingSecretName            = "test-secret"
 	testNamespace                           = "test-ns"
 	testServiceInstanceCredentialSecretName = "test-secret"
@@ -386,12 +388,12 @@ func getTestClusterServiceBrokerWithAuth(authInfo *v1beta1.ServiceBrokerAuthInfo
 // a bindable service class wired to the result of getTestClusterServiceBroker()
 func getTestClusterServiceClass() *v1beta1.ClusterServiceClass {
 	return &v1beta1.ClusterServiceClass{
-		ObjectMeta: metav1.ObjectMeta{Name: serviceClassGUID},
+		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceClassGUID},
 		Spec: v1beta1.ClusterServiceClassSpec{
 			ClusterServiceBrokerName: testClusterServiceBrokerName,
 			Description:              "a test service",
 			ExternalName:             testClusterServiceClassName,
-			ExternalID:               serviceClassGUID,
+			ExternalID:               testClusterServiceClassGUID,
 			Bindable:                 true,
 		},
 	}
@@ -399,12 +401,12 @@ func getTestClusterServiceClass() *v1beta1.ClusterServiceClass {
 
 func getTestRemovedClusterServiceClass() *v1beta1.ClusterServiceClass {
 	return &v1beta1.ClusterServiceClass{
-		ObjectMeta: metav1.ObjectMeta{Name: removedClusterServiceClassGUID},
+		ObjectMeta: metav1.ObjectMeta{Name: testRemovedClusterServiceClassGUID},
 		Spec: v1beta1.ClusterServiceClassSpec{
 			ClusterServiceBrokerName: testClusterServiceBrokerName,
 			Description:              "a test service that should be removed",
 			ExternalName:             testRemovedClusterServiceClassName,
-			ExternalID:               removedClusterServiceClassGUID,
+			ExternalID:               testRemovedClusterServiceClassGUID,
 			Bindable:                 true,
 		},
 	}
@@ -412,14 +414,14 @@ func getTestRemovedClusterServiceClass() *v1beta1.ClusterServiceClass {
 
 func getTestClusterServicePlan() *v1beta1.ClusterServicePlan {
 	return &v1beta1.ClusterServicePlan{
-		ObjectMeta: metav1.ObjectMeta{Name: planGUID},
+		ObjectMeta: metav1.ObjectMeta{Name: testClusterServicePlanGUID},
 		Spec: v1beta1.ClusterServicePlanSpec{
 			ClusterServiceBrokerName: testClusterServiceBrokerName,
-			ExternalID:               planGUID,
+			ExternalID:               testClusterServicePlanGUID,
 			ExternalName:             testClusterServicePlanName,
 			Bindable:                 truePtr(),
 			ClusterServiceClassRef: v1.LocalObjectReference{
-				Name: serviceClassGUID,
+				Name: testClusterServiceClassGUID,
 			},
 		},
 	}
@@ -427,14 +429,14 @@ func getTestClusterServicePlan() *v1beta1.ClusterServicePlan {
 
 func getTestRemovedClusterServicePlan() *v1beta1.ClusterServicePlan {
 	return &v1beta1.ClusterServicePlan{
-		ObjectMeta: metav1.ObjectMeta{Name: removedClusterServicePlanGUID},
+		ObjectMeta: metav1.ObjectMeta{Name: testRemovedClusterServicePlanGUID},
 		Spec: v1beta1.ClusterServicePlanSpec{
 			ClusterServiceBrokerName: testClusterServiceBrokerName,
-			ExternalID:               removedClusterServicePlanGUID,
+			ExternalID:               testRemovedClusterServicePlanGUID,
 			ExternalName:             testRemovedClusterServicePlanName,
 			Bindable:                 truePtr(),
 			ClusterServiceClassRef: v1.LocalObjectReference{
-				Name: serviceClassGUID,
+				Name: testClusterServiceClassGUID,
 			},
 		},
 	}
@@ -442,13 +444,13 @@ func getTestRemovedClusterServicePlan() *v1beta1.ClusterServicePlan {
 
 func getTestClusterServicePlanNonbindable() *v1beta1.ClusterServicePlan {
 	return &v1beta1.ClusterServicePlan{
-		ObjectMeta: metav1.ObjectMeta{Name: nonbindablePlanGUID},
+		ObjectMeta: metav1.ObjectMeta{Name: testNonbindableClusterServicePlanGUID},
 		Spec: v1beta1.ClusterServicePlanSpec{
 			ExternalName: testNonbindableClusterServicePlanName,
-			ExternalID:   nonbindablePlanGUID,
+			ExternalID:   testNonbindableClusterServicePlanGUID,
 			Bindable:     falsePtr(),
 			ClusterServiceClassRef: v1.LocalObjectReference{
-				Name: serviceClassGUID,
+				Name: testClusterServiceClassGUID,
 			},
 		},
 	}
@@ -457,11 +459,11 @@ func getTestClusterServicePlanNonbindable() *v1beta1.ClusterServicePlan {
 // an unbindable service class wired to the result of getTestClusterServiceBroker()
 func getTestNonbindableClusterServiceClass() *v1beta1.ClusterServiceClass {
 	return &v1beta1.ClusterServiceClass{
-		ObjectMeta: metav1.ObjectMeta{Name: nonbindableClusterServiceClassGUID},
+		ObjectMeta: metav1.ObjectMeta{Name: testNonbindableClusterServiceClassGUID},
 		Spec: v1beta1.ClusterServiceClassSpec{
 			ClusterServiceBrokerName: testClusterServiceBrokerName,
 			ExternalName:             testNonbindableClusterServiceClassName,
-			ExternalID:               nonbindableClusterServiceClassGUID,
+			ExternalID:               testNonbindableClusterServiceClassGUID,
 			Bindable:                 false,
 		},
 	}
@@ -474,20 +476,20 @@ func getTestCatalog() *osb.CatalogResponse {
 		Services: []osb.Service{
 			{
 				Name:        testClusterServiceClassName,
-				ID:          serviceClassGUID,
+				ID:          testClusterServiceClassGUID,
 				Description: "a test service",
 				Bindable:    true,
 				Plans: []osb.Plan{
 					{
 						Name:        testClusterServicePlanName,
 						Free:        truePtr(),
-						ID:          testServicePlanGUID,
+						ID:          testClusterServicePlanGUID,
 						Description: "a test plan",
 					},
 					{
 						Name:        testNonbindableClusterServicePlanName,
 						Free:        truePtr(),
-						ID:          testNonbindableServicePlanGUID,
+						ID:          testNonbindableClusterServicePlanGUID,
 						Description: "a test plan",
 						Bindable:    falsePtr(),
 					},
@@ -506,8 +508,8 @@ func getTestCatalog() *osb.CatalogResponse {
 // Service[Class|Plan]Lister.get(spec.Service[Class|Plan]Ref.Name)
 func getTestServiceInstanceWithRefs() *v1beta1.ServiceInstance {
 	sc := getTestServiceInstance()
-	sc.Spec.ClusterServiceClassRef = &v1.ObjectReference{Name: serviceClassGUID}
-	sc.Spec.ClusterServicePlanRef = &v1.ObjectReference{Name: planGUID}
+	sc.Spec.ClusterServiceClassRef = &v1.ObjectReference{Name: testClusterServiceClassGUID}
+	sc.Spec.ClusterServicePlanRef = &v1.ObjectReference{Name: testClusterServicePlanGUID}
 	return sc
 }
 
@@ -529,7 +531,7 @@ func getTestServiceInstance() *v1beta1.ServiceInstance {
 				ExternalClusterServiceClassName: testClusterServiceClassName,
 				ExternalClusterServicePlanName:  testClusterServicePlanName,
 			},
-			ExternalID: instanceGUID,
+			ExternalID: testServiceInstanceGUID,
 		},
 	}
 }
@@ -539,8 +541,8 @@ func getTestNonbindableServiceInstance() *v1beta1.ServiceInstance {
 	i := getTestServiceInstance()
 	i.Spec.ExternalClusterServiceClassName = testNonbindableClusterServiceClassName
 	i.Spec.ExternalClusterServicePlanName = testNonbindableClusterServicePlanName
-	i.Spec.ClusterServiceClassRef = &v1.ObjectReference{Name: nonbindableClusterServiceClassGUID}
-	i.Spec.ClusterServicePlanRef = &v1.ObjectReference{Name: nonbindablePlanGUID}
+	i.Spec.ClusterServiceClassRef = &v1.ObjectReference{Name: testNonbindableClusterServiceClassGUID}
+	i.Spec.ClusterServicePlanRef = &v1.ObjectReference{Name: testNonbindableClusterServicePlanGUID}
 
 	return i
 }
@@ -549,7 +551,7 @@ func getTestNonbindableServiceInstance() *v1beta1.ServiceInstance {
 func getTestServiceInstanceNonbindableServiceBindablePlan() *v1beta1.ServiceInstance {
 	i := getTestNonbindableServiceInstance()
 	i.Spec.ExternalClusterServicePlanName = testClusterServicePlanName
-	i.Spec.ClusterServicePlanRef = &v1.ObjectReference{Name: planGUID}
+	i.Spec.ClusterServicePlanRef = &v1.ObjectReference{Name: testClusterServicePlanGUID}
 
 	return i
 }
@@ -557,7 +559,7 @@ func getTestServiceInstanceNonbindableServiceBindablePlan() *v1beta1.ServiceInst
 func getTestServiceInstanceBindableServiceNonbindablePlan() *v1beta1.ServiceInstance {
 	i := getTestServiceInstanceWithRefs()
 	i.Spec.ExternalClusterServicePlanName = testNonbindableClusterServicePlanName
-	i.Spec.ClusterServicePlanRef = &v1.ObjectReference{Name: nonbindablePlanGUID}
+	i.Spec.ClusterServicePlanRef = &v1.ObjectReference{Name: testNonbindableClusterServicePlanGUID}
 
 	return i
 }


### PR DESCRIPTION
I find it difficult to keep track of how the test constants are named. This is my take on fixing that (here's your description @pmorie)