### PR TITLE
Send deprovision request when an instance is deleted even when the provision request failed

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -614,18 +614,21 @@ type ServiceInstancePropertiesState struct {
 type ServiceInstanceDeprovisionStatus string
 
 const (
-	// A provision request has not been sent for the ServiceInstance, so no
-	// deprovision request needs to be made.
+	// ServiceInstanceDeprovisionStatusNotRequired indicates that a provision
+	// request has not been sent for the ServiceInstance, so no deprovision
+	// request needs to be made.
 	ServiceInstanceDeprovisionStatusNotRequired ServiceInstanceDeprovisionStatus = "Not Required"
-	// A provision request has been sent for the ServiceInstance. A
-	// deprovision request must be made before deleting the ServiceInstance.
+	// ServiceInstanceDeprovisionStatusRequired indicates that a provision
+	// request has been sent for the ServiceInstance. A deprovision request
+	// must be made before deleting the ServiceInstance.
 	ServiceInstanceDeprovisionStatusRequired ServiceInstanceDeprovisionStatus = "Required"
-	// A deprovisionm request has been sent for the ServiceInstance, and the
-	// request was successful.
+	// ServiceInstanceDeprovisionStatusSucceeded indicates that a deprovision
+	// request has been sent for the ServiceInstance, and the request was
+	// successful.
 	ServiceInstanceDeprovisionStatusSucceeded ServiceInstanceDeprovisionStatus = "Succeeded"
-	// A deprovision requests have been sent for the ServiceInstance but they
-	// failed. The controller has given up on sending more deprovision
-	// requests.
+	// ServiceInstanceDeprovisionStatusFailed indicates that deprovision
+	// requests have been sent for the ServiceInstance but they failed. The
+	// controller has given up on sending more deprovision requests.
 	ServiceInstanceDeprovisionStatusFailed ServiceInstanceDeprovisionStatus = "Failed"
 )
 

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -533,6 +533,10 @@ type ServiceInstanceStatus struct {
 	// ExternalProperties is the properties state of the ServiceInstance which the
 	// broker knows about.
 	ExternalProperties *ServiceInstancePropertiesState
+
+	// DeprovisionStatus describes what has been done to deprovision the
+	// ServiceInstance.
+	DeprovisionStatus ServiceInstanceDeprovisionStatus
 }
 
 // ServiceInstanceCondition contains condition information about an Instance.
@@ -604,6 +608,26 @@ type ServiceInstancePropertiesState struct {
 	// UserInfo is information about the user that made the request.
 	UserInfo *UserInfo
 }
+
+// ServiceInstanceDeprovisionStatus is the status of deprovisioning a
+// ServiceInstance
+type ServiceInstanceDeprovisionStatus string
+
+const (
+	// A provision request has not been sent for the ServiceInstance, so no
+	// deprovision request needs to be made.
+	ServiceInstanceDeprovisionStatusNotRequired ServiceInstanceDeprovisionStatus = "Not Required"
+	// A provision request has been sent for the ServiceInstance. A
+	// deprovision request must be made before deleting the ServiceInstance.
+	ServiceInstanceDeprovisionStatusRequired ServiceInstanceDeprovisionStatus = "Required"
+	// A deprovisionm request has been sent for the ServiceInstance, and the
+	// request was successful.
+	ServiceInstanceDeprovisionStatusSucceeded ServiceInstanceDeprovisionStatus = "Succeeded"
+	// A deprovision requests have been sent for the ServiceInstance but they
+	// failed. The controller has given up on sending more deprovision
+	// requests.
+	ServiceInstanceDeprovisionStatusFailed ServiceInstanceDeprovisionStatus = "Failed"
+)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -617,7 +617,7 @@ const (
 	// ServiceInstanceDeprovisionStatusNotRequired indicates that a provision
 	// request has not been sent for the ServiceInstance, so no deprovision
 	// request needs to be made.
-	ServiceInstanceDeprovisionStatusNotRequired ServiceInstanceDeprovisionStatus = "Not Required"
+	ServiceInstanceDeprovisionStatusNotRequired ServiceInstanceDeprovisionStatus = "NotRequired"
 	// ServiceInstanceDeprovisionStatusRequired indicates that a provision
 	// request has been sent for the ServiceInstance. A deprovision request
 	// must be made before deleting the ServiceInstance.

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -556,6 +556,10 @@ type ServiceInstanceStatus struct {
 	// ExternalProperties is the properties state of the ServiceInstance which the
 	// broker knows about.
 	ExternalProperties *ServiceInstancePropertiesState `json:"externalProperties,omitempty"`
+
+	// DeprovisionStatus describes what has been done to deprovision the
+	// ServiceInstance.
+	DeprovisionStatus ServiceInstanceDeprovisionStatus `json:"deprovisionStatus"`
 }
 
 // ServiceInstanceCondition contains condition information about an Instance.
@@ -627,6 +631,26 @@ type ServiceInstancePropertiesState struct {
 	// UserInfo is information about the user that made the request.
 	UserInfo *UserInfo `json:"userInfo,omitempty"`
 }
+
+// ServiceInstanceDeprovisionStatus is the status of deprovisioning a
+// ServiceInstance
+type ServiceInstanceDeprovisionStatus string
+
+const (
+	// A provision request has not been sent for the ServiceInstance, so no
+	// deprovision request needs to be made.
+	ServiceInstanceDeprovisionStatusNotRequired ServiceInstanceDeprovisionStatus = "Not Required"
+	// A provision request has been sent for the ServiceInstance. A
+	// deprovision request must be made before deleting the ServiceInstance.
+	ServiceInstanceDeprovisionStatusRequired ServiceInstanceDeprovisionStatus = "Required"
+	// A deprovisionm request has been sent for the ServiceInstance, and the
+	// request was successful.
+	ServiceInstanceDeprovisionStatusSucceeded ServiceInstanceDeprovisionStatus = "Succeeded"
+	// A deprovision requests have been sent for the ServiceInstance but they
+	// failed. The controller has given up on sending more deprovision
+	// requests.
+	ServiceInstanceDeprovisionStatusFailed ServiceInstanceDeprovisionStatus = "Failed"
+)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -637,18 +637,21 @@ type ServiceInstancePropertiesState struct {
 type ServiceInstanceDeprovisionStatus string
 
 const (
-	// A provision request has not been sent for the ServiceInstance, so no
-	// deprovision request needs to be made.
+	// ServiceInstanceDeprovisionStatusNotRequired indicates that a provision
+	// request has not been sent for the ServiceInstance, so no deprovision
+	// request needs to be made.
 	ServiceInstanceDeprovisionStatusNotRequired ServiceInstanceDeprovisionStatus = "Not Required"
-	// A provision request has been sent for the ServiceInstance. A
-	// deprovision request must be made before deleting the ServiceInstance.
+	// ServiceInstanceDeprovisionStatusRequired indicates that a provision
+	// request has been sent for the ServiceInstance. A deprovision request
+	// must be made before deleting the ServiceInstance.
 	ServiceInstanceDeprovisionStatusRequired ServiceInstanceDeprovisionStatus = "Required"
-	// A deprovisionm request has been sent for the ServiceInstance, and the
-	// request was successful.
+	// ServiceInstanceDeprovisionStatusSucceeded indicates that a deprovision
+	// request has been sent for the ServiceInstance, and the request was
+	// successful.
 	ServiceInstanceDeprovisionStatusSucceeded ServiceInstanceDeprovisionStatus = "Succeeded"
-	// A deprovision requests have been sent for the ServiceInstance but they
-	// failed. The controller has given up on sending more deprovision
-	// requests.
+	// ServiceInstanceDeprovisionStatusFailed indicates that deprovision
+	// requests have been sent for the ServiceInstance but they failed. The
+	// controller has given up on sending more deprovision requests.
 	ServiceInstanceDeprovisionStatusFailed ServiceInstanceDeprovisionStatus = "Failed"
 )
 

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -640,7 +640,7 @@ const (
 	// ServiceInstanceDeprovisionStatusNotRequired indicates that a provision
 	// request has not been sent for the ServiceInstance, so no deprovision
 	// request needs to be made.
-	ServiceInstanceDeprovisionStatusNotRequired ServiceInstanceDeprovisionStatus = "Not Required"
+	ServiceInstanceDeprovisionStatusNotRequired ServiceInstanceDeprovisionStatus = "NotRequired"
 	// ServiceInstanceDeprovisionStatusRequired indicates that a provision
 	// request has been sent for the ServiceInstance. A deprovision request
 	// must be made before deleting the ServiceInstance.

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
@@ -996,6 +996,7 @@ func autoConvert_v1beta1_ServiceInstanceStatus_To_servicecatalog_ServiceInstance
 	out.OperationStartTime = (*v1.Time)(unsafe.Pointer(in.OperationStartTime))
 	out.InProgressProperties = (*servicecatalog.ServiceInstancePropertiesState)(unsafe.Pointer(in.InProgressProperties))
 	out.ExternalProperties = (*servicecatalog.ServiceInstancePropertiesState)(unsafe.Pointer(in.ExternalProperties))
+	out.DeprovisionStatus = servicecatalog.ServiceInstanceDeprovisionStatus(in.DeprovisionStatus)
 	return nil
 }
 
@@ -1015,6 +1016,7 @@ func autoConvert_servicecatalog_ServiceInstanceStatus_To_v1beta1_ServiceInstance
 	out.OperationStartTime = (*v1.Time)(unsafe.Pointer(in.OperationStartTime))
 	out.InProgressProperties = (*ServiceInstancePropertiesState)(unsafe.Pointer(in.InProgressProperties))
 	out.ExternalProperties = (*ServiceInstancePropertiesState)(unsafe.Pointer(in.ExternalProperties))
+	out.DeprovisionStatus = ServiceInstanceDeprovisionStatus(in.DeprovisionStatus)
 	return nil
 }
 

--- a/pkg/apis/servicecatalog/validation/instance.go
+++ b/pkg/apis/servicecatalog/validation/instance.go
@@ -171,7 +171,7 @@ func validateServiceInstanceStatus(status *sc.ServiceInstanceStatus, fldPath *fi
 
 	if create {
 		if status.DeprovisionStatus != sc.ServiceInstanceDeprovisionStatusNotRequired {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("deprovisionStatus"), status.DeprovisionStatus, `deprovisionStatus must be "Not Required" on create`))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("deprovisionStatus"), status.DeprovisionStatus, `deprovisionStatus must be "NotRequired" on create`))
 		}
 	} else {
 		if !validServiceInstanceDeprovisionStatuses[status.DeprovisionStatus] {

--- a/pkg/apis/servicecatalog/validation/instance.go
+++ b/pkg/apis/servicecatalog/validation/instance.go
@@ -45,6 +45,23 @@ var validServiceInstanceOperationValues = func() []string {
 	return validValues
 }()
 
+var validServiceInstanceDeprovisionStatuses = map[sc.ServiceInstanceDeprovisionStatus]bool{
+	sc.ServiceInstanceDeprovisionStatusNotRequired: true,
+	sc.ServiceInstanceDeprovisionStatusRequired:    true,
+	sc.ServiceInstanceDeprovisionStatusSucceeded:   true,
+	sc.ServiceInstanceDeprovisionStatusFailed:      true,
+}
+
+var validServiceInstanceDeprovisionStatusValues = func() []string {
+	validValues := make([]string, len(validServiceInstanceDeprovisionStatuses))
+	i := 0
+	for operation := range validServiceInstanceDeprovisionStatuses {
+		validValues[i] = string(operation)
+		i++
+	}
+	return validValues
+}()
+
 // ValidateServiceInstance validates an Instance and returns a list of errors.
 func ValidateServiceInstance(instance *sc.ServiceInstance) field.ErrorList {
 	return internalValidateServiceInstance(instance, true)
@@ -150,6 +167,16 @@ func validateServiceInstanceStatus(status *sc.ServiceInstanceStatus, fldPath *fi
 
 	if status.ExternalProperties != nil {
 		allErrs = append(allErrs, validateServiceInstancePropertiesState(status.ExternalProperties, fldPath.Child("externalProperties"), create)...)
+	}
+
+	if create {
+		if status.DeprovisionStatus != sc.ServiceInstanceDeprovisionStatusNotRequired {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("deprovisionStatus"), status.DeprovisionStatus, `deprovisionStatus must be "Not Required" on create`))
+		}
+	} else {
+		if !validServiceInstanceDeprovisionStatuses[status.DeprovisionStatus] {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("deprovisionStatus"), status.DeprovisionStatus, validServiceInstanceDeprovisionStatusValues))
+		}
 	}
 
 	return allErrs

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -72,7 +72,7 @@ const (
 	errorDeletedClusterServicePlanMessage      string = "ReferencesDeletedServicePlan"
 	errorFindingNamespaceServiceInstanceReason string = "ErrorFindingNamespaceForInstance"
 	errorOrphanMitigationFailedReason          string = "OrphanMitigationFailed"
-	errorInvalidDeprovisionStatusReason        string = "InvalidDeprovsionStatus"
+	errorInvalidDeprovisionStatusReason        string = "InvalidDeprovisionStatus"
 	errorInvalidDeprovisionStatusMessage       string = "The deprovision status is invalid"
 
 	asyncProvisioningReason                 string = "Provisioning"

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -1277,6 +1277,7 @@ func TestReconcileServiceInstanceDelete(t *testing.T) {
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{}
+	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 
 	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		return true, instance, nil
@@ -1343,6 +1344,7 @@ func TestReconcileServiceInstanceDeleteBlockedByCredentials(t *testing.T) {
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{}
+	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 
 	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		return true, instance, nil
@@ -1445,6 +1447,7 @@ func TestReconcileServiceInstanceDeleteAsynchronous(t *testing.T) {
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{}
+	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 
 	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		return true, instance, nil
@@ -1498,10 +1501,10 @@ func TestReconcileServiceInstanceDeleteAsynchronous(t *testing.T) {
 	}
 }
 
-// TestReconcileServiceInstanceDeleteFailedProvision tests that an instance
-// that failed to provision will be finalized, but no deprovision request will
-// be sent to the broker.
-func TestReconcileServiceInstanceDeleteFailedProvision(t *testing.T) {
+// TestReconcileServiceInstanceDeleteFailedProvisionWithoutRequest tests that
+// an instance that failed to provision without making a provision request
+// will be finalized, but no deprovision request will be sent to the broker.
+func TestReconcileServiceInstanceDeleteFailedProvisionWithoutRequest(t *testing.T) {
 	fakeKubeClient, fakeCatalogClient, fakeClusterServiceBrokerClient, testController, sharedInformers := newTestController(t, noFakeActions())
 
 	sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(getTestClusterServiceBroker())
@@ -1512,9 +1515,116 @@ func TestReconcileServiceInstanceDeleteFailedProvision(t *testing.T) {
 	instance.ObjectMeta.DeletionTimestamp = &metav1.Time{}
 	instance.ObjectMeta.Finalizers = []string{v1beta1.FinalizerServiceCatalog}
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{}
+	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusNotRequired
 
-	// we only invoke the broker client to deprovision if we have a reconciled generation set
-	// as that implies a previous success.
+	instance.Generation = 1
+	instance.Status.ReconciledGeneration = 0
+
+	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, instance, nil
+	})
+
+	err := testController.reconcileServiceInstance(instance)
+	if err != nil {
+		t.Fatalf("Unexpected error from reconcileServiceInstance: %v", err)
+	}
+
+	brokerActions := fakeClusterServiceBrokerClient.Actions()
+	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 0)
+
+	// Verify no core kube actions occurred
+	kubeActions := fakeKubeClient.Actions()
+	assertNumberOfActions(t, kubeActions, 0)
+
+	actions := fakeCatalogClient.Actions()
+	assertNumberOfActions(t, actions, 1)
+
+	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
+	assertEmptyFinalizers(t, updatedServiceInstance)
+
+	events := getRecordedEvents(testController)
+	assertNumEvents(t, events, 0)
+}
+
+// TestReconcileServiceInstanceDeleteFailedProvisionWithRequest tests that an
+// instance that failed to provision but for which a provision request was
+// made will have a deprovision request sent to the broker.
+func TestReconcileServiceInstanceDeleteFailedProvisionWithRequest(t *testing.T) {
+	fakeKubeClient, fakeCatalogClient, fakeClusterServiceBrokerClient, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
+		DeprovisionReaction: &fakeosb.DeprovisionReaction{
+			Response: &osb.DeprovisionResponse{},
+		},
+	})
+
+	sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(getTestClusterServiceBroker())
+	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(getTestClusterServiceClass())
+	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
+
+	instance := getTestServiceInstanceWithFailedStatus()
+	instance.ObjectMeta.DeletionTimestamp = &metav1.Time{}
+	instance.ObjectMeta.Finalizers = []string{v1beta1.FinalizerServiceCatalog}
+	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{}
+	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
+
+	instance.Generation = 2
+	instance.Status.ReconciledGeneration = 1
+
+	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, instance, nil
+	})
+
+	err := testController.reconcileServiceInstance(instance)
+	if err != nil {
+		t.Fatalf("Unexpected error from reconcileServiceInstance: %v", err)
+	}
+
+	brokerActions := fakeClusterServiceBrokerClient.Actions()
+	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
+	assertDeprovision(t, brokerActions[0], &osb.DeprovisionRequest{
+		AcceptsIncomplete: true,
+		InstanceID:        testServiceInstanceGUID,
+		ServiceID:         testClusterServiceClassGUID,
+		PlanID:            testClusterServicePlanGUID,
+	})
+
+	// Verify no core kube actions occurred
+	kubeActions := fakeKubeClient.Actions()
+	assertNumberOfActions(t, kubeActions, 0)
+
+	actions := fakeCatalogClient.Actions()
+	assertNumberOfActions(t, actions, 2)
+
+	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
+	assertServiceInstanceOperationInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationDeprovision, testClusterServicePlanName, instance)
+
+	updatedServiceInstance = assertUpdateStatus(t, actions[1], instance)
+	assertServiceInstanceOperationSuccess(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationDeprovision, testClusterServicePlanName, instance)
+
+	events := getRecordedEvents(testController)
+	assertNumEvents(t, events, 1)
+
+	expectedEvent := corev1.EventTypeNormal + " " + successDeprovisionReason + " " + "The instance was deprovisioned successfully"
+	if e, a := expectedEvent, events[0]; e != a {
+		t.Fatalf("Received unexpected event: %v\nExpected: %v", a, e)
+	}
+}
+
+// TestReconcileServiceInstanceDeleteWhenAlreadyDeprovisionedSuccessfully
+// tests that an instance that has already been deprovisioned will be
+// finalized, but no deprovision request will be sent to the broker.
+func TestReconcileServiceInstanceDeleteWhenAlreadyDeprovisionedSuccessfully(t *testing.T) {
+	fakeKubeClient, fakeCatalogClient, fakeClusterServiceBrokerClient, testController, sharedInformers := newTestController(t, noFakeActions())
+
+	sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(getTestClusterServiceBroker())
+	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(getTestClusterServiceClass())
+	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
+
+	instance := getTestServiceInstanceWithFailedStatus()
+	instance.ObjectMeta.DeletionTimestamp = &metav1.Time{}
+	instance.ObjectMeta.Finalizers = []string{v1beta1.FinalizerServiceCatalog}
+	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{}
+	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusSucceeded
+
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
 
@@ -1544,6 +1654,50 @@ func TestReconcileServiceInstanceDeleteFailedProvision(t *testing.T) {
 	assertNumEvents(t, events, 0)
 }
 
+// TestReconcileServiceInstanceDeleteWhenAlreadyDeprovisionedUnsuccessfully
+// tests that an instance that has already had a failed deprovision request
+// will not be finalized and no further deprovision request will be sent to
+// the broker.
+func TestReconcileServiceInstanceDeleteWhenAlreadyDeprovisionedUnsuccessfully(t *testing.T) {
+	fakeKubeClient, fakeCatalogClient, fakeClusterServiceBrokerClient, testController, sharedInformers := newTestController(t, noFakeActions())
+
+	sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(getTestClusterServiceBroker())
+	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(getTestClusterServiceClass())
+	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
+
+	instance := getTestServiceInstanceWithFailedStatus()
+	instance.ObjectMeta.DeletionTimestamp = &metav1.Time{}
+	instance.ObjectMeta.Finalizers = []string{v1beta1.FinalizerServiceCatalog}
+	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{}
+	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusFailed
+
+	instance.Generation = 2
+	instance.Status.ReconciledGeneration = 1
+
+	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, instance, nil
+	})
+
+	err := testController.reconcileServiceInstance(instance)
+	if err != nil {
+		t.Fatalf("Unexpected error from reconcileServiceInstance: %v", err)
+	}
+
+	brokerActions := fakeClusterServiceBrokerClient.Actions()
+	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 0)
+
+	// Verify no core kube actions occurred
+	kubeActions := fakeKubeClient.Actions()
+	assertNumberOfActions(t, kubeActions, 0)
+
+	// Verify no catalog client actions occurred
+	actions := fakeCatalogClient.Actions()
+	assertNumberOfActions(t, actions, 0)
+
+	events := getRecordedEvents(testController)
+	assertNumEvents(t, events, 0)
+}
+
 // TestReconcileServiceInstanceDeleteFailedUpdate tests that an instance
 // that failed after having been successfully provisioned will send a
 // deprovision request to the broker.
@@ -1564,6 +1718,7 @@ func TestReconcileServiceInstanceDeleteFailedUpdate(t *testing.T) {
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{}
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 2
+	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 
 	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		return true, instance, nil
@@ -1623,6 +1778,7 @@ func TestReconcileServiceInstanceDeleteDoesNotInvokeClusterServiceBroker(t *test
 	instance.ObjectMeta.Finalizers = []string{v1beta1.FinalizerServiceCatalog}
 	instance.Generation = 1
 	instance.Status.ReconciledGeneration = 0
+	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusNotRequired
 
 	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		return true, instance, nil
@@ -2542,9 +2698,7 @@ func TestReconcileServiceInstanceWithStatusUpdateError(t *testing.T) {
 func TestSetServiceInstanceCondition(t *testing.T) {
 	instanceWithCondition := func(condition *v1beta1.ServiceInstanceCondition) *v1beta1.ServiceInstance {
 		instance := getTestServiceInstance()
-		instance.Status = v1beta1.ServiceInstanceStatus{
-			Conditions: []v1beta1.ServiceInstanceCondition{*condition},
-		}
+		instance.Status.Conditions = []v1beta1.ServiceInstanceCondition{*condition}
 
 		return instance
 	}
@@ -2914,6 +3068,7 @@ func TestReconcileInstanceDeleteUsingOriginatingIdentity(t *testing.T) {
 			// ReconciledGeneration set as that implies a previous success.
 			instance.Generation = 2
 			instance.Status.ReconciledGeneration = 1
+			instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 			if tc.includeUserInfo {
 				instance.Spec.UserInfo = testUserInfo
 			}
@@ -3282,6 +3437,7 @@ func TestReconcileServiceInstanceOrphanMitigation(t *testing.T) {
 		instance.ObjectMeta.Finalizers = []string{v1beta1.FinalizerServiceCatalog}
 		instance.Status.CurrentOperation = v1beta1.ServiceInstanceOperationProvision
 		instance.Status.OrphanMitigationInProgress = true
+		instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 
 		if tc.async {
 			instance.Status.AsyncOpInProgress = true
@@ -3551,6 +3707,7 @@ func TestReconcileServiceInstanceUpdateParameters(t *testing.T) {
 	instance := getTestServiceInstanceWithRefs()
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
+	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 
 	oldParameters := map[string]interface{}{
 		"args": map[string]interface{}{
@@ -3749,6 +3906,7 @@ func TestReconcileServiceInstanceUpdatePlan(t *testing.T) {
 	instance := getTestServiceInstanceWithRefs()
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
+	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 
 	oldParameters := map[string]interface{}{
 		"args": map[string]interface{}{
@@ -4179,6 +4337,7 @@ func TestReconcileServiceInstanceUpdateAsynchronous(t *testing.T) {
 	instance := getTestServiceInstanceWithRefs()
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
+	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{
 		ClusterServicePlanExternalName: "old-plan-name",

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -564,6 +564,9 @@ func getTestServiceInstance() *v1beta1.ServiceInstance {
 			},
 			ExternalID: testServiceInstanceGUID,
 		},
+		Status: v1beta1.ServiceInstanceStatus{
+			DeprovisionStatus: v1beta1.ServiceInstanceDeprovisionStatusRequired,
+		},
 	}
 }
 
@@ -654,6 +657,7 @@ func getTestServiceInstanceUpdatingPlan() *v1beta1.ServiceInstance {
 		},
 		// It's been provisioned successfully.
 		ReconciledGeneration: 1,
+		DeprovisionStatus:    v1beta1.ServiceInstanceDeprovisionStatusRequired,
 	}
 
 	return instance
@@ -672,6 +676,7 @@ func getTestServiceInstanceUpdatingParameters() *v1beta1.ServiceInstance {
 		},
 		// It's been provisioned successfully.
 		ReconciledGeneration: 1,
+		DeprovisionStatus:    v1beta1.ServiceInstanceDeprovisionStatusRequired,
 	}
 
 	return instance
@@ -690,6 +695,7 @@ func getTestServiceInstanceUpdatingParametersOfDeletedPlan() *v1beta1.ServiceIns
 		},
 		// It's been provisioned successfully.
 		ReconciledGeneration: 1,
+		DeprovisionStatus:    v1beta1.ServiceInstanceDeprovisionStatusRequired,
 	}
 
 	return instance
@@ -713,6 +719,7 @@ func getTestServiceInstanceAsyncProvisioning(operation string) *v1beta1.ServiceI
 		InProgressProperties: &v1beta1.ServiceInstancePropertiesState{
 			ClusterServicePlanExternalName: testClusterServicePlanName,
 		},
+		DeprovisionStatus: v1beta1.ServiceInstanceDeprovisionStatusRequired,
 	}
 	if operation != "" {
 		instance.Status.LastOperation = &operation
@@ -745,6 +752,7 @@ func getTestServiceInstanceAsyncUpdating(operation string) *v1beta1.ServiceInsta
 		ExternalProperties: &v1beta1.ServiceInstancePropertiesState{
 			ClusterServicePlanExternalName: "old-plan-name",
 		},
+		DeprovisionStatus: v1beta1.ServiceInstanceDeprovisionStatusRequired,
 	}
 	if operation != "" {
 		instance.Status.LastOperation = &operation
@@ -772,6 +780,7 @@ func getTestServiceInstanceAsyncDeprovisioning(operation string) *v1beta1.Servic
 		ExternalProperties: &v1beta1.ServiceInstancePropertiesState{
 			ClusterServicePlanExternalName: testClusterServicePlanName,
 		},
+		DeprovisionStatus: v1beta1.ServiceInstanceDeprovisionStatusRequired,
 	}
 	if operation != "" {
 		instance.Status.LastOperation = &operation
@@ -1814,6 +1823,16 @@ func assertServiceInstanceDashboardURL(t *testing.T, obj runtime.Object, dashboa
 	}
 }
 
+func assertServiceInstanceDeprovisionStatus(t *testing.T, obj runtime.Object, deprovisionStatus v1beta1.ServiceInstanceDeprovisionStatus) {
+	instance, ok := obj.(*v1beta1.ServiceInstance)
+	if !ok {
+		fatalf(t, "Couldn't convert object %+v into a *v1beta1.ServiceInstance", obj)
+	}
+	if e, a := deprovisionStatus, instance.Status.DeprovisionStatus; e != a {
+		fatalf(t, "Unexpected value for DeprovisionStatus: expected %v, got %v", e, a)
+	}
+}
+
 func assertServiceInstanceErrorBeforeRequest(t *testing.T, obj runtime.Object, reason string, originalInstance *v1beta1.ServiceInstance) {
 	assertServiceInstanceReadyFalse(t, obj, reason)
 	assertServiceInstanceCurrentOperationClear(t, obj)
@@ -1823,6 +1842,7 @@ func assertServiceInstanceErrorBeforeRequest(t *testing.T, obj runtime.Object, r
 	assertServiceInstanceOrphanMitigationInProgressFalse(t, obj)
 	assertServiceInstanceInProgressPropertiesNil(t, obj)
 	assertServiceInstanceExternalPropertiesUnchanged(t, obj, originalInstance)
+	assertServiceInstanceDeprovisionStatus(t, obj, originalInstance.Status.DeprovisionStatus)
 }
 
 func assertServiceInstanceOperationInProgress(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, planName string, originalInstance *v1beta1.ServiceInstance) {
@@ -1853,6 +1873,7 @@ func assertServiceInstanceOperationInProgressWithParameters(t *testing.T, obj ru
 		assertServiceInstanceInProgressPropertiesNil(t, obj)
 	}
 	assertServiceInstanceExternalPropertiesUnchanged(t, obj, originalInstance)
+	assertServiceInstanceDeprovisionStatus(t, obj, v1beta1.ServiceInstanceDeprovisionStatusRequired)
 }
 
 func assertServiceInstanceStartingOrphanMitigation(t *testing.T, obj runtime.Object, originalInstance *v1beta1.ServiceInstance) {
@@ -1861,6 +1882,7 @@ func assertServiceInstanceStartingOrphanMitigation(t *testing.T, obj runtime.Obj
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceOrphanMitigationInProgressTrue(t, obj)
+	assertServiceInstanceDeprovisionStatus(t, obj, v1beta1.ServiceInstanceDeprovisionStatusRequired)
 }
 
 func assertServiceInstanceOperationSuccess(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, planName string, originalInstance *v1beta1.ServiceInstance) {
@@ -1869,19 +1891,23 @@ func assertServiceInstanceOperationSuccess(t *testing.T, obj runtime.Object, ope
 
 func assertServiceInstanceOperationSuccessWithParameters(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, planName string, externalParameters map[string]interface{}, externalParametersChecksum string, originalInstance *v1beta1.ServiceInstance) {
 	var (
-		reason      string
-		readyStatus v1beta1.ConditionStatus
+		reason            string
+		readyStatus       v1beta1.ConditionStatus
+		deprovisionStatus v1beta1.ServiceInstanceDeprovisionStatus
 	)
 	switch operation {
 	case v1beta1.ServiceInstanceOperationProvision:
 		reason = successProvisionReason
 		readyStatus = v1beta1.ConditionTrue
+		deprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 	case v1beta1.ServiceInstanceOperationUpdate:
 		reason = successUpdateInstanceReason
 		readyStatus = v1beta1.ConditionTrue
+		deprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 	case v1beta1.ServiceInstanceOperationDeprovision:
 		reason = successDeprovisionReason
 		readyStatus = v1beta1.ConditionFalse
+		deprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusSucceeded
 	}
 	assertServiceInstanceReadyCondition(t, obj, readyStatus, reason)
 	assertServiceInstanceCurrentOperationClear(t, obj)
@@ -1900,21 +1926,28 @@ func assertServiceInstanceOperationSuccessWithParameters(t *testing.T, obj runti
 	case v1beta1.ServiceInstanceOperationDeprovision:
 		assertServiceInstanceExternalPropertiesNil(t, obj)
 	}
+	assertServiceInstanceDeprovisionStatus(t, obj, deprovisionStatus)
 }
 
 func assertServiceInstanceRequestFailingError(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, readyReason string, failureReason string, originalInstance *v1beta1.ServiceInstance) {
-	var readyStatus v1beta1.ConditionStatus
+	var (
+		readyStatus       v1beta1.ConditionStatus
+		deprovisionStatus v1beta1.ServiceInstanceDeprovisionStatus
+	)
 	switch operation {
 	case v1beta1.ServiceInstanceOperationProvision, v1beta1.ServiceInstanceOperationUpdate:
 		readyStatus = v1beta1.ConditionFalse
+		deprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 	case v1beta1.ServiceInstanceOperationDeprovision:
 		readyStatus = v1beta1.ConditionUnknown
+		deprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusFailed
 	}
 	assertServiceInstanceReadyCondition(t, obj, readyStatus, readyReason)
 	assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionFailed, v1beta1.ConditionTrue, failureReason)
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertAsyncOpInProgressFalse(t, obj)
 	assertServiceInstanceExternalPropertiesUnchanged(t, obj, originalInstance)
+	assertServiceInstanceDeprovisionStatus(t, obj, deprovisionStatus)
 }
 
 func assertServiceInstanceRequestFailingErrorNoOrphanMitigation(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, readyReason string, failureReason string, originalInstance *v1beta1.ServiceInstance) {
@@ -1956,6 +1989,7 @@ func assertServiceInstanceRequestRetriableErrorWithParameters(t *testing.T, obj 
 		assertServiceInstanceInProgressPropertiesNil(t, obj)
 	}
 	assertServiceInstanceExternalPropertiesUnchanged(t, obj, originalInstance)
+	assertServiceInstanceDeprovisionStatus(t, obj, originalInstance.Status.DeprovisionStatus)
 }
 
 func assertServiceInstanceAsyncInProgress(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, operationKey string, planName string, originalInstance *v1beta1.ServiceInstance) {
@@ -1981,6 +2015,7 @@ func assertServiceInstanceAsyncInProgress(t *testing.T, obj runtime.Object, oper
 		assertServiceInstanceInProgressPropertiesNil(t, obj)
 	}
 	assertAsyncOpInProgressTrue(t, obj)
+	assertServiceInstanceDeprovisionStatus(t, obj, originalInstance.Status.DeprovisionStatus)
 }
 
 func assertServiceInstanceConditionHasLastOperationDescription(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, lastOperationDescription string) {

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1443,8 +1443,15 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref:         ref("github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.ServiceInstancePropertiesState"),
 							},
 						},
+						"deprovisionStatus": {
+							SchemaProps: spec.SchemaProps{
+								Description: "DeprovisionStatus describes what has been done to deprovision the ServiceInstance.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 					},
-					Required: []string{"conditions", "asyncOpInProgress", "orphanMitigationInProgress", "reconciledGeneration"},
+					Required: []string{"conditions", "asyncOpInProgress", "orphanMitigationInProgress", "reconciledGeneration", "deprovisionStatus"},
 				},
 			},
 			Dependencies: []string{

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -217,7 +217,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"url", "relistBehavior", "relistRequests"},
+					Required: []string{"url", "relistBehavior"},
 				},
 			},
 			Dependencies: []string{
@@ -1359,7 +1359,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"externalID", "updateRequests"},
+					Required: []string{"externalID"},
 				},
 			},
 			Dependencies: []string{

--- a/pkg/registry/servicecatalog/instance/strategy.go
+++ b/pkg/registry/servicecatalog/instance/strategy.go
@@ -114,12 +114,14 @@ func (instanceRESTStrategy) PrepareForCreate(ctx genericapirequest.Context, obj 
 	// Creating a brand new object, thus it must have no
 	// status. We can't fail here if they passed a status in, so
 	// we just wipe it clean.
-	instance.Status = sc.ServiceInstanceStatus{}
+	instance.Status = sc.ServiceInstanceStatus{
+		// Fill in the first entry set to "creating"?
+		Conditions:        []sc.ServiceInstanceCondition{},
+		DeprovisionStatus: sc.ServiceInstanceDeprovisionStatusNotRequired,
+	}
 
 	instance.Spec.ClusterServiceClassRef = nil
 	instance.Spec.ClusterServicePlanRef = nil
-	// Fill in the first entry set to "creating"?
-	instance.Status.Conditions = []sc.ServiceInstanceCondition{}
 	instance.Finalizers = []string{sc.FinalizerServiceCatalog}
 	instance.Generation = 1
 }

--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -836,6 +836,9 @@ func testInstanceClient(sType server.StorageType, client servicecatalogclient.In
 			Parameters: &runtime.RawExtension{Raw: []byte(instanceParameter)},
 			ExternalID: osbGUID,
 		},
+		Status: v1beta1.ServiceInstanceStatus{
+			DeprovisionStatus: v1beta1.ServiceInstanceDeprovisionStatusNotRequired,
+		},
 	}
 
 	// list the instances & expect there to be none
@@ -921,6 +924,7 @@ func testInstanceClient(sType server.StorageType, client servicecatalogclient.In
 	instanceServer.Status = v1beta1.ServiceInstanceStatus{
 		ReconciledGeneration: instanceServer.Generation,
 		Conditions:           []v1beta1.ServiceInstanceCondition{readyConditionTrue},
+		DeprovisionStatus:    v1beta1.ServiceInstanceDeprovisionStatusNotRequired,
 	}
 
 	_, err = instanceClient.UpdateStatus(instanceServer)

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -478,9 +478,11 @@ func TestProvisionFailure(t *testing.T) {
 				Description:  strPtr("You're out of quota!"),
 			},
 		},
-		// no DeprovisionReaction is configured, so that the client will
-		// return an unexpected call error message if deprovision is called on
-		// the broker.
+		DeprovisionReaction: &fakeosb.DeprovisionReaction{
+			Response: &osb.DeprovisionResponse{
+				Async: false,
+			},
+		},
 	})
 	defer shutdownController()
 	defer shutdownServer()


### PR DESCRIPTION
Fixes #1461.
Fixes #1437.

Add a `DeprovisionStatus` field to `ServiceInstanceStatus`. The field tracks the status of the ServiceInstance with respect to what needs to be done or has been done for deprovisioning the ServiceIntstance.

* When a ServiceInstance is created, the `DeprovisionStatus` is set to **Not Required**. This indicates that a deprovision request does not need to be made for the ServiceInstance when it is deleted.
* When a provision request is made for a ServiceInstance, the `DeprovisionStatus` is set to **Required**. This indicates that a deprovision request does need to be made for the ServiceInstance when it is deleted.
* When a deprovision request is seuccesful for a ServiceInstance, the `DeprovisionStatus` is set to **Succeeded**. This indicates that no further deprovision requests need to be made for the ServiceInstance, and it unblocks the controller from removing the finalizer for the ServiceInstance.
* When the controller gives up on sending deprovision requests due to failures, the `DeprovisionStatus` is set to **Failed**. This indicates that no further deprovision requests need to be made for the ServiceInstance, but it blocks the controller from removing the finalizer for the ServiceInstance. This keeps the resource around so that the user can negotiate deprovisioning directly with the broker. The user must force-delete the ServiceInstance to remove it.
