### PR TITLE
update comment for instance generation check

### DIFF
--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -513,19 +513,9 @@ func (c *controller) reconcileServiceInstance(instance *v1beta1.ServiceInstance)
 		return nil
 	}
 
-	// If there's no async op in progress, determine whether there is a new
-	// generation of the object. If the instance's generation does not match
-	// the reconciled generation, then there is a new generation, indicating
-	// that changes have been made to the instance's spec. If there is an
-	// async op in progress, we need to keep polling, hence do not bail if
-	// there is not a new generation.
-	//
-	// Note: currently the instance spec is immutable because we do not yet
-	// support plan or parameter updates.  This logic is currently meant only
-	// to facilitate re-trying provision requests where there was a problem
-	// communicating with the broker.  In the future the same logic will
-	// result in an instance that requires update being processed by the
-	// controller.
+	// If the instance's "metadata.generation" matches its
+	// "status.reconciledGeneration", then no new changes have been made to
+	// the instance's spec, and we can just return.
 	if instance.Status.ReconciledGeneration == instance.Generation {
 		glog.V(4).Infof(
 			`ServiceInstance "%s/%s": Not processing event because reconciled generation showed there is no work to do`,


### PR DESCRIPTION
The comment here does not match the current state of the world where updates are supported and async operations are dealt with before creation/updates.