### PR TITLE
Reformatting how controller_binding_test outputs errors and using helper functions

### DIFF
--- a/pkg/controller/controller_events_test.go
+++ b/pkg/controller/controller_events_test.go
@@ -18,11 +18,19 @@ package controller
 
 import (
 	"fmt"
+	"strings"
 )
 
-func checkEvents(actual, expected []string) error {
+func checkEventCounts(actual, expected []string) error {
 	if len(actual) != len(expected) {
 		return fmt.Errorf("expected %d events, got %d", len(expected), len(actual))
+	}
+	return nil
+}
+
+func checkEvents(actual, expected []string) error {
+	if err := checkEventCounts(actual, expected); err != nil {
+		return err
 	}
 	for i, actualEvt := range actual {
 		if expectedEvt := expected[i]; actualEvt != expectedEvt {
@@ -30,4 +38,29 @@ func checkEvents(actual, expected []string) error {
 		}
 	}
 	return nil
+}
+
+func checkEventPrefixes(actual, expected []string) error {
+	if err := checkEventCounts(actual, expected); err != nil {
+		return err
+	}
+	for i, e := range expected {
+		a := actual[i]
+		if !strings.HasPrefix(a, e) {
+			return fmt.Errorf("received unexpected event prefix:\n %s", expectedGot(e, a))
+		}
+	}
+	return nil
+}
+
+func checkEventContains(actual, expected string) error {
+	if !strings.Contains(actual, expected) {
+		return fmt.Errorf("received unexpected event (contains):\n %s", expectedGot(expected, actual))
+	}
+
+	return nil
+}
+
+func expectedGot(a ...interface{}) string {
+	return fmt.Sprintf("\nexpected:\n\t '%v',\ngot:\n\t '%v'", a...)
 }


### PR DESCRIPTION
Leveraging a helper comparison function in the controller test namespace.

Reformatting Expected: Got: to be standard and easy to debug when running unit tests.