### PR TITLE
Make instance UpdateRequests and broker RelistRequests optional

### DIFF
--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -74,6 +74,7 @@ type ClusterServiceBrokerSpec struct {
 
 	// RelistRequests is a strictly increasing, non-negative integer counter that
 	// can be manually incremented by a user to manually trigger a relist.
+	// +optional
 	RelistRequests int64 `json:"relistRequests"`
 }
 
@@ -508,6 +509,7 @@ type ServiceInstanceSpec struct {
 	// can be manually incremented by a user to manually trigger an update. This
 	// allows for parameters to be updated with any out-of-band changes that have
 	// been made to the secrets from which the parameters are sourced.
+	// +optional
 	UpdateRequests int64 `json:"updateRequests"`
 }
 

--- a/pkg/registry/servicecatalog/broker/strategy.go
+++ b/pkg/registry/servicecatalog/broker/strategy.go
@@ -125,6 +125,11 @@ func (brokerRESTStrategy) PrepareForUpdate(ctx genericapirequest.Context, new, o
 
 	newClusterServiceBroker.Status = oldClusterServiceBroker.Status
 
+	// Ignore the RelistRequests field when it is the default value
+	if newClusterServiceBroker.Spec.RelistRequests == 0 {
+		newClusterServiceBroker.Spec.RelistRequests = oldClusterServiceBroker.Spec.RelistRequests
+	}
+
 	// Spec updates bump the generation so that we can distinguish between
 	// spec changes and other changes to the object.
 	if !apiequality.Semantic.DeepEqual(oldClusterServiceBroker.Spec, newClusterServiceBroker.Spec) {

--- a/pkg/registry/servicecatalog/broker/strategy_test.go
+++ b/pkg/registry/servicecatalog/broker/strategy_test.go
@@ -125,3 +125,52 @@ func TestBrokerUpdate(t *testing.T) {
 		}
 	}
 }
+
+// TestBrokerUpdateForRelistRequests tests that the RelistRequests field is
+// ignored during updates when it is the default value.
+func TestBrokerUpdateForRelistRequests(t *testing.T) {
+	cases := []struct {
+		name          string
+		oldValue      int64
+		newValue      int64
+		expectedValue int64
+	}{
+		{
+			name:          "both default",
+			oldValue:      0,
+			newValue:      0,
+			expectedValue: 0,
+		},
+		{
+			name:          "old default",
+			oldValue:      0,
+			newValue:      1,
+			expectedValue: 1,
+		},
+		{
+			name:          "new default",
+			oldValue:      1,
+			newValue:      0,
+			expectedValue: 1,
+		},
+		{
+			name:          "neither default",
+			oldValue:      1,
+			newValue:      2,
+			expectedValue: 2,
+		},
+	}
+	for _, tc := range cases {
+		oldBroker := brokerWithOldSpec()
+		oldBroker.Spec.RelistRequests = tc.oldValue
+
+		newBroker := brokerWithOldSpec()
+		newBroker.Spec.RelistRequests = tc.newValue
+
+		brokerRESTStrategies.PrepareForUpdate(nil, newBroker, oldBroker)
+
+		if e, a := tc.expectedValue, newBroker.Spec.RelistRequests; e != a {
+			t.Errorf("%s: got unexpected RelistRequests: expected %v, got %v", tc.name, e, a)
+		}
+	}
+}

--- a/pkg/registry/servicecatalog/instance/strategy.go
+++ b/pkg/registry/servicecatalog/instance/strategy.go
@@ -158,6 +158,11 @@ func (instanceRESTStrategy) PrepareForUpdate(ctx genericapirequest.Context, new,
 		newServiceInstance.Spec.ClusterServicePlanRef = nil
 	}
 
+	// Ignore the UpdateRequests field when it is the default value
+	if newServiceInstance.Spec.UpdateRequests == 0 {
+		newServiceInstance.Spec.UpdateRequests = oldServiceInstance.Spec.UpdateRequests
+	}
+
 	// Spec updates bump the generation so that we can distinguish between
 	// spec changes and other changes to the object.
 	if !apiequality.Semantic.DeepEqual(oldServiceInstance.Spec, newServiceInstance.Spec) {

--- a/pkg/registry/servicecatalog/instance/strategy_test.go
+++ b/pkg/registry/servicecatalog/instance/strategy_test.go
@@ -163,3 +163,52 @@ func TestInstanceUserInfo(t *testing.T) {
 		t.Errorf("unexpected user info in deleted spec: expected %v, got %v", e, a)
 	}
 }
+
+// TestInstanceUpdateForUpdateRequests tests that the UpdateRequests field is
+// ignored during updates when it is the default value.
+func TestInstanceUpdateForUpdateRequests(t *testing.T) {
+	cases := []struct {
+		name          string
+		oldValue      int64
+		newValue      int64
+		expectedValue int64
+	}{
+		{
+			name:          "both default",
+			oldValue:      0,
+			newValue:      0,
+			expectedValue: 0,
+		},
+		{
+			name:          "old default",
+			oldValue:      0,
+			newValue:      1,
+			expectedValue: 1,
+		},
+		{
+			name:          "new default",
+			oldValue:      1,
+			newValue:      0,
+			expectedValue: 1,
+		},
+		{
+			name:          "neither default",
+			oldValue:      1,
+			newValue:      2,
+			expectedValue: 2,
+		},
+	}
+	for _, tc := range cases {
+		oldInstance := getTestInstance()
+		oldInstance.Spec.UpdateRequests = tc.oldValue
+
+		newInstance := getTestInstance()
+		newInstance.Spec.UpdateRequests = tc.newValue
+
+		instanceRESTStrategies.PrepareForUpdate(nil, newInstance, oldInstance)
+
+		if e, a := tc.expectedValue, newInstance.Spec.UpdateRequests; e != a {
+			t.Errorf("%s: got unexpected UpdateRequests: expected %v, got %v", tc.name, e, a)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1454.

* Add `+optional` to `ClusterServiceBrokerSpec.RelistRequests` and `ServiceInstanceSpec.UpdateRequests`.
* Ignore those two fields on updates when the new value is the default value. This allows a user to do a full update of the resource without needing to explicitly supply the value for the `RelistRequests` or `UpdateRequests` fields.