### PR TITLE
add back 'Processing' message for instance deprovision

### DIFF
--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -223,6 +223,11 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1beta1.ServiceIns
 		return nil
 	}
 
+	glog.V(4).Infof(
+		`%s "%s/%s": Processing deleting event`,
+		typeSI, instance.Namespace, instance.Name,
+	)
+
 	// Determine if any credentials exist for this instance.  We don't want to
 	// delete the instance if there are any associated creds
 	credentialsLister := c.bindingLister.ServiceBindings(instance.Namespace)


### PR DESCRIPTION
Somehow we lost the "Processing" message when we are doing a deprovision. Adding it back in, as every other reconciliation attempt across all resources has the same message, and it made it hard to look through the logs for resource reconciliations.