### PR TITLE
Moving a duplicated block of code to an independent function.

### DIFF
--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1554,7 +1554,7 @@ func (c *controller) pollServiceInstance(instance *v1beta1.ServiceInstance) erro
 	return nil
 }
 
-// reconciliationTimeExpired tests if the current Operation State time has
+// isReconciliationRetryDurationExceeded tests if the current Operation State time has
 // elapsed the reconciliationRetryDuration time period
 func (c *controller) isReconciliationRetryDurationExceeded(instance *v1beta1.ServiceInstance) bool {
 	if time.Now().After(instance.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
@@ -1563,7 +1563,7 @@ func (c *controller) isReconciliationRetryDurationExceeded(instance *v1beta1.Ser
 	return false
 }
 
-// reconciliationTimeExpiredFinishPollingServiceInstance marks the instance as
+// reconciliationRetryDurationExceededFinishPollingServiceInstance marks the instance as
 // failed from time expired based on current state and then prepares the
 // instance for removal from reconciliation
 func (c *controller) reconciliationRetryDurationExceededFinishPollingServiceInstance(instance *v1beta1.ServiceInstance, mitigatingOrphan, provisioning, deleting bool) error {

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1238,45 +1238,8 @@ func (c *controller) pollServiceInstance(instance *v1beta1.ServiceInstance) erro
 		glog.V(4).Info(pcb.Message(s))
 		c.recorder.Event(instance, corev1.EventTypeWarning, errorPollingLastOperationReason, s)
 
-		if !time.Now().Before(instance.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
-			clone, err := api.Scheme.DeepCopy(instance)
-			if err != nil {
-				return err
-			}
-			toUpdate := clone.(*v1beta1.ServiceInstance)
-			s := "Stopping reconciliation retries because too much time has elapsed"
-			glog.Info(pcb.Message(s))
-			c.recorder.Event(instance, corev1.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
-
-			if mitigatingOrphan {
-				setServiceInstanceCondition(
-					toUpdate,
-					v1beta1.ServiceInstanceConditionReady,
-					v1beta1.ConditionUnknown,
-					errorOrphanMitigationFailedReason,
-					"Orphan mitigation failed: "+s)
-			} else {
-				setServiceInstanceCondition(toUpdate,
-					v1beta1.ServiceInstanceConditionFailed,
-					v1beta1.ConditionTrue,
-					errorReconciliationRetryTimeoutReason,
-					s)
-			}
-
-			if !provisioning {
-				c.clearServiceInstanceCurrentOperation(toUpdate)
-			} else {
-				c.setServiceInstanceStartOrphanMitigation(toUpdate)
-			}
-
-			if deleting {
-				toUpdate.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusFailed
-			}
-
-			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
-				return err
-			}
-			return c.finishPollingServiceInstance(instance)
+		if c.reconciliationTimeExpired(instance) {
+			return c.reconciliationTimeExpiredFinishPollingServiceInstance(instance, mitigatingOrphan, provisioning, deleting)
 		}
 
 		return c.continuePollingServiceInstance(instance)
@@ -1522,49 +1485,67 @@ func (c *controller) pollServiceInstance(instance *v1beta1.ServiceInstance) erro
 		return c.finishPollingServiceInstance(instance)
 	default:
 		glog.Warning(pcb.Messagef("Got invalid state in LastOperationResponse: %q", response.State))
-		if !time.Now().Before(instance.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
-			clone, err := api.Scheme.DeepCopy(instance)
-			if err != nil {
-				return err
-			}
-			toUpdate := clone.(*v1beta1.ServiceInstance)
-			s := "Stopping reconciliation retries on ServiceInstance because too much time has elapsed"
-			glog.Info(pcb.Message(s))
-			c.recorder.Event(instance, corev1.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
-
-			if mitigatingOrphan {
-				setServiceInstanceCondition(
-					toUpdate,
-					v1beta1.ServiceInstanceConditionReady,
-					v1beta1.ConditionUnknown,
-					errorOrphanMitigationFailedReason,
-					"Orphan mitigation failed: "+s)
-			} else {
-				setServiceInstanceCondition(toUpdate,
-					v1beta1.ServiceInstanceConditionFailed,
-					v1beta1.ConditionTrue,
-					errorReconciliationRetryTimeoutReason,
-					s)
-			}
-
-			if !provisioning {
-				c.clearServiceInstanceCurrentOperation(toUpdate)
-			} else {
-				c.setServiceInstanceStartOrphanMitigation(toUpdate)
-			}
-
-			if deleting {
-				toUpdate.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusFailed
-			}
-
-			if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
-				return err
-			}
-			return c.finishPollingServiceInstance(instance)
+		if c.reconciliationTimeExpired(instance) {
+			return c.reconciliationTimeExpiredFinishPollingServiceInstance(instance, mitigatingOrphan, provisioning, deleting)
 		}
 		return fmt.Errorf(`Got invalid state in LastOperationResponse: %q`, response.State)
 	}
 	return nil
+}
+
+// reconciliationTimeExpired tests if the current Operation State time has
+// elapsed the reconciliationRetryDuration time period
+func (c *controller) reconciliationTimeExpired(instance *v1beta1.ServiceInstance) bool {
+	if !time.Now().Before(instance.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
+		return true
+	}
+	return false
+}
+
+// reconciliationTimeExpiredFinishPollingServiceInstance marks the instance as
+// failed from time expired based on current state and then prepares the
+// instance for removal from reconciliation
+func (c *controller) reconciliationTimeExpiredFinishPollingServiceInstance(instance *v1beta1.ServiceInstance, mitigatingOrphan, provisioning, deleting bool) error {
+	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+
+	clone, err := api.Scheme.DeepCopy(instance)
+	if err != nil {
+		return err
+	}
+	toUpdate := clone.(*v1beta1.ServiceInstance)
+	s := "Stopping reconciliation retries on ServiceInstance because too much time has elapsed"
+	glog.Info(pcb.Message(s))
+	c.recorder.Event(instance, corev1.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
+
+	if mitigatingOrphan {
+		setServiceInstanceCondition(
+			toUpdate,
+			v1beta1.ServiceInstanceConditionReady,
+			v1beta1.ConditionUnknown,
+			errorOrphanMitigationFailedReason,
+			"Orphan mitigation failed: "+s)
+	} else {
+		setServiceInstanceCondition(toUpdate,
+			v1beta1.ServiceInstanceConditionFailed,
+			v1beta1.ConditionTrue,
+			errorReconciliationRetryTimeoutReason,
+			s)
+	}
+
+	if !provisioning {
+		c.clearServiceInstanceCurrentOperation(toUpdate)
+	} else {
+		c.setServiceInstanceStartOrphanMitigation(toUpdate)
+	}
+
+	if deleting {
+		toUpdate.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusFailed
+	}
+
+	if _, err := c.updateServiceInstanceStatus(toUpdate); err != nil {
+		return err
+	}
+	return c.finishPollingServiceInstance(instance)
 }
 
 // resolveReferences checks to see if ClusterServiceClassRef and/or ClusterServicePlanRef are


### PR DESCRIPTION
Inspecting the code I have found exact duplicated code inside of the service instance controller reconciliation loop. Moving this block out to be able to test it independently and also to not duplicate code. 

A followup will be to add unit tests to the new functions after the refactoring of controller_instance_test has been committed in https://github.com/kubernetes-incubator/service-catalog/pull/1507