### PR TITLE
update OSB client to 2.13

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 39183edc8f22afb55e916e80f27605e49a01be2b61b9a33f12289deac66aa4af
-updated: 2017-10-10T10:29:07.829903971+11:00
+hash: 136f4ca30d35d8db275ed74b9bba9a682b95de829d8383b2ab2f399af4ff7525
+updated: 2017-10-13T11:16:36.881475637-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -253,7 +253,7 @@ imports:
 - name: github.com/pkg/errors
   version: a22138067af1c4942683050411a841ade67fe1eb
 - name: github.com/pmorie/go-open-service-broker-client
-  version: 962a416798366b37a20a06fdb0a09180589ca964
+  version: 530248ec023d52217c43db2f06fa03ce844c40cc
   subpackages:
   - v2
   - v2/fake

--- a/glide.yaml
+++ b/glide.yaml
@@ -88,4 +88,4 @@ import:
 - package: code.cloudfoundry.org/lager
   version: dfcbcba2dd4a5228c43b0292d219d5c010daed3a
 - package: github.com/pmorie/go-open-service-broker-client
-  version: 962a416798366b37a20a06fdb0a09180589ca964
+  version: 530248ec023d52217c43db2f06fa03ce844c40cc

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -584,7 +584,7 @@ func convertClusterServicePlans(plans []osb.Plan, serviceClassID string) ([]*v1b
 			servicePlans[i].Spec.ExternalMetadata = &runtime.RawExtension{Raw: metadata}
 		}
 
-		if schemas := plan.AlphaParameterSchemas; schemas != nil {
+		if schemas := plan.ParameterSchemas; schemas != nil {
 			if instanceSchemas := schemas.ServiceInstances; instanceSchemas != nil {
 				if instanceCreateSchema := instanceSchemas.Create; instanceCreateSchema != nil && instanceCreateSchema.Parameters != nil {
 					schema, err := json.Marshal(instanceCreateSchema.Parameters)

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -1743,7 +1743,7 @@ func TestReconcileBindingUsingOriginatingIdentity(t *testing.T) {
 				t.Errorf("%v: unexpected request type; expected %T, got %T", tc.name, &osb.BindRequest{}, actualRequest)
 				return
 			}
-			var expectedOriginatingIdentity *osb.AlphaOriginatingIdentity
+			var expectedOriginatingIdentity *osb.OriginatingIdentity
 			if tc.expectedOriginatingIdentity {
 				expectedOriginatingIdentity = testOriginatingIdentity
 			}
@@ -1794,7 +1794,7 @@ func TestReconcileBindingDeleteUsingOriginatingIdentity(t *testing.T) {
 				t.Errorf("%v: unexpected request type; expected %T, got %T", tc.name, &osb.UnbindRequest{}, actualRequest)
 				return
 			}
-			var expectedOriginatingIdentity *osb.AlphaOriginatingIdentity
+			var expectedOriginatingIdentity *osb.OriginatingIdentity
 			if tc.expectedOriginatingIdentity {
 				expectedOriginatingIdentity = testOriginatingIdentity
 			}

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -702,7 +702,7 @@ func (c *controller) reconcileServiceInstance(instance *v1beta1.ServiceInstance)
 		UserInfo:                       instance.Spec.UserInfo,
 	}
 
-	var originatingIdentity *osb.AlphaOriginatingIdentity
+	var originatingIdentity *osb.OriginatingIdentity
 	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {
 		originatingIdentity, err = buildOriginatingIdentity(instance.Spec.UserInfo)
 		if err != nil {

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -2716,7 +2716,7 @@ func TestReconcileInstanceUsingOriginatingIdentity(t *testing.T) {
 				t.Errorf("%v: unexpected request type; expected %T, got %T", tc.name, &osb.ProvisionRequest{}, actualRequest)
 				return
 			}
-			var expectedOriginatingIdentity *osb.AlphaOriginatingIdentity
+			var expectedOriginatingIdentity *osb.OriginatingIdentity
 			if tc.expectedOriginatingIdentity {
 				expectedOriginatingIdentity = testOriginatingIdentity
 			}
@@ -2770,7 +2770,7 @@ func TestReconcileInstanceDeleteUsingOriginatingIdentity(t *testing.T) {
 				t.Errorf("%v: unexpected request type; expected %T, got %T", tc.name, &osb.DeprovisionRequest{}, actualRequest)
 				return
 			}
-			var expectedOriginatingIdentity *osb.AlphaOriginatingIdentity
+			var expectedOriginatingIdentity *osb.OriginatingIdentity
 			if tc.expectedOriginatingIdentity {
 				expectedOriginatingIdentity = testOriginatingIdentity
 			}
@@ -2817,7 +2817,7 @@ func TestPollInstanceUsingOriginatingIdentity(t *testing.T) {
 				t.Errorf("%v: unexpected request type; expected %T, got %T", tc.name, &osb.LastOperationRequest{}, actualRequest)
 				return
 			}
-			var expectedOriginatingIdentity *osb.AlphaOriginatingIdentity
+			var expectedOriginatingIdentity *osb.OriginatingIdentity
 			if tc.expectedOriginatingIdentity {
 				expectedOriginatingIdentity = testOriginatingIdentity
 			}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -350,7 +350,7 @@ const testOriginatingIdentityValue = `{
 	"fakekey": ["fakevalue"]
 }`
 
-var testOriginatingIdentity = &osb.AlphaOriginatingIdentity{
+var testOriginatingIdentity = &osb.OriginatingIdentity{
 	Platform: originatingIdentityPlatform,
 	Value:    testOriginatingIdentityValue,
 }
@@ -775,7 +775,7 @@ func TestCatalogConversion(t *testing.T) {
 	checkPlan(servicePlans[1], "0f4008b5-XXXX-XXXX-XXXX-dace631cd648", "fake-plan-2", "Shared fake Server, 5tb persistent disk, 40 max concurrent connections. 100 async", t)
 }
 
-func TestCatalogConversionWithAlphaParameterSchemas(t *testing.T) {
+func TestCatalogConversionWithParameterSchemas(t *testing.T) {
 	catalog := &osb.CatalogResponse{}
 	err := json.Unmarshal([]byte(alphaParameterSchemaCatalogBytes), &catalog)
 	if err != nil {
@@ -2473,7 +2473,7 @@ func assertUnbind(t *testing.T, action fakeosb.Action, request *osb.UnbindReques
 	}
 }
 
-func assertOriginatingIdentity(t *testing.T, expected *osb.AlphaOriginatingIdentity, actual *osb.AlphaOriginatingIdentity) {
+func assertOriginatingIdentity(t *testing.T, expected *osb.OriginatingIdentity, actual *osb.OriginatingIdentity) {
 	if e, a := expected, actual; (e != nil) != (a != nil) {
 		fatalf(t, "unexpected originating identity in request: expected %q, got %q", e, a)
 	}

--- a/pkg/controller/originating_identity.go
+++ b/pkg/controller/originating_identity.go
@@ -30,7 +30,7 @@ const (
 	originatingIdentityGroups   = "groups"
 )
 
-func buildOriginatingIdentity(userInfo *v1beta1.UserInfo) (*osb.AlphaOriginatingIdentity, error) {
+func buildOriginatingIdentity(userInfo *v1beta1.UserInfo) (*osb.OriginatingIdentity, error) {
 	if userInfo == nil {
 		return nil, nil
 	}
@@ -45,7 +45,7 @@ func buildOriginatingIdentity(userInfo *v1beta1.UserInfo) (*osb.AlphaOriginating
 	if err != nil {
 		return nil, err
 	}
-	oi := &osb.AlphaOriginatingIdentity{
+	oi := &osb.OriginatingIdentity{
 		Platform: originatingIdentityPlatform,
 		Value:    string(oiValue),
 	}

--- a/vendor/github.com/pmorie/go-open-service-broker-client/.travis.yml
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/.travis.yml
@@ -4,4 +4,6 @@ go:
   - 1.7.4
 before_install:
   - go get github.com/mattn/goveralls
-script: "go build ./... && go test ./... && $HOME/gopath/bin/goveralls -service=travis-ci"
+before_script:
+  - gofmt -d .  
+script: "go build ./... && go test ./... && $HOME/gopath/bin/goveralls -service=travis-ci"                                

--- a/vendor/github.com/pmorie/go-open-service-broker-client/README.md
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/pmorie/go-open-service-broker-client.svg?branch=master)](https://travis-ci.org/pmorie/go-open-service-broker-client)
 [![Coverage Status](https://coveralls.io/repos/github/pmorie/go-open-service-broker-client/badge.svg)](https://coveralls.io/github/pmorie/go-open-service-broker-client)
+[![Go Report Card](https://goreportcard.com/badge/github.com/pmorie/go-open-service-broker-client)](https://goreportcard.com/report/github.com/pmorie/go-open-service-broker-client)
+[![Godoc documentation](https://img.shields.io/badge/godoc-documentation-blue.svg)](https://godoc.org/github.com/pmorie/go-open-service-broker-client)
 
 A golang client for communicating with service brokers implementing the
 [Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker).
@@ -36,6 +38,7 @@ func GetBrokerCatalog(URL string) (*osb.CatalogResponse, error) {
 This client library supports the following versions of the
 [Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker):
 
+- [v2.13](https://github.com/openservicebrokerapi/servicebroker/tree/v2.13)
 - [v2.12](https://github.com/openservicebrokerapi/servicebroker/tree/v2.12)
 - [v2.11](https://github.com/openservicebrokerapi/servicebroker/tree/v2.11)
 

--- a/vendor/github.com/pmorie/go-open-service-broker-client/docs/README.md
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/docs/README.md
@@ -22,10 +22,352 @@ recommended before reading this documentation.
 
 There are 7 operations in the API:
 
-1.  Getting a broker's 'catalog' of services `Client.GetCatalog`
-2.  Provisioning a new instance of a service `Client.ProvisionInstance`
-3.  Updating properties of an instance `Client.UpdateInstance`
-4.  Deprovisioning an instance `Client.DeprovisionInstance`
-5.  Checking the status of an asynchronous operation (provision, update, or deprovision) on an instance `Client.PollLastOperation`
-6.  Binding to an instance `Client.Bind`
-7.  Unbinding from an instance `Client.Unbind`
+1.  Getting a broker's 'catalog' of services: [`Client.GetCatalog`](#getting-a-brokers-catalog)
+2.  Provisioning a new instance of a service: [`Client.ProvisionInstance`](#provisioning-a-new-instance-of-a-service)
+3.  Updating properties of an instance: [`Client.UpdateInstance`](#updating-properties-of-an-instance)
+4.  Deprovisioning an instance: [`Client.DeprovisionInstance`](#deprovisioning-an-instance)
+5.  Checking the status of an asynchronous operation (provision, update, or deprovision) on an instance: [`Client.PollLastOperation`](#provisioning-a-new-instance-of-a-service)
+6.  Binding to an instance: [`Client.Bind`](#binding-to-an-instance)
+7.  Unbinding from an instance: [`Client.Unbind`](#unbinding-from-an-instance)
+
+### Getting a broker's catalog
+
+A broker's catalog holds information about the services a broker provides and
+their plans.  A platform implementing the OSB API must first get the broker's
+catalog.
+
+```go
+import (
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+)
+
+func GetBrokerCatalog(URL string) (*osb.CatalogResponse, error) {
+	config := osb.DefaultClientConfiguration()
+	config.URL = URL
+
+	client, err := osb.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.GetCatalog()
+}
+```
+
+### Provisioning a new instance of a service
+
+To provision a new instance of a service, call the `Client.Provision` method.
+
+Key points:
+
+1. `ProvisionInstance` returns a response from the broker for successful
+   operations, or an error if the broker returned an error response or
+   there was a problem communicating with the broker
+2. Use the `IsHTTPError` method to test and convert errors from Brokers
+   into the standard broker error type, allowing access to conventional
+   broker-provided fields
+3. The `response.Async` field indicates whether the broker is performing the
+   provision concurrently; see the [`LastOperation`](#checking-the-status-of-an-async-operation)
+   method for information about handling asynchronous operations
+
+```go
+import (
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+)
+
+func ProvisionService(client osb.Client, request osb.ProvisionRequest) (*osb.CatalogResponse, error) {
+	request := &ProvisionRequest{
+		InstanceID: "my-dbaas-service-instance",
+
+		// Made up parameters for a hypothetical service
+		ServiceID: "dbaas-service",
+		PlanID:    "dbaas-gold-plan",
+		Parameters: map[string]interface{}{
+			"tablespace-page-cost":      100,
+			"tablespace-io-concurrency": 5,
+		},
+
+		// Set the AcceptsIncomplete field to indicate that this client can
+		// support asynchronous operations (provision, update, deprovision).
+		AcceptsIncomplete: true,
+	}
+
+	// ProvisionInstance returns a response from the broker for successful
+	// operations, or an error if the broker returned an error response or
+	// there was a problem communicating with the broker.
+	resp, err := client.ProvisionInstance(request)
+	if err != nil {
+		// Use the IsHTTPError method to test and convert errors from Brokers
+		// into the standard broker error type, allowing access to conventional
+		// broker-provided fields.
+		errHttp, isError := osb.IsHTTPError(err)
+		if isError {
+			// handle error response from broker
+		} else {
+			// handle errors communicating with the broker
+		}
+	}
+
+	// The response.Async field indicates whether the broker is performing the
+	// provision concurrently.  See the LastOperation method for information
+	// about handling asynchronous operations.
+	if response.Async {
+		// handle asynchronous operation
+	}
+}
+```
+
+### Updating properties of an instance
+
+To update the plan and/or parameters of a service instance, call the `UpdateInstance` method.
+
+Key points:
+
+1. A service's plan may be changed only if that service is `PlanUpdatable`
+2. `UpdateInstance` returns a response from the broker for successful
+   operations, or an error if the broker returned an error response or
+   there was a problem communicating with the broker
+3. Use the `IsHTTPError` method to test and convert errors from Brokers
+   into the standard broker error type, allowing access to conventional
+   broker-provided fields
+4. The `response.Async` field indicates whether the broker is performing the
+   provision concurrently; see the [`LastOperation`](#checking-the-status-of-an-async-operation)
+   method for information about handling asynchronous operations
+5. Passing `PlanID` or `Parameters` fields to this operation indicates
+   that the user wishes to update those fields; values for these fields
+   should not be passed if those fields have not changed
+
+```go
+import (
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+)
+
+func UpdateService(client osb.Client) {
+	newPlan := "dbaas-quadruple-plan",
+
+	request := &osb.UpdateInstanceRequest{
+		InstanceID:        "my-dbaas-service-instance",
+		ServiceID:         "dbaas-service",
+		AcceptsIncomplete: true,
+
+		// Passing the plan indicates that the user
+		// wants the plan to change.
+		PlanID: &newPlan,
+
+		// Passing a parameter indicates that the user
+		// wants the parameter value to change.
+		Parameters: map[string]interface{}{
+			"tablespace-page-cost":      50,
+			"tablespace-io-concurrency": 100,
+		},
+	}
+
+	response, err := client.UpdateInstance(request)
+	if err != nil {
+		httpErr, isError := osb.IsHTTPError(err)
+		if isError {
+			// handle errors from broker
+		} else {
+			// handle errors communicating with broker
+		}
+	}
+
+	if response.Async {
+		// handle asynchronous update operation
+	} else {
+		// handle successful update
+	}
+}
+```
+
+### Deprovisioning an instance
+
+To deprovision a service instance, call the `DeprovisionInstance` method.
+
+Key points:
+
+1. `DeprovisionInstance` returns a response from the broker for successful
+   operations, or an error if the broker returned an error response or
+   there was a problem communicating with the broker
+2. Use the `IsHTTPError` method to test and convert errors from Brokers
+   into the standard broker error type, allowing access to conventional
+   broker-provided fields
+3. An HTTP `Gone` response is equivalent to success -- use `IsGoneError` to
+   test for this condition
+4. The `response.Async` field indicates whether the broker is performing the
+   deprovision concurrently; see the [`LastOperation`](#checking-the-status-of-an-async-operation)
+   method for information about handling asynchronous operations
+
+```go
+import (
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+)
+
+func DeprovisionService(client osb.Client) {
+	request := &osb.DeprovisionRequest{
+		InstanceID:        "my-dbaas-service-instance",
+		ServiceID:         "dbaas-service",
+		PlanID:            "dbaas-gold-plan",
+		AcceptsIncomplete: true,
+	}
+
+	response, err := client.DeprovisionInstance(request)
+	if err != nil {
+		httpErr, isError := osb.IsHTTPError(err)
+		if isError {
+			// handle errors from broker
+
+			if osb.IsGoneError(httpErr) {
+				// A 'gone' status code means that the service instance
+				// doesn't exist.  This means there is no more work to do and
+				// should be equivalent to a success.
+			}
+		} else {
+			// handle errors communicating with broker
+		}
+	}
+
+	if response.Async {
+		// handle asynchronous deprovisions
+	} else {
+		// handle successful deprovision
+	}
+}
+```
+
+### Checking the status of an asynchronous operation
+
+If the client returns a response from [`ProvisionInstance`](#provisioning-a-new-instance-of-a-service),
+[`UpdateInstance`](#updating-properties-of-an-instance), or
+[`DeprovisionInstance`](#deprovisioning-an-instance) with the `response.Async`
+field set to true, it means the broker is executing the operation
+asynchronously.  You must call the `PollLastOperation` method on the client to
+check on the status of the operation.
+
+```go
+import (
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+)
+
+func PollServiceInstance(client osb.Client, deleting bool) error {
+	request := &osb.LastOperationRequest{
+		InstanceID: "my-dbaas-service-instance"
+		ServiceID:  "dbaas-service",
+		PlanID:     "dbaas-gold-plan",
+
+		// Brokers may provide an identifying key for an asychronous operation.
+		OperationKey: osb.OperationKey("12345")
+	}
+	
+	response, err := client.PollLastOperation(request)
+	if err != nil {
+		// If the operation was for delete and we receive a http.StatusGone,
+		// this is considered a success as per the spec.
+		if osb.IsGoneError(err) && deleting {
+			// handle instances that we were deprovisioning and that are now
+			// gone
+		}
+
+		// The broker returned an error.  While polling last operation, this
+		// represents an invalid response and callers should continue polling
+		// last operation.
+	}
+
+	switch response.State {
+	case osb.StateInProgress:
+		// The operation is still in progress
+	case osb.StateSucceeded:
+		// The operation succeeded
+	case osb.StateFailed:
+		// The operation failed.
+	}
+}
+
+```
+
+### Binding to an instance
+
+To create a new binding to an instance, call the `Bind` method.
+
+Key points:
+
+1. `Bind` returns a response from the broker for successful
+   operations, or an error if the broker returned an error response or
+   there was a problem communicating with the broker
+2. Use the `IsHTTPError` method to test and convert errors from Brokers
+   into the standard broker error type, allowing access to conventional
+   broker-provided fields
+
+```go
+import (
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+)
+
+func BindToInstance(client osb.Client) {
+	request := &osb.BindRequest{
+		BindingID:  "binding-id",
+		InstanceID: "instance-id",
+		ServiceID:  "dbaas-service",
+		PlanID:     "dbaas-gold-plan",
+
+		// platforms might want to pass an identifier for applications here
+		AppGUID: "app-guid",
+
+		// pass parameters here
+		Parameters: map[string]interface{}{},
+	}
+
+	response, err := brokerClient.Bind(request)
+	if err != nil {
+		httpErr, isError := osb.IsHTTPError(err)
+		if isError {
+			// handle errors from the broker
+		} else {
+			// handle errors communicating with the broker
+		}
+	}
+
+	// do something with the credentials
+}
+```
+
+### Unbinding from an instance
+
+To unbind from a service instance, call the `Unbind` method.
+
+Key points:
+
+1. `Unbind` returns a response from the broker for successful
+   operations, or an error if the broker returned an error response or
+   there was a problem communicating with the broker
+2. Use the `IsHTTPError` method to test and convert errors from Brokers
+   into the standard broker error type, allowing access to conventional
+   broker-provided fields
+
+```go
+import (
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+)
+
+func UnbindFromInstance(client osb.Client) {
+	request := &osb.UnbindRequest{
+		BindingID:  "binding-id",
+		InstanceID: "instance-id",
+		ServiceID:  "dbaas-service",
+		PlanID:     "dbaas-gold-plan",
+		AppGUID: "app-guid",
+	}
+
+	response, err := brokerClient.Unbind(request)
+	if err != nil {
+		httpErr, isError := osb.IsHTTPError(err)
+		if isError {
+			// handle errors from the broker
+		} else {
+			// handle errors communicating with the broker
+		}
+	}
+
+	// handle successful unbind
+}
+```

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/auth_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/auth_test.go
@@ -64,15 +64,15 @@ func addBasicAuthCheck(t *testing.T, name string, authConfig *BasicAuthConfig, f
 		u, p, ok := request.BasicAuth()
 		if !ok && authConfig != nil {
 			t.Errorf("%s: Expected basic auth in request but none found", name)
-			return nil, walkingGhostErr
+			return nil, errWalkingGhost
 		} else if ok && authConfig != nil {
 			if u != authConfig.Username {
 				t.Errorf("%s: basic auth username test failed: expected %q but got %q", name, authConfig.Username, u)
-				return nil, walkingGhostErr
+				return nil, errWalkingGhost
 			}
 			if p != authConfig.Password {
 				t.Errorf("%s: basic auth password test failed: expected %q but got %q", name, authConfig.Password, p)
-				return nil, walkingGhostErr
+				return nil, errWalkingGhost
 			}
 		}
 
@@ -86,18 +86,18 @@ func addBearerAuthCheck(t *testing.T, name string, authConfig *BearerConfig, f d
 		if auth == "" {
 			if authConfig != nil {
 				t.Errorf("%s: Expected bearer auth in request but none found", name)
-				return nil, walkingGhostErr
+				return nil, errWalkingGhost
 			}
 			return f(request)
 		}
 		token, ok := parseBearerToken(auth)
 		if !ok && authConfig != nil {
 			t.Errorf("%s: Expected bearer auth in request but none found", name)
-			return nil, walkingGhostErr
+			return nil, errWalkingGhost
 		} else if ok && authConfig != nil {
 			if token != authConfig.Token {
 				t.Errorf("%s: bearer token test failed: expected %q but got %q", name, authConfig.Token, token)
-				return nil, walkingGhostErr
+				return nil, errWalkingGhost
 			}
 		}
 

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/bind.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/bind.go
@@ -12,6 +12,7 @@ type bindRequestBody struct {
 	PlanID       string                 `json:"plan_id"`
 	Parameters   map[string]interface{} `json:"parameters,omitempty"`
 	BindResource map[string]interface{} `json:"bind_resource,omitempty"`
+	Context      map[string]interface{} `json:"context,omitempty"`
 }
 
 const (
@@ -30,6 +31,10 @@ func (c *client) Bind(r *BindRequest) (*BindResponse, error) {
 		ServiceID:  r.ServiceID,
 		PlanID:     r.PlanID,
 		Parameters: r.Parameters,
+	}
+
+	if c.APIVersion.AtLeast(Version2_13()) {
+		requestBody.Context = r.Context
 	}
 
 	if r.BindResource != nil {
@@ -58,8 +63,6 @@ func (c *client) Bind(r *BindRequest) (*BindResponse, error) {
 	default:
 		return nil, c.handleFailureResponse(response)
 	}
-
-	return nil, nil
 }
 
 func validateBindRequest(request *BindRequest) error {

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/client.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/client.go
@@ -18,10 +18,11 @@ import (
 )
 
 const (
-	// XBrokerAPIVersion is the header for the Open Service Broker API
-	// version.
+	// APIVersionHeader is the header value associated with the version of the Open
+	// Service Broker API version.
 	APIVersionHeader = "X-Broker-API-Version"
-	// XBrokerAPIOriginatingIdentity is the header for the originating identity
+	// OriginatingIdentityHeader is the header associated with originating
+	// identity.
 	OriginatingIdentityHeader = "X-Broker-API-Originating-Identity"
 
 	catalogURL            = "%s/v2/catalog"
@@ -119,7 +120,7 @@ const (
 // message body, and executes the request, returning an http.Response or an
 // error.  Errors returned from this function represent http-layer errors and
 // not errors in the Open Service Broker API.
-func (c *client) prepareAndDo(method, URL string, params map[string]string, body interface{}, originatingIdentity *AlphaOriginatingIdentity) (*http.Response, error) {
+func (c *client) prepareAndDo(method, URL string, params map[string]string, body interface{}, originatingIdentity *OriginatingIdentity) (*http.Response, error) {
 	var bodyReader io.Reader
 
 	if body != nil {
@@ -151,7 +152,7 @@ func (c *client) prepareAndDo(method, URL string, params map[string]string, body
 		}
 	}
 
-	if c.EnableAlphaFeatures && originatingIdentity != nil {
+	if c.APIVersion.AtLeast(Version2_13()) && originatingIdentity != nil {
 		headerValue, err := buildOriginatingIdentityHeaderValue(originatingIdentity)
 		if err != nil {
 			return nil, err
@@ -214,7 +215,7 @@ func (c *client) handleFailureResponse(response *http.Response) error {
 	}
 }
 
-func buildOriginatingIdentityHeaderValue(i *AlphaOriginatingIdentity) (string, error) {
+func buildOriginatingIdentityHeaderValue(i *OriginatingIdentity) (string, error) {
 	if i == nil {
 		return "", nil
 	}

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/client_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/client_test.go
@@ -10,11 +10,6 @@ import (
 	"testing"
 )
 
-// func init() {
-// 	flag.Set("alsologtostderr", "true")
-// 	flag.Set("v", "5")
-// }
-
 const malformedResponse = `{`
 
 const conventionalFailureResponseBody = `{
@@ -28,12 +23,12 @@ const (
 	testOriginatingIdentityHeaderValue = "fakeplatform eyJ1c2VyIjoibmFtZSJ9"
 )
 
-var testOriginatingIdentity *AlphaOriginatingIdentity = &AlphaOriginatingIdentity{
+var testOriginatingIdentity = &OriginatingIdentity{
 	Platform: testOriginatingIdentityPlatform,
 	Value:    testOriginatingIdentityValue,
 }
 
-func testHttpStatusCodeError() error {
+func testHTTPStatusCodeError() error {
 	errorMessage := "TestError"
 	description := "test error description"
 	return HTTPStatusCodeError{
@@ -87,20 +82,20 @@ func newTestClient(t *testing.T, name string, version APIVersion, enableAlpha bo
 	}
 }
 
-var walkingGhostErr = fmt.Errorf("test has already failed")
+var errWalkingGhost = fmt.Errorf("test has already failed")
 
 func doHTTP(t *testing.T, name string, checks httpChecks, reaction httpReaction) func(*http.Request) (*http.Response, error) {
 	return func(request *http.Request) (*http.Response, error) {
 		if len(checks.URL) > 0 && checks.URL != request.URL.Path {
 			t.Errorf("%v: unexpected URL; expected %v, got %v", name, checks.URL, request.URL.Path)
-			return nil, walkingGhostErr
+			return nil, errWalkingGhost
 		}
 
 		for k, v := range checks.headers {
 			actualValue := request.Header.Get(k)
 			if e, a := v, actualValue; e != a {
 				t.Errorf("%v: unexpected header value for key %q; expected %v, got %v", name, k, e, a)
-				return nil, walkingGhostErr
+				return nil, errWalkingGhost
 			}
 		}
 
@@ -108,7 +103,7 @@ func doHTTP(t *testing.T, name string, checks httpChecks, reaction httpReaction)
 			actualValue := request.URL.Query().Get(k)
 			if e, a := v, actualValue; e != a {
 				t.Errorf("%v: unexpected parameter value for key %q; expected %v, got %v", name, k, e, a)
-				return nil, walkingGhostErr
+				return nil, errWalkingGhost
 			}
 		}
 
@@ -118,13 +113,13 @@ func doHTTP(t *testing.T, name string, checks httpChecks, reaction httpReaction)
 			bodyBytes, err = ioutil.ReadAll(request.Body)
 			if err != nil {
 				t.Errorf("%v: error reading request body bytes: %v", name, err)
-				return nil, walkingGhostErr
+				return nil, errWalkingGhost
 			}
 		}
 
 		if e, a := checks.body, string(bodyBytes); e != a {
 			t.Errorf("%v: unexpected request body: expected %v, got %v", name, e, a)
-			return nil, walkingGhostErr
+			return nil, errWalkingGhost
 		}
 
 		return &http.Response{
@@ -186,7 +181,7 @@ func TestBuildOriginatingIdentityHeaderValue(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		originatingIdentity := &AlphaOriginatingIdentity{
+		originatingIdentity := &OriginatingIdentity{
 			Platform: tc.platform,
 			Value:    tc.value,
 		}

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/deprovision_instance.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/deprovision_instance.go
@@ -29,6 +29,12 @@ func (c *client) DeprovisionInstance(r *DeprovisionRequest) (*DeprovisionRespons
 	case http.StatusOK, http.StatusGone:
 		return &DeprovisionResponse{}, nil
 	case http.StatusAccepted:
+		if !r.AcceptsIncomplete {
+			// If the client did not signify that it could handle asynchronous
+			// operations, a '202 Accepted' response should be treated as an error.
+			return nil, c.handleFailureResponse(response)
+		}
+
 		responseBodyObj := &asyncSuccessResponseBody{}
 		if err := c.unmarshalResponse(response, responseBodyObj); err != nil {
 			return nil, err
@@ -50,8 +56,6 @@ func (c *client) DeprovisionInstance(r *DeprovisionRequest) (*DeprovisionRespons
 	default:
 		return nil, c.handleFailureResponse(response)
 	}
-
-	return nil, nil
 }
 
 func validateDeprovisionRequest(request *DeprovisionRequest) error {

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/errors.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/errors.go
@@ -32,7 +32,7 @@ type HTTPStatusCodeError struct {
 	// Description is a human-readable description of the error that may be
 	// returned by the broker.
 	Description *string
-	// ResponseError is set to the error that occured when unmarshalling a
+	// ResponseError is set to the error that occurred when unmarshalling a
 	// response body from the broker.
 	ResponseError error
 }
@@ -87,10 +87,10 @@ func IsConflictError(err error) bool {
 	return statusCodeError.StatusCode == http.StatusConflict
 }
 
+// Constants are used to check for "Async" and "RequiresApp" errors and their messages
 const (
-	AsyncErrorMessage     = "AsyncRequired"
-	AsyncErrorDescription = "This service plan requires client support for asynchronous service operations."
-
+	AsyncErrorMessage               = "AsyncRequired"
+	AsyncErrorDescription           = "This service plan requires client support for asynchronous service operations."
 	AppGUIDRequiredErrorMessage     = "RequiresApp"
 	AppGUIDRequiredErrorDescription = "This service supports generation of credentials through binding an application only."
 )

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/fake/fake.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/fake/fake.go
@@ -60,6 +60,7 @@ type Action struct {
 // FakeClient.
 type ActionType string
 
+// These are the set of actions that can be taken on a FakeClient.
 const (
 	GetCatalog          ActionType = "GetCatalog"
 	ProvisionInstance   ActionType = "ProvisionInstance"
@@ -89,6 +90,8 @@ type FakeClient struct {
 
 var _ v2.Client = &FakeClient{}
 
+// Actions is a method defined on FakeClient that returns the actions taken on
+// it.
 func (c *FakeClient) Actions() []Action {
 	c.Mutex.Lock()
 	defer c.Mutex.Unlock()
@@ -96,6 +99,7 @@ func (c *FakeClient) Actions() []Action {
 	return c.actions
 }
 
+// GetCatalog implements the Client.GetCatalog method for the FakeClient.
 func (c *FakeClient) GetCatalog() (*v2.CatalogResponse, error) {
 	c.Mutex.Lock()
 	defer c.Mutex.Unlock()
@@ -109,6 +113,8 @@ func (c *FakeClient) GetCatalog() (*v2.CatalogResponse, error) {
 	return nil, UnexpectedActionError()
 }
 
+// ProvisionInstance implements the Client.ProvisionRequest method for the
+// FakeClient.
 func (c *FakeClient) ProvisionInstance(r *v2.ProvisionRequest) (*v2.ProvisionResponse, error) {
 	c.Mutex.Lock()
 	defer c.Mutex.Unlock()
@@ -122,6 +128,8 @@ func (c *FakeClient) ProvisionInstance(r *v2.ProvisionRequest) (*v2.ProvisionRes
 	return nil, UnexpectedActionError()
 }
 
+// UpdateInstance implements the Client.UpdateInstance method for the
+// FakeClient.
 func (c *FakeClient) UpdateInstance(r *v2.UpdateInstanceRequest) (*v2.UpdateInstanceResponse, error) {
 	c.Mutex.Lock()
 	defer c.Mutex.Unlock()
@@ -135,6 +143,8 @@ func (c *FakeClient) UpdateInstance(r *v2.UpdateInstanceRequest) (*v2.UpdateInst
 	return nil, UnexpectedActionError()
 }
 
+// DeprovisionInstance implements the Client.DeprovisionInstance method on the
+// FakeClient.
 func (c *FakeClient) DeprovisionInstance(r *v2.DeprovisionRequest) (*v2.DeprovisionResponse, error) {
 	c.Mutex.Lock()
 	defer c.Mutex.Unlock()
@@ -148,6 +158,8 @@ func (c *FakeClient) DeprovisionInstance(r *v2.DeprovisionRequest) (*v2.Deprovis
 	return nil, UnexpectedActionError()
 }
 
+// PollLastOperation implements the Client.PollLastOperation method on the
+// FakeClient.
 func (c *FakeClient) PollLastOperation(r *v2.LastOperationRequest) (*v2.LastOperationResponse, error) {
 	c.Mutex.Lock()
 	defer c.Mutex.Unlock()
@@ -161,6 +173,7 @@ func (c *FakeClient) PollLastOperation(r *v2.LastOperationRequest) (*v2.LastOper
 	return nil, UnexpectedActionError()
 }
 
+// Bind implements the Client.Bind method on the FakeClient.
 func (c *FakeClient) Bind(r *v2.BindRequest) (*v2.BindResponse, error) {
 	c.Mutex.Lock()
 	defer c.Mutex.Unlock()
@@ -174,6 +187,7 @@ func (c *FakeClient) Bind(r *v2.BindRequest) (*v2.BindResponse, error) {
 	return nil, UnexpectedActionError()
 }
 
+// Unbind implements the Client.Unbind method on the FakeClient.
 func (c *FakeClient) Unbind(r *v2.UnbindRequest) (*v2.UnbindResponse, error) {
 	c.Mutex.Lock()
 	defer c.Mutex.Unlock()
@@ -187,40 +201,50 @@ func (c *FakeClient) Unbind(r *v2.UnbindRequest) (*v2.UnbindResponse, error) {
 	return nil, UnexpectedActionError()
 }
 
+// UnexpectedActionError returns an error message when an action is not found
+// in the FakeClient's action array.
 func UnexpectedActionError() error {
 	return errors.New("Unexpected action")
 }
 
+// CatalogReaction is sent as the response to GetCatalog requests.
 type CatalogReaction struct {
 	Response *v2.CatalogResponse
 	Error    error
 }
 
+// ProvisionReaction is sent as the response ProvisionInstance requests.
 type ProvisionReaction struct {
 	Response *v2.ProvisionResponse
 	Error    error
 }
 
+// UpdateInstanceReaction is sent as the response UpdateInstance requests.
 type UpdateInstanceReaction struct {
 	Response *v2.UpdateInstanceResponse
 	Error    error
 }
 
+// DeprovisionReaction is sent as the response DeprovisionInstance requests.
 type DeprovisionReaction struct {
 	Response *v2.DeprovisionResponse
 	Error    error
 }
 
+// PollLastOperationReaction is sent as the response to PollLastOperation
+// requests.
 type PollLastOperationReaction struct {
 	Response *v2.LastOperationResponse
 	Error    error
 }
 
+// BindReaction is sent as the response Bind requests.
 type BindReaction struct {
 	Response *v2.BindResponse
 	Error    error
 }
 
+// UnbindReaction is sent as the response Unbind requests.
 type UnbindReaction struct {
 	Response *v2.UnbindResponse
 	Error    error

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/fake/fake_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/fake/fake_test.go
@@ -506,3 +506,39 @@ func TestFakeAppGUIDRequiredError(t *testing.T) {
 		}
 	}
 }
+
+func TestNewFakeClient(t *testing.T) {
+	newfakeClient := fake.NewFakeClient(fake.FakeClientConfiguration{
+		BindReaction: &fake.BindReaction{
+			Response: bindResponse(),
+		},
+	})
+
+	testfakeclient := fake.FakeClient{BindReaction: &fake.BindReaction{
+		Response: bindResponse(),
+	},
+	}
+
+	response, err := newfakeClient.Bind(&v2.BindRequest{})
+	response2, err2 := testfakeclient.Bind(&v2.BindRequest{})
+
+	//for _, tc := range cases {
+	//		fakeClient := fake.NewFakeClient(tc.config)
+
+	if !reflect.DeepEqual(response, response2) {
+		t.Errorf("%v: unexpected response; expected %+v, got %+v", response, response2)
+	}
+
+	if !reflect.DeepEqual(err, err2) {
+		t.Errorf("%v: unexpected error; expected %+v, got %+v", err, err2)
+	}
+
+	actions := newfakeClient.Actions()
+	if e, a := 1, len(actions); e != a {
+		t.Errorf("%v: unexpected actions; expected %v, got %v; actions = %+v", e, a, actions)
+	}
+	if e, a := fake.Bind, actions[0].Type; e != a {
+		t.Errorf("%v: unexpected action type; expected %v, got %v", e, a)
+	}
+
+}

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/get_catalog.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/get_catalog.go
@@ -20,10 +20,10 @@ func (c *client) GetCatalog() (*CatalogResponse, error) {
 			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
-		if !c.EnableAlphaFeatures {
+		if !c.APIVersion.AtLeast(Version2_13()) {
 			for ii := range catalogResponse.Services {
 				for jj := range catalogResponse.Services[ii].Plans {
-					catalogResponse.Services[ii].Plans[jj].AlphaParameterSchemas = nil
+					catalogResponse.Services[ii].Plans[jj].ParameterSchemas = nil
 				}
 			}
 		}

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/get_catalog_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/get_catalog_test.go
@@ -166,21 +166,21 @@ const alphaParameterSchemaCatalogBytes = `{
 
 func alphaParameterCatalogResponse() *CatalogResponse {
 	catalog := okCatalogResponse()
-	catalog.Services[0].Plans[0].AlphaParameterSchemas = &AlphaParameterSchemas{
-		ServiceInstances: &AlphaServiceInstanceSchema{
-			Create: &AlphaInputParameters{
+	catalog.Services[0].Plans[0].ParameterSchemas = &ParameterSchemas{
+		ServiceInstances: &ServiceInstanceSchema{
+			Create: &InputParameters{
 				Parameters: map[string]interface{}{
 					"foo": "bar",
 				},
 			},
-			Update: &AlphaInputParameters{
+			Update: &InputParameters{
 				Parameters: map[string]interface{}{
 					"baz": "zap",
 				},
 			},
 		},
-		ServiceBindings: &AlphaServiceBindingSchema{
-			Create: &AlphaInputParameters{
+		ServiceBindings: &ServiceBindingSchema{
+			Create: &InputParameters{
 				Parameters: map[string]interface{}{
 					"zoo": "blu",
 				},
@@ -194,6 +194,7 @@ func alphaParameterCatalogResponse() *CatalogResponse {
 func TestGetCatalog(t *testing.T) {
 	cases := []struct {
 		name               string
+		version            APIVersion
 		enableAlpha        bool
 		httpReaction       httpReaction
 		expectedResponse   *CatalogResponse
@@ -245,11 +246,11 @@ func TestGetCatalog(t *testing.T) {
 				status: http.StatusInternalServerError,
 				body:   conventionalFailureResponseBody,
 			},
-			expectedErr: testHttpStatusCodeError(),
+			expectedErr: testHTTPStatusCodeError(),
 		},
 		{
-			name:        "alpha enabled - schemas",
-			enableAlpha: true,
+			name:    "schemas included if API version >= 2.13",
+			version: Version2_13(),
 			httpReaction: httpReaction{
 				status: http.StatusOK,
 				body:   alphaParameterSchemaCatalogBytes,
@@ -257,7 +258,8 @@ func TestGetCatalog(t *testing.T) {
 			expectedResponse: alphaParameterCatalogResponse(),
 		},
 		{
-			name: "alpha disabled - schemas",
+			name:    "schemas not included if API version < 2.13",
+			version: Version2_12(),
 			httpReaction: httpReaction{
 				status: http.StatusOK,
 				body:   alphaParameterSchemaCatalogBytes,
@@ -271,8 +273,11 @@ func TestGetCatalog(t *testing.T) {
 			URL: "/v2/catalog",
 		}
 
-		version := Version2_11()
-		klient := newTestClient(t, tc.name, version, tc.enableAlpha, httpChecks, tc.httpReaction)
+		if tc.version.label == "" {
+			tc.version = Version2_11()
+		}
+
+		klient := newTestClient(t, tc.name, tc.version, tc.enableAlpha, httpChecks, tc.httpReaction)
 
 		response, err := klient.GetCatalog()
 

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/interface_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/interface_test.go
@@ -1,0 +1,19 @@
+package v2
+
+import (
+	"testing"
+)
+
+func TestDefaultClientConfiguration(t *testing.T) {
+	testConfiguration := DefaultClientConfiguration()
+
+	if testConfiguration.APIVersion != LatestAPIVersion() {
+		t.Error("unexpected API Version")
+	}
+	if testConfiguration.TimeoutSeconds != 60 {
+		t.Error("unexpected TimeoutSeconds")
+	}
+	if testConfiguration.EnableAlphaFeatures != false {
+		t.Error("expected Alpha Features to be disabled")
+	}
+}

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/poll_last_operation.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/poll_last_operation.go
@@ -47,8 +47,6 @@ func (c *client) PollLastOperation(r *LastOperationRequest) (*LastOperationRespo
 	default:
 		return nil, c.handleFailureResponse(response)
 	}
-
-	return nil, nil
 }
 
 func validateLastOperationRequest(request *LastOperationRequest) error {

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/poll_last_operation_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/poll_last_operation_test.go
@@ -8,9 +8,10 @@ import (
 
 func defaultLastOperationRequest() *LastOperationRequest {
 	return &LastOperationRequest{
-		InstanceID: testInstanceID,
-		ServiceID:  strPtr(testServiceID),
-		PlanID:     strPtr(testPlanID),
+		InstanceID:   testInstanceID,
+		ServiceID:    strPtr(testServiceID),
+		PlanID:       strPtr(testPlanID),
+		OperationKey: &testOperation,
 	}
 }
 
@@ -46,8 +47,9 @@ const failedLastOperationResponseBody = `{"state":"failed","description":"test d
 func TestPollLastOperation(t *testing.T) {
 	cases := []struct {
 		name                string
+		version             APIVersion
 		enableAlpha         bool
-		originatingIdentity *AlphaOriginatingIdentity
+		originatingIdentity *OriginatingIdentity
 		request             *LastOperationRequest
 		httpChecks          httpChecks
 		httpReaction        httpReaction
@@ -103,12 +105,12 @@ func TestPollLastOperation(t *testing.T) {
 			expectedErrMessage: "Status: 500; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
-			name: "500 with convential response",
+			name: "500 with conventional response",
 			httpReaction: httpReaction{
 				status: http.StatusInternalServerError,
 				body:   conventionalFailureResponseBody,
 			},
-			expectedErr: testHttpStatusCodeError(),
+			expectedErr: testHTTPStatusCodeError(),
 		},
 		{
 			name: "op succeeded",
@@ -120,7 +122,7 @@ func TestPollLastOperation(t *testing.T) {
 		},
 		{
 			name:                "originating identity included",
-			enableAlpha:         true,
+			version:             Version2_13(),
 			originatingIdentity: testOriginatingIdentity,
 			httpChecks:          httpChecks{headers: map[string]string{OriginatingIdentityHeader: testOriginatingIdentityHeaderValue}},
 			httpReaction: httpReaction{
@@ -131,7 +133,7 @@ func TestPollLastOperation(t *testing.T) {
 		},
 		{
 			name:                "originating identity excluded",
-			enableAlpha:         true,
+			version:             Version2_13(),
 			originatingIdentity: nil,
 			httpChecks:          httpChecks{headers: map[string]string{OriginatingIdentityHeader: ""}},
 			httpReaction: httpReaction{
@@ -141,8 +143,8 @@ func TestPollLastOperation(t *testing.T) {
 			expectedResponse: successLastOperationResponse(),
 		},
 		{
-			name:                "originating identity not sent unless alpha enabled",
-			enableAlpha:         false,
+			name:                "originating identity not sent unless API version >= 2.13",
+			version:             Version2_12(),
 			originatingIdentity: testOriginatingIdentity,
 			httpChecks:          httpChecks{headers: map[string]string{OriginatingIdentityHeader: ""}},
 			httpReaction: httpReaction{
@@ -168,10 +170,14 @@ func TestPollLastOperation(t *testing.T) {
 			tc.httpChecks.params = map[string]string{}
 			tc.httpChecks.params[serviceIDKey] = testServiceID
 			tc.httpChecks.params[planIDKey] = testPlanID
+			tc.httpChecks.params[operationKey] = "test-operation-key"
 		}
 
-		version := Version2_11()
-		klient := newTestClient(t, tc.name, version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		if tc.version.label == "" {
+			tc.version = Version2_11()
+		}
+
+		klient := newTestClient(t, tc.name, tc.version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.PollLastOperation(tc.request)
 

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/provision_instance.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/provision_instance.go
@@ -53,7 +53,20 @@ func (c *client) ProvisionInstance(r *ProvisionRequest) (*ProvisionResponse, err
 	}
 
 	switch response.StatusCode {
-	case http.StatusCreated, http.StatusOK, http.StatusAccepted:
+	case http.StatusCreated, http.StatusOK:
+		userResponse := &ProvisionResponse{}
+		if err := c.unmarshalResponse(response, userResponse); err != nil {
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
+		}
+
+		return userResponse, nil
+	case http.StatusAccepted:
+		if !r.AcceptsIncomplete {
+			// If the client did not signify that it could handle asynchronous
+			// operations, a '202 Accepted' response should be treated as an error.
+			return nil, c.handleFailureResponse(response)
+		}
+
 		responseBodyObj := &provisionSuccessResponseBody{}
 		if err := c.unmarshalResponse(response, responseBodyObj); err != nil {
 			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
@@ -67,14 +80,13 @@ func (c *client) ProvisionInstance(r *ProvisionRequest) (*ProvisionResponse, err
 		}
 
 		userResponse := &ProvisionResponse{
+			Async:        true,
 			DashboardURL: responseBodyObj.DashboardURL,
 			OperationKey: opPtr,
 		}
-		if response.StatusCode == http.StatusAccepted {
-			if c.Verbose {
-				glog.Infof("broker %q: received asynchronous response", c.Name)
-			}
-			userResponse.Async = true
+
+		if c.Verbose {
+			glog.Infof("broker %q: received asynchronous response", c.Name)
 		}
 
 		return userResponse, nil

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/provision_instance_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/provision_instance_test.go
@@ -60,13 +60,11 @@ func successProvisionResponseAsync() *ProvisionResponse {
 const contextProvisionRequestBody = `{"service_id":"test-service-id","plan_id":"test-plan-id","organization_guid":"test-organization-guid","space_guid":"test-space-guid","context":{"foo":"bar"}}`
 
 func TestProvisionInstance(t *testing.T) {
-	v2_12 := Version2_12()
-
 	cases := []struct {
 		name                string
-		version             *APIVersion
+		version             APIVersion
 		enableAlpha         bool
-		originatingIdentity *AlphaOriginatingIdentity
+		originatingIdentity *OriginatingIdentity
 		request             *ProvisionRequest
 		httpChecks          httpChecks
 		httpReaction        httpReaction
@@ -121,6 +119,14 @@ func TestProvisionInstance(t *testing.T) {
 			expectedErrMessage: "http error",
 		},
 		{
+			name: "202 with no async support",
+			httpReaction: httpReaction{
+				status: http.StatusAccepted,
+				body:   successAsyncProvisionResponseBody,
+			},
+			expectedErrMessage: "Status: 202; ErrorMessage: <nil>; Description: <nil>; ResponseError: <nil>",
+		},
+		{
 			name: "200 with malformed response",
 			httpReaction: httpReaction{
 				status: http.StatusOK,
@@ -142,11 +148,11 @@ func TestProvisionInstance(t *testing.T) {
 				status: http.StatusInternalServerError,
 				body:   conventionalFailureResponseBody,
 			},
-			expectedErr: testHttpStatusCodeError(),
+			expectedErr: testHTTPStatusCodeError(),
 		},
 		{
 			name:    "context - 2.12",
-			version: &v2_12,
+			version: Version2_12(),
 			request: func() *ProvisionRequest {
 				r := defaultProvisionRequest()
 				r.Context = map[string]interface{}{
@@ -183,7 +189,7 @@ func TestProvisionInstance(t *testing.T) {
 		},
 		{
 			name:                "originating identity included",
-			enableAlpha:         true,
+			version:             Version2_13(),
 			originatingIdentity: testOriginatingIdentity,
 			httpChecks:          httpChecks{headers: map[string]string{OriginatingIdentityHeader: testOriginatingIdentityHeaderValue}},
 			httpReaction: httpReaction{
@@ -194,7 +200,7 @@ func TestProvisionInstance(t *testing.T) {
 		},
 		{
 			name:                "originating identity excluded",
-			enableAlpha:         true,
+			version:             Version2_13(),
 			originatingIdentity: nil,
 			httpChecks:          httpChecks{headers: map[string]string{OriginatingIdentityHeader: ""}},
 			httpReaction: httpReaction{
@@ -204,8 +210,8 @@ func TestProvisionInstance(t *testing.T) {
 			expectedResponse: successProvisionResponse(),
 		},
 		{
-			name:                "originating identity not sent unless alpha enabled",
-			enableAlpha:         false,
+			name:                "originating identity not sent unless API version >= 2.13",
+			version:             Version2_12(),
 			originatingIdentity: testOriginatingIdentity,
 			httpChecks:          httpChecks{headers: map[string]string{OriginatingIdentityHeader: ""}},
 			httpReaction: httpReaction{
@@ -231,13 +237,11 @@ func TestProvisionInstance(t *testing.T) {
 			tc.httpChecks.body = successProvisionRequestBody
 		}
 
-		defaultVersion := Version2_11()
-		version := &defaultVersion
-		if tc.version != nil {
-			version = tc.version
+		if tc.version.label == "" {
+			tc.version = Version2_11()
 		}
 
-		klient := newTestClient(t, tc.name, *version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		klient := newTestClient(t, tc.name, tc.version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.ProvisionInstance(tc.request)
 

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/unbind.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/unbind.go
@@ -31,8 +31,6 @@ func (c *client) Unbind(r *UnbindRequest) (*UnbindResponse, error) {
 	default:
 		return nil, c.handleFailureResponse(response)
 	}
-
-	return nil, nil
 }
 
 func validateUnbindRequest(request *UnbindRequest) error {

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/version.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/version.go
@@ -23,21 +23,32 @@ const (
 	// Broker API.
 	internalAPIVersion2_11 = "2.11"
 
-	// internalAPIVersion2_11 represents the 2.11 version of the Open Service
+	// internalAPIVersion2_12 represents the 2.12 version of the Open Service
 	// Broker API.
 	internalAPIVersion2_12 = "2.12"
+
+	// internalAPIVersion2_13 represents the 2.13 version of the Open Service
+	// Broker API.
+	internalAPIVersion2_13 = "2.13"
 )
 
+//Version2_11 returns an APIVersion struct with the internal API version set to "2.11"
+func Version2_11() APIVersion {
+	return APIVersion{label: internalAPIVersion2_11, order: 0}
+}
+
+//Version2_12 returns an APIVersion struct with the internal API version set to "2.12"
 func Version2_12() APIVersion {
 	return APIVersion{label: internalAPIVersion2_12, order: 1}
 }
 
-func Version2_11() APIVersion {
-	return APIVersion{label: internalAPIVersion2_12, order: 0}
+//Version2_13 returns an APIVersion struct with the internal API version set to "2.13"
+func Version2_13() APIVersion {
+	return APIVersion{label: internalAPIVersion2_13, order: 2}
 }
 
 // LatestAPIVersion returns the latest supported API version in the current
 // release of this library.
 func LatestAPIVersion() APIVersion {
-	return Version2_12()
+	return Version2_13()
 }

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/version_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/version_test.go
@@ -16,3 +16,10 @@ func TestAtLeast(t *testing.T) {
 		t.Error("Expected 2.11 < 2.12")
 	}
 }
+
+func TestLatestAPIVersion(t *testing.T) {
+
+	if LatestAPIVersion() != Version2_13() {
+		t.Error("Unexpected Latest API Version--expected 2.13")
+	}
+}


### PR DESCRIPTION
Updates our `glide.yaml` to the version of `github.com/pmorie/go-open-service-broker-client` that includes support for v2.13 of the OSB API.

Closes #1329 