### PR TITLE
Use the base debian image from kube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,19 +59,7 @@ PLATFORM?=linux
 ARCH?=amd64
 
 # TODO: Consider using busybox instead of debian
-ifeq ($(ARCH),amd64)
-	BASEIMAGE?=debian:jessie
-else ifeq ($(ARCH),arm)
-	BASEIMAGE?=arm32v7/debian:jessie
-else ifeq ($(ARCH),arm64)
-	BASEIMAGE?=arm64v8/debian:jessie
-else ifeq ($(ARCH),ppc64le)
-	BASEIMAGE?=ppc64le/debian:jessie
-else ifeq ($(ARCH),s390x)
-	BASEIMAGE?=s390x/debian:jessie
-else
-$(error Unsupported platform to compile for)
-endif
+BASEIMAGE?=gcr.io/google-containers/debian-base-$(ARCH):0.2
 
 GO_BUILD       = env GOOS=$(PLATFORM) GOARCH=$(ARCH) go build -i $(GOFLAGS) \
                    -ldflags "-X $(SC_PKG)/pkg.VERSION=$(VERSION) $(BUILD_LDFLAGS)"


### PR DESCRIPTION
Fixes #1473.

The docker images for architectures other than the native architecture cannot be built because they include `RUN` commands. To execute the `RUN` commands, the containers need to support emulation. The images used by https://github.com/kubernetes/kubernetes already support emulation. So rather than build our own images, let's use the ones that already exist.

A side effect of this is that the service-catalog images will be about half the size since the images from https://github.com/kubernetes/kubernetes are trimmed down from  basic debian image to remove unneeded parts.