### PR TITLE
Delete removed serviceplans when they have no instances left

### DIFF
--- a/pkg/controller/controller_serviceplan.go
+++ b/pkg/controller/controller_serviceplan.go
@@ -19,6 +19,10 @@ package controller
 import (
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -33,17 +37,6 @@ func (c *controller) servicePlanAdd(obj interface{}) {
 	c.servicePlanQueue.Add(key)
 }
 
-// reconcileClusterServicePlanKey reconciles a ClusterServicePlan due to resync
-//  or an event on the ClusterServicePlan.  Note that this is NOT the main
-// reconciliation loop for ClusterServicePlans. ClusterServicePlans are
-// primarily reconciled in a separate flow when a ClusterServiceBroker is
-// reconciled.
-func (c *controller) reconcileClusterServicePlanKey(key string) error {
-	// currently, this is a no-op.  In the future, we'll maintain status
-	// information here.
-	return nil
-}
-
 func (c *controller) servicePlanUpdate(oldObj, newObj interface{}) {
 	c.servicePlanAdd(newObj)
 }
@@ -55,4 +48,55 @@ func (c *controller) servicePlanDelete(obj interface{}) {
 	}
 
 	glog.V(4).Infof("ClusterServicePlan: Received delete event for %v; no further processing will occur", servicePlan.Name)
+}
+
+// reconcileClusterServicePlanKey reconciles a ClusterServicePlan due to resync
+//  or an event on the ClusterServicePlan.  Note that this is NOT the main
+// reconciliation loop for ClusterServicePlans. ClusterServicePlans are
+// primarily reconciled in a separate flow when a ClusterServiceBroker is
+// reconciled.
+func (c *controller) reconcileClusterServicePlanKey(key string) error {
+	plan, err := c.servicePlanLister.Get(key)
+	if errors.IsNotFound(err) {
+		glog.Infof("ClusterServicePlan %q: Not doing work because it has been deleted", key)
+		return nil
+	}
+	if err != nil {
+		glog.Infof("ClusterServicePlan %q: Unable to retrieve object from store: %v", key, err)
+		return err
+	}
+
+	return c.reconcileClusterServicePlan(plan)
+}
+
+func (c *controller) reconcileClusterServicePlan(servicePlan *v1beta1.ClusterServicePlan) error {
+	glog.Infof("ClusterServicePlan %q (ExternalName: %q): processing", servicePlan.Name, servicePlan.Spec.ExternalName)
+
+	if !servicePlan.Status.RemovedFromBrokerCatalog {
+		return nil
+	}
+
+	glog.Infof("ClusterServicePlan %q (ExternalName: %q): has been removed from broker catalog; determining whether there are instances remaining", servicePlan.Name, servicePlan.Spec.ExternalName)
+
+	serviceInstances, err := c.findServiceInstancesOnClusterServicePlan(servicePlan)
+	if err != nil {
+		return err
+	}
+
+	if len(serviceInstances.Items) != 0 {
+		return nil
+	}
+
+	glog.Infof("ClusterServicePlan %q (ExternalName: %q): has been removed from broker catalog and has zero instances remaining; deleting", servicePlan.Name, servicePlan.Spec.ExternalName)
+	return c.serviceCatalogClient.ClusterServicePlans().Delete(servicePlan.Name, &metav1.DeleteOptions{})
+}
+
+func (c *controller) findServiceInstancesOnClusterServicePlan(servicePlan *v1beta1.ClusterServicePlan) (*v1beta1.ServiceInstanceList, error) {
+	fieldSet := fields.Set{
+		"spec.clusterServicePlanRef.name": servicePlan.Name,
+	}
+	fieldSelector := fields.SelectorFromSet(fieldSet).String()
+	listOpts := metav1.ListOptions{FieldSelector: fieldSelector}
+
+	return c.serviceCatalogClient.ServiceInstances(metav1.NamespaceAll).List(listOpts)
 }

--- a/pkg/controller/controller_serviceplan_test.go
+++ b/pkg/controller/controller_serviceplan_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/test/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+func TestReconcileClusterServicePlanRemovedFromCatalog(t *testing.T) {
+	getRemovedPlan := func() *v1beta1.ClusterServicePlan {
+		p := getTestClusterServicePlan()
+		p.Status.RemovedFromBrokerCatalog = true
+		return p
+	}
+
+	cases := []struct {
+		name                    string
+		plan                    *v1beta1.ClusterServicePlan
+		instances               []v1beta1.ServiceInstance
+		catalogClientPrepFunc   func(*fake.Clientset)
+		shouldError             bool
+		errText                 *string
+		catalogActionsCheckFunc func(t *testing.T, name string, actions []clientgotesting.Action)
+	}{
+		{
+			name:        "not removed from catalog",
+			plan:        getTestClusterServicePlan(),
+			shouldError: false,
+		},
+		{
+			name:        "removed from catalog, instances left",
+			plan:        getRemovedPlan(),
+			instances:   []v1beta1.ServiceInstance{*getTestServiceInstance()},
+			shouldError: false,
+			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+				listRestrictions := clientgotesting.ListRestrictions{
+					Labels: labels.Everything(),
+					Fields: fields.OneTermEqualSelector("spec.clusterServicePlanRef.name", "PGUID"),
+				}
+
+				expectNumberOfActions(t, name, actions, 1)
+				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
+			},
+		},
+		{
+			name:        "removed from catalog, no instances left",
+			plan:        getRemovedPlan(),
+			instances:   nil,
+			shouldError: false,
+			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+				listRestrictions := clientgotesting.ListRestrictions{
+					Labels: labels.Everything(),
+					Fields: fields.OneTermEqualSelector("spec.clusterServicePlanRef.name", "PGUID"),
+				}
+
+				expectNumberOfActions(t, name, actions, 2)
+				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
+				assertDelete(t, actions[1], getRemovedPlan())
+			},
+		},
+		{
+			name: "removed from catalog, no instances left, delete fails", plan: getRemovedPlan(),
+			instances:   nil,
+			shouldError: true,
+			catalogClientPrepFunc: func(client *fake.Clientset) {
+				client.AddReactor("delete", "clusterserviceplans", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("oops")
+				})
+			},
+			errText: strPtr("oops"),
+			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+				listRestrictions := clientgotesting.ListRestrictions{
+					Labels: labels.Everything(),
+					Fields: fields.OneTermEqualSelector("spec.clusterServicePlanRef.name", "PGUID"),
+				}
+
+				expectNumberOfActions(t, name, actions, 2)
+				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
+				assertDelete(t, actions[1], getRemovedPlan())
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		_, fakeCatalogClient, _, testController, _ := newTestController(t, noFakeActions())
+
+		fakeCatalogClient.AddReactor("list", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			return true, &v1beta1.ServiceInstanceList{Items: tc.instances}, nil
+		})
+
+		if tc.catalogClientPrepFunc != nil {
+			tc.catalogClientPrepFunc(fakeCatalogClient)
+		}
+
+		err := testController.reconcileClusterServicePlan(tc.plan)
+		if err != nil {
+			if !tc.shouldError {
+				t.Errorf("%v: unexpected error from method under test: %v", tc.name, err)
+				continue
+			} else if tc.errText != nil && *tc.errText != err.Error() {
+				t.Errorf("%v: unexpected error text from method under test; expected %v, got %v", tc.name, tc.errText, err.Error())
+				continue
+			}
+		}
+
+		actions := fakeCatalogClient.Actions()
+
+		if tc.catalogActionsCheckFunc != nil {
+			tc.catalogActionsCheckFunc(t, tc.name, actions)
+		} else {
+			expectNumberOfActions(t, tc.name, actions, 0)
+		}
+	}
+}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -438,6 +438,7 @@ func getTestClusterServicePlan() *v1beta1.ClusterServicePlan {
 				Name: testClusterServiceClassGUID,
 			},
 		},
+		Status: v1beta1.ClusterServicePlanStatus{},
 	}
 }
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -26,11 +26,11 @@ runTests() {
   kube::etcd::start
 
   go test -race -i github.com/kubernetes-incubator/service-catalog/test/integration/... -c \
-      && ./integration.test -test.v
+      && ./integration.test -test.v $@
 }
 
 # Run cleanup to stop etcd on interrupt or other kill signal.
 trap kube::etcd::cleanup EXIT
 
-runTests
+runTests $@
 

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -49,27 +49,22 @@ import (
 )
 
 const (
-	testNamespace               = "test-namespace"
-	testBrokerName              = "test-broker"
-	testClusterServiceClassName = "test-service"
-	testClusterServiceClassID   = "12345"
-	testPlanName                = "test-plan"
-	testPlanExternalID          = "34567"
-	testInstanceName            = "test-instance"
-	testBindingName             = "test-binding"
-	testSecretName              = "test-secret"
-	testBrokerURL               = "https://example.com"
-	testExternalID              = "9737b6ed-ca95-4439-8219-c53fcad118ab"
-	testDashboardURL            = "http://test-dashboard.example.com"
-	testCreatorUsername         = "create-username"
-	testUpdaterUsername         = "update-username"
-	testDeleterUsername         = "delete-username"
+	testNamespace                = "test-namespace"
+	testClusterServiceBrokerName = "test-broker"
+	testClusterServiceClassName  = "test-service"
+	testClusterServiceClassGUID  = "12345"
+	testClusterServicePlanName   = "test-plan"
+	testPlanExternalID           = "34567"
+	testInstanceName             = "test-instance"
+	testBindingName              = "test-binding"
+	testSecretName               = "test-secret"
+	testBrokerURL                = "https://example.com"
+	testExternalID               = "9737b6ed-ca95-4439-8219-c53fcad118ab"
+	testDashboardURL             = "http://test-dashboard.example.com"
+	testCreatorUsername          = "create-username"
+	testUpdaterUsername          = "update-username"
+	testDeleterUsername          = "delete-username"
 )
-
-func truePtr() *bool {
-	b := true
-	return &b
-}
 
 // TestBasicFlowsSync tests:
 //
@@ -119,7 +114,7 @@ func TestBasicFlowsSync(t *testing.T) {
 	client := catalogClient.ServicecatalogV1beta1()
 
 	broker := &v1beta1.ClusterServiceBroker{
-		ObjectMeta: metav1.ObjectMeta{Name: testBrokerName},
+		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
 		Spec: v1beta1.ClusterServiceBrokerSpec{
 			URL: testBrokerURL,
 		},
@@ -131,7 +126,7 @@ func TestBasicFlowsSync(t *testing.T) {
 	}
 
 	err = util.WaitForBrokerCondition(client,
-		testBrokerName,
+		testClusterServiceBrokerName,
 		v1beta1.ServiceBrokerCondition{
 			Type:   v1beta1.ServiceBrokerConditionReady,
 			Status: v1beta1.ConditionTrue,
@@ -140,7 +135,7 @@ func TestBasicFlowsSync(t *testing.T) {
 		t.Fatalf("error waiting for broker to become ready: %v", err)
 	}
 
-	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassID)
+	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
 	if nil != err {
 		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
 	}
@@ -155,7 +150,7 @@ func TestBasicFlowsSync(t *testing.T) {
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
 				ClusterServiceClassExternalName: testClusterServiceClassName,
-				ClusterServicePlanExternalName:  testPlanName,
+				ClusterServicePlanExternalName:  testClusterServicePlanName,
 			},
 			ExternalID: testExternalID,
 		},
@@ -255,7 +250,7 @@ func TestBasicFlowsSync(t *testing.T) {
 	// End provision test
 
 	// Delete the broker
-	err = client.ClusterServiceBrokers().Delete(testBrokerName, &metav1.DeleteOptions{})
+	err = client.ClusterServiceBrokers().Delete(testClusterServiceBrokerName, &metav1.DeleteOptions{})
 	if nil != err {
 		t.Fatalf("broker should be deleted (%s)", err)
 	}
@@ -265,7 +260,7 @@ func TestBasicFlowsSync(t *testing.T) {
 		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
 	}
 
-	err = util.WaitForBrokerToNotExist(client, testBrokerName)
+	err = util.WaitForBrokerToNotExist(client, testClusterServiceBrokerName)
 	if err != nil {
 		t.Fatalf("error waiting for Broker to not exist: %v", err)
 	}
@@ -314,7 +309,7 @@ func TestBasicFlowsAsync(t *testing.T) {
 	client := catalogClient.ServicecatalogV1beta1()
 
 	broker := &v1beta1.ClusterServiceBroker{
-		ObjectMeta: metav1.ObjectMeta{Name: testBrokerName},
+		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
 		Spec: v1beta1.ClusterServiceBrokerSpec{
 			URL: testBrokerURL,
 		},
@@ -326,7 +321,7 @@ func TestBasicFlowsAsync(t *testing.T) {
 	}
 
 	err = util.WaitForBrokerCondition(client,
-		testBrokerName,
+		testClusterServiceBrokerName,
 		v1beta1.ServiceBrokerCondition{
 			Type:   v1beta1.ServiceBrokerConditionReady,
 			Status: v1beta1.ConditionTrue,
@@ -335,7 +330,7 @@ func TestBasicFlowsAsync(t *testing.T) {
 		t.Fatalf("error waiting for broker to become ready: %v", err)
 	}
 
-	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassID)
+	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
 	if nil != err {
 		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
 	}
@@ -350,7 +345,7 @@ func TestBasicFlowsAsync(t *testing.T) {
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
 				ClusterServiceClassExternalName: testClusterServiceClassName,
-				ClusterServicePlanExternalName:  testPlanName,
+				ClusterServicePlanExternalName:  testClusterServicePlanName,
 			},
 			ExternalID: testExternalID,
 		},
@@ -450,7 +445,7 @@ func TestBasicFlowsAsync(t *testing.T) {
 	// End provision test
 
 	// Delete the broker
-	err = client.ClusterServiceBrokers().Delete(testBrokerName, &metav1.DeleteOptions{})
+	err = client.ClusterServiceBrokers().Delete(testClusterServiceBrokerName, &metav1.DeleteOptions{})
 	if nil != err {
 		t.Fatalf("broker should be deleted (%s)", err)
 	}
@@ -460,7 +455,7 @@ func TestBasicFlowsAsync(t *testing.T) {
 		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
 	}
 
-	err = util.WaitForBrokerToNotExist(client, testBrokerName)
+	err = util.WaitForBrokerToNotExist(client, testClusterServiceBrokerName)
 	if err != nil {
 		t.Fatalf("error waiting for Broker to not exist: %v", err)
 	}
@@ -493,7 +488,7 @@ func TestProvisionFailure(t *testing.T) {
 	client := catalogClient.ServicecatalogV1beta1()
 
 	broker := &v1beta1.ClusterServiceBroker{
-		ObjectMeta: metav1.ObjectMeta{Name: testBrokerName},
+		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
 		Spec: v1beta1.ClusterServiceBrokerSpec{
 			URL: testBrokerURL,
 		},
@@ -505,7 +500,7 @@ func TestProvisionFailure(t *testing.T) {
 	}
 
 	err = util.WaitForBrokerCondition(client,
-		testBrokerName,
+		testClusterServiceBrokerName,
 		v1beta1.ServiceBrokerCondition{
 			Type:   v1beta1.ServiceBrokerConditionReady,
 			Status: v1beta1.ConditionTrue,
@@ -514,7 +509,7 @@ func TestProvisionFailure(t *testing.T) {
 		t.Fatalf("error waiting for broker to become ready: %v", err)
 	}
 
-	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassID)
+	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
 	if nil != err {
 		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
 	}
@@ -529,7 +524,7 @@ func TestProvisionFailure(t *testing.T) {
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
 				ClusterServiceClassExternalName: testClusterServiceClassName,
-				ClusterServicePlanExternalName:  testPlanName,
+				ClusterServicePlanExternalName:  testClusterServicePlanName,
 			},
 			ExternalID: testExternalID,
 		},
@@ -572,7 +567,7 @@ func TestProvisionFailure(t *testing.T) {
 	// End provision test
 
 	// Delete the broker
-	err = client.ClusterServiceBrokers().Delete(testBrokerName, &metav1.DeleteOptions{})
+	err = client.ClusterServiceBrokers().Delete(testClusterServiceBrokerName, &metav1.DeleteOptions{})
 	if nil != err {
 		t.Fatalf("broker should be deleted (%s)", err)
 	}
@@ -582,7 +577,7 @@ func TestProvisionFailure(t *testing.T) {
 		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
 	}
 
-	err = util.WaitForBrokerToNotExist(client, testBrokerName)
+	err = util.WaitForBrokerToNotExist(client, testClusterServiceBrokerName)
 	if err != nil {
 		t.Fatalf("error waiting for Broker to not exist: %v", err)
 	}
@@ -620,7 +615,7 @@ func TestBindingFailure(t *testing.T) {
 	client := fakeCatalogClient.ServicecatalogV1beta1()
 
 	broker := &v1beta1.ClusterServiceBroker{
-		ObjectMeta: metav1.ObjectMeta{Name: testBrokerName},
+		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
 		Spec: v1beta1.ClusterServiceBrokerSpec{
 			URL: testBrokerURL,
 		},
@@ -632,7 +627,7 @@ func TestBindingFailure(t *testing.T) {
 	}
 
 	err = util.WaitForBrokerCondition(client,
-		testBrokerName,
+		testClusterServiceBrokerName,
 		v1beta1.ServiceBrokerCondition{
 			Type:   v1beta1.ServiceBrokerConditionReady,
 			Status: v1beta1.ConditionTrue,
@@ -641,7 +636,7 @@ func TestBindingFailure(t *testing.T) {
 		t.Fatalf("error waiting for broker to become ready: %v", err)
 	}
 
-	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassID)
+	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
 	if nil != err {
 		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
 	}
@@ -656,7 +651,7 @@ func TestBindingFailure(t *testing.T) {
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
 				ClusterServiceClassExternalName: testClusterServiceClassName,
-				ClusterServicePlanExternalName:  testPlanName,
+				ClusterServicePlanExternalName:  testClusterServicePlanName,
 			},
 			ExternalID: testExternalID,
 		},
@@ -737,7 +732,7 @@ func TestBindingFailure(t *testing.T) {
 	// End provision test
 
 	// Delete the broker
-	err = client.ClusterServiceBrokers().Delete(testBrokerName, &metav1.DeleteOptions{})
+	err = client.ClusterServiceBrokers().Delete(testClusterServiceBrokerName, &metav1.DeleteOptions{})
 	if nil != err {
 		t.Fatalf("broker should be deleted (%s)", err)
 	}
@@ -747,7 +742,7 @@ func TestBindingFailure(t *testing.T) {
 		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
 	}
 
-	err = util.WaitForBrokerToNotExist(client, testBrokerName)
+	err = util.WaitForBrokerToNotExist(client, testClusterServiceBrokerName)
 	if err != nil {
 		t.Fatalf("error waiting for Broker to not exist: %v", err)
 	}
@@ -771,7 +766,7 @@ func TestBasicFlowsWithOriginatingIdentity(t *testing.T) {
 						Bindable:    true,
 						Plans: []osb.Plan{
 							{
-								Name:        testPlanName,
+								Name:        testClusterServicePlanName,
 								Free:        truePtr(),
 								ID:          "34567",
 								Description: "a test plan",
@@ -812,7 +807,7 @@ func TestBasicFlowsWithOriginatingIdentity(t *testing.T) {
 	client := catalogClient.ServicecatalogV1beta1()
 
 	broker := &v1beta1.ClusterServiceBroker{
-		ObjectMeta: metav1.ObjectMeta{Name: testBrokerName},
+		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
 		Spec: v1beta1.ClusterServiceBrokerSpec{
 			URL: testBrokerURL,
 		},
@@ -824,7 +819,7 @@ func TestBasicFlowsWithOriginatingIdentity(t *testing.T) {
 	}
 
 	err = util.WaitForBrokerCondition(client,
-		testBrokerName,
+		testClusterServiceBrokerName,
 		v1beta1.ServiceBrokerCondition{
 			Type:   v1beta1.ServiceBrokerConditionReady,
 			Status: v1beta1.ConditionTrue,
@@ -833,7 +828,7 @@ func TestBasicFlowsWithOriginatingIdentity(t *testing.T) {
 		t.Fatalf("error waiting for broker to become ready: %v", err)
 	}
 
-	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassID)
+	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
 	if nil != err {
 		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
 	}
@@ -855,7 +850,7 @@ func TestBasicFlowsWithOriginatingIdentity(t *testing.T) {
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
 				ClusterServiceClassExternalName: testClusterServiceClassName,
-				ClusterServicePlanExternalName:  testPlanName,
+				ClusterServicePlanExternalName:  testClusterServicePlanName,
 			},
 			ExternalID: testExternalID,
 		},
@@ -1031,7 +1026,7 @@ func TestServiceInstanceOrphanMitigation(t *testing.T) {
 	client := catalogClient.ServicecatalogV1beta1()
 
 	broker := &v1beta1.ClusterServiceBroker{
-		ObjectMeta: metav1.ObjectMeta{Name: testBrokerName},
+		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
 		Spec: v1beta1.ClusterServiceBrokerSpec{
 			URL: testBrokerURL,
 		},
@@ -1043,7 +1038,7 @@ func TestServiceInstanceOrphanMitigation(t *testing.T) {
 	}
 
 	err = util.WaitForBrokerCondition(client,
-		testBrokerName,
+		testClusterServiceBrokerName,
 		v1beta1.ServiceBrokerCondition{
 			Type:   v1beta1.ServiceBrokerConditionReady,
 			Status: v1beta1.ConditionTrue,
@@ -1052,7 +1047,7 @@ func TestServiceInstanceOrphanMitigation(t *testing.T) {
 		t.Fatalf("error waiting for broker to become ready: %v", err)
 	}
 
-	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassID)
+	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
 	if nil != err {
 		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
 	}
@@ -1067,7 +1062,7 @@ func TestServiceInstanceOrphanMitigation(t *testing.T) {
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
 				ClusterServiceClassExternalName: testClusterServiceClassName,
-				ClusterServicePlanExternalName:  testPlanName,
+				ClusterServicePlanExternalName:  testClusterServicePlanName,
 			},
 			ExternalID: testExternalID,
 		},
@@ -1115,7 +1110,7 @@ func TestServiceInstanceOrphanMitigation(t *testing.T) {
 	// End orphan mitigation test
 
 	// Delete the broker
-	err = client.ClusterServiceBrokers().Delete(testBrokerName, &metav1.DeleteOptions{})
+	err = client.ClusterServiceBrokers().Delete(testClusterServiceBrokerName, &metav1.DeleteOptions{})
 	if nil != err {
 		t.Fatalf("broker should be deleted (%s)", err)
 	}
@@ -1125,7 +1120,7 @@ func TestServiceInstanceOrphanMitigation(t *testing.T) {
 		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
 	}
 
-	err = util.WaitForBrokerToNotExist(client, testBrokerName)
+	err = util.WaitForBrokerToNotExist(client, testClusterServiceBrokerName)
 	if err != nil {
 		t.Fatalf("error waiting for Broker to not exist: %v", err)
 	}
@@ -1158,7 +1153,7 @@ func TestServiceBindingOrphanMitigation(t *testing.T) {
 	client := fakeCatalogClient.ServicecatalogV1beta1()
 
 	broker := &v1beta1.ClusterServiceBroker{
-		ObjectMeta: metav1.ObjectMeta{Name: testBrokerName},
+		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
 		Spec: v1beta1.ClusterServiceBrokerSpec{
 			URL: testBrokerURL,
 		},
@@ -1170,7 +1165,7 @@ func TestServiceBindingOrphanMitigation(t *testing.T) {
 	}
 
 	err = util.WaitForBrokerCondition(client,
-		testBrokerName,
+		testClusterServiceBrokerName,
 		v1beta1.ServiceBrokerCondition{
 			Type:   v1beta1.ServiceBrokerConditionReady,
 			Status: v1beta1.ConditionTrue,
@@ -1179,7 +1174,7 @@ func TestServiceBindingOrphanMitigation(t *testing.T) {
 		t.Fatalf("error waiting for broker to become ready: %v", err)
 	}
 
-	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassID)
+	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
 	if nil != err {
 		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
 	}
@@ -1194,7 +1189,7 @@ func TestServiceBindingOrphanMitigation(t *testing.T) {
 		Spec: v1beta1.ServiceInstanceSpec{
 			PlanReference: v1beta1.PlanReference{
 				ClusterServiceClassExternalName: testClusterServiceClassName,
-				ClusterServicePlanExternalName:  testPlanName,
+				ClusterServicePlanExternalName:  testClusterServicePlanName,
 			},
 			ExternalID: testExternalID,
 		},
@@ -1283,7 +1278,7 @@ func TestServiceBindingOrphanMitigation(t *testing.T) {
 	// End provision test
 
 	// Delete the broker
-	err = client.ClusterServiceBrokers().Delete(testBrokerName, &metav1.DeleteOptions{})
+	err = client.ClusterServiceBrokers().Delete(testClusterServiceBrokerName, &metav1.DeleteOptions{})
 	if nil != err {
 		t.Fatalf("broker should be deleted (%s)", err)
 	}
@@ -1293,7 +1288,7 @@ func TestServiceBindingOrphanMitigation(t *testing.T) {
 		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
 	}
 
-	err = util.WaitForBrokerToNotExist(client, testBrokerName)
+	err = util.WaitForBrokerToNotExist(client, testClusterServiceBrokerName)
 	if err != nil {
 		t.Fatalf("error waiting for Broker to not exist: %v", err)
 	}
@@ -1401,7 +1396,7 @@ func getTestCatalogResponse() *osb.CatalogResponse {
 				Bindable:    true,
 				Plans: []osb.Plan{
 					{
-						Name:        testPlanName,
+						Name:        testClusterServicePlanName,
 						Free:        truePtr(),
 						ID:          testPlanExternalID,
 						Description: "a test plan",

--- a/test/integration/deleted_services_and_plans_test.go
+++ b/test/integration/deleted_services_and_plans_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	// avoid error `servicecatalog/v1beta1 is not enabled`
+	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
+
+	fakeosb "github.com/pmorie/go-open-service-broker-client/v2/fake"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/test/util"
+)
+
+func TestClusterServicePlanRemovedFromCatalogWithoutInstances(t *testing.T) {
+	_, catalogClient, _, _, _, _, shutdownServer, shutdownController := newTestController(t, fakeosb.FakeClientConfiguration{
+		CatalogReaction: &fakeosb.CatalogReaction{
+			Response: getTestCatalogResponse(),
+		},
+	})
+	defer shutdownController()
+	defer shutdownServer()
+
+	client := catalogClient.ServicecatalogV1beta1()
+
+	broker := &v1beta1.ClusterServiceBroker{
+		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
+		Spec: v1beta1.ClusterServiceBrokerSpec{
+			URL: testBrokerURL,
+		},
+	}
+
+	_, err := client.ClusterServiceBrokers().Create(broker)
+	if nil != err {
+		t.Fatalf("error creating the broker %q (%q)", broker.Name, err)
+	}
+
+	err = util.WaitForBrokerCondition(client,
+		testClusterServiceBrokerName,
+		v1beta1.ServiceBrokerCondition{
+			Type:   v1beta1.ServiceBrokerConditionReady,
+			Status: v1beta1.ConditionTrue,
+		})
+	if err != nil {
+		t.Fatalf("error waiting for broker to become ready: %v", err)
+	}
+
+	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
+	if nil != err {
+		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
+	}
+
+	removedPlan := getTestClusterServicePlanRemoved()
+	removedPlan, err = client.ClusterServicePlans().Create(removedPlan)
+	if err != nil {
+		t.Fatalf("error creating ClusterServicePlan: %v", err)
+	}
+
+	err = util.WaitForClusterServicePlanToExist(client, testRemovedClusterServicePlanGUID)
+	if err != nil {
+		t.Fatalf("error waiting for ClusterServicePlan to exist: %v", err)
+	}
+
+	t.Log("updating ClusterServiceClass status")
+	removedPlan.Status.RemovedFromBrokerCatalog = true
+	_, err = client.ClusterServicePlans().UpdateStatus(removedPlan)
+	if err != nil {
+		t.Fatalf("error marking ClusterServicePlan as removed from catalog: %v", err)
+	}
+
+	err = util.WaitForClusterServicePlanToNotExist(client, testRemovedClusterServicePlanGUID)
+	if err != nil {
+		t.Fatalf("error waiting for remove ClusterServicePlan to not exist: %v", err)
+	}
+}
+
+const (
+	testRemovedClusterServicePlanGUID         = "removed-plan"
+	testRemovedClusterServicePlanExternalName = "removed-plan-name"
+)
+
+func getTestClusterServicePlanRemoved() *v1beta1.ClusterServicePlan {
+	return &v1beta1.ClusterServicePlan{
+		ObjectMeta: metav1.ObjectMeta{Name: testRemovedClusterServicePlanGUID},
+		Spec: v1beta1.ClusterServicePlanSpec{
+			ClusterServiceBrokerName: testClusterServiceBrokerName,
+			ExternalID:               testRemovedClusterServicePlanGUID,
+			ExternalName:             testRemovedClusterServicePlanExternalName,
+			Description:              "a plan that will be removed",
+			Bindable:                 truePtr(),
+			ClusterServiceClassRef: v1beta1.ClusterObjectReference{
+				Name: testClusterServiceClassGUID,
+			},
+		},
+		Status: v1beta1.ClusterServicePlanStatus{},
+	}
+}

--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -21,3 +21,8 @@ package integration
 func strPtr(s string) *string {
 	return &s
 }
+
+func truePtr() *bool {
+	b := true
+	return &b
+}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -93,6 +93,42 @@ func WaitForClusterServiceClassToExist(client v1beta1servicecatalog.Servicecatal
 	)
 }
 
+// WaitForClusterServiceClassToExist waits for the ClusterServiceClass with the given name
+// to exist.
+func WaitForClusterServicePlanToExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {
+	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
+		func() (bool, error) {
+			glog.V(5).Infof("Waiting for ClusterServicePlan %v to exist", name)
+			_, err := client.ClusterServicePlans().Get(name, metav1.GetOptions{})
+			if nil == err {
+				return true, nil
+			}
+
+			return false, nil
+		},
+	)
+}
+
+// WaitForClusterServicePlanToNotExist waits for the ClusterServicePlan with the given name
+// to not exist.
+func WaitForClusterServicePlanToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {
+	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
+		func() (bool, error) {
+			glog.V(5).Infof("Waiting for ClusterServicePlan %q to not exist", name)
+			_, err := client.ClusterServicePlans().Get(name, metav1.GetOptions{})
+			if nil == err {
+				return false, nil
+			}
+
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+
+			return false, nil
+		},
+	)
+}
+
 // WaitForClusterServiceClassToNotExist waits for the ClusterServiceClass with the given
 // name to no longer exist.
 func WaitForClusterServiceClassToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {


### PR DESCRIPTION
Part of #1424; remove serviceplans that are removed from the broker catalog when they have no instances remaining.