### PR TITLE
fix travis tag checker

### DIFF
--- a/contrib/travis/deploy.sh
+++ b/contrib/travis/deploy.sh
@@ -22,7 +22,7 @@ export REGISTRY=quay.io/kubernetes-service-catalog/
 
 docker login -e="${QUAY_EMAIL}" -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
 
-if [[ "${TRAVIS_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[a-z]*$ ]]; then
+if [[ "${TRAVIS_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[a-z]*(-(r|R)(c|C)[0-9]+)*$ ]]; then
     echo "Pushing images with tags '${TRAVIS_TAG}' and 'latest'."
     VERSION="${TRAVIS_TAG}" MUTABLE_TAG="latest" make release-push
 elif [[ "${TRAVIS_BRANCH}" == "master" ]]; then


### PR DESCRIPTION
Allow for optional `-rc#` to be at the end of the tag name.

closes #1364

Signed-off-by: Doug Davis <dug@us.ibm.com>