### PR TITLE
Actually test properties are correct when updating instance

### DIFF
--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -3611,7 +3611,7 @@ func TestReconcileServiceInstanceUpdateParameters(t *testing.T) {
 	expectedParameters := map[string]interface{}{
 		"args": map[string]interface{}{
 			"first":  "first-arg",
-			"second": "second-arg",
+			"second": "new-second-arg",
 		},
 		"name": "test-param",
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1846,7 +1846,7 @@ func assertServiceInstanceOperationInProgressWithParameters(t *testing.T, obj ru
 	assertAsyncOpInProgressFalse(t, obj)
 	assertServiceInstanceOrphanMitigationInProgressFalse(t, obj)
 	switch operation {
-	case v1beta1.ServiceInstanceOperationProvision:
+	case v1beta1.ServiceInstanceOperationProvision, v1beta1.ServiceInstanceOperationUpdate:
 		assertServiceInstanceInProgressPropertiesPlanName(t, obj, planName)
 		assertServiceInstanceInProgressPropertiesParameters(t, obj, inProgressParameters, inProgressParametersChecksum)
 	case v1beta1.ServiceInstanceOperationDeprovision:
@@ -1894,7 +1894,7 @@ func assertServiceInstanceOperationSuccessWithParameters(t *testing.T, obj runti
 	}
 	assertServiceInstanceInProgressPropertiesNil(t, obj)
 	switch operation {
-	case v1beta1.ServiceInstanceOperationProvision:
+	case v1beta1.ServiceInstanceOperationProvision, v1beta1.ServiceInstanceOperationUpdate:
 		assertServiceInstanceExternalPropertiesPlanName(t, obj, planName)
 		assertServiceInstanceExternalPropertiesParameters(t, obj, externalParameters, externalParametersChecksum)
 	case v1beta1.ServiceInstanceOperationDeprovision:


### PR DESCRIPTION
The asserts that test operation in progress and operation success are not actually testing that the in-progress and external properties, respectively, are correct. These changes fix that.