### PR TITLE
Fix walkthrough

### DIFF
--- a/docs/walkthrough-1.7.md
+++ b/docs/walkthrough-1.7.md
@@ -27,18 +27,18 @@ Otherwise, to install with sensible defaults, run the following command:
 helm install charts/ups-broker --name ups-broker --namespace ups-broker
 ```
 
-# Step 2 - Creating a `ServiceBroker` Resource
+# Step 2 - Creating a `ClusterServiceBroker` Resource
 
 Because we haven't created any resources in the service-catalog API server yet,
 `kubectl get` will return an empty list of resources.
 
 ```console
-kubectl get servicebrokers,serviceclasses,serviceinstances,servicebindings
+kubectl get clusterservicebrokers,clusterserviceclasses,serviceinstances,servicebindings
 No resources found.
 ```
 
 We'll register a broker server with the catalog by creating a new
-[`ServiceBroker`](../contrib/examples/walkthrough/ups-broker.yaml) resource.
+[`ClusterServiceBroker`](../contrib/examples/walkthrough/ups-broker.yaml) resource.
 Do so with the following command:
 
 ```console
@@ -51,28 +51,28 @@ The output of that command should be the following:
 servicebroker "ups-broker" created
 ```
 
-When we create this `ServiceBroker` resource, the service catalog controller responds
+When we create this `ClusterServiceBroker` resource, the service catalog controller responds
 by querying the broker server to see what services it offers and creates a
-`ServiceClass` for each.
+`ClusterServiceClass` for each.
 
 We can check the status of the broker using `kubectl get`:
 
 ```console
-kubectl get servicebrokers ups-broker -o yaml
+kubectl get clusterservicebrokers ups-broker -o yaml
 ```
 
 We should see something like:
 
 ```yaml
 apiVersion: servicecatalog.k8s.io/v1alpha1
-kind: ServiceBroker
+kind: ClusterServiceBroker
 metadata:
   creationTimestamp: 2017-03-03T04:11:17Z
   finalizers:
   - kubernetes-incubator/service-catalog
   name: ups-broker
   resourceVersion: "6"
-  selfLink: /apis/servicecatalog.k8s.io/v1alpha1/servicebrokers/ups-broker
+  selfLink: /apis/servicecatalog.k8s.io/v1alpha1/clusterservicebrokers/ups-broker
   uid: 72fa629b-ffc7-11e6-b111-0242ac110005
 spec:
   url: http://ups-broker-ups-broker.ups-broker.svc.cluster.local
@@ -88,14 +88,14 @@ Notice that the `status` field has been set to reflect that the broker server's
 catalog of service offerings has been successfully added to our cluster's
 service catalog.
 
-# Step 3 - Viewing `ServiceClass`es
+# Step 3 - Viewing `ClusterServiceClass`es
 
-The controller created a `ServiceClass` for each service that the UPS broker
-provides. We can view the `ServiceClass` resources available in the cluster by
+The controller created a `ClusterServiceClass` for each service that the UPS broker
+provides. We can view the `ClusterServiceClass` resources available in the cluster by
 executing:
 
 ```console
-$ kubectl get serviceclasses -o=custom-columns=NAME:.metadata.name,EXTERNAL\ NAME:.spec.externalName
+$ kubectl get clusterserviceclasses -o=custom-columns=NAME:.metadata.name,EXTERNAL\ NAME:.spec.externalName
 ```
 
 We should see something like:
@@ -106,7 +106,7 @@ NAME                                   EXTERNAL NAME
 ```
 
 **NOTE:** The above command uses a custom set of columns.  The `NAME` field is
-the Kubernetes name of the ServiceClass and the `EXTERNAL NAME` field is the
+the Kubernetes name of the ClusterServiceClass and the `EXTERNAL NAME` field is the
 human-readable name for the service that the broker returns.
 
 The UPS broker provides a service with the external name
@@ -114,19 +114,19 @@ The UPS broker provides a service with the external name
 offering:
 
 ```console
-kubectl get serviceclasses 4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468 -o yaml
+kubectl get clusterserviceclasses 4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468 -o yaml
 ```
 
 We should see something like:
 
 ```yaml
 apiVersion: servicecatalog.k8s.io/v1alpha1
-kind: ServiceClass
+kind: ClusterServiceClass
 metadata:
   creationTimestamp: 2017-03-03T04:11:17Z
   name: user-provided-service
   resourceVersion: "7"
-  selfLink: /apis/servicecatalog.k8s.io/v1alpha1/serviceclasses/user-provided-service
+  selfLink: /apis/servicecatalog.k8s.io/v1alpha1/clusterserviceclasses/user-provided-service
   uid: 72fef5ce-ffc7-11e6-b111-0242ac110005
 brokerName: ups-broker
 externalID: 4F6E6CF6-FFDD-425F-A2C7-3C9258AD2468
@@ -140,11 +140,11 @@ plans:
 
 # Step 4 - Creating a New `ServiceInstance`
 
-Now that a `ServiceClass` named `user-provided-service` exists within our
+Now that a `ClusterServiceClass` named `user-provided-service` exists within our
 cluster's service catalog, we can create a `ServiceInstance` that points to
 it.
 
-Unlike `ServiceBroker` and `ServiceClass` resources, `ServiceInstance` 
+Unlike `ClusterServiceBroker` and `ClusterServiceClass` resources, `ServiceInstance` 
 resources must be namespaced, so we'll need to create a namespace to start.
 Do so with this command:
 
@@ -189,8 +189,8 @@ metadata:
   uid: 07ecf19d-a781-11e7-8b18-0242ac110005
 spec:
   externalID: 7f2c176a-ae67-4b5e-a826-58591d85a1d7
-  externalServiceClassName: user-provided-service
-  externalServicePlanName: default
+  externalClusterServiceClassName: user-provided-service
+  externalClusterServicePlanName: default
   parameters:
     credentials:
       param-1: value-1
@@ -204,7 +204,7 @@ status:
     status: "True"
     type: Ready
   externalProperties:
-    externalServicePlanName: default
+    externalClusterServicePlanName: default
     parameterChecksum: e65c764db8429f9afef45f1e8f71bcbf9fdbe9a13306b86fd5dcc3c5d11e5dd3
     parameters:
       credentials:
@@ -308,21 +308,21 @@ Now, we can deprovision the instance. To do this, we simply *delete* the
 kubectl delete -n test-ns serviceinstances ups-instance
 ```
 
-# Step 8 - Deleting the `ServiceBroker`
+# Step 8 - Deleting the `ClusterServiceBroker`
 
-Next, we should remove the `ServiceBroker` resource. This tells the service
+Next, we should remove the `ClusterServiceBroker` resource. This tells the service
 catalog to remove the broker's services from the catalog. Do so with this
 command:
 
 ```console
-kubectl delete servicebrokers ups-broker
+kubectl delete clusterservicebrokers ups-broker
 ```
 
-We should then see that all the `ServiceClass` resources that came from that
+We should then see that all the `ClusterServiceClass` resources that came from that
 broker have also been deleted:
 
 ```console
-kubectl get serviceclasses
+kubectl get clusterserviceclasses
 No resources found.
 ```
 


### PR DESCRIPTION
Previously I had not updated the walkthrough for
Service[Broker|Class|Plan] renames to ClusterService[Broker|Class|Plan]

This addresses that.