### PR TITLE
travis: skip cleanup before deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
 script:
 - make verify build test images
 deploy:
+  skip_cleanup: true
   provider: script
   script: contrib/travis/deploy.sh
   on:


### PR DESCRIPTION
This is a temporary measure to get around an issue we've started hitting with travis deployments.  By default, travis runs a `git stash --all` command in the working directory before running the deployment.  This is failing in our build for 0.1.0-rc1 because of permissions on that file, see:

https://travis-ci.org/kubernetes-incubator/service-catalog/builds/285930705

```console
Preparing deploy

Cleaning up git repository with `git stash --all`. If you need build artifacts for deployment, set `deploy.skip_cleanup: true`. See https://docs.travis-ci.com/user/deployment/#Uploading-Files.

error: open(".kube/config"): Permission denied

fatal: Unable to process path .kube/config

Cannot save the untracked files
```