### PR TITLE
Do not set Ready/False condition in API Server when updating an instance

### DIFF
--- a/pkg/registry/servicecatalog/instance/strategy.go
+++ b/pkg/registry/servicecatalog/instance/strategy.go
@@ -165,7 +165,6 @@ func (instanceRESTStrategy) PrepareForUpdate(ctx genericapirequest.Context, new,
 			setServiceInstanceUserInfo(newServiceInstance, ctx)
 		}
 		newServiceInstance.Generation = oldServiceInstance.Generation + 1
-		setServiceInstanceReadyFalseCondition(newServiceInstance)
 	}
 }
 
@@ -274,35 +273,4 @@ func setServiceInstanceUserInfo(instance *sc.ServiceInstance, ctx genericapirequ
 			}
 		}
 	}
-}
-
-func setServiceInstanceReadyFalseCondition(instance *sc.ServiceInstance) {
-	newCondition := sc.ServiceInstanceCondition{
-		Type:    sc.ServiceInstanceConditionReady,
-		Status:  sc.ConditionFalse,
-		Reason:  "UpdateInitiated",
-		Message: "Update initiated on ServiceInstance",
-	}
-
-	if len(instance.Status.Conditions) == 0 {
-		newCondition.LastTransitionTime = metav1.Now()
-		instance.Status.Conditions = []sc.ServiceInstanceCondition{newCondition}
-		return
-	}
-
-	for i, cond := range instance.Status.Conditions {
-		if cond.Type == sc.ServiceInstanceConditionReady {
-			if cond.Status != newCondition.Status {
-				newCondition.LastTransitionTime = metav1.Now()
-			} else {
-				newCondition.LastTransitionTime = cond.LastTransitionTime
-			}
-
-			instance.Status.Conditions[i] = newCondition
-			return
-		}
-	}
-
-	newCondition.LastTransitionTime = metav1.Now()
-	instance.Status.Conditions = append(instance.Status.Conditions, newCondition)
 }

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -192,11 +192,8 @@ func TestBasicFlowsSync(t *testing.T) {
 		t.Fatalf("error updating Instance: %v", err)
 	}
 
-	if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1alpha1.ServiceInstanceCondition{
-		Type:   v1alpha1.ServiceInstanceConditionReady,
-		Status: v1alpha1.ConditionTrue,
-	}); err != nil {
-		t.Fatalf("error waiting for instance to become ready: %v", err)
+	if err := util.WaitForInstanceReconciledGeneration(client, testNamespace, testInstanceName, retInst.Status.ReconciledGeneration+1); err != nil {
+		t.Fatalf("error waiting for instance to reconcile: %v", err)
 	}
 
 	retInst, err = client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
@@ -388,11 +385,8 @@ func TestBasicFlowsAsync(t *testing.T) {
 		t.Fatalf("error updating Instance: %v", err)
 	}
 
-	if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1alpha1.ServiceInstanceCondition{
-		Type:   v1alpha1.ServiceInstanceConditionReady,
-		Status: v1alpha1.ConditionTrue,
-	}); err != nil {
-		t.Fatalf("error waiting for instance to become ready: %v", err)
+	if err := util.WaitForInstanceReconciledGeneration(client, testNamespace, testInstanceName, retInst.Status.ReconciledGeneration+1); err != nil {
+		t.Fatalf("error waiting for instance to reconcile: %v", err)
 	}
 
 	retInst, err = client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
@@ -896,11 +890,8 @@ func TestBasicFlowsWithOriginatingIdentity(t *testing.T) {
 		t.Fatalf("error updating Instance: %v", err)
 	}
 
-	if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1alpha1.ServiceInstanceCondition{
-		Type:   v1alpha1.ServiceInstanceConditionReady,
-		Status: v1alpha1.ConditionTrue,
-	}); err != nil {
-		t.Fatalf("error waiting for instance to become ready: %v", err)
+	if err := util.WaitForInstanceReconciledGeneration(client, testNamespace, testInstanceName, retInst.Status.ReconciledGeneration+1); err != nil {
+		t.Fatalf("error waiting for instance to reconcile: %v", err)
 	}
 
 	retInst, err = client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -159,6 +159,26 @@ func WaitForInstanceToNotExist(client v1alpha1servicecatalog.ServicecatalogV1alp
 	)
 }
 
+// WaitForInstanceReconciledGeneration waits for the status of the named instance to
+// have the specified reconciled generation.
+func WaitForInstanceReconciledGeneration(client v1alpha1servicecatalog.ServicecatalogV1alpha1Interface, namespace, name string, reconciledGeneration int64) error {
+	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
+		func() (bool, error) {
+			glog.V(5).Infof("Waiting for instance %v/%v to have reconciled generation of %v", namespace, name, reconciledGeneration)
+			instance, err := client.ServiceInstances(namespace).Get(name, metav1.GetOptions{})
+			if nil != err {
+				return false, fmt.Errorf("error getting Instance %v/%v: %v", namespace, name, err)
+			}
+
+			if instance.Status.ReconciledGeneration == reconciledGeneration {
+				return true, nil
+			}
+
+			return false, nil
+		},
+	)
+}
+
 // WaitForBindingCondition waits for the status of the named binding to
 // contain a condition whose type and status matches the supplied one.
 func WaitForBindingCondition(client v1alpha1servicecatalog.ServicecatalogV1alpha1Interface, namespace, name string, condition v1alpha1.ServiceInstanceCredentialCondition) error {


### PR DESCRIPTION
This covers fixing the issue that @pmorie found in the late stages of reviewing #1289.