### PR TITLE
Modify Makefile to only specify ldflags once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,7 @@ $(error Unsupported platform to compile for)
 endif
 
 GO_BUILD       = env GOOS=$(PLATFORM) GOARCH=$(ARCH) go build -i $(GOFLAGS) \
-                   -ldflags "-X $(SC_PKG)/pkg.VERSION=$(VERSION)" \
-                   -ldflags "$(BUILD_LDFLAGS)"
+                   -ldflags "-X $(SC_PKG)/pkg.VERSION=$(VERSION) $(BUILD_LDFLAGS)"
 BASE_PATH      = $(ROOT:/src/github.com/kubernetes-incubator/service-catalog/=)
 export GOPATH  = $(BASE_PATH):$(ROOT)/vendor
 


### PR DESCRIPTION
They are not cumulative, so latter ldflags will cause the previous ones to not
be set. In this case, that caused the version information to not be set as
expected.

Closes #1469