### PR TITLE
Updated missed fields in service and plan specs

### DIFF
--- a/pkg/controller/controller_broker.go
+++ b/pkg/controller/controller_broker.go
@@ -598,6 +598,8 @@ func (c *controller) reconcileClusterServiceClassFromClusterServiceBrokerCatalog
 	toUpdate.Spec.Tags = serviceClass.Spec.Tags
 	toUpdate.Spec.Description = serviceClass.Spec.Description
 	toUpdate.Spec.Requires = serviceClass.Spec.Requires
+	toUpdate.Spec.ExternalName = serviceClass.Spec.ExternalName
+	toUpdate.Spec.ExternalMetadata = serviceClass.Spec.ExternalMetadata
 
 	if _, err := c.serviceCatalogClient.ClusterServiceClasses().Update(toUpdate); err != nil {
 		glog.Errorf(
@@ -663,6 +665,8 @@ func (c *controller) reconcileClusterServicePlanFromClusterServiceBrokerCatalog(
 	toUpdate.Spec.Description = servicePlan.Spec.Description
 	toUpdate.Spec.Bindable = servicePlan.Spec.Bindable
 	toUpdate.Spec.Free = servicePlan.Spec.Free
+	toUpdate.Spec.ExternalName = servicePlan.Spec.ExternalName
+	toUpdate.Spec.ExternalMetadata = servicePlan.Spec.ExternalMetadata
 	toUpdate.Spec.ServiceInstanceCreateParameterSchema = servicePlan.Spec.ServiceInstanceCreateParameterSchema
 	toUpdate.Spec.ServiceInstanceUpdateParameterSchema = servicePlan.Spec.ServiceInstanceUpdateParameterSchema
 	toUpdate.Spec.ServiceBindingCreateParameterSchema = servicePlan.Spec.ServiceBindingCreateParameterSchema


### PR DESCRIPTION
Closes #1388. Looks like these fields were missed; making this PR now since the fix is obvious, will add tests in a follow-up.