### PR TITLE
make verify validates that versioned APIs contain json tags for fields, addresses #1303

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,8 @@ verify: .init .generate_files verify-client-gen
 	@$(DOCKER_CMD) verify-links.sh -t .
 	@echo Running errexit checker:
 	@$(DOCKER_CMD) build/verify-errexit.sh
+	@echo Running tag verification:
+	@$(DOCKER_CMD) build/verify-tags.sh
 
 verify-client-gen: .init .generate_files
 	$(DOCKER_CMD) $(BUILD_DIR)/verify-client-gen.sh

--- a/build/verify-tags.sh
+++ b/build/verify-tags.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+result=0
+
+find_files() {
+  find . -not \( \
+      \( \
+        -wholename './output' \
+        -o -wholename './_output' \
+        -o -wholename './_gopath' \
+        -o -wholename './release' \
+        -o -wholename './target' \
+        -o -wholename '*/third_party/*' \
+        -o -wholename '*/vendor/*' \
+      \) -prune \
+    \) \
+    \( -wholename '*pkg/api/v*/types.go' \
+       -o -wholename '*pkg/apis/*/v*/types.go' \
+       -o -wholename '*pkg/api/unversioned/types.go' \
+    \)
+}
+
+if [[ $# -eq 0 ]]; then
+  versioned_api_files=$(find_files | egrep "pkg/(.[^/]*)+/((v.[^/]*)|unversioned)/types\.go")
+else
+  versioned_api_files="${*}"
+fi
+
+for file in $versioned_api_files; do
+  if tail -n +22 "${file}" | egrep -v "(\/\/|{|}|\(|\)|type|=)" | sed '/^\s*$/d' | grep -v json; then 
+#  if grep metav1 "${file}" | grep -v // | grep -v "\".*\"" | grep -v json ; then
+    echo "versioned APIs should contain json tags for fields in file ${file}"
+    result=1
+  fi
+done
+exit ${result}

--- a/build/verify-tags.sh
+++ b/build/verify-tags.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#This script makes sure each versioned API in service catalog
+# This script makes sure each versioned API in service catalog
 #has as json tag
 
 set -o errexit
@@ -46,8 +46,8 @@ else
 fi
 
 for file in $versioned_api_files; do
-  if tail -n +22 "${file}" | egrep -v "(\/\/|{|}|\(|\)|type|=)" | sed '/^\s*$/d' | grep -v json; then 
-    echo "versioned APIs should contain json tags for fields in file ${file}"
+  if cat -n "${file}" | tail -n +22 | grep -v "^\s*[0-9]*\s$" | egrep -v "(\/\/|{|}|\(|\)|type|=)" | grep -v json; then 
+    echo "Versioned APIs should contain json tags for fields in file ${file}"
     result=1
   fi
 done

--- a/build/verify-tags.sh
+++ b/build/verify-tags.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#This script makes sure each versioned API in service catalog
+#has as json tag
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -24,11 +27,9 @@ find_files() {
   find . -not \( \
       \( \
         -wholename './output' \
-        -o -wholename './_output' \
         -o -wholename './_gopath' \
         -o -wholename './release' \
         -o -wholename './target' \
-        -o -wholename '*/third_party/*' \
         -o -wholename '*/vendor/*' \
       \) -prune \
     \) \
@@ -46,7 +47,6 @@ fi
 
 for file in $versioned_api_files; do
   if tail -n +22 "${file}" | egrep -v "(\/\/|{|}|\(|\)|type|=)" | sed '/^\s*$/d' | grep -v json; then 
-#  if grep metav1 "${file}" | grep -v // | grep -v "\".*\"" | grep -v json ; then
     echo "versioned APIs should contain json tags for fields in file ${file}"
     result=1
   fi

--- a/build/verify-tags.sh
+++ b/build/verify-tags.sh
@@ -46,7 +46,7 @@ else
 fi
 
 for file in $versioned_api_files; do
-  if cat -n "${file}" | tail -n +22 | grep -v "^\s*[0-9]*\s$" | egrep -v "(\/\/|{|}|\(|\)|type|=)" | grep -v json; then 
+  if cat -n "${file}" | sed -n '/genclient/,$p' | grep -v "^\s*[0-9]*\s$" | egrep -v "(\/\/|{|}|\(|\)|type|=)" | grep -v json; then 
     echo "Versioned APIs should contain json tags for fields in file ${file}"
     result=1
   fi


### PR DESCRIPTION
Closes #1303 

It works. However, I'm looking for feedback on the way I went about it. See code comments.

Based on a good ol' 'netes script https://github.com/kubernetes/kubernetes/blob/master/hack/verify-description.sh