### PR TITLE
fix RBAC resource names for ClusterServiceBroker

### DIFF
--- a/charts/catalog/templates/rbac.yaml
+++ b/charts/catalog/templates/rbac.yaml
@@ -92,10 +92,10 @@ items:
     resources: ["serviceplans"]
     verbs:     ["get","list","watch","create","patch","update","delete"]
   - apiGroups: ["servicecatalog.k8s.io"]
-    resources: ["servicebrokers","serviceinstances","serviceinstancecredentials"]
+    resources: ["clusterservicebrokers","serviceinstances","serviceinstancecredentials"]
     verbs:     ["get","list","watch"]
   - apiGroups: ["servicecatalog.k8s.io"]
-    resources: ["servicebrokers/status","serviceinstances/status","serviceinstances/reference","serviceinstancecredentials/status"]
+    resources: ["clusterservicebrokers/status","serviceinstances/status","serviceinstances/reference","serviceinstancecredentials/status"]
     verbs:     ["update"]
 # give the controller-manager service account access to whats defined in its role.
 - apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
The ServiceBroker -> ClusterServiceBroker rename went in without the accompanying RBAC name changes.

I've tested this against the walkthrough manually and confirmed this worked. RBAC enforcement will be coming to Jenkins shortly to automatically enforce this.