### PR TITLE
Delete removed serviceClasses when they have no instances remaining

### DIFF
--- a/pkg/controller/controller_serviceclass.go
+++ b/pkg/controller/controller_serviceclass.go
@@ -19,6 +19,10 @@ package controller
 import (
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -33,21 +37,6 @@ func (c *controller) serviceClassAdd(obj interface{}) {
 	c.serviceClassQueue.Add(key)
 }
 
-// reconcileServiceClassKey reconciles a ServiceClass due to controller resync
-// or an event on the ServiceClass.  Note that this is NOT the main
-// reconciliation loop for ServiceClass. ServiceClasses are primarily
-// reconciled in a separate flow when a ClusterServiceBroker is reconciled.
-func (c *controller) reconcileClusterServiceClassKey(key string) error {
-	// currently, this is a no-op.  In the future, we'll maintain status
-	// information here.
-	return nil
-}
-
-func (c *controller) reconcileClusterServiceClass(serviceClass *v1beta1.ClusterServiceClass) error {
-	glog.V(4).Infof("Processing ServiceClass %v", serviceClass.Name)
-	return nil
-}
-
 func (c *controller) serviceClassUpdate(oldObj, newObj interface{}) {
 	c.serviceClassAdd(newObj)
 }
@@ -59,4 +48,54 @@ func (c *controller) serviceClassDelete(obj interface{}) {
 	}
 
 	glog.V(4).Infof("Received delete event for ServiceClass %v; no further processing will occur", serviceClass.Name)
+}
+
+// reconcileServiceClassKey reconciles a ServiceClass due to controller resync
+// or an event on the ServiceClass.  Note that this is NOT the main
+// reconciliation loop for ServiceClass. ServiceClasses are primarily
+// reconciled in a separate flow when a ClusterServiceBroker is reconciled.
+func (c *controller) reconcileClusterServiceClassKey(key string) error {
+	plan, err := c.serviceClassLister.Get(key)
+	if errors.IsNotFound(err) {
+		glog.Infof("ClusterServiceClass %q: Not doing work because it has been deleted", key)
+		return nil
+	}
+	if err != nil {
+		glog.Infof("ClusterServiceClass %q: Unable to retrieve object from store: %v", key, err)
+		return err
+	}
+
+	return c.reconcileClusterServiceClass(plan)
+}
+
+func (c *controller) reconcileClusterServiceClass(serviceClass *v1beta1.ClusterServiceClass) error {
+	glog.Infof("ClusterServiceClass %q (ExternalName: %q): processing", serviceClass.Name, serviceClass.Spec.ExternalName)
+
+	if !serviceClass.Status.RemovedFromBrokerCatalog {
+		return nil
+	}
+
+	glog.Infof("ClusterServiceClass %q (ExternalName: %q): has been removed from broker catalog; determining whether there are instances remaining", serviceClass.Name, serviceClass.Spec.ExternalName)
+
+	serviceInstances, err := c.findServiceInstancesOnClusterServiceClass(serviceClass)
+	if err != nil {
+		return err
+	}
+
+	if len(serviceInstances.Items) != 0 {
+		return nil
+	}
+
+	glog.Infof("ClusterServiceClass %q (ExternalName: %q): has been removed from broker catalog and has zero instances remaining; deleting", serviceClass.Name, serviceClass.Spec.ExternalName)
+	return c.serviceCatalogClient.ClusterServiceClasses().Delete(serviceClass.Name, &metav1.DeleteOptions{})
+}
+
+func (c *controller) findServiceInstancesOnClusterServiceClass(serviceClass *v1beta1.ClusterServiceClass) (*v1beta1.ServiceInstanceList, error) {
+	fieldSet := fields.Set{
+		"spec.clusterServiceClassRef.name": serviceClass.Name,
+	}
+	fieldSelector := fields.SelectorFromSet(fieldSet).String()
+	listOpts := metav1.ListOptions{FieldSelector: fieldSelector}
+
+	return c.serviceCatalogClient.ServiceInstances(metav1.NamespaceAll).List(listOpts)
 }

--- a/pkg/controller/controller_serviceclass_test.go
+++ b/pkg/controller/controller_serviceclass_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/test/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
+	getRemovedServiceClass := func() *v1beta1.ClusterServiceClass {
+		p := getTestClusterServiceClass()
+		p.Status.RemovedFromBrokerCatalog = true
+		return p
+	}
+
+	cases := []struct {
+		name                    string
+		serviceClass            *v1beta1.ClusterServiceClass
+		instances               []v1beta1.ServiceInstance
+		catalogClientPrepFunc   func(*fake.Clientset)
+		shouldError             bool
+		errText                 *string
+		catalogActionsCheckFunc func(t *testing.T, name string, actions []clientgotesting.Action)
+	}{
+		{
+			name:         "not removed from catalog",
+			serviceClass: getTestClusterServiceClass(),
+			shouldError:  false,
+		},
+		{
+			name:         "removed from catalog, instances left",
+			serviceClass: getRemovedServiceClass(),
+			instances:    []v1beta1.ServiceInstance{*getTestServiceInstance()},
+			shouldError:  false,
+			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+				listRestrictions := clientgotesting.ListRestrictions{
+					Labels: labels.Everything(),
+					Fields: fields.OneTermEqualSelector("spec.clusterServiceClassRef.name", "SCGUID"),
+				}
+
+				expectNumberOfActions(t, name, actions, 1)
+				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
+			},
+		},
+		{
+			name:         "removed from catalog, no instances left",
+			serviceClass: getRemovedServiceClass(),
+			instances:    nil,
+			shouldError:  false,
+			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+				listRestrictions := clientgotesting.ListRestrictions{
+					Labels: labels.Everything(),
+					Fields: fields.OneTermEqualSelector("spec.clusterServiceClassRef.name", "SCGUID"),
+				}
+
+				expectNumberOfActions(t, name, actions, 2)
+				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
+				assertDelete(t, actions[1], getRemovedServiceClass())
+			},
+		},
+		{
+			name: "removed from catalog, no instances left, delete fails", serviceClass: getRemovedServiceClass(),
+			instances:   nil,
+			shouldError: true,
+			catalogClientPrepFunc: func(client *fake.Clientset) {
+				client.AddReactor("delete", "clusterserviceclasses", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("oops")
+				})
+			},
+			errText: strPtr("oops"),
+			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+				listRestrictions := clientgotesting.ListRestrictions{
+					Labels: labels.Everything(),
+					Fields: fields.OneTermEqualSelector("spec.clusterServiceClassRef.name", "SCGUID"),
+				}
+
+				expectNumberOfActions(t, name, actions, 2)
+				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
+				assertDelete(t, actions[1], getRemovedServiceClass())
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		_, fakeCatalogClient, _, testController, _ := newTestController(t, noFakeActions())
+
+		fakeCatalogClient.AddReactor("list", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			return true, &v1beta1.ServiceInstanceList{Items: tc.instances}, nil
+		})
+
+		if tc.catalogClientPrepFunc != nil {
+			tc.catalogClientPrepFunc(fakeCatalogClient)
+		}
+
+		err := testController.reconcileClusterServiceClass(tc.serviceClass)
+		if err != nil {
+			if !tc.shouldError {
+				t.Errorf("%v: unexpected error from method under test: %v", tc.name, err)
+				continue
+			} else if tc.errText != nil && *tc.errText != err.Error() {
+				t.Errorf("%v: unexpected error text from method under test; expected %v, got %v", tc.name, tc.errText, err.Error())
+				continue
+			}
+		}
+
+		actions := fakeCatalogClient.Actions()
+
+		if tc.catalogActionsCheckFunc != nil {
+			tc.catalogActionsCheckFunc(t, tc.name, actions)
+		} else {
+			expectNumberOfActions(t, tc.name, actions, 0)
+		}
+	}
+}


### PR DESCRIPTION
Final part of #1424; depends on #1444 

Delete removed serviceClasses when they have no instances remaining.