### PR TITLE
Send Context with UpdateInstanceRequest

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6c1b2a39353c28851d5507cbe5549799df804373c616dc59412a60b67e8f3bb7
-updated: 2017-10-30T09:23:27.85098026-07:00
+hash: 550e1b129ba4ba9aa803720e21906cb16964a1e0e35afe33f9402958d12c8cbe
+updated: 2017-11-02T09:48:23.459124865-04:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -253,7 +253,7 @@ imports:
 - name: github.com/pkg/errors
   version: a22138067af1c4942683050411a841ade67fe1eb
 - name: github.com/pmorie/go-open-service-broker-client
-  version: 50dc046133ca9f1216e570c7efda008a01e088a6
+  version: 9e257974620c1db53c4d3549fd9eddaa2d2d653e
   subpackages:
   - v2
   - v2/fake

--- a/glide.yaml
+++ b/glide.yaml
@@ -90,4 +90,4 @@ import:
 - package: github.com/gorilla/context
   version: 215affda49addc4c8ef7e2534915df2c8c35c6cd
 - package: github.com/pmorie/go-open-service-broker-client
-  version: 50dc046133ca9f1216e570c7efda008a01e088a6
+  version: 9e257974620c1db53c4d3549fd9eddaa2d2d653e 

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -749,6 +749,13 @@ func (c *controller) reconcileServiceInstance(instance *v1beta1.ServiceInstance)
 		}
 	}
 
+	// osb client handles whether or not to really send this based
+	// on the version of the client.
+	requestContext := map[string]interface{}{
+		"platform":  ContextProfilePlatformKubernetes,
+		"namespace": instance.Namespace,
+	}
+
 	var (
 		isProvisioning             bool
 		provisionRequest           *osb.ProvisionRequest
@@ -760,12 +767,6 @@ func (c *controller) reconcileServiceInstance(instance *v1beta1.ServiceInstance)
 	)
 	if toUpdate.Status.ReconciledGeneration == 0 {
 		isProvisioning = true
-		// osb client handles whether or not to really send this based
-		// on the version of the client.
-		requestContext := map[string]interface{}{
-			"platform":  ContextProfilePlatformKubernetes,
-			"namespace": instance.Namespace,
-		}
 		provisionRequest = &osb.ProvisionRequest{
 			AcceptsIncomplete:   true,
 			InstanceID:          instance.Spec.ExternalID,
@@ -788,6 +789,7 @@ func (c *controller) reconcileServiceInstance(instance *v1beta1.ServiceInstance)
 			AcceptsIncomplete:   true,
 			InstanceID:          instance.Spec.ExternalID,
 			ServiceID:           serviceClass.Spec.ExternalID,
+			Context:             requestContext,
 			OriginatingIdentity: originatingIdentity,
 		}
 		// Only send the plan ID if the plan ID has changed from what the Broker has

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -3869,6 +3869,10 @@ func TestReconcileServiceInstanceUpdateParameters(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            nil, // no change to plan
+		Context: map[string]interface{}{
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+		},
 		Parameters: map[string]interface{}{
 			"args": map[string]interface{}{
 				"first":  "first-arg",
@@ -4070,7 +4074,11 @@ func TestReconcileServiceInstanceUpdatePlan(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
-		Parameters:        nil, // no change to parameters
+		Context: map[string]interface{}{
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+		},
+		Parameters: nil, // no change to parameters
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -4138,6 +4146,10 @@ func TestReconcileServiceInstanceWithUpdateCallFailure(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
+		Context: map[string]interface{}{
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+		},
 	})
 
 	// verify no kube resources created
@@ -4199,6 +4211,10 @@ func TestReconcileServiceInstanceWithUpdateFailure(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
+		Context: map[string]interface{}{
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+		},
 	})
 
 	// verify one kube action occurred
@@ -4475,6 +4491,10 @@ func TestReconcileServiceInstanceUpdateAsynchronous(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
+		Context: map[string]interface{}{
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+		},
 	})
 
 	actions := fakeCatalogClient.Actions()

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/types.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/types.go
@@ -217,6 +217,11 @@ type UpdateInstanceRequest struct {
 	// unset, indicates that the client does not wish to update the parameters
 	// for an instance.
 	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	// Context requires a client API version >= 2.12.
+	//
+	// Context is platform-specific contextual information under which the
+	// service instance was created.
+	Context map[string]interface{} `json:"context,omitempty"`
 	// OriginatingIdentity is the identity on the platform of the user making this request.
 	OriginatingIdentity *OriginatingIdentity `json:"originatingIdentity,omitempty"`
 

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/update_instance.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/update_instance.go
@@ -11,6 +11,7 @@ type updateInstanceRequestBody struct {
 	ServiceID  string                 `json:"service_id"`
 	PlanID     *string                `json:"plan_id,omitempty"`
 	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	Context    map[string]interface{} `json:"context,omitempty"`
 
 	// Note: this client does not currently support the 'previous_values'
 	// field of this request body.
@@ -31,6 +32,10 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 		ServiceID:  r.ServiceID,
 		PlanID:     r.PlanID,
 		Parameters: r.Parameters,
+	}
+
+	if c.APIVersion.AtLeast(Version2_12()) {
+		requestBody.Context = r.Context
 	}
 
 	response, err := c.prepareAndDo(http.MethodPatch, fullURL, params, requestBody, r.OriginatingIdentity)

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/update_instance_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/update_instance_test.go
@@ -20,6 +20,8 @@ func defaultAsyncUpdateInstanceRequest() *UpdateInstanceRequest {
 	return r
 }
 
+const successUpdateInstanceRequestBody = `{"service_id":"test-service-id","plan_id":"test-plan-id"}`
+
 const successUpdateInstanceResponseBody = `{}`
 
 func successUpdateInstanceResponse() *UpdateInstanceResponse {
@@ -36,6 +38,8 @@ func successUpdateInstanceResponseAsync() *UpdateInstanceResponse {
 	r.OperationKey = &testOperation
 	return r
 }
+
+const contextUpdateInstanceRequestBody = `{"service_id":"test-service-id","plan_id":"test-plan-id","context":{"foo":"bar"}}`
 
 func TestUpdateInstanceInstance(t *testing.T) {
 	cases := []struct {
@@ -133,6 +137,43 @@ func TestUpdateInstanceInstance(t *testing.T) {
 				body:   conventionalFailureResponseBody,
 			},
 			expectedErr: testHTTPStatusCodeError(),
+		},
+		{
+			name:    "context - 2.12",
+			version: Version2_12(),
+			request: func() *UpdateInstanceRequest {
+				r := defaultUpdateInstanceRequest()
+				r.Context = map[string]interface{}{
+					"foo": "bar",
+				}
+				return r
+			}(),
+			httpChecks: httpChecks{
+				body: contextUpdateInstanceRequestBody,
+			},
+			httpReaction: httpReaction{
+				status: http.StatusOK,
+				body:   successUpdateInstanceResponseBody,
+			},
+			expectedResponse: successUpdateInstanceResponse(),
+		},
+		{
+			name: "context - 2.11",
+			request: func() *UpdateInstanceRequest {
+				r := defaultUpdateInstanceRequest()
+				r.Context = map[string]interface{}{
+					"foo": "bar",
+				}
+				return r
+			}(),
+			httpChecks: httpChecks{
+				body: successUpdateInstanceRequestBody,
+			},
+			httpReaction: httpReaction{
+				status: http.StatusOK,
+				body:   successUpdateInstanceResponseBody,
+			},
+			expectedResponse: successUpdateInstanceResponse(),
 		},
 		{
 			name:                "originating identity included",


### PR DESCRIPTION
Fixes #1427.

Fill in the Context parameter for UpdateInstanceRequests.

Note: glide wanted to upgrade google.golang.com/appengine, which is used by github.com/emicklei/go-restful. Rather than allowing the upgrade, I tried adding that dependency to glide.yaml. But, I could not immediately figure out the right repo to use to get it working. In the short term, I have manually edited glide.lock to avoid the upgrade. I will address this properly in a follow-on PR.