### PR TITLE
Remove deprecated basic auth config support

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -100,11 +100,6 @@ type ServiceBrokerAuthInfo struct {
 	// The value is referenced from the 'token' field of the given secret.  This value should only
 	// contain the token value and not the `Bearer` scheme.
 	Bearer *BearerTokenAuthConfig
-
-	// DEPRECATED: use `Basic` field for configuring basic authentication instead.
-	// BasicAuthSecret is a reference to a Secret containing auth information the
-	// catalog should use to authenticate to this ServiceBroker using basic auth.
-	BasicAuthSecret *ObjectReference
 }
 
 // BasicAuthConfig provides config for the basic authentication.

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -100,11 +100,6 @@ type ServiceBrokerAuthInfo struct {
 	// The value is referenced from the 'token' field of the given secret.  This value should only
 	// contain the token value and not the `Bearer` scheme.
 	Bearer *BearerTokenAuthConfig `json:"bearer,omitempty"`
-
-	// DEPRECATED: use `Basic` field for configuring basic authentication instead.
-	// BasicAuthSecret is a reference to a Secret containing auth information the
-	// catalog should use to authenticate to this ServiceBroker using basic auth.
-	BasicAuthSecret *ObjectReference `json:"basicAuthSecret,omitempty"`
 }
 
 // BasicAuthConfig provides config for the basic authentication.

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
@@ -792,7 +792,6 @@ func Convert_servicecatalog_ServiceBindingStatus_To_v1beta1_ServiceBindingStatus
 func autoConvert_v1beta1_ServiceBrokerAuthInfo_To_servicecatalog_ServiceBrokerAuthInfo(in *ServiceBrokerAuthInfo, out *servicecatalog.ServiceBrokerAuthInfo, s conversion.Scope) error {
 	out.Basic = (*servicecatalog.BasicAuthConfig)(unsafe.Pointer(in.Basic))
 	out.Bearer = (*servicecatalog.BearerTokenAuthConfig)(unsafe.Pointer(in.Bearer))
-	out.BasicAuthSecret = (*servicecatalog.ObjectReference)(unsafe.Pointer(in.BasicAuthSecret))
 	return nil
 }
 
@@ -804,7 +803,6 @@ func Convert_v1beta1_ServiceBrokerAuthInfo_To_servicecatalog_ServiceBrokerAuthIn
 func autoConvert_servicecatalog_ServiceBrokerAuthInfo_To_v1beta1_ServiceBrokerAuthInfo(in *servicecatalog.ServiceBrokerAuthInfo, out *ServiceBrokerAuthInfo, s conversion.Scope) error {
 	out.Basic = (*BasicAuthConfig)(unsafe.Pointer(in.Basic))
 	out.Bearer = (*BearerTokenAuthConfig)(unsafe.Pointer(in.Bearer))
-	out.BasicAuthSecret = (*ObjectReference)(unsafe.Pointer(in.BasicAuthSecret))
 	return nil
 }
 

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.deepcopy.go
@@ -951,15 +951,6 @@ func (in *ServiceBrokerAuthInfo) DeepCopyInto(out *ServiceBrokerAuthInfo) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
-	if in.BasicAuthSecret != nil {
-		in, out := &in.BasicAuthSecret, &out.BasicAuthSecret
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectReference)
-			**out = **in
-		}
-	}
 	return
 }
 

--- a/pkg/apis/servicecatalog/validation/broker.go
+++ b/pkg/apis/servicecatalog/validation/broker.go
@@ -82,16 +82,6 @@ func validateClusterServiceBrokerSpec(spec *sc.ClusterServiceBrokerSpec, fldPath
 					field.Required(fldPath.Child("authInfo", "bearer", "secretRef"), "a basic auth secret is required"),
 				)
 			}
-		} else if spec.AuthInfo.BasicAuthSecret != nil {
-			basicAuthSecret := spec.AuthInfo.BasicAuthSecret
-			if basicAuthSecret != nil {
-				for _, msg := range apivalidation.ValidateNamespaceName(basicAuthSecret.Namespace, false /* prefix */) {
-					allErrs = append(allErrs, field.Invalid(fldPath.Child("authInfo", "basicAuthSecret", "namespace"), basicAuthSecret.Namespace, msg))
-				}
-				for _, msg := range apivalidation.NameIsDNSSubdomain(basicAuthSecret.Name, false /* prefix */) {
-					allErrs = append(allErrs, field.Invalid(fldPath.Child("authInfo", "basicAuthSecret", "name"), basicAuthSecret.Name, msg))
-				}
-			}
 		} else {
 			// Authentication
 			allErrs = append(

--- a/pkg/apis/servicecatalog/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/zz_generated.deepcopy.go
@@ -951,15 +951,6 @@ func (in *ServiceBrokerAuthInfo) DeepCopyInto(out *ServiceBrokerAuthInfo) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
-	if in.BasicAuthSecret != nil {
-		in, out := &in.BasicAuthSecret, &out.BasicAuthSecret
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectReference)
-			**out = **in
-		}
-	}
 	return
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -446,19 +446,6 @@ func getAuthCredentialsFromClusterServiceBroker(client kubernetes.Interface, bro
 		return &osb.AuthConfig{
 			BearerConfig: bearerConfig,
 		}, nil
-	} else if authInfo.BasicAuthSecret != nil {
-		secretRef := authInfo.BasicAuthSecret
-		secret, err := client.Core().Secrets(secretRef.Namespace).Get(secretRef.Name, metav1.GetOptions{})
-		if err != nil {
-			return nil, err
-		}
-		basicAuthConfig, err := getBasicAuthConfig(secret)
-		if err != nil {
-			return nil, err
-		}
-		return &osb.AuthConfig{
-			BasicAuthConfig: basicAuthConfig,
-		}, nil
 	}
 	return nil, fmt.Errorf("empty auth info or unsupported auth mode: %s", authInfo)
 }

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1054,17 +1054,11 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref:         ref("github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.BearerTokenAuthConfig"),
 							},
 						},
-						"basicAuthSecret": {
-							SchemaProps: spec.SchemaProps{
-								Description: "DEPRECATED: use `Basic` field for configuring basic authentication instead. BasicAuthSecret is a reference to a Secret containing auth information the catalog should use to authenticate to this ServiceBroker using basic auth.",
-								Ref:         ref("github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.ObjectReference"),
-							},
-						},
 					},
 				},
 			},
 			Dependencies: []string{
-				"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.BasicAuthConfig", "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.BearerTokenAuthConfig", "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.ObjectReference"},
+				"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.BasicAuthConfig", "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.BearerTokenAuthConfig"},
 		},
 		"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.ServiceBrokerCondition": {
 			Schema: spec.Schema{

--- a/plugin/pkg/admission/broker/authsarcheck/admission.go
+++ b/plugin/pkg/admission/broker/authsarcheck/admission.go
@@ -90,9 +90,6 @@ func (s *sarcheck) Admit(a admission.Attributes) error {
 		secretRef = clusterClusterServiceBroker.Spec.AuthInfo.Basic.SecretRef
 	} else if clusterClusterServiceBroker.Spec.AuthInfo.Bearer != nil {
 		secretRef = clusterClusterServiceBroker.Spec.AuthInfo.Bearer.SecretRef
-	} else if clusterClusterServiceBroker.Spec.AuthInfo.BasicAuthSecret != nil {
-		// TODO: this field is deprecated, remove in v1beta1
-		secretRef = clusterClusterServiceBroker.Spec.AuthInfo.BasicAuthSecret
 	}
 	userInfo := a.GetUserInfo()
 

--- a/plugin/pkg/admission/broker/authsarcheck/admission_test.go
+++ b/plugin/pkg/admission/broker/authsarcheck/admission_test.go
@@ -123,28 +123,6 @@ func TestAdmissionBroker(t *testing.T) {
 			allowed: true,
 		},
 		{
-			name: "broker with basic auth, user authenticated (deprecated authinfo field)",
-			broker: &servicecatalog.ClusterServiceBroker{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-broker",
-				},
-				Spec: servicecatalog.ClusterServiceBrokerSpec{
-					URL: "http://example.com",
-					AuthInfo: &servicecatalog.ServiceBrokerAuthInfo{
-						BasicAuthSecret: &servicecatalog.ObjectReference{
-							Namespace: "test-ns",
-							Name:      "test-secret",
-						},
-					},
-				},
-			},
-			userInfo: &user.DefaultInfo{
-				Name:   "system:serviceaccount:test-ns:catalog",
-				Groups: []string{"system:serviceaccount", "system:serviceaccounts:test-ns"},
-			},
-			allowed: true,
-		},
-		{
 			name: "broker with bearer token, user authenticated",
 			broker: &servicecatalog.ClusterServiceBroker{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixes #1421
I believe it was the only deprecated field in our API (at least explicitly marked as deprecated).