### PR TITLE
clean up logic and fix event for failed poll

### DIFF
--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -2041,7 +2041,7 @@ func TestPollServiceInstanceFailureDeprovisioningWithOperation(t *testing.T) {
 
 	events := getRecordedEvents(testController)
 	assertNumEvents(t, events, 1)
-	expectedEvent := corev1.EventTypeWarning + " " + errorDeprovisionCalledReason + " " + "Error deprovisioning: \"\""
+	expectedEvent := corev1.EventTypeWarning + " " + errorDeprovisionCalledReason + " " + "Deprovision call failed: (no description provided)"
 	if e, a := expectedEvent, events[0]; e != a {
 		t.Fatalf("Received unexpected event: %v\nExpected: %v", a, e)
 	}


### PR DESCRIPTION
- Event reason was always using `errorDeprovisionCalledReason`
- When no description provided, the message would just end in a colon. Changed to say "(no description provided)"
- Cleans up logic to only use one switch block