### PR TITLE
Broker Reconciliation occurs too frequently

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -144,6 +144,10 @@ type ClusterServiceBrokerStatus struct {
 
 	// OperationStartTime is the time at which the current operation began.
 	OperationStartTime *metav1.Time
+
+	// LastCatalogRetrievalTime is the time the Catalog was last fetched from
+	// the Service Broker
+	LastCatalogRetrievalTime *metav1.Time
 }
 
 // ServiceBrokerCondition contains condition information for a Service Broker.

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -145,6 +145,10 @@ type ClusterServiceBrokerStatus struct {
 
 	// OperationStartTime is the time at which the current operation began.
 	OperationStartTime *metav1.Time `json:"operationStartTime,omitempty"`
+
+	// LastCatalogRetrievalTime is the time the Catalog was last fetched from
+	// the Service Broker
+	LastCatalogRetrievalTime *metav1.Time `json:"lastCatalogRetrievalTime,omitempty"`
 }
 
 // ServiceBrokerCondition contains condition information for a Broker.

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
@@ -259,6 +259,7 @@ func autoConvert_v1beta1_ClusterServiceBrokerStatus_To_servicecatalog_ClusterSer
 	out.Conditions = *(*[]servicecatalog.ServiceBrokerCondition)(unsafe.Pointer(&in.Conditions))
 	out.ReconciledGeneration = in.ReconciledGeneration
 	out.OperationStartTime = (*v1.Time)(unsafe.Pointer(in.OperationStartTime))
+	out.LastCatalogRetrievalTime = (*v1.Time)(unsafe.Pointer(in.LastCatalogRetrievalTime))
 	return nil
 }
 
@@ -271,6 +272,7 @@ func autoConvert_servicecatalog_ClusterServiceBrokerStatus_To_v1beta1_ClusterSer
 	out.Conditions = *(*[]ServiceBrokerCondition)(unsafe.Pointer(&in.Conditions))
 	out.ReconciledGeneration = in.ReconciledGeneration
 	out.OperationStartTime = (*v1.Time)(unsafe.Pointer(in.OperationStartTime))
+	out.LastCatalogRetrievalTime = (*v1.Time)(unsafe.Pointer(in.LastCatalogRetrievalTime))
 	return nil
 }
 

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.deepcopy.go
@@ -367,6 +367,15 @@ func (in *ClusterServiceBrokerStatus) DeepCopyInto(out *ClusterServiceBrokerStat
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.LastCatalogRetrievalTime != nil {
+		in, out := &in.LastCatalogRetrievalTime, &out.LastCatalogRetrievalTime
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Time)
+			(*in).DeepCopyInto(*out)
+		}
+	}
 	return
 }
 

--- a/pkg/apis/servicecatalog/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/zz_generated.deepcopy.go
@@ -367,6 +367,15 @@ func (in *ClusterServiceBrokerStatus) DeepCopyInto(out *ClusterServiceBrokerStat
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.LastCatalogRetrievalTime != nil {
+		in, out := &in.LastCatalogRetrievalTime, &out.LastCatalogRetrievalTime
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Time)
+			(*in).DeepCopyInto(*out)
+		}
+	}
 	return
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -368,13 +368,28 @@ func getTestClusterServiceBroker() *v1beta1.ClusterServiceBroker {
 }
 
 func getTestClusterServiceBrokerWithStatus(status v1beta1.ConditionStatus) *v1beta1.ClusterServiceBroker {
+	lastTransitionTime := metav1.NewTime(time.Now().Add(-5 * time.Minute))
 	broker := getTestClusterServiceBroker()
 	broker.Status = v1beta1.ClusterServiceBrokerStatus{
 		Conditions: []v1beta1.ServiceBrokerCondition{{
 			Type:               v1beta1.ServiceBrokerConditionReady,
 			Status:             status,
-			LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
+			LastTransitionTime: lastTransitionTime,
 		}},
+		LastCatalogRetrievalTime: &lastTransitionTime,
+	}
+	return broker
+}
+
+func getTestClusterServiceBrokerWithStatusAndTime(status v1beta1.ConditionStatus, lastTransitionTime, lastRelistTime metav1.Time) *v1beta1.ClusterServiceBroker {
+	broker := getTestClusterServiceBroker()
+	broker.Status = v1beta1.ClusterServiceBrokerStatus{
+		Conditions: []v1beta1.ServiceBrokerCondition{{
+			Type:               v1beta1.ServiceBrokerConditionReady,
+			Status:             status,
+			LastTransitionTime: lastTransitionTime,
+		}},
+		LastCatalogRetrievalTime: &lastRelistTime,
 	}
 	return broker
 }

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -253,6 +253,12 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 							},
 						},
+						"lastCatalogRetrievalTime": {
+							SchemaProps: spec.SchemaProps{
+								Description: "LastCatalogRetrievalTime is the time the Catalog was last fetched from the Service Broker",
+								Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+							},
+						},
 					},
 					Required: []string{"conditions", "reconciledGeneration"},
 				},


### PR DESCRIPTION
fixes #1513 

Added a new field for Broker's last reconciled time.  When determining if we should reconcile the broker, check that the last reconciled time vs the Ready condition's LastTransitionTime as LTT won't change over time under normal good circumstances when status remains Ready=True.  