### PR TITLE
Disable link checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,8 +241,8 @@ verify: .init .generate_files verify-client-gen
 	@bash -c '[ "`cat .out`" == "" ] || (cat .out ; false)'
 	@rm .out
 	@#
-	@echo Running href checker:
-	@$(DOCKER_CMD) verify-links.sh -t .
+	@#echo Running href checker:
+	@#$(DOCKER_CMD) verify-links.sh -t .
 	@echo Running errexit checker:
 	@$(DOCKER_CMD) build/verify-errexit.sh
 


### PR DESCRIPTION
Because goreportcard.com is down, which is failing builds.