### PR TITLE
remove internal instance poll method

### DIFF
--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -533,7 +533,7 @@ func isServiceInstanceFailed(instance *v1beta1.ServiceInstance) bool {
 // processed and should be resubmitted at a later time.
 func (c *controller) reconcileServiceInstance(instance *v1beta1.ServiceInstance) error {
 	if instance.Status.AsyncOpInProgress {
-		return c.pollServiceInstanceInternal(instance)
+		return c.pollServiceInstance(instance)
 	}
 
 	if instance.ObjectMeta.DeletionTimestamp != nil || instance.Status.OrphanMitigationInProgress {
@@ -1040,7 +1040,7 @@ func (c *controller) reconcileServiceInstance(instance *v1beta1.ServiceInstance)
 	return nil
 }
 
-func (c *controller) pollServiceInstanceInternal(instance *v1beta1.ServiceInstance) error {
+func (c *controller) pollServiceInstance(instance *v1beta1.ServiceInstance) error {
 	glog.V(4).Infof(
 		`%s "%s/%s": Processing`,
 		typeSI, instance.Namespace, instance.Name,
@@ -1050,10 +1050,7 @@ func (c *controller) pollServiceInstanceInternal(instance *v1beta1.ServiceInstan
 	if err != nil {
 		return err
 	}
-	return c.pollServiceInstance(serviceClass, servicePlan, brokerName, brokerClient, instance)
-}
 
-func (c *controller) pollServiceInstance(serviceClass *v1beta1.ClusterServiceClass, servicePlan *v1beta1.ClusterServicePlan, brokerName string, brokerClient osb.Client, instance *v1beta1.ServiceInstance) error {
 	// There are three possible operations that require polling:
 	// 1) Normal asynchronous provision
 	// 2) Normal asynchronous deprovision

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -1546,9 +1546,9 @@ func TestPollServiceInstanceInProgressProvisioningWithOperation(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	err := testController.pollServiceInstanceInternal(instance)
+	err := testController.pollServiceInstance(instance)
 	if err != nil {
-		t.Fatalf("pollServiceInstanceInternal failed: %s", err)
+		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
 	if testController.pollingQueue.NumRequeues(instanceKey) != 1 {
@@ -1603,9 +1603,9 @@ func TestPollServiceInstanceSuccessProvisioningWithOperation(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	err := testController.pollServiceInstanceInternal(instance)
+	err := testController.pollServiceInstance(instance)
 	if err != nil {
-		t.Fatalf("pollServiceInstanceInternal failed: %s", err)
+		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
 	if testController.pollingQueue.NumRequeues(instanceKey) != 0 {
@@ -1657,9 +1657,9 @@ func TestPollServiceInstanceFailureProvisioningWithOperation(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	err := testController.pollServiceInstanceInternal(instance)
+	err := testController.pollServiceInstance(instance)
 	if err != nil {
-		t.Fatalf("pollServiceInstanceInternal failed: %s", err)
+		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
 	if testController.pollingQueue.NumRequeues(instanceKey) != 0 {
@@ -1719,9 +1719,9 @@ func TestPollServiceInstanceInProgressDeprovisioningWithOperationNoFinalizer(t *
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	err := testController.pollServiceInstanceInternal(instance)
+	err := testController.pollServiceInstance(instance)
 	if err != nil {
-		t.Fatalf("pollServiceInstanceInternal failed: %s", err)
+		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
 	if testController.pollingQueue.NumRequeues(instanceKey) != 1 {
@@ -1776,9 +1776,9 @@ func TestPollServiceInstanceSuccessDeprovisioningWithOperationNoFinalizer(t *tes
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	err := testController.pollServiceInstanceInternal(instance)
+	err := testController.pollServiceInstance(instance)
 	if err != nil {
-		t.Fatalf("pollServiceInstanceInternal failed: %s", err)
+		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
 	if testController.pollingQueue.NumRequeues(instanceKey) != 0 {
@@ -1837,9 +1837,9 @@ func TestPollServiceInstanceFailureDeprovisioningWithOperation(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	err := testController.pollServiceInstanceInternal(instance)
+	err := testController.pollServiceInstance(instance)
 	if err != nil {
-		t.Fatalf("pollServiceInstanceInternal failed: %s", err)
+		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
 	if testController.pollingQueue.NumRequeues(instanceKey) != 0 {
@@ -1906,9 +1906,9 @@ func TestPollServiceInstanceStatusGoneDeprovisioningWithOperationNoFinalizer(t *
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	err := testController.pollServiceInstanceInternal(instance)
+	err := testController.pollServiceInstance(instance)
 	if err != nil {
-		t.Fatalf("pollServiceInstanceInternal failed: %s", err)
+		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
 	if testController.pollingQueue.NumRequeues(instanceKey) != 0 {
@@ -1967,9 +1967,9 @@ func TestPollServiceInstanceClusterServiceBrokerError(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	err := testController.pollServiceInstanceInternal(instance)
+	err := testController.pollServiceInstance(instance)
 	if err != nil {
-		t.Fatalf("pollServiceInstanceInternal failed: %v", err)
+		t.Fatalf("pollServiceInstance failed: %v", err)
 	}
 
 	if testController.pollingQueue.NumRequeues(instanceKey) != 1 {
@@ -2030,9 +2030,9 @@ func TestPollServiceInstanceSuccessDeprovisioningWithOperationWithFinalizer(t *t
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	err := testController.pollServiceInstanceInternal(instance)
+	err := testController.pollServiceInstance(instance)
 	if err != nil {
-		t.Fatalf("pollServiceInstanceInternal failed: %s", err)
+		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
 	if testController.pollingQueue.NumRequeues(instanceKey) != 0 {
@@ -2225,8 +2225,8 @@ func TestPollServiceInstanceSuccessOnFinalRetry(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	if err := testController.pollServiceInstanceInternal(instance); err != nil {
-		t.Fatalf("pollServiceInstanceInternal failed: %s", err)
+	if err := testController.pollServiceInstance(instance); err != nil {
+		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
 	if testController.pollingQueue.NumRequeues(instanceKey) != 0 {
@@ -2280,7 +2280,7 @@ func TestPollServiceInstanceFailureOnFinalRetry(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	if err := testController.pollServiceInstanceInternal(instance); err != nil {
+	if err := testController.pollServiceInstance(instance); err != nil {
 		t.Fatalf("Should have return no error because the retry duration has elapsed: %v", err)
 	}
 
@@ -2805,9 +2805,9 @@ func TestPollInstanceUsingOriginatingIdentity(t *testing.T) {
 				instance.Spec.UserInfo = testUserInfo
 			}
 
-			err := testController.pollServiceInstanceInternal(instance)
+			err := testController.pollServiceInstance(instance)
 			if err != nil {
-				t.Fatalf("Expected pollServiceInstanceInternal to not fail while in progress")
+				t.Fatalf("Expected pollServiceInstance to not fail while in progress")
 			}
 
 			brokerActions := fakeBrokerClient.Actions()
@@ -4052,9 +4052,9 @@ func TestPollServiceInstanceAsyncInProgressUpdating(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	err := testController.pollServiceInstanceInternal(instance)
+	err := testController.pollServiceInstance(instance)
 	if err != nil {
-		t.Fatalf("pollServiceInstanceInternal failed: %s", err)
+		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
 	if testController.pollingQueue.NumRequeues(instanceKey) != 1 {
@@ -4109,9 +4109,9 @@ func TestPollServiceInstanceAsyncSuccessUpdating(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	err := testController.pollServiceInstanceInternal(instance)
+	err := testController.pollServiceInstance(instance)
 	if err != nil {
-		t.Fatalf("pollServiceInstanceInternal failed: %s", err)
+		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
 	if testController.pollingQueue.NumRequeues(instanceKey) != 0 {
@@ -4163,9 +4163,9 @@ func TestPollServiceInstanceAsyncFailureUpdating(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	err := testController.pollServiceInstanceInternal(instance)
+	err := testController.pollServiceInstance(instance)
 	if err != nil {
-		t.Fatalf("pollServiceInstanceInternal failed: %s", err)
+		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
 	if testController.pollingQueue.NumRequeues(instanceKey) != 0 {


### PR DESCRIPTION
Small change. There are currently two poll methods for instances, with one designated internal. Only one is used, so just consolidate them into one.