### PR TITLE
Move "External" around in some resource names/properties

### DIFF
--- a/contrib/examples/apiserver/instance.yaml
+++ b/contrib/examples/apiserver/instance.yaml
@@ -4,5 +4,5 @@ metadata:
   name: test-instance
   namespace: test-ns
 spec:
-  externalClusterServiceClassName: test-serviceclass
-  externalClusterServicePlanName: example-plan-1
+  clusterServiceClassExternalName: test-serviceclass
+  clusterServicePlanExternalName: example-plan-1

--- a/contrib/examples/walkthrough/ups-instance-default-sp.yaml
+++ b/contrib/examples/walkthrough/ups-instance-default-sp.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ups-instance-default
   namespace: test-ns
 spec:
-  externalClusterServiceClassName: user-provided-service
+  clusterServiceClassExternalName: user-provided-service
   parameters:
     credentials:
       name: root

--- a/contrib/examples/walkthrough/ups-instance.yaml
+++ b/contrib/examples/walkthrough/ups-instance.yaml
@@ -4,8 +4,8 @@ metadata:
   name: ups-instance
   namespace: test-ns
 spec:
-  externalClusterServiceClassName: user-provided-service
-  externalClusterServicePlanName: default
+  clusterServiceClassExternalName: user-provided-service
+  clusterServicePlanExternalName: default
   parameters:
     credentials:
       param-1: value-1

--- a/docs/walkthrough-1.6.md
+++ b/docs/walkthrough-1.6.md
@@ -201,8 +201,8 @@ metadata:
   uid: 07ecf19d-a781-11e7-8b18-0242ac110005
 spec:
   externalID: 7f2c176a-ae67-4b5e-a826-58591d85a1d7
-  externalClusterServiceClassName: user-provided-service
-  externalClusterServicePlanName: default
+  clusterServiceClassExternalName: user-provided-service
+  clusterServicePlanExternalName: default
   parameters:
     credentials:
       param-1: value-1
@@ -216,7 +216,7 @@ status:
     status: "True"
     type: Ready
   externalProperties:
-    externalClusterServicePlanName: default
+    clusterServicePlanExternalName: default
     parameterChecksum: e65c764db8429f9afef45f1e8f71bcbf9fdbe9a13306b86fd5dcc3c5d11e5dd3
     parameters:
       credentials:

--- a/docs/walkthrough-1.7.md
+++ b/docs/walkthrough-1.7.md
@@ -189,8 +189,8 @@ metadata:
   uid: 07ecf19d-a781-11e7-8b18-0242ac110005
 spec:
   externalID: 7f2c176a-ae67-4b5e-a826-58591d85a1d7
-  externalClusterServiceClassName: user-provided-service
-  externalClusterServicePlanName: default
+  clusterServiceClassExternalName: user-provided-service
+  clusterServicePlanExternalName: default
   parameters:
     credentials:
       param-1: value-1
@@ -204,7 +204,7 @@ status:
     status: "True"
     type: Ready
   externalProperties:
-    externalClusterServicePlanName: default
+    clusterServicePlanExternalName: default
     parameterChecksum: e65c764db8429f9afef45f1e8f71bcbf9fdbe9a13306b86fd5dcc3c5d11e5dd3
     parameters:
       credentials:

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -416,20 +416,20 @@ type ServiceInstance struct {
 // specify the desired Class/Plan, this structure specifies the
 // allowed ways to specify the intent.
 type PlanReference struct {
-	// ExternalClusterServiceClassName is the human-readable name of the
+	// ClusterServiceClassExternalName is the human-readable name of the
 	// service as reported by the broker. Note that if the broker changes
 	// the name of the ClusterServiceClass, it will not be reflected here,
 	// and to see the current name of the ClusterServiceClass, you should
 	// follow the ClusterServiceClassRef below.
 	//
 	// Immutable.
-	ExternalClusterServiceClassName string
-	// ExternalClusterServicePlanName is the human-readable name of the plan
+	ClusterServiceClassExternalName string
+	// ClusterServicePlanExternalName is the human-readable name of the plan
 	// as reported by the broker. Note that if the broker changes the name
 	// of the ClusterServicePlan, it will not be reflected here, and to see
 	// the current name of the ClusterServicePlan, you should follow the
 	// ClusterServicePlanRef below.
-	ExternalClusterServicePlanName string
+	ClusterServicePlanExternalName string
 
 	// ClusterServiceClassName is the kubernetes name of the
 	// ClusterServiceClass.
@@ -446,11 +446,11 @@ type ServiceInstanceSpec struct {
 
 	// ClusterServiceClassRef is a reference to the ClusterServiceClass
 	// that the user selected.
-	// This is set by the controller based on ExternalClusterServiceClassName
+	// This is set by the controller based on ClusterServiceClassExternalName
 	ClusterServiceClassRef *ClusterObjectReference
 	// ClusterServicePlanRef is a reference to the ClusterServicePlan
 	// that the user selected.
-	// This is set by the controller based on ExternalClusterServicePlanName
+	// This is set by the controller based on ClusterServicePlanExternalName
 	ClusterServicePlanRef *ClusterObjectReference
 
 	// Parameters is a set of the parameters to be passed to the underlying
@@ -593,10 +593,10 @@ const (
 // ServiceInstancePropertiesState is the state of a ServiceInstance that
 // the ServiceBroker knows about.
 type ServiceInstancePropertiesState struct {
-	// ExternalClusterServicePlanName is the name of the plan that the broker knows this
+	// ClusterServicePlanExternalName is the name of the plan that the broker knows this
 	// ServiceInstance to be on. This is the human readable plan name from the
 	// OSB API.
-	ExternalClusterServicePlanName string
+	ClusterServicePlanExternalName string
 
 	// Parameters is a blob of the parameters and their values that the broker
 	// knows about for this ServiceInstance.  If a parameter was sourced from

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -428,26 +428,26 @@ type ServiceInstance struct {
 // allowed ways to specify the intent.
 //
 // Currently supported ways:
-//  - ExternalClusterServiceClassName and ExternalClusterServicePlanName
+//  - ClusterServiceClassExternalName and ClusterServicePlanExternalName
 //  - ClusterServiceClassName and ClusterServicePlanName
 //
 // For both of these ways, if a ClusterServiceClass only has one plan
 // then leaving the *ServicePlanName is optional.
 type PlanReference struct {
-	// ExternalClusterServiceClassName is the human-readable name of the
+	// ClusterServiceClassExternalName is the human-readable name of the
 	// service as reported by the broker. Note that if the broker changes
 	// the name of the ClusterServiceClass, it will not be reflected here,
 	// and to see the current name of the ClusterServiceClass, you should
 	// follow the ClusterServiceClassRef below.
 	//
 	// Immutable.
-	ExternalClusterServiceClassName string `json:"externalClusterServiceClassName,omitempty"`
-	// ExternalClusterServicePlanName is the human-readable name of the plan
+	ClusterServiceClassExternalName string `json:"clusterServiceClassExternalName,omitempty"`
+	// ClusterServicePlanExternalName is the human-readable name of the plan
 	// as reported by the broker. Note that if the broker changes the name
 	// of the ClusterServicePlan, it will not be reflected here, and to see
 	// the current name of the ClusterServicePlan, you should follow the
 	// ClusterServicePlanRef below.
-	ExternalClusterServicePlanName string `json:"externalClusterServicePlanName,omitempty"`
+	ClusterServicePlanExternalName string `json:"clusterServicePlanExternalName,omitempty"`
 
 	// ClusterServiceClassName is the kubernetes name of the
 	// ClusterServiceClass.
@@ -466,12 +466,12 @@ type ServiceInstanceSpec struct {
 	// ClusterServiceClassRef is a reference to the ClusterServiceClass
 	// that the user selected.
 	// This is set by the controller based on
-	// ExternalClusterServiceClassName
+	// ClusterServiceClassExternalName
 	ClusterServiceClassRef *ClusterObjectReference `json:"clusterServiceClassRef,omitempty"`
 	// ClusterServicePlanRef is a reference to the ClusterServicePlan
 	// that the user selected.
 	// This is set by the controller based on
-	// ExternalClusterServicePlanName
+	// ClusterServicePlanExternalName
 	ClusterServicePlanRef *ClusterObjectReference `json:"clusterServicePlanRef,omitempty"`
 
 	// Parameters is a set of the parameters to be passed to the underlying
@@ -614,10 +614,10 @@ const (
 // ServiceInstancePropertiesState is the state of a ServiceInstance that
 // the ClusterServiceBroker knows about.
 type ServiceInstancePropertiesState struct {
-	// ExternalClusterServicePlanName is the name of the plan that the
+	// ClusterServicePlanExternalName is the name of the plan that the
 	// broker knows this ServiceInstance to be on. This is the human
 	// readable plan name from the OSB API.
-	ExternalClusterServicePlanName string `json:"externalClusterServicePlanName"`
+	ClusterServicePlanExternalName string `json:"clusterServicePlanExternalName"`
 
 	// Parameters is a blob of the parameters and their values that the broker
 	// knows about for this ServiceInstance.  If a parameter was sourced from

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
@@ -570,8 +570,8 @@ func Convert_servicecatalog_ParametersFromSource_To_v1beta1_ParametersFromSource
 }
 
 func autoConvert_v1beta1_PlanReference_To_servicecatalog_PlanReference(in *PlanReference, out *servicecatalog.PlanReference, s conversion.Scope) error {
-	out.ExternalClusterServiceClassName = in.ExternalClusterServiceClassName
-	out.ExternalClusterServicePlanName = in.ExternalClusterServicePlanName
+	out.ClusterServiceClassExternalName = in.ClusterServiceClassExternalName
+	out.ClusterServicePlanExternalName = in.ClusterServicePlanExternalName
 	out.ClusterServiceClassName = in.ClusterServiceClassName
 	out.ClusterServicePlanName = in.ClusterServicePlanName
 	return nil
@@ -583,8 +583,8 @@ func Convert_v1beta1_PlanReference_To_servicecatalog_PlanReference(in *PlanRefer
 }
 
 func autoConvert_servicecatalog_PlanReference_To_v1beta1_PlanReference(in *servicecatalog.PlanReference, out *PlanReference, s conversion.Scope) error {
-	out.ExternalClusterServiceClassName = in.ExternalClusterServiceClassName
-	out.ExternalClusterServicePlanName = in.ExternalClusterServicePlanName
+	out.ClusterServiceClassExternalName = in.ClusterServiceClassExternalName
+	out.ClusterServicePlanExternalName = in.ClusterServicePlanExternalName
 	out.ClusterServiceClassName = in.ClusterServiceClassName
 	out.ClusterServicePlanName = in.ClusterServicePlanName
 	return nil
@@ -924,7 +924,7 @@ func Convert_servicecatalog_ServiceInstanceList_To_v1beta1_ServiceInstanceList(i
 }
 
 func autoConvert_v1beta1_ServiceInstancePropertiesState_To_servicecatalog_ServiceInstancePropertiesState(in *ServiceInstancePropertiesState, out *servicecatalog.ServiceInstancePropertiesState, s conversion.Scope) error {
-	out.ExternalClusterServicePlanName = in.ExternalClusterServicePlanName
+	out.ClusterServicePlanExternalName = in.ClusterServicePlanExternalName
 	out.Parameters = (*runtime.RawExtension)(unsafe.Pointer(in.Parameters))
 	out.ParametersChecksum = in.ParametersChecksum
 	out.UserInfo = (*servicecatalog.UserInfo)(unsafe.Pointer(in.UserInfo))
@@ -937,7 +937,7 @@ func Convert_v1beta1_ServiceInstancePropertiesState_To_servicecatalog_ServiceIns
 }
 
 func autoConvert_servicecatalog_ServiceInstancePropertiesState_To_v1beta1_ServiceInstancePropertiesState(in *servicecatalog.ServiceInstancePropertiesState, out *ServiceInstancePropertiesState, s conversion.Scope) error {
-	out.ExternalClusterServicePlanName = in.ExternalClusterServicePlanName
+	out.ClusterServicePlanExternalName = in.ClusterServicePlanExternalName
 	out.Parameters = (*runtime.RawExtension)(unsafe.Pointer(in.Parameters))
 	out.ParametersChecksum = in.ParametersChecksum
 	out.UserInfo = (*UserInfo)(unsafe.Pointer(in.UserInfo))

--- a/pkg/apis/servicecatalog/validation/instance.go
+++ b/pkg/apis/servicecatalog/validation/instance.go
@@ -230,8 +230,8 @@ func internalValidateServiceInstanceUpdateAllowed(new *sc.ServiceInstance, old *
 	if old.Generation != new.Generation && old.Status.ReconciledGeneration != old.Generation {
 		errors = append(errors, field.Forbidden(field.NewPath("spec"), "Another update for this service instance is in progress"))
 	}
-	if old.Spec.ExternalClusterServicePlanName != new.Spec.ExternalClusterServicePlanName && new.Spec.ClusterServicePlanRef != nil {
-		errors = append(errors, field.Forbidden(field.NewPath("spec").Child("clusterServicePlanRef"), "clusterServicePlanRef must not be present when externalServicePlanName is being changed"))
+	if old.Spec.ClusterServicePlanExternalName != new.Spec.ClusterServicePlanExternalName && new.Spec.ClusterServicePlanRef != nil {
+		errors = append(errors, field.Forbidden(field.NewPath("spec").Child("clusterServicePlanRef"), "clusterServicePlanRef must not be present when servicePlanExternalName is being changed"))
 	}
 	return errors
 }
@@ -246,7 +246,7 @@ func ValidateServiceInstanceUpdate(new *sc.ServiceInstance, old *sc.ServiceInsta
 	allErrs = append(allErrs, internalValidateServiceInstanceUpdateAllowed(new, old)...)
 	allErrs = append(allErrs, internalValidateServiceInstance(new, false)...)
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Spec.ExternalClusterServiceClassName, old.Spec.ExternalClusterServiceClassName, specFieldPath.Child("externalClusterServiceClassName"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Spec.ClusterServiceClassExternalName, old.Spec.ClusterServiceClassExternalName, specFieldPath.Child("clusterServiceClassExternalName"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Spec.ExternalID, old.Spec.ExternalID, specFieldPath.Child("externalID"))...)
 
 	if new.Spec.UpdateRequests < old.Spec.UpdateRequests {
@@ -305,34 +305,34 @@ func validatePlanReference(p *sc.PlanReference, fldPath *field.Path) field.Error
 	allErrs := field.ErrorList{}
 
 	// Just to make reading of the conditionals in the code easier.
-	externalClassSet := p.ExternalClusterServiceClassName != ""
-	externalPlanSet := p.ExternalClusterServicePlanName != ""
+	externalClassSet := p.ClusterServiceClassExternalName != ""
+	externalPlanSet := p.ClusterServicePlanExternalName != ""
 	k8sClassSet := p.ClusterServiceClassName != ""
 	k8sPlanSet := p.ClusterServicePlanName != ""
 
 	// Can't specify both External and k8s name but must specify one.
 	if externalClassSet == k8sClassSet {
-		allErrs = append(allErrs, field.Required(fldPath.Child("externalClusterServiceClassName"), "exactly one of externalClusterServiceClassName or clusterServiceClassName required"))
-		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServiceClassName"), "exactly one of externalClusterServiceClassName or clusterServiceClassName required"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServiceClassExternalName"), "exactly one of clusterServiceClassExternalName or clusterServiceClassName required"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServiceClassName"), "exactly one of clusterServiceClassExternalName or clusterServiceClassName required"))
 	}
 	// Can't specify both External and k8s name but must specify one.
 	if externalPlanSet == k8sPlanSet {
-		allErrs = append(allErrs, field.Required(fldPath.Child("externalClusterServicePlanName"), "exactly one of externalClusterServicePlanName or clusterServicePlanName required"))
-		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServicePlanName"), "exactly one of externalClusterServicePlanName or clusterServicePlanName required"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServicePlanExternalName"), "exactly one of clusterServicePlanExternalName or clusterServicePlanName required"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServicePlanName"), "exactly one of clusterServicePlanExternalName or clusterServicePlanName required"))
 	}
 
 	if externalClassSet {
-		for _, msg := range validateServiceClassName(p.ExternalClusterServiceClassName, false /* prefix */) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("externalClusterServiceClassName"), p.ExternalClusterServiceClassName, msg))
+		for _, msg := range validateServiceClassName(p.ClusterServiceClassExternalName, false /* prefix */) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("clusterServiceClassExternalName"), p.ClusterServiceClassExternalName, msg))
 		}
 
-		// If ExternalClusterServiceClassName given, must use ExternalClusterServicePlanName
+		// If ClusterServiceClassExternalName given, must use ClusterServicePlanExternalName
 		if !externalPlanSet {
-			allErrs = append(allErrs, field.Required(fldPath.Child("externalClusterServicePlanName"), "must specify externalClusterServicePlanName with externalClusterServiceClassName"))
+			allErrs = append(allErrs, field.Required(fldPath.Child("clusterServicePlanExternalName"), "must specify clusterServicePlanExternalName with clusterServiceClassExternalName"))
 		}
 
-		for _, msg := range validateServicePlanName(p.ExternalClusterServicePlanName, false /* prefix */) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("externalClusterServicePlanName"), p.ClusterServicePlanName, msg))
+		for _, msg := range validateServicePlanName(p.ClusterServicePlanExternalName, false /* prefix */) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("clusterServicePlanExternalName"), p.ClusterServicePlanName, msg))
 		}
 	}
 	if k8sClassSet {
@@ -355,7 +355,7 @@ func validatePlanReferenceUpdate(pOld *sc.PlanReference, pNew *sc.PlanReference,
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validatePlanReference(pOld, fldPath)...)
 	allErrs = append(allErrs, validatePlanReference(pNew, fldPath)...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(pNew.ExternalClusterServiceClassName, pOld.ExternalClusterServiceClassName, field.NewPath("spec").Child("externalClusterServiceClassName"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(pNew.ClusterServiceClassExternalName, pOld.ClusterServiceClassExternalName, field.NewPath("spec").Child("clusterServiceClassExternalName"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(pNew.ClusterServiceClassName, pOld.ClusterServiceClassName, field.NewPath("spec").Child("clusterServiceClassName"))...)
 	return allErrs
 }

--- a/pkg/apis/servicecatalog/validation/instance_test.go
+++ b/pkg/apis/servicecatalog/validation/instance_test.go
@@ -28,16 +28,16 @@ import (
 )
 
 const (
-	externalClusterServiceClassName = "test-serviceclass"
-	externalClusterServicePlanName  = "test-plan"
+	clusterServiceClassExternalName = "test-serviceclass"
+	clusterServicePlanExternalName  = "test-plan"
 	clusterServiceClassName         = "test-k8s-serviceclass"
 	clusterServicePlanName          = "test-k8s-plan-name"
 )
 
 func validPlanReferenceExternal() servicecatalog.PlanReference {
 	return servicecatalog.PlanReference{
-		ExternalClusterServiceClassName: externalClusterServiceClassName,
-		ExternalClusterServicePlanName:  externalClusterServicePlanName,
+		ClusterServiceClassExternalName: clusterServiceClassExternalName,
+		ClusterServicePlanExternalName:  clusterServicePlanExternalName,
 	}
 }
 
@@ -108,10 +108,10 @@ func TestValidateServiceInstance(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "missing externalClusterServiceClassName and clusterServiceClassName",
+			name: "missing clusterServiceClassExternalName and clusterServiceClassName",
 			instance: func() *servicecatalog.ServiceInstance {
 				i := validServiceInstance()
-				i.Spec.ExternalClusterServiceClassName = ""
+				i.Spec.ClusterServiceClassExternalName = ""
 				return i
 			}(),
 			valid: false,
@@ -120,7 +120,7 @@ func TestValidateServiceInstance(t *testing.T) {
 			name: "invalid serviceClassName",
 			instance: func() *servicecatalog.ServiceInstance {
 				i := validServiceInstance()
-				i.Spec.ExternalClusterServiceClassName = "oing20&)*^&"
+				i.Spec.ClusterServiceClassExternalName = "oing20&)*^&"
 				return i
 			}(),
 			valid: false,
@@ -129,7 +129,7 @@ func TestValidateServiceInstance(t *testing.T) {
 			name: "missing planName",
 			instance: func() *servicecatalog.ServiceInstance {
 				i := validServiceInstance()
-				i.Spec.ExternalClusterServicePlanName = ""
+				i.Spec.ClusterServicePlanExternalName = ""
 				return i
 			}(),
 			valid: false,
@@ -138,7 +138,7 @@ func TestValidateServiceInstance(t *testing.T) {
 			name: "invalid planName",
 			instance: func() *servicecatalog.ServiceInstance {
 				i := validServiceInstance()
-				i.Spec.ExternalClusterServicePlanName = "9651.JVHbebe"
+				i.Spec.ClusterServicePlanExternalName = "9651.JVHbebe"
 				return i
 			}(),
 			valid: false,
@@ -423,8 +423,8 @@ func TestValidateServiceInstance(t *testing.T) {
 			name: "valid create with k8s name",
 			instance: func() *servicecatalog.ServiceInstance {
 				i := validServiceInstanceForCreate()
-				i.Spec.ExternalClusterServiceClassName = ""
-				i.Spec.ExternalClusterServicePlanName = ""
+				i.Spec.ClusterServiceClassExternalName = ""
+				i.Spec.ClusterServicePlanExternalName = ""
 				i.Spec.ClusterServiceClassName = clusterServiceClassName
 				i.Spec.ClusterServicePlanName = clusterServicePlanName
 				return i
@@ -585,8 +585,8 @@ func TestInternalValidateServiceInstanceUpdateAllowed(t *testing.T) {
 			},
 			Spec: servicecatalog.ServiceInstanceSpec{
 				PlanReference: servicecatalog.PlanReference{
-					ExternalClusterServiceClassName: externalClusterServiceClassName,
-					ExternalClusterServicePlanName:  externalClusterServicePlanName,
+					ClusterServiceClassExternalName: clusterServiceClassExternalName,
+					ClusterServicePlanExternalName:  clusterServicePlanExternalName,
 				},
 			},
 		}
@@ -604,8 +604,8 @@ func TestInternalValidateServiceInstanceUpdateAllowed(t *testing.T) {
 			},
 			Spec: servicecatalog.ServiceInstanceSpec{
 				PlanReference: servicecatalog.PlanReference{
-					ExternalClusterServiceClassName: "test-serviceclass",
-					ExternalClusterServicePlanName:  "test-plan",
+					ClusterServiceClassExternalName: "test-serviceclass",
+					ClusterServicePlanExternalName:  "test-plan",
 				},
 			},
 		}
@@ -665,8 +665,8 @@ func TestInternalValidateServiceInstanceUpdateAllowedForPlanChange(t *testing.T)
 			},
 			Spec: servicecatalog.ServiceInstanceSpec{
 				PlanReference: servicecatalog.PlanReference{
-					ExternalClusterServiceClassName: "test-serviceclass",
-					ExternalClusterServicePlanName:  tc.oldPlan,
+					ClusterServiceClassExternalName: "test-serviceclass",
+					ClusterServicePlanExternalName:  tc.oldPlan,
 				},
 				ClusterServiceClassRef: &servicecatalog.ClusterObjectReference{},
 				ClusterServicePlanRef:  &servicecatalog.ClusterObjectReference{},
@@ -680,8 +680,8 @@ func TestInternalValidateServiceInstanceUpdateAllowedForPlanChange(t *testing.T)
 			},
 			Spec: servicecatalog.ServiceInstanceSpec{
 				PlanReference: servicecatalog.PlanReference{
-					ExternalClusterServiceClassName: externalClusterServiceClassName,
-					ExternalClusterServicePlanName:  tc.newPlan,
+					ClusterServiceClassExternalName: clusterServiceClassExternalName,
+					ClusterServicePlanExternalName:  tc.newPlan,
 				},
 				ClusterServiceClassRef: &servicecatalog.ClusterObjectReference{},
 				ClusterServicePlanRef:  tc.newPlanRef,
@@ -833,8 +833,8 @@ func TestValidateServiceInstanceStatusUpdate(t *testing.T) {
 			},
 			Spec: servicecatalog.ServiceInstanceSpec{
 				PlanReference: servicecatalog.PlanReference{
-					ExternalClusterServiceClassName: externalClusterServiceClassName,
-					ExternalClusterServicePlanName:  externalClusterServicePlanName,
+					ClusterServiceClassExternalName: clusterServiceClassExternalName,
+					ClusterServicePlanExternalName:  clusterServicePlanExternalName,
 				},
 				ClusterServiceClassRef: &servicecatalog.ClusterObjectReference{},
 				ClusterServicePlanRef:  &servicecatalog.ClusterObjectReference{},
@@ -850,8 +850,8 @@ func TestValidateServiceInstanceStatusUpdate(t *testing.T) {
 			},
 			Spec: servicecatalog.ServiceInstanceSpec{
 				PlanReference: servicecatalog.PlanReference{
-					ExternalClusterServiceClassName: externalClusterServiceClassName,
-					ExternalClusterServicePlanName:  externalClusterServicePlanName,
+					ClusterServiceClassExternalName: clusterServiceClassExternalName,
+					ClusterServicePlanExternalName:  clusterServicePlanExternalName,
 				},
 				ClusterServiceClassRef: &servicecatalog.ClusterObjectReference{},
 				ClusterServicePlanRef:  &servicecatalog.ClusterObjectReference{},
@@ -965,7 +965,7 @@ func TestValidatePlanReference(t *testing.T) {
 			name:          "invalid -- empty struct",
 			ref:           servicecatalog.PlanReference{},
 			valid:         false,
-			expectedError: "exactly one of externalClusterServicePlanName",
+			expectedError: "exactly one of clusterServicePlanExternalName",
 		},
 		{
 			name:  "valid -- external",
@@ -975,11 +975,11 @@ func TestValidatePlanReference(t *testing.T) {
 		{
 			name: "invalid -- external name, k8s plan",
 			ref: servicecatalog.PlanReference{
-				ExternalClusterServiceClassName: externalClusterServiceClassName,
-				ClusterServicePlanName:          externalClusterServicePlanName,
+				ClusterServiceClassExternalName: clusterServiceClassExternalName,
+				ClusterServicePlanName:          clusterServicePlanExternalName,
 			},
 			valid:         false,
-			expectedError: "must specify externalClusterServicePlanName",
+			expectedError: "must specify clusterServicePlanExternalName",
 		},
 		{
 			name:  "valid -- k8s",
@@ -990,7 +990,7 @@ func TestValidatePlanReference(t *testing.T) {
 			name: "invalid -- valid k8s name, external plan",
 			ref: servicecatalog.PlanReference{
 				ClusterServiceClassName:        clusterServiceClassName,
-				ExternalClusterServicePlanName: externalClusterServicePlanName,
+				ClusterServicePlanExternalName: clusterServicePlanExternalName,
 			},
 			valid:         false,
 			expectedError: "must specify clusterServicePlanName",
@@ -999,21 +999,21 @@ func TestValidatePlanReference(t *testing.T) {
 			name: "invalid -- external and k8s name specified",
 			ref: servicecatalog.PlanReference{
 				ClusterServiceClassName:         clusterServiceClassName,
-				ExternalClusterServiceClassName: externalClusterServiceClassName,
-				ExternalClusterServicePlanName:  externalClusterServicePlanName,
+				ClusterServiceClassExternalName: clusterServiceClassExternalName,
+				ClusterServicePlanExternalName:  clusterServicePlanExternalName,
 			},
 			valid:         false,
-			expectedError: "exactly one of externalClusterServiceClassName",
+			expectedError: "exactly one of clusterServiceClassExternalName",
 		},
 		{
 			name: "invalid -- external and k8s plan specified",
 			ref: servicecatalog.PlanReference{
-				ExternalClusterServiceClassName: externalClusterServiceClassName,
-				ExternalClusterServicePlanName:  externalClusterServicePlanName,
+				ClusterServiceClassExternalName: clusterServiceClassExternalName,
+				ClusterServicePlanExternalName:  clusterServicePlanExternalName,
 				ClusterServicePlanName:          clusterServicePlanName,
 			},
 			valid:         false,
-			expectedError: "exactly one of externalClusterServicePlanName",
+			expectedError: "exactly one of clusterServicePlanExternalName",
 		},
 	}
 	for _, tc := range cases {
@@ -1063,18 +1063,18 @@ func TestValidatePlanReferenceUpdate(t *testing.T) {
 			name: "invalid -- changing external class name",
 			old:  validPlanReferenceExternal(),
 			new: servicecatalog.PlanReference{
-				ExternalClusterServiceClassName: clusterServiceClassName,
-				ExternalClusterServicePlanName:  externalClusterServicePlanName,
+				ClusterServiceClassExternalName: clusterServiceClassName,
+				ClusterServicePlanExternalName:  clusterServicePlanExternalName,
 			},
 			valid:         false,
-			expectedError: "externalClusterServiceClassName",
+			expectedError: "clusterServiceClassExternalName",
 		},
 		{
 			name: "valid -- changing external plan name",
 			old:  validPlanReferenceExternal(),
 			new: servicecatalog.PlanReference{
-				ExternalClusterServiceClassName: externalClusterServiceClassName,
-				ExternalClusterServicePlanName:  clusterServicePlanName,
+				ClusterServiceClassExternalName: clusterServiceClassExternalName,
+				ClusterServicePlanExternalName:  clusterServicePlanName,
 			},
 			valid: true,
 		},
@@ -1082,7 +1082,7 @@ func TestValidatePlanReferenceUpdate(t *testing.T) {
 			name: "invalid -- changing k8s class name",
 			old:  validPlanReferenceK8S(),
 			new: servicecatalog.PlanReference{
-				ClusterServiceClassName: externalClusterServiceClassName,
+				ClusterServiceClassName: clusterServiceClassExternalName,
 				ClusterServicePlanName:  clusterServicePlanName,
 			},
 			valid:         false,
@@ -1093,7 +1093,7 @@ func TestValidatePlanReferenceUpdate(t *testing.T) {
 			old:  validPlanReferenceK8S(),
 			new: servicecatalog.PlanReference{
 				ClusterServiceClassName: clusterServiceClassName,
-				ClusterServicePlanName:  externalClusterServicePlanName,
+				ClusterServicePlanName:  clusterServicePlanExternalName,
 			},
 			valid: true,
 		},

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -253,7 +253,7 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBroker(instance 
 	if err != nil {
 		s := fmt.Sprintf(
 			"References a non-existent ClusterServiceClass (K8S: %q ExternalName: %q)",
-			instance.Spec.ClusterServiceClassRef.Name, instance.Spec.ExternalClusterServiceClassName,
+			instance.Spec.ClusterServiceClassRef.Name, instance.Spec.ClusterServiceClassExternalName,
 		)
 		glog.Info(pcb.Message(s))
 		c.updateServiceInstanceCondition(
@@ -271,7 +271,7 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBroker(instance 
 	if nil != err {
 		s := fmt.Sprintf(
 			"References a non-existent ClusterServicePlan (K8S: %q ExternalName: %q) on ClusterServiceClass (K8S: %q ExternalName: %q)",
-			instance.Spec.ClusterServicePlanName, instance.Spec.ExternalClusterServicePlanName, serviceClass.Name, serviceClass.Spec.ExternalName,
+			instance.Spec.ClusterServicePlanName, instance.Spec.ClusterServicePlanExternalName, serviceClass.Name, serviceClass.Spec.ExternalName,
 		)
 		glog.Warning(pcb.Message(s))
 		c.updateServiceInstanceCondition(
@@ -337,7 +337,7 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 	if err != nil {
 		s := fmt.Sprintf(
 			"References a non-existent ClusterServiceClass (K8S: %q ExternalName: %q)",
-			instance.Spec.ClusterServiceClassRef.Name, instance.Spec.ExternalClusterServiceClassName,
+			instance.Spec.ClusterServiceClassRef.Name, instance.Spec.ClusterServiceClassExternalName,
 		)
 		glog.Warning(pcb.Message(s))
 		c.updateServiceBindingCondition(
@@ -355,7 +355,7 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 	if nil != err {
 		s := fmt.Sprintf(
 			"References a non-existent ClusterServicePlan (K8S: %q ExternalName: %q) on ClusterServiceClass (K8S: %q ExternalName: %q)",
-			instance.Spec.ClusterServicePlanName, instance.Spec.ExternalClusterServicePlanName, serviceClass.Name, serviceClass.Spec.ExternalName,
+			instance.Spec.ClusterServicePlanName, instance.Spec.ClusterServicePlanExternalName, serviceClass.Name, serviceClass.Spec.ExternalName,
 		)
 		glog.Warning(pcb.Message(s))
 		c.updateServiceBindingCondition(

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -243,7 +243,7 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 	if !isPlanBindable(serviceClass, servicePlan) {
 		s := fmt.Sprintf(
 			`References a non-bindable ClusterServiceClass (K8S: %q ExternalName: %q) and Plan (%q) combination`,
-			serviceClass.Name, serviceClass.Spec.ExternalName, instance.Spec.ExternalClusterServicePlanName,
+			serviceClass.Name, serviceClass.Spec.ExternalName, instance.Spec.ClusterServicePlanExternalName,
 		)
 		glog.Warningf(
 			`%s "%s/%s": %s`,

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -99,8 +99,8 @@ func TestReconcileServiceBindingUnresolvedClusterServiceClassReference(t *testin
 		ObjectMeta: metav1.ObjectMeta{Name: testServiceInstanceName, Namespace: testNamespace},
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
-				ExternalClusterServiceClassName: testNonExistentClusterServiceClassName,
-				ExternalClusterServicePlanName:  testClusterServicePlanName,
+				ClusterServiceClassExternalName: testNonExistentClusterServiceClassName,
+				ClusterServicePlanExternalName:  testClusterServicePlanName,
 			},
 			ExternalID: testServiceInstanceGUID,
 		},
@@ -147,8 +147,8 @@ func TestReconcileServiceBindingUnresolvedClusterServicePlanReference(t *testing
 		ObjectMeta: metav1.ObjectMeta{Name: testServiceInstanceName, Namespace: testNamespace},
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
-				ExternalClusterServiceClassName: testNonExistentClusterServiceClassName,
-				ExternalClusterServicePlanName:  testClusterServicePlanName,
+				ClusterServiceClassExternalName: testNonExistentClusterServiceClassName,
+				ClusterServicePlanExternalName:  testClusterServicePlanName,
 			},
 			ExternalID:             testServiceInstanceGUID,
 			ClusterServiceClassRef: &v1beta1.ClusterObjectReference{Name: "Some Ref"},
@@ -197,8 +197,8 @@ func TestReconcileServiceBindingNonExistingClusterServiceClass(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: testServiceInstanceName, Namespace: testNamespace},
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
-				ExternalClusterServiceClassName: testNonExistentClusterServiceClassName,
-				ExternalClusterServicePlanName:  testClusterServicePlanName,
+				ClusterServiceClassExternalName: testNonExistentClusterServiceClassName,
+				ClusterServicePlanExternalName:  testClusterServicePlanName,
 			},
 			ExternalID:             testServiceInstanceGUID,
 			ClusterServiceClassRef: &v1beta1.ClusterObjectReference{Name: "nosuchclassid"},

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -61,8 +61,8 @@ func TestReconcileServiceInstanceNonExistentClusterServiceClass(t *testing.T) {
 		},
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
-				ExternalClusterServiceClassName: "nothere",
-				ExternalClusterServicePlanName:  "nothere",
+				ClusterServiceClassExternalName: "nothere",
+				ClusterServicePlanExternalName:  "nothere",
 			},
 			ExternalID: testServiceInstanceGUID,
 		},
@@ -80,7 +80,7 @@ func TestReconcileServiceInstanceNonExistentClusterServiceClass(t *testing.T) {
 
 	listRestrictions := clientgotesting.ListRestrictions{
 		Labels: labels.Everything(),
-		Fields: fields.OneTermEqualSelector("spec.externalName", instance.Spec.ExternalClusterServiceClassName),
+		Fields: fields.OneTermEqualSelector("spec.externalName", instance.Spec.ClusterServiceClassExternalName),
 	}
 	assertList(t, actions[0], &v1beta1.ClusterServiceClass{}, listRestrictions)
 
@@ -243,8 +243,8 @@ func TestReconcileServiceInstanceNonExistentClusterServicePlan(t *testing.T) {
 		},
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
-				ExternalClusterServiceClassName: testClusterServiceClassName,
-				ExternalClusterServicePlanName:  "nothere",
+				ClusterServiceClassExternalName: testClusterServiceClassName,
+				ClusterServicePlanExternalName:  "nothere",
 			},
 			ClusterServiceClassRef: &v1beta1.ClusterObjectReference{
 				Name: testClusterServiceClassGUID,
@@ -491,7 +491,7 @@ func TestReconcileServiceInstanceResolvesReferences(t *testing.T) {
 
 	listRestrictions := clientgotesting.ListRestrictions{
 		Labels: labels.Everything(),
-		Fields: fields.OneTermEqualSelector("spec.externalName", instance.Spec.ExternalClusterServiceClassName),
+		Fields: fields.OneTermEqualSelector("spec.externalName", instance.Spec.ClusterServiceClassExternalName),
 	}
 	assertList(t, actions[0], &v1beta1.ClusterServiceClass{}, listRestrictions)
 
@@ -3408,7 +3408,7 @@ func TestResolveReferencesNoClusterServiceClass(t *testing.T) {
 
 	listRestrictions := clientgotesting.ListRestrictions{
 		Labels: labels.Everything(),
-		Fields: fields.OneTermEqualSelector("spec.externalName", instance.Spec.ExternalClusterServiceClassName),
+		Fields: fields.OneTermEqualSelector("spec.externalName", instance.Spec.ClusterServiceClassExternalName),
 	}
 	assertList(t, actions[0], &v1beta1.ClusterServiceClass{}, listRestrictions)
 
@@ -3477,7 +3477,7 @@ func TestReconcileServiceInstanceUpdateParameters(t *testing.T) {
 	}
 
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{
-		ExternalClusterServicePlanName: testClusterServicePlanName,
+		ClusterServicePlanExternalName: testClusterServicePlanName,
 		Parameters:                     oldParametersRaw,
 		ParametersChecksum:             oldParametersChecksum,
 	}
@@ -3597,7 +3597,7 @@ func TestResolveReferencesNoClusterServicePlan(t *testing.T) {
 
 	listRestrictions := clientgotesting.ListRestrictions{
 		Labels: labels.Everything(),
-		Fields: fields.OneTermEqualSelector("spec.externalName", instance.Spec.ExternalClusterServiceClassName),
+		Fields: fields.OneTermEqualSelector("spec.externalName", instance.Spec.ClusterServiceClassExternalName),
 	}
 	assertList(t, actions[0], &v1beta1.ClusterServiceClass{}, listRestrictions)
 
@@ -3675,7 +3675,7 @@ func TestReconcileServiceInstanceUpdatePlan(t *testing.T) {
 	}
 
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{
-		ExternalClusterServicePlanName: "old-plan-name",
+		ClusterServicePlanExternalName: "old-plan-name",
 		Parameters:                     oldParametersRaw,
 		ParametersChecksum:             oldParametersChecksum,
 	}
@@ -3761,7 +3761,7 @@ func TestReconcileServiceInstanceWithUpdateCallFailure(t *testing.T) {
 	instance.Status.ReconciledGeneration = 1
 
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{
-		ExternalClusterServicePlanName: "old-plan-name",
+		ClusterServicePlanExternalName: "old-plan-name",
 	}
 
 	if err := testController.reconcileServiceInstance(instance); err == nil {
@@ -3828,7 +3828,7 @@ func TestReconcileServiceInstanceWithUpdateFailure(t *testing.T) {
 	instance.Status.ReconciledGeneration = 1
 
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{
-		ExternalClusterServicePlanName: "old-plan-name",
+		ClusterServicePlanExternalName: "old-plan-name",
 	}
 
 	if err := testController.reconcileServiceInstance(instance); err != nil {
@@ -3916,7 +3916,7 @@ func TestResolveReferencesWorks(t *testing.T) {
 
 	listRestrictions := clientgotesting.ListRestrictions{
 		Labels: labels.Everything(),
-		Fields: fields.OneTermEqualSelector("spec.externalName", instance.Spec.ExternalClusterServiceClassName),
+		Fields: fields.OneTermEqualSelector("spec.externalName", instance.Spec.ClusterServiceClassExternalName),
 	}
 	assertList(t, actions[0], &v1beta1.ClusterServiceClass{}, listRestrictions)
 
@@ -3973,7 +3973,7 @@ func TestResolveReferencesForPlanChange(t *testing.T) {
 		return true, &v1beta1.ClusterServicePlanList{Items: spItems}, nil
 	})
 
-	instance.Spec.ExternalClusterServicePlanName = newPlanName
+	instance.Spec.ClusterServicePlanExternalName = newPlanName
 	instance.Spec.ClusterServicePlanRef = nil
 
 	updatedInstance, err := testController.resolveReferences(instance)
@@ -4097,7 +4097,7 @@ func TestReconcileServiceInstanceUpdateAsynchronous(t *testing.T) {
 	instance.Status.ReconciledGeneration = 1
 
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{
-		ExternalClusterServicePlanName: "old-plan-name",
+		ClusterServicePlanExternalName: "old-plan-name",
 	}
 
 	instanceKey := testNamespace + "/" + testServiceInstanceName

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -502,7 +502,7 @@ func getTestCatalog() *osb.CatalogResponse {
 // instance referencing the result of getTestClusterServiceClass()
 // and getTestClusterServicePlan()
 // This version sets:
-// ExternalClusterServiceClassName and ExternalClusterServicePlanName as well
+// ClusterServiceClassExternalName and ClusterServicePlanExternalName as well
 // as ClusterServiceClassRef and ClusterServicePlanRef which means that the
 // ClusterServiceClass and ClusterServicePlan are fetched using
 // Service[Class|Plan]Lister.get(spec.Service[Class|Plan]Ref.Name)
@@ -516,7 +516,7 @@ func getTestServiceInstanceWithRefs() *v1beta1.ServiceInstance {
 // instance referencing the result of getTestClusterServiceClass()
 // and getTestClusterServicePlan()
 // This version sets:
-// ExternalClusterServiceClassName and ExternalClusterServicePlanName, so depending on the
+// ClusterServiceClassExternalName and ClusterServicePlanExternalName, so depending on the
 // test, you may need to add reactors that deal with List due to the need
 // to resolve Names to IDs for both ClusterServiceClass and ClusterServicePlan
 func getTestServiceInstance() *v1beta1.ServiceInstance {
@@ -528,8 +528,8 @@ func getTestServiceInstance() *v1beta1.ServiceInstance {
 		},
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
-				ExternalClusterServiceClassName: testClusterServiceClassName,
-				ExternalClusterServicePlanName:  testClusterServicePlanName,
+				ClusterServiceClassExternalName: testClusterServiceClassName,
+				ClusterServicePlanExternalName:  testClusterServicePlanName,
 			},
 			ExternalID: testServiceInstanceGUID,
 		},
@@ -560,8 +560,8 @@ func getTestServiceInstanceK8SNames() *v1beta1.ServiceInstance {
 // an instance referencing the result of getTestNonbindableClusterServiceClass, on the non-bindable plan.
 func getTestNonbindableServiceInstance() *v1beta1.ServiceInstance {
 	i := getTestServiceInstance()
-	i.Spec.ExternalClusterServiceClassName = testNonbindableClusterServiceClassName
-	i.Spec.ExternalClusterServicePlanName = testNonbindableClusterServicePlanName
+	i.Spec.ClusterServiceClassExternalName = testNonbindableClusterServiceClassName
+	i.Spec.ClusterServicePlanExternalName = testNonbindableClusterServicePlanName
 	i.Spec.ClusterServiceClassRef = &v1beta1.ClusterObjectReference{Name: testNonbindableClusterServiceClassGUID}
 	i.Spec.ClusterServicePlanRef = &v1beta1.ClusterObjectReference{Name: testNonbindableClusterServicePlanGUID}
 
@@ -571,7 +571,7 @@ func getTestNonbindableServiceInstance() *v1beta1.ServiceInstance {
 // an instance referencing the result of getTestNonbindableClusterServiceClass, on the bindable plan.
 func getTestServiceInstanceNonbindableServiceBindablePlan() *v1beta1.ServiceInstance {
 	i := getTestNonbindableServiceInstance()
-	i.Spec.ExternalClusterServicePlanName = testClusterServicePlanName
+	i.Spec.ClusterServicePlanExternalName = testClusterServicePlanName
 	i.Spec.ClusterServicePlanRef = &v1beta1.ClusterObjectReference{Name: testClusterServicePlanGUID}
 
 	return i
@@ -579,7 +579,7 @@ func getTestServiceInstanceNonbindableServiceBindablePlan() *v1beta1.ServiceInst
 
 func getTestServiceInstanceBindableServiceNonbindablePlan() *v1beta1.ServiceInstance {
 	i := getTestServiceInstanceWithRefs()
-	i.Spec.ExternalClusterServicePlanName = testNonbindableClusterServicePlanName
+	i.Spec.ClusterServicePlanExternalName = testNonbindableClusterServicePlanName
 	i.Spec.ClusterServicePlanRef = &v1beta1.ClusterObjectReference{Name: testNonbindableClusterServicePlanGUID}
 
 	return i
@@ -626,7 +626,7 @@ func getTestServiceInstanceAsyncProvisioning(operation string) *v1beta1.ServiceI
 		OperationStartTime: &operationStartTime,
 		CurrentOperation:   v1beta1.ServiceInstanceOperationProvision,
 		InProgressProperties: &v1beta1.ServiceInstancePropertiesState{
-			ExternalClusterServicePlanName: testClusterServicePlanName,
+			ClusterServicePlanExternalName: testClusterServicePlanName,
 		},
 	}
 	if operation != "" {
@@ -655,10 +655,10 @@ func getTestServiceInstanceAsyncUpdating(operation string) *v1beta1.ServiceInsta
 		OperationStartTime: &operationStartTime,
 		CurrentOperation:   v1beta1.ServiceInstanceOperationUpdate,
 		InProgressProperties: &v1beta1.ServiceInstancePropertiesState{
-			ExternalClusterServicePlanName: testClusterServicePlanName,
+			ClusterServicePlanExternalName: testClusterServicePlanName,
 		},
 		ExternalProperties: &v1beta1.ServiceInstancePropertiesState{
-			ExternalClusterServicePlanName: "old-plan-name",
+			ClusterServicePlanExternalName: "old-plan-name",
 		},
 	}
 	if operation != "" {
@@ -685,7 +685,7 @@ func getTestServiceInstanceAsyncDeprovisioning(operation string) *v1beta1.Servic
 		CurrentOperation:     v1beta1.ServiceInstanceOperationDeprovision,
 		ReconciledGeneration: 1,
 		ExternalProperties: &v1beta1.ServiceInstancePropertiesState{
-			ExternalClusterServicePlanName: testClusterServicePlanName,
+			ClusterServicePlanExternalName: testClusterServicePlanName,
 		},
 	}
 	if operation != "" {
@@ -1999,7 +1999,7 @@ func assertServiceInstancePropertiesStatePlanName(t *testing.T, propsLabel strin
 	if actualProps == nil {
 		fatalf(t, "expected %v properties to not be nil", propsLabel)
 	}
-	if e, a := expectedPlanName, actualProps.ExternalClusterServicePlanName; e != a {
+	if e, a := expectedPlanName, actualProps.ClusterServicePlanExternalName; e != a {
 		fatalf(t, "unexpected %v properties external service plan name: expected %v, actual %v", propsLabel, e, a)
 	}
 }

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -697,18 +697,18 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.PlanReference": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "PlanReference defines the user specification for the desired ServicePlan and ServiceClass. Because there are multiple ways to specify the desired Class/Plan, this structure specifies the allowed ways to specify the intent.\n\nCurrently supported ways:\n - ExternalClusterServiceClassName and ExternalClusterServicePlanName\n - ClusterServiceClassName and ClusterServicePlanName\n\nFor both of these ways, if a ClusterServiceClass only has one plan then leaving the *ServicePlanName is optional.",
+					Description: "PlanReference defines the user specification for the desired ServicePlan and ServiceClass. Because there are multiple ways to specify the desired Class/Plan, this structure specifies the allowed ways to specify the intent.\n\nCurrently supported ways:\n - ClusterServiceClassExternalName and ClusterServicePlanExternalName\n - ClusterServiceClassName and ClusterServicePlanName\n\nFor both of these ways, if a ClusterServiceClass only has one plan then leaving the *ServicePlanName is optional.",
 					Properties: map[string]spec.Schema{
-						"externalClusterServiceClassName": {
+						"clusterServiceClassExternalName": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ExternalClusterServiceClassName is the human-readable name of the service as reported by the broker. Note that if the broker changes the name of the ClusterServiceClass, it will not be reflected here, and to see the current name of the ClusterServiceClass, you should follow the ClusterServiceClassRef below.\n\nImmutable.",
+								Description: "ClusterServiceClassExternalName is the human-readable name of the service as reported by the broker. Note that if the broker changes the name of the ClusterServiceClass, it will not be reflected here, and to see the current name of the ClusterServiceClass, you should follow the ClusterServiceClassRef below.\n\nImmutable.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
 						},
-						"externalClusterServicePlanName": {
+						"clusterServicePlanExternalName": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ExternalClusterServicePlanName is the human-readable name of the plan as reported by the broker. Note that if the broker changes the name of the ClusterServicePlan, it will not be reflected here, and to see the current name of the ClusterServicePlan, you should follow the ClusterServicePlanRef below.",
+								Description: "ClusterServicePlanExternalName is the human-readable name of the plan as reported by the broker. Note that if the broker changes the name of the ClusterServicePlan, it will not be reflected here, and to see the current name of the ClusterServicePlan, you should follow the ClusterServicePlanRef below.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
@@ -1247,9 +1247,9 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 				SchemaProps: spec.SchemaProps{
 					Description: "ServiceInstancePropertiesState is the state of a ServiceInstance that the ClusterServiceBroker knows about.",
 					Properties: map[string]spec.Schema{
-						"externalClusterServicePlanName": {
+						"clusterServicePlanExternalName": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ExternalClusterServicePlanName is the name of the plan that the broker knows this ServiceInstance to be on. This is the human readable plan name from the OSB API.",
+								Description: "ClusterServicePlanExternalName is the name of the plan that the broker knows this ServiceInstance to be on. This is the human readable plan name from the OSB API.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
@@ -1274,7 +1274,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"externalClusterServicePlanName"},
+					Required: []string{"clusterServicePlanExternalName"},
 				},
 			},
 			Dependencies: []string{
@@ -1285,16 +1285,16 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 				SchemaProps: spec.SchemaProps{
 					Description: "ServiceInstanceSpec represents the desired state of an Instance.",
 					Properties: map[string]spec.Schema{
-						"externalClusterServiceClassName": {
+						"clusterServiceClassExternalName": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ExternalClusterServiceClassName is the human-readable name of the service as reported by the broker. Note that if the broker changes the name of the ClusterServiceClass, it will not be reflected here, and to see the current name of the ClusterServiceClass, you should follow the ClusterServiceClassRef below.\n\nImmutable.",
+								Description: "ClusterServiceClassExternalName is the human-readable name of the service as reported by the broker. Note that if the broker changes the name of the ClusterServiceClass, it will not be reflected here, and to see the current name of the ClusterServiceClass, you should follow the ClusterServiceClassRef below.\n\nImmutable.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
 						},
-						"externalClusterServicePlanName": {
+						"clusterServicePlanExternalName": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ExternalClusterServicePlanName is the human-readable name of the plan as reported by the broker. Note that if the broker changes the name of the ClusterServicePlan, it will not be reflected here, and to see the current name of the ClusterServicePlan, you should follow the ClusterServicePlanRef below.",
+								Description: "ClusterServicePlanExternalName is the human-readable name of the plan as reported by the broker. Note that if the broker changes the name of the ClusterServicePlan, it will not be reflected here, and to see the current name of the ClusterServicePlan, you should follow the ClusterServicePlanRef below.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
@@ -1315,13 +1315,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"clusterServiceClassRef": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ClusterServiceClassRef is a reference to the ClusterServiceClass that the user selected. This is set by the controller based on ExternalClusterServiceClassName",
+								Description: "ClusterServiceClassRef is a reference to the ClusterServiceClass that the user selected. This is set by the controller based on ClusterServiceClassExternalName",
 								Ref:         ref("github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.ClusterObjectReference"),
 							},
 						},
 						"clusterServicePlanRef": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ClusterServicePlanRef is a reference to the ClusterServicePlan that the user selected. This is set by the controller based on ExternalClusterServicePlanName",
+								Description: "ClusterServicePlanRef is a reference to the ClusterServicePlan that the user selected. This is set by the controller based on ClusterServicePlanExternalName",
 								Ref:         ref("github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.ClusterObjectReference"),
 							},
 						},

--- a/pkg/registry/servicecatalog/instance/strategy.go
+++ b/pkg/registry/servicecatalog/instance/strategy.go
@@ -154,7 +154,7 @@ func (instanceRESTStrategy) PrepareForUpdate(ctx genericapirequest.Context, new,
 	newServiceInstance.Spec.ClusterServicePlanRef = oldServiceInstance.Spec.ClusterServicePlanRef
 
 	// Clear out the ClusterServicePlanRef so that it is resolved during reconciliation
-	if newServiceInstance.Spec.ExternalClusterServicePlanName != oldServiceInstance.Spec.ExternalClusterServicePlanName {
+	if newServiceInstance.Spec.ClusterServicePlanExternalName != oldServiceInstance.Spec.ClusterServicePlanExternalName {
 		newServiceInstance.Spec.ClusterServicePlanRef = nil
 	}
 

--- a/pkg/registry/servicecatalog/instance/strategy_test.go
+++ b/pkg/registry/servicecatalog/instance/strategy_test.go
@@ -36,8 +36,8 @@ func getTestInstance() *servicecatalog.ServiceInstance {
 		},
 		Spec: servicecatalog.ServiceInstanceSpec{
 			PlanReference: servicecatalog.PlanReference{
-				ExternalClusterServiceClassName: "test-serviceclass",
-				ExternalClusterServicePlanName:  "test-plan",
+				ClusterServiceClassExternalName: "test-serviceclass",
+				ClusterServicePlanExternalName:  "test-plan",
 			},
 			ClusterServiceClassRef: &servicecatalog.ClusterObjectReference{},
 			ClusterServicePlanRef:  &servicecatalog.ClusterObjectReference{},
@@ -97,7 +97,7 @@ func TestInstanceUpdate(t *testing.T) {
 			older: getTestInstance(),
 			newer: func() *servicecatalog.ServiceInstance {
 				i := getTestInstance()
-				i.Spec.ExternalClusterServicePlanName = "new-test-plan"
+				i.Spec.ClusterServicePlanExternalName = "new-test-plan"
 				return i
 			}(),
 			shouldGenerationIncrement: true,

--- a/plugin/pkg/admission/serviceplan/changevalidator/admission.go
+++ b/plugin/pkg/admission/serviceplan/changevalidator/admission.go
@@ -72,10 +72,10 @@ func (d *denyPlanChangeIfNotUpdatable) Admit(a admission.Attributes) error {
 		return apierrors.NewBadRequest("Resource was marked with kind Instance but was unable to be converted")
 	}
 
-	sc, err := d.scLister.Get(instance.Spec.ExternalClusterServiceClassName)
+	sc, err := d.scLister.Get(instance.Spec.ClusterServiceClassExternalName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			glog.V(5).Infof("Could not locate service class %v, can not determine if UpdateablePlan.", instance.Spec.ExternalClusterServiceClassName)
+			glog.V(5).Infof("Could not locate service class %v, can not determine if UpdateablePlan.", instance.Spec.ClusterServiceClassExternalName)
 			return nil // should this be `return err`? why would we allow the instance in if we cannot determine it is updatable?
 		}
 		glog.Error(err)
@@ -86,15 +86,15 @@ func (d *denyPlanChangeIfNotUpdatable) Admit(a admission.Attributes) error {
 		return nil
 	}
 
-	if instance.Spec.ExternalClusterServicePlanName != "" {
+	if instance.Spec.ClusterServicePlanExternalName != "" {
 		lister := d.instanceLister.ServiceInstances(instance.Namespace)
 		origInstance, err := lister.Get(instance.Name)
 		if err != nil {
 			glog.Errorf("Error locating instance %v/%v", instance.Namespace, instance.Name)
 			return err
 		}
-		if instance.Spec.ExternalClusterServicePlanName != origInstance.Spec.ExternalClusterServicePlanName {
-			glog.V(4).Infof("update Service Instance %v/%v request specified Plan Name %v while original instance had %v", instance.Namespace, instance.Name, instance.Spec.ExternalClusterServicePlanName, origInstance.Spec.ExternalClusterServicePlanName)
+		if instance.Spec.ClusterServicePlanExternalName != origInstance.Spec.ClusterServicePlanExternalName {
+			glog.V(4).Infof("update Service Instance %v/%v request specified Plan Name %v while original instance had %v", instance.Namespace, instance.Name, instance.Spec.ClusterServicePlanExternalName, origInstance.Spec.ClusterServicePlanExternalName)
 			msg := fmt.Sprintf("The Service Class %v does not allow plan changes.", sc.Name)
 			glog.Error(msg)
 			return admission.NewForbidden(a, errors.New(msg))

--- a/plugin/pkg/admission/serviceplan/changevalidator/admission_test.go
+++ b/plugin/pkg/admission/serviceplan/changevalidator/admission_test.go
@@ -69,8 +69,8 @@ func newServiceInstance(namespace string, serviceClassName string, planName stri
 	instance := servicecatalog.ServiceInstance{
 		ObjectMeta: metav1.ObjectMeta{Name: "instance", Namespace: namespace},
 	}
-	instance.Spec.ExternalClusterServiceClassName = serviceClassName
-	instance.Spec.ExternalClusterServicePlanName = planName
+	instance.Spec.ClusterServiceClassExternalName = serviceClassName
+	instance.Spec.ClusterServicePlanExternalName = planName
 	return instance
 }
 

--- a/plugin/pkg/admission/serviceplan/defaultserviceplan/admission_test.go
+++ b/plugin/pkg/admission/serviceplan/defaultserviceplan/admission_test.go
@@ -171,7 +171,7 @@ func TestWithListFailure(t *testing.T) {
 	informerFactory.Start(wait.NeverStop)
 
 	instance := newServiceInstance("dummy")
-	instance.Spec.ExternalClusterServiceClassName = "foo"
+	instance.Spec.ClusterServiceClassExternalName = "foo"
 
 	err = handler.Admit(admission.NewAttributesRecord(&instance, nil, servicecatalog.Kind("ServiceInstance").WithVersion("version"), instance.Namespace, instance.Name, servicecatalog.Resource("serviceinstances").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
@@ -180,7 +180,7 @@ func TestWithListFailure(t *testing.T) {
 		t.Errorf("did not find expected error, got %q", err)
 	}
 	assertPlanReference(t,
-		servicecatalog.PlanReference{ExternalClusterServiceClassName: "foo"},
+		servicecatalog.PlanReference{ClusterServiceClassExternalName: "foo"},
 		instance.Spec.PlanReference)
 }
 
@@ -193,8 +193,8 @@ func TestWithPlanWorks(t *testing.T) {
 	informerFactory.Start(wait.NeverStop)
 
 	instance := newServiceInstance("dummy")
-	instance.Spec.ExternalClusterServiceClassName = "foo"
-	instance.Spec.ExternalClusterServicePlanName = "bar"
+	instance.Spec.ClusterServiceClassExternalName = "foo"
+	instance.Spec.ClusterServicePlanExternalName = "bar"
 
 	err = handler.Admit(admission.NewAttributesRecord(&instance, nil, servicecatalog.Kind("ServiceInstance").WithVersion("version"), instance.Namespace, instance.Name, servicecatalog.Resource("serviceinstances").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
@@ -205,7 +205,7 @@ func TestWithPlanWorks(t *testing.T) {
 		t.Errorf("unexpected error %q returned from admission handler: %v", err, actions)
 	}
 	assertPlanReference(t,
-		servicecatalog.PlanReference{ExternalClusterServiceClassName: "foo", ExternalClusterServicePlanName: "bar"},
+		servicecatalog.PlanReference{ClusterServiceClassExternalName: "foo", ClusterServicePlanExternalName: "bar"},
 		instance.Spec.PlanReference)
 }
 
@@ -218,7 +218,7 @@ func TestWithNoPlanFailsWithNoClusterServiceClass(t *testing.T) {
 	informerFactory.Start(wait.NeverStop)
 
 	instance := newServiceInstance("dummy")
-	instance.Spec.ExternalClusterServiceClassName = "foobar"
+	instance.Spec.ClusterServiceClassExternalName = "foobar"
 
 	err = handler.Admit(admission.NewAttributesRecord(&instance, nil, servicecatalog.Kind("ServiceInstance").WithVersion("version"), instance.Namespace, instance.Name, servicecatalog.Resource("serviceinstances").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
@@ -227,7 +227,7 @@ func TestWithNoPlanFailsWithNoClusterServiceClass(t *testing.T) {
 		t.Errorf("did not find expected error, got %q", err)
 	}
 	assertPlanReference(t,
-		servicecatalog.PlanReference{ExternalClusterServiceClassName: "foobar"},
+		servicecatalog.PlanReference{ClusterServiceClassExternalName: "foobar"},
 		instance.Spec.PlanReference)
 }
 
@@ -245,7 +245,7 @@ func TestWithNoPlanWorksWithSinglePlan(t *testing.T) {
 	informerFactory.Start(wait.NeverStop)
 
 	instance := newServiceInstance("dummy")
-	instance.Spec.ExternalClusterServiceClassName = "foo"
+	instance.Spec.ClusterServiceClassExternalName = "foo"
 
 	err = handler.Admit(admission.NewAttributesRecord(&instance, nil, servicecatalog.Kind("ServiceInstance").WithVersion("version"), instance.Namespace, instance.Name, servicecatalog.Resource("serviceinstances").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
@@ -256,7 +256,7 @@ func TestWithNoPlanWorksWithSinglePlan(t *testing.T) {
 		t.Errorf("unexpected error %q returned from admission handler: %v", err, actions)
 	}
 	assertPlanReference(t,
-		servicecatalog.PlanReference{ExternalClusterServiceClassName: "foo", ExternalClusterServicePlanName: "bar"},
+		servicecatalog.PlanReference{ClusterServiceClassExternalName: "foo", ClusterServicePlanExternalName: "bar"},
 		instance.Spec.PlanReference)
 }
 
@@ -273,7 +273,7 @@ func TestWithNoPlanFailsWithMultiplePlans(t *testing.T) {
 	informerFactory.Start(wait.NeverStop)
 
 	instance := newServiceInstance("dummy")
-	instance.Spec.ExternalClusterServiceClassName = "foo"
+	instance.Spec.ClusterServiceClassExternalName = "foo"
 
 	err = handler.Admit(admission.NewAttributesRecord(&instance, nil, servicecatalog.Kind("ServiceInstance").WithVersion("version"), instance.Namespace, instance.Name, servicecatalog.Resource("serviceinstances").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
@@ -283,7 +283,7 @@ func TestWithNoPlanFailsWithMultiplePlans(t *testing.T) {
 		t.Errorf("did not find expected error, got %q", err)
 	}
 	assertPlanReference(t,
-		servicecatalog.PlanReference{ExternalClusterServiceClassName: "foo"},
+		servicecatalog.PlanReference{ClusterServiceClassExternalName: "foo"},
 		instance.Spec.PlanReference)
 }
 
@@ -302,7 +302,7 @@ func TestWithNoPlanSucceedsWithMultiplePlansFromDifferentClasses(t *testing.T) {
 	informerFactory.Start(wait.NeverStop)
 
 	instance := newServiceInstance("dummy")
-	instance.Spec.ExternalClusterServiceClassName = "foo"
+	instance.Spec.ClusterServiceClassExternalName = "foo"
 
 	err = handler.Admit(admission.NewAttributesRecord(&instance, nil, servicecatalog.Kind("ServiceInstance").WithVersion("version"), instance.Namespace, instance.Name, servicecatalog.Resource("serviceinstances").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
@@ -313,7 +313,7 @@ func TestWithNoPlanSucceedsWithMultiplePlansFromDifferentClasses(t *testing.T) {
 		t.Errorf("unexpected error %q returned from admission handler: %v", err, actions)
 	}
 	assertPlanReference(t,
-		servicecatalog.PlanReference{ExternalClusterServiceClassName: "foo", ExternalClusterServicePlanName: "bar"},
+		servicecatalog.PlanReference{ClusterServiceClassExternalName: "foo", ClusterServicePlanExternalName: "bar"},
 		instance.Spec.PlanReference)
 }
 

--- a/test/e2e/instance.go
+++ b/test/e2e/instance.go
@@ -42,8 +42,8 @@ func newTestInstance(name, serviceClassName, planName string) *v1beta1.ServiceIn
 		},
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
-				ExternalClusterServicePlanName:  planName,
-				ExternalClusterServiceClassName: serviceClassName,
+				ClusterServicePlanExternalName:  planName,
+				ClusterServiceClassExternalName: serviceClassName,
 			},
 		},
 	}

--- a/test/e2e/walkthrough.go
+++ b/test/e2e/walkthrough.go
@@ -126,8 +126,8 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 			},
 			Spec: v1beta1.ServiceInstanceSpec{
 				PlanReference: v1beta1.PlanReference{
-					ExternalClusterServiceClassName: serviceclassName,
-					ExternalClusterServicePlanName:  "default",
+					ClusterServiceClassExternalName: serviceclassName,
+					ClusterServicePlanExternalName:  "default",
 				},
 			},
 		}
@@ -218,7 +218,7 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 			},
 			Spec: v1beta1.ServiceInstanceSpec{
 				PlanReference: v1beta1.PlanReference{
-					ExternalClusterServiceClassName: serviceclassName,
+					ClusterServiceClassExternalName: serviceclassName,
 				},
 			},
 		}

--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -824,8 +824,8 @@ func testInstanceClient(sType server.StorageType, client servicecatalogclient.In
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
-				ExternalClusterServiceClassName: "service-class-name",
-				ExternalClusterServicePlanName:  "plan-name",
+				ClusterServiceClassExternalName: "service-class-name",
+				ClusterServicePlanExternalName:  "plan-name",
 			},
 			ClusterServiceClassRef: &v1beta1.ClusterObjectReference{
 				Name: "test-serviceclass",

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -154,8 +154,8 @@ func TestBasicFlowsSync(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
-				ExternalClusterServiceClassName: testClusterServiceClassName,
-				ExternalClusterServicePlanName:  testPlanName,
+				ClusterServiceClassExternalName: testClusterServiceClassName,
+				ClusterServicePlanExternalName:  testPlanName,
 			},
 			ExternalID: testExternalID,
 		},
@@ -349,8 +349,8 @@ func TestBasicFlowsAsync(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
-				ExternalClusterServiceClassName: testClusterServiceClassName,
-				ExternalClusterServicePlanName:  testPlanName,
+				ClusterServiceClassExternalName: testClusterServiceClassName,
+				ClusterServicePlanExternalName:  testPlanName,
 			},
 			ExternalID: testExternalID,
 		},
@@ -528,8 +528,8 @@ func TestProvisionFailure(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
-				ExternalClusterServiceClassName: testClusterServiceClassName,
-				ExternalClusterServicePlanName:  testPlanName,
+				ClusterServiceClassExternalName: testClusterServiceClassName,
+				ClusterServicePlanExternalName:  testPlanName,
 			},
 			ExternalID: testExternalID,
 		},
@@ -655,8 +655,8 @@ func TestBindingFailure(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
-				ExternalClusterServiceClassName: testClusterServiceClassName,
-				ExternalClusterServicePlanName:  testPlanName,
+				ClusterServiceClassExternalName: testClusterServiceClassName,
+				ClusterServicePlanExternalName:  testPlanName,
 			},
 			ExternalID: testExternalID,
 		},
@@ -854,8 +854,8 @@ func TestBasicFlowsWithOriginatingIdentity(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
-				ExternalClusterServiceClassName: testClusterServiceClassName,
-				ExternalClusterServicePlanName:  testPlanName,
+				ClusterServiceClassExternalName: testClusterServiceClassName,
+				ClusterServicePlanExternalName:  testPlanName,
 			},
 			ExternalID: testExternalID,
 		},
@@ -1066,8 +1066,8 @@ func TestServiceInstanceOrphanMitigation(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
-				ExternalClusterServiceClassName: testClusterServiceClassName,
-				ExternalClusterServicePlanName:  testPlanName,
+				ClusterServiceClassExternalName: testClusterServiceClassName,
+				ClusterServicePlanExternalName:  testPlanName,
 			},
 			ExternalID: testExternalID,
 		},
@@ -1193,8 +1193,8 @@ func TestServiceBindingOrphanMitigation(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
-				ExternalClusterServiceClassName: testClusterServiceClassName,
-				ExternalClusterServicePlanName:  testPlanName,
+				ClusterServiceClassExternalName: testClusterServiceClassName,
+				ClusterServicePlanExternalName:  testPlanName,
 			},
 			ExternalID: testExternalID,
 		},


### PR DESCRIPTION
Per https://github.com/kubernetes-incubator/service-catalog/pull/1350/files#r143453045 I see no value to the end-user to have the word "External" there. They shouldn't know, or care, if the service is external or not, and in fact it may not be.  