### PR TITLE
differentiate between failed updates and provisions during deletion

### DIFF
--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -250,11 +250,11 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1beta1.ServiceIns
 
 	// If there is no op in progress, and the instance either was never
 	// provisioned or was already deprovisioned due to orphan mitigation,
-	// we can just clear the finalizer and delete. One possible  scenario
-	// is if  the service class name referenced never existed.
-	if !instance.Status.AsyncOpInProgress &&
-		!instance.Status.OrphanMitigationInProgress &&
-		(isServiceInstanceFailed(instance) || instance.Status.ReconciledGeneration == 0) {
+	// we can just clear the finalizer and delete. One possible scenario
+	// is if the service class name referenced never existed.
+	if instance.Status.CurrentOperation == "" &&
+		instance.Status.ReconciledGeneration == 0 ||
+		(isServiceInstanceFailed(instance) && instance.Status.ReconciledGeneration == 1) {
 
 		glog.V(5).Infof(`ServiceInstance "%s/%s": Clearing catalog finalizer`, instance.Namespace, instance.Name)
 		clone, err := api.Scheme.DeepCopy(instance)


### PR DESCRIPTION
Currently, we assume that a failed instance had failed during provision, which either would have never been provisioned at all, or would have been cleaned up via orphan mitigation, so during deletion we just remove the finalizer.

However, with the addition of updates, we must also consider the situation where an update has failed but the instance was still provisioned successfully earlier.