### PR TITLE
fix status update when starting orphan mitigation

### DIFF
--- a/pkg/apis/servicecatalog/validation/binding.go
+++ b/pkg/apis/servicecatalog/validation/binding.go
@@ -95,8 +95,8 @@ func validateServiceBindingStatus(status *sc.ServiceBindingStatus, fldPath *fiel
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("operationStartTime"), "operationStartTime must not be present when currentOperation is not present"))
 		}
 	} else {
-		if status.OperationStartTime == nil {
-			allErrs = append(allErrs, field.Required(fldPath.Child("operationStartTime"), "operationStartTime is required when currentOperation is present"))
+		if status.OperationStartTime == nil && !status.OrphanMitigationInProgress {
+			allErrs = append(allErrs, field.Required(fldPath.Child("operationStartTime"), "operationStartTime is required when currentOperation is present and no orphan mitigation in progress"))
 		}
 		// Do not allow the binding to be ready if there is an on-going operation
 		for i, c := range status.Conditions {

--- a/pkg/apis/servicecatalog/validation/binding_test.go
+++ b/pkg/apis/servicecatalog/validation/binding_test.go
@@ -412,6 +412,45 @@ func TestValidateServiceBinding(t *testing.T) {
 			create: false,
 			valid:  false,
 		},
+		{
+			name: "failed bind starting orphan mitigation",
+			binding: func() *servicecatalog.ServiceBinding {
+				b := validServiceBindingWithInProgressBind()
+				b.Status.OperationStartTime = nil
+				b.Status.OrphanMitigationInProgress = true
+				b.Status.Conditions = []servicecatalog.ServiceBindingCondition{
+					{
+						Type:   servicecatalog.ServiceBindingConditionReady,
+						Status: servicecatalog.ConditionFalse,
+					},
+					{
+						Type:	servicecatalog.ServiceBindingConditionFailed,
+						Status: servicecatalog.ConditionTrue,
+					},
+				}
+				return b
+			}(),
+			valid: true,
+		},
+		{
+			name: "in-progress orphan mitigation",
+			binding: func() *servicecatalog.ServiceBinding {
+				b := validServiceBindingWithInProgressBind()
+				b.Status.OrphanMitigationInProgress = true
+				b.Status.Conditions = []servicecatalog.ServiceBindingCondition{
+					{
+						Type:   servicecatalog.ServiceBindingConditionReady,
+						Status: servicecatalog.ConditionFalse,
+					},
+					{
+						Type:	servicecatalog.ServiceBindingConditionFailed,
+						Status: servicecatalog.ConditionTrue,
+					},
+				}
+				return b
+			}(),
+			valid: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/apis/servicecatalog/validation/binding_test.go
+++ b/pkg/apis/servicecatalog/validation/binding_test.go
@@ -424,7 +424,7 @@ func TestValidateServiceBinding(t *testing.T) {
 						Status: servicecatalog.ConditionFalse,
 					},
 					{
-						Type:	servicecatalog.ServiceBindingConditionFailed,
+						Type:   servicecatalog.ServiceBindingConditionFailed,
 						Status: servicecatalog.ConditionTrue,
 					},
 				}
@@ -443,7 +443,7 @@ func TestValidateServiceBinding(t *testing.T) {
 						Status: servicecatalog.ConditionFalse,
 					},
 					{
-						Type:	servicecatalog.ServiceBindingConditionFailed,
+						Type:   servicecatalog.ServiceBindingConditionFailed,
 						Status: servicecatalog.ConditionTrue,
 					},
 				}

--- a/pkg/apis/servicecatalog/validation/instance.go
+++ b/pkg/apis/servicecatalog/validation/instance.go
@@ -122,8 +122,8 @@ func validateServiceInstanceStatus(status *sc.ServiceInstanceStatus, fldPath *fi
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("lastOperation"), "lastOperation cannot be true when currentOperation is not present"))
 		}
 	} else {
-		if status.OperationStartTime == nil {
-			allErrs = append(allErrs, field.Required(fldPath.Child("operationStartTime"), "operationStartTime is required when currentOperation is present"))
+		if status.OperationStartTime == nil && !status.OrphanMitigationInProgress {
+			allErrs = append(allErrs, field.Required(fldPath.Child("operationStartTime"), "operationStartTime is required when currentOperation is present and no orphan mitigation in progress"))
 		}
 		// Do not allow the instance to be ready if there is an on-going operation
 		for i, c := range status.Conditions {

--- a/pkg/apis/servicecatalog/validation/instance_test.go
+++ b/pkg/apis/servicecatalog/validation/instance_test.go
@@ -493,6 +493,45 @@ func TestValidateServiceInstance(t *testing.T) {
 			create: true,
 			valid:  false,
 		},
+		{
+			name: "failed provision starting orphan mitigation",
+			instance: func() *servicecatalog.ServiceInstance {
+				i := validServiceInstanceWithInProgressProvision()
+				i.Status.OperationStartTime = nil
+				i.Status.OrphanMitigationInProgress = true
+				i.Status.Conditions = []servicecatalog.ServiceInstanceCondition{
+					{
+						Type:   servicecatalog.ServiceInstanceConditionReady,
+						Status: servicecatalog.ConditionFalse,
+					},
+					{
+						Type:	servicecatalog.ServiceInstanceConditionFailed,
+						Status: servicecatalog.ConditionTrue,
+					},
+				}
+				return i
+			}(),
+			valid: true,
+		},
+		{
+			name: "in-progress orphan mitigation",
+			instance: func() *servicecatalog.ServiceInstance {
+				i := validServiceInstanceWithInProgressProvision()
+				i.Status.OrphanMitigationInProgress = true
+				i.Status.Conditions = []servicecatalog.ServiceInstanceCondition{
+					{
+						Type:   servicecatalog.ServiceInstanceConditionReady,
+						Status: servicecatalog.ConditionFalse,
+					},
+					{
+						Type:	servicecatalog.ServiceInstanceConditionFailed,
+						Status: servicecatalog.ConditionTrue,
+					},
+				}
+				return i
+			}(),
+			valid: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/apis/servicecatalog/validation/instance_test.go
+++ b/pkg/apis/servicecatalog/validation/instance_test.go
@@ -505,7 +505,7 @@ func TestValidateServiceInstance(t *testing.T) {
 						Status: servicecatalog.ConditionFalse,
 					},
 					{
-						Type:	servicecatalog.ServiceInstanceConditionFailed,
+						Type:   servicecatalog.ServiceInstanceConditionFailed,
 						Status: servicecatalog.ConditionTrue,
 					},
 				}
@@ -524,7 +524,7 @@ func TestValidateServiceInstance(t *testing.T) {
 						Status: servicecatalog.ConditionFalse,
 					},
 					{
-						Type:	servicecatalog.ServiceInstanceConditionFailed,
+						Type:   servicecatalog.ServiceInstanceConditionFailed,
 						Status: servicecatalog.ConditionTrue,
 					},
 				}

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -131,7 +131,6 @@ func (c *controller) setAndUpdateOrphanMitigation(binding *v1beta1.ServiceBindin
 	)
 	toUpdate.Status.OrphanMitigationInProgress = true
 	toUpdate.Status.OperationStartTime = nil
-	toUpdate.Status.InProgressProperties = nil
 	glog.V(5).Info(s)
 
 	c.setServiceBindingCondition(

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -543,6 +543,7 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 		// request, so this is what the Broker knows about the state of the
 		// binding.
 		toUpdate.Status.ExternalProperties = toUpdate.Status.InProgressProperties
+		toUpdate.Status.InProgressProperties = nil
 
 		err = c.injectServiceBinding(binding, response.Credentials)
 		if err != nil {

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1934,7 +1934,6 @@ func setServiceInstanceStartOrphanMitigation(toUpdate *v1beta1.ServiceInstance) 
 	toUpdate.Status.OperationStartTime = nil
 	toUpdate.Status.AsyncOpInProgress = false
 	toUpdate.Status.OrphanMitigationInProgress = true
-	toUpdate.Status.InProgressProperties = nil
 }
 
 // shouldStartOrphanMitigation returns whether an error with the given status

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -2898,14 +2898,18 @@ func TestReconcileServiceInstanceWithHTTPStatusCodeErrorOrphanMitigation(t *test
 			continue
 		}
 
-		if tc.triggersOrphanMitigation && err == nil {
-			t.Errorf("%v: Reconciler should return error so that instance is orphan mitigated", tc.name)
-			continue
-		}
-
-		if !tc.triggersOrphanMitigation && err != nil {
-			t.Errorf("%v: Reconciler should treat as terminal condition and not requeue", tc.name)
-			continue
+		if tc.triggersOrphanMitigation {
+			// TODO(mkibbe): Rework this to be an expects, not asserts
+			assertServiceInstanceStartingOrphanMitigation(t, updatedServiceInstance, errorProvisionCallFailedReason, instance)
+			if err == nil {
+				t.Errorf("%v: Reconciler should return error so that instance is orphan mitigated", tc.name)
+				continue
+			}
+		} else {
+			if err != nil {
+				t.Errorf("%v: Reconciler should treat as terminal condition and not requeue", tc.name)
+				continue
+			}
 		}
 	}
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1762,6 +1762,14 @@ func assertServiceInstanceOperationInProgressWithParameters(t *testing.T, obj ru
 	assertServiceInstanceExternalPropertiesUnchanged(t, obj, originalInstance)
 }
 
+func assertServiceInstanceStartingOrphanMitigation(t *testing.T, obj runtime.Object, readyReason string, originalInstance *v1beta1.ServiceInstance) {
+	assertServiceInstanceCurrentOperation(t, obj, v1beta1.ServiceInstanceOperationProvision)
+	assertServiceInstanceReadyFalse(t, obj, readyReason)
+	assertServiceInstanceOperationStartTimeSet(t, obj, false)
+	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
+	assertServiceInstanceOrphanMitigationInProgressTrue(t, obj)
+}
+
 func assertServiceInstanceOperationSuccess(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, planName string, originalInstance *v1beta1.ServiceInstance) {
 	assertServiceInstanceOperationSuccessWithParameters(t, obj, operation, planName, nil, "", originalInstance)
 }
@@ -1813,7 +1821,6 @@ func assertServiceInstanceRequestFailingError(t *testing.T, obj runtime.Object, 
 	assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionFailed, v1beta1.ConditionTrue, failureReason)
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertAsyncOpInProgressFalse(t, obj)
-	assertServiceInstanceInProgressPropertiesNil(t, obj)
 	assertServiceInstanceExternalPropertiesUnchanged(t, obj, originalInstance)
 }
 
@@ -1822,6 +1829,7 @@ func assertServiceInstanceRequestFailingErrorNoOrphanMitigation(t *testing.T, ob
 	assertServiceInstanceCurrentOperationClear(t, obj)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Generation)
 	assertServiceInstanceOrphanMitigationInProgressFalse(t, obj)
+	assertServiceInstanceInProgressPropertiesNil(t, obj)
 }
 
 func assertServiceInstanceRequestFailingErrorStartOrphanMitigation(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, readyReason string, failureReason string, originalInstance *v1beta1.ServiceInstance) {
@@ -2146,6 +2154,14 @@ func assertServiceBindingOperationInProgressWithParameters(t *testing.T, obj run
 		assertServiceBindingInProgressPropertiesNil(t, obj)
 	}
 	assertServiceBindingExternalPropertiesUnchanged(t, obj, originalBinding)
+}
+
+func assertServiceBindingStartingOrphanMitigation(t *testing.T, obj runtime.Object, originalBinding *v1beta1.ServiceBinding) {
+	assertServiceBindingCurrentOperation(t, obj, v1beta1.ServiceBindingOperationBind)
+	assertServiceBindingReadyFalse(t, obj, errorServiceBindingOrphanMitigation)
+	assertServiceBindingOperationStartTimeSet(t, obj, false)
+	assertServiceBindingReconciledGeneration(t, obj, originalBinding.Status.ReconciledGeneration)
+	assertServiceBindingOrphanMitigationSet(t, obj, true)
 }
 
 func assertServiceBindingOperationSuccess(t *testing.T, obj runtime.Object, operation v1beta1.ServiceBindingOperation, originalBinding *v1beta1.ServiceBinding) {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -1009,6 +1009,298 @@ func TestBasicFlowsWithOriginatingIdentity(t *testing.T) {
 	}
 }
 
+// TestServiceInstanceOrphanMitigation tests whether an instance is
+// successfully deprovisioned after a provision request returns a status code
+// that should trigger orphan mitigation.
+func TestServiceInstanceOrphanMitigation(t *testing.T) {
+	_, catalogClient, _, _, _, _, shutdownServer, shutdownController := newTestController(t, fakeosb.FakeClientConfiguration{
+		CatalogReaction: &fakeosb.CatalogReaction{
+			Response: getTestCatalogResponse(),
+		},
+		ProvisionReaction: &fakeosb.ProvisionReaction{
+			Error: osb.HTTPStatusCodeError{
+				StatusCode:   http.StatusInternalServerError,
+			},
+		},
+		DeprovisionReaction: &fakeosb.DeprovisionReaction{
+			Response: &osb.DeprovisionResponse{},
+		},
+	})
+	defer shutdownController()
+	defer shutdownServer()
+
+	client := catalogClient.ServicecatalogV1beta1()
+
+	broker := &v1beta1.ClusterServiceBroker{
+		ObjectMeta: metav1.ObjectMeta{Name: testBrokerName},
+		Spec: v1beta1.ClusterServiceBrokerSpec{
+			URL: testBrokerURL,
+		},
+	}
+
+	_, err := client.ClusterServiceBrokers().Create(broker)
+	if nil != err {
+		t.Fatalf("error creating the broker %q (%q)", broker.Name, err)
+	}
+
+	err = util.WaitForBrokerCondition(client,
+		testBrokerName,
+		v1beta1.ServiceBrokerCondition{
+			Type:   v1beta1.ServiceBrokerConditionReady,
+			Status: v1beta1.ConditionTrue,
+		})
+	if err != nil {
+		t.Fatalf("error waiting for broker to become ready: %v", err)
+	}
+
+	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassID)
+	if nil != err {
+		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
+	}
+
+	// TODO: find some way to compose scenarios; extract method here for real
+	// logic for this test.
+
+	//-----------------
+
+	instance := &v1beta1.ServiceInstance{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
+		Spec: v1beta1.ServiceInstanceSpec{
+			PlanReference: v1beta1.PlanReference{
+				ExternalClusterServiceClassName: testClusterServiceClassName,
+				ExternalClusterServicePlanName:  testPlanName,
+			},
+			ExternalID: testExternalID,
+		},
+	}
+
+
+	if _, err := client.ServiceInstances(testNamespace).Create(instance); err != nil {
+		t.Fatalf("error creating Instance: %v", err)
+	}
+
+	if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
+		Type:   v1beta1.ServiceInstanceConditionFailed,
+		Status: v1beta1.ConditionTrue,
+	}); err != nil {
+		t.Fatalf("error waiting for instance to become failed: %v", err)
+	}
+
+	if err := util.WaitForInstanceReconciledGeneration(client, testNamespace, testInstanceName, instance.Status.ReconciledGeneration+1); err != nil {
+		t.Fatalf("error waiting for instance to reconcile: %v", err)
+	}
+
+	retInst, err := client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
+	}
+
+	util.AssertServiceInstanceCondition(
+		t,
+		retInst,
+		v1beta1.ServiceInstanceConditionReady,
+		v1beta1.ConditionFalse,
+		"DeprovisionedSuccessfully",
+	)
+
+	err = client.ServiceInstances(testNamespace).Delete(testInstanceName, &metav1.DeleteOptions{})
+	if nil != err {
+		t.Fatalf("instance delete should have been accepted: %v", err)
+	}
+
+	err = util.WaitForInstanceToNotExist(client, testNamespace, testInstanceName)
+	if err != nil {
+		t.Fatalf("error waiting for instance to be deleted: %v", err)
+	}
+
+	//-----------------
+	// End orphan mitigation test
+
+	// Delete the broker
+	err = client.ClusterServiceBrokers().Delete(testBrokerName, &metav1.DeleteOptions{})
+	if nil != err {
+		t.Fatalf("broker should be deleted (%s)", err)
+	}
+
+	err = util.WaitForClusterServiceClassToNotExist(client, testClusterServiceClassName)
+	if err != nil {
+		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
+	}
+
+	err = util.WaitForBrokerToNotExist(client, testBrokerName)
+	if err != nil {
+		t.Fatalf("error waiting for Broker to not exist: %v", err)
+	}
+}
+
+// TestServiceBindingOrphanMitigation tests whether a binding is
+// successfully deleted after a bind request returns a status code
+// that should trigger orphan mitigation.
+func TestServiceBindingOrphanMitigation(t *testing.T) {
+	_, fakeCatalogClient, _, _, _, _, shutdownServer, shutdownController := newTestController(t, fakeosb.FakeClientConfiguration{
+		CatalogReaction: &fakeosb.CatalogReaction{
+			Response: getTestCatalogResponse(),
+		},
+		BindReaction: &fakeosb.BindReaction{
+			Error: osb.HTTPStatusCodeError{
+				StatusCode:   http.StatusInternalServerError,
+			},
+		},
+		UnbindReaction: &fakeosb.UnbindReaction{},
+		ProvisionReaction: &fakeosb.ProvisionReaction{
+			Response: &osb.ProvisionResponse{},
+		},
+		DeprovisionReaction: &fakeosb.DeprovisionReaction{
+			Response: &osb.DeprovisionResponse{},
+		},
+	})
+	defer shutdownController()
+	defer shutdownServer()
+
+	client := fakeCatalogClient.ServicecatalogV1beta1()
+
+	broker := &v1beta1.ClusterServiceBroker{
+		ObjectMeta: metav1.ObjectMeta{Name: testBrokerName},
+		Spec: v1beta1.ClusterServiceBrokerSpec{
+			URL: testBrokerURL,
+		},
+	}
+
+	_, err := client.ClusterServiceBrokers().Create(broker)
+	if nil != err {
+		t.Fatalf("error creating the broker %q (%q)", broker.Name, err)
+	}
+
+	err = util.WaitForBrokerCondition(client,
+		testBrokerName,
+		v1beta1.ServiceBrokerCondition{
+			Type:   v1beta1.ServiceBrokerConditionReady,
+			Status: v1beta1.ConditionTrue,
+		})
+	if err != nil {
+		t.Fatalf("error waiting for broker to become ready: %v", err)
+	}
+
+	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassID)
+	if nil != err {
+		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
+	}
+
+	// TODO: find some way to compose scenarios; extract method here for real
+	// logic for this test.
+
+	//-----------------
+
+	instance := &v1beta1.ServiceInstance{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
+		Spec: v1beta1.ServiceInstanceSpec{
+			PlanReference: v1beta1.PlanReference{
+				ExternalClusterServiceClassName: testClusterServiceClassName,
+				ExternalClusterServicePlanName:  testPlanName,
+			},
+			ExternalID: testExternalID,
+		},
+	}
+
+	if _, err := client.ServiceInstances(testNamespace).Create(instance); err != nil {
+		t.Fatalf("error creating Instance: %v", err)
+	}
+
+	if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
+		Type:   v1beta1.ServiceInstanceConditionReady,
+		Status: v1beta1.ConditionTrue,
+	}); err != nil {
+		t.Fatalf("error waiting for instance to become ready: %v", err)
+	}
+
+	retInst, err := client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
+	}
+	if retInst.Spec.ExternalID != instance.Spec.ExternalID {
+		t.Fatalf(
+			"returned OSB GUID '%s' doesn't match original '%s'",
+			retInst.Spec.ExternalID,
+			instance.Spec.ExternalID,
+		)
+	}
+
+	// Binding test begins here
+	//-----------------
+	binding := &v1beta1.ServiceBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testBindingName},
+		Spec: v1beta1.ServiceBindingSpec{
+			ServiceInstanceRef: corev1.LocalObjectReference{
+				Name: testInstanceName,
+			},
+		},
+	}
+
+	_, err = client.ServiceBindings(testNamespace).Create(binding)
+	if err != nil {
+		t.Fatalf("error creating Binding: %v", binding)
+	}
+
+	if err := util.WaitForBindingReconciledGeneration(client, testNamespace, testBindingName, binding.Status.ReconciledGeneration+1); err != nil {
+		t.Fatalf("error waiting for binding to reconcile: %v", err)
+	}
+
+	retBinding, err := client.ServiceBindings(binding.Namespace).Get(binding.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting binding %s/%s back", binding.Namespace, binding.Name)
+	}
+
+	util.AssertServiceBindingCondition(
+		t,
+		retBinding,
+		v1beta1.ServiceBindingConditionReady,
+		v1beta1.ConditionFalse,
+		"OrphanMitigationSuccessful",
+	)
+
+	err = client.ServiceBindings(testNamespace).Delete(testBindingName, &metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("binding delete should have been accepted: %v", err)
+	}
+
+	err = util.WaitForBindingToNotExist(client, testNamespace, testBindingName)
+	if err != nil {
+		t.Fatalf("error waiting for binding to not exist: %v", err)
+	}
+
+	//-----------------
+	// End binding test
+
+	err = client.ServiceInstances(testNamespace).Delete(testInstanceName, &metav1.DeleteOptions{})
+	if nil != err {
+		t.Fatalf("instance delete should have been accepted: %v", err)
+	}
+
+	err = util.WaitForInstanceToNotExist(client, testNamespace, testInstanceName)
+	if err != nil {
+		t.Fatalf("error waiting for instance to be deleted: %v", err)
+	}
+
+	//-----------------
+	// End provision test
+
+	// Delete the broker
+	err = client.ClusterServiceBrokers().Delete(testBrokerName, &metav1.DeleteOptions{})
+	if nil != err {
+		t.Fatalf("broker should be deleted (%s)", err)
+	}
+
+	err = util.WaitForClusterServiceClassToNotExist(client, testClusterServiceClassName)
+	if err != nil {
+		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
+	}
+
+	err = util.WaitForBrokerToNotExist(client, testBrokerName)
+	if err != nil {
+		t.Fatalf("error waiting for Broker to not exist: %v", err)
+	}
+}
+
 // newTestController creates a new test controller injected with fake clients
 // and returns:
 //

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/golang/glog"
@@ -225,4 +226,68 @@ func WaitForBindingToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1
 			return false, nil
 		},
 	)
+}
+
+// WaitForBindingReconciledGeneration waits for the status of the named binding to
+// have the specified reconciled generation.
+func WaitForBindingReconciledGeneration(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, namespace, name string, reconciledGeneration int64) error {
+	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
+		func() (bool, error) {
+			glog.V(5).Infof("Waiting for binding %v/%v to have reconciled generation of %v", namespace, name, reconciledGeneration)
+			binding, err := client.ServiceBindings(namespace).Get(name, metav1.GetOptions{})
+			if nil != err {
+				return false, fmt.Errorf("error getting ServiceBinding %v/%v: %v", namespace, name, err)
+			}
+
+			fmt.Printf("BINDING: %+v\n\n\n", binding)
+
+			if binding.Status.ReconciledGeneration == reconciledGeneration {
+				return true, nil
+			}
+
+			return false, nil
+		},
+	)
+}
+
+// AssertServiceInstanceCondition asserts that the instance's status contains
+// the given condition type, status, and reason.
+func AssertServiceInstanceCondition(t *testing.T, instance *v1beta1.ServiceInstance, conditionType v1beta1.ServiceInstanceConditionType, status v1beta1.ConditionStatus, reason ...string) {
+	foundCondition := false
+	for _, condition := range instance.Status.Conditions {
+		if condition.Type == conditionType {
+			foundCondition = true
+			if condition.Status != status {
+				t.Fatalf("%v condition had unexpected status; expected %v, got %v", conditionType, status, condition.Status)
+			}
+			if len(reason) == 1 && condition.Reason != reason[0] {
+				t.Fatalf("unexpected reason; expected %v, got %v", reason[0], condition.Reason)
+			}
+		}
+	}
+
+	if !foundCondition {
+		t.Fatalf("%v condition not found", conditionType)
+	}
+}
+
+// AssertServiceBindingCondition asserts that the binding's status contains
+// the given condition type, status, and reason.
+func AssertServiceBindingCondition(t *testing.T, binding *v1beta1.ServiceBinding, conditionType v1beta1.ServiceBindingConditionType, status v1beta1.ConditionStatus, reason ...string) {
+	foundCondition := false
+	for _, condition := range binding.Status.Conditions {
+		if condition.Type == conditionType {
+			foundCondition = true
+			if condition.Status != status {
+				t.Fatalf("%v condition had unexpected status; expected %v, got %v", conditionType, status, condition.Status)
+			}
+			if len(reason) == 1 && condition.Reason != reason[0] {
+				t.Fatalf("unexpected reason; expected %v, got %v", reason[0], condition.Reason)
+			}
+		}
+	}
+
+	if !foundCondition {
+		t.Fatalf("%v condition not found", conditionType)
+	}
 }


### PR DESCRIPTION
The API server currently is validating that if `CurrentOperation` is set, `InProgressProperties` and `OperationStartTime` must both also be set. However, when orphan mitigation starts, we were clearing these two fields, causing the API server to reject the update request.

This PR makes starting orphan mitigation (for both instances and bindings) not clear `InProgressProperties` and makes the API server distinguish whether `OrphanMitigationInProgress` is set when evaluating the validity of `OperationStartTime`.

This adds unit tests; I'm currently writing an integration test, but was wanting to get eyes on this quickly since it's breaking functionality at the moment.

Closes: #1366 