### PR TITLE
Disambiguate k8s and external names in log messages for broker

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -475,7 +475,9 @@ func getBearerConfig(secret *apiv1.Secret) (*osb.BearerConfig, error) {
 	}, nil
 }
 
-// convertCatalog converts a service broker catalog into an array of ClusterServiceClasses
+// convertCatalog converts a service broker catalog into an array of
+// ClusterServiceClasses and an array of ClusterServicePlans.  The ClusterServiceClasses and
+// ClusterServicePlans returned by this method are named in K8S with the OSB ID.
 func convertCatalog(in *osb.CatalogResponse) ([]*v1alpha1.ClusterServiceClass, []*v1alpha1.ClusterServicePlan, error) {
 	serviceClasses := make([]*v1alpha1.ClusterServiceClass, len(in.Services))
 	servicePlans := []*v1alpha1.ClusterServicePlan{}

--- a/pkg/controller/controller_broker_test.go
+++ b/pkg/controller/controller_broker_test.go
@@ -274,7 +274,7 @@ func TestReconcileClusterServiceBrokerExistingClusterServiceClassDifferentBroker
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
 
-	expectedEvent := apiv1.EventTypeWarning + " " + errorSyncingCatalogReason + ` Error reconciling ClusterServiceClass "test-serviceclass" (broker "test-broker"): ClusterServiceClass "test-serviceclass" for ClusterServiceBroker "test-broker" already exists for Broker "notTheSame"`
+	expectedEvent := apiv1.EventTypeWarning + " " + errorSyncingCatalogReason + ` Error reconciling ClusterServiceClass "test-serviceclass" (broker "test-broker"): ClusterServiceBroker "test-broker": ClusterServiceClass "test-serviceclass" already exists for Broker "notTheSame"`
 	if e, a := expectedEvent, events[0]; e != a {
 		t.Fatalf("Received unexpected event; expected\n%v, got\n%v", e, a)
 	}
@@ -368,7 +368,7 @@ func TestReconcileClusterServiceBrokerErrorFetchingCatalog(t *testing.T) {
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
 
-	expectedEvent := apiv1.EventTypeWarning + " " + errorFetchingCatalogReason + " " + "Error getting broker catalog for broker \"test-broker\": ooops"
+	expectedEvent := apiv1.EventTypeWarning + " " + errorFetchingCatalogReason + " " + `ClusterServiceBroker "test-broker": Error getting broker catalog: ooops`
 	if e, a := expectedEvent, events[0]; e != a {
 		t.Fatalf("Received unexpected event: %v", a)
 	}
@@ -565,7 +565,7 @@ func testReconcileClusterServiceBrokerWithAuth(t *testing.T, authInfo *v1alpha1.
 	if shouldSucceed {
 		expectedEvent = apiv1.EventTypeNormal + " " + successFetchedCatalogReason + " " + successFetchedCatalogMessage
 	} else {
-		expectedEvent = apiv1.EventTypeWarning + " " + errorAuthCredentialsReason + " " + "Error getting broker auth credentials for broker \"test-broker\""
+		expectedEvent = apiv1.EventTypeWarning + " " + errorAuthCredentialsReason + " " + `ClusterServiceBroker "test-broker": Error getting broker auth credentials`
 	}
 	if e, a := expectedEvent, events[0]; !strings.HasPrefix(a, e) {
 		t.Fatalf("Received unexpected event: %v", a)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -422,7 +422,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 		"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1.ClusterServicePlanList": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "ServicePlanList is a list of ServicePlans.",
+					Description: "ClusterServicePlanList is a list of ServicePlans.",
 					Properties: map[string]spec.Schema{
 						"kind": {
 							SchemaProps: spec.SchemaProps{


### PR DESCRIPTION
Controller log is not especially helpful currently because the names used in logs are ambiguous.  I've been trying to debug a downstream e2e run and found it basically impossible to do without these changes :)