### PR TITLE
When a SI is unbindable, mark the binding request failed.

### DIFF
--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -254,6 +254,14 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 			errorNonbindableClusterServiceClassReason,
 			s,
 		)
+		setServiceBindingCondition(
+			toUpdate,
+			v1beta1.ServiceBindingConditionFailed,
+			v1beta1.ConditionTrue,
+			errorNonbindableClusterServiceClassReason,
+			s,
+		)
+		clearServiceBindingCurrentOperation(toUpdate)
 		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
 			return err
 		}
@@ -461,7 +469,7 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 					v1beta1.ConditionFalse,
 					errorBindCallReason,
 					"Bind call failed. "+s)
-				c.clearServiceBindingCurrentOperation(toUpdate)
+				clearServiceBindingCurrentOperation(toUpdate)
 				if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
 					return err
 				}
@@ -490,7 +498,7 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 					v1beta1.ConditionTrue,
 					errorReconciliationRetryTimeoutReason,
 					s)
-				c.clearServiceBindingCurrentOperation(toUpdate)
+				clearServiceBindingCurrentOperation(toUpdate)
 				if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
 					return err
 				}
@@ -546,7 +554,7 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 			return err
 		}
 
-		c.clearServiceBindingCurrentOperation(toUpdate)
+		clearServiceBindingCurrentOperation(toUpdate)
 
 		setServiceBindingCondition(
 			toUpdate,
@@ -662,7 +670,7 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 						errorUnbindCallReason,
 						"Unbind call failed. "+s)
 				}
-				c.clearServiceBindingCurrentOperation(toUpdate)
+				clearServiceBindingCurrentOperation(toUpdate)
 				if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
 					return err
 				}
@@ -696,7 +704,7 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 						errorReconciliationRetryTimeoutReason,
 						s)
 				}
-				c.clearServiceBindingCurrentOperation(toUpdate)
+				clearServiceBindingCurrentOperation(toUpdate)
 				if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
 					return err
 				}
@@ -731,7 +739,7 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 		}
 
 		toUpdate.Status.ExternalProperties = nil
-		c.clearServiceBindingCurrentOperation(toUpdate)
+		clearServiceBindingCurrentOperation(toUpdate)
 		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
 			return err
 		}
@@ -995,7 +1003,7 @@ func (c *controller) recordStartOfServiceBindingOperation(toUpdate *v1beta1.Serv
 // clearServiceBindingCurrentOperation sets the fields of the binding's
 // Status to indicate that there is no current operation being performed. The
 // Status is *not* recorded in the registry.
-func (c *controller) clearServiceBindingCurrentOperation(toUpdate *v1beta1.ServiceBinding) {
+func clearServiceBindingCurrentOperation(toUpdate *v1beta1.ServiceBinding) {
 	toUpdate.Status.CurrentOperation = ""
 	toUpdate.Status.OperationStartTime = nil
 	toUpdate.Status.ReconciledGeneration = toUpdate.Generation

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -527,11 +527,11 @@ func TestReconcileServiceBindingNonbindableClusterServiceClass(t *testing.T) {
 
 	// There should only be one action that says binding was created
 	updatedServiceBinding := assertUpdateStatus(t, actions[0], binding)
-	assertServiceBindingErrorBeforeRequest(t, updatedServiceBinding, errorNonbindableClusterServiceClassReason, binding)
+	assertServiceBindingFailedBeforeRequest(t, updatedServiceBinding, errorNonbindableClusterServiceClassReason, binding)
 	assertServiceBindingOrphanMitigationSet(t, updatedServiceBinding, false)
+	assertServiceBindingReconciledGeneration(t, updatedServiceBinding, binding.Generation)
 
 	events := getRecordedEvents(testController)
-	assertNumEvents(t, events, 1)
 
 	expectedEvent := warningEventBuilder(errorNonbindableClusterServiceClassReason).msgf(
 		"References a non-bindable ClusterServiceClass (K8S: %q ExternalName: %q) and Plan (%q) combination",
@@ -692,7 +692,7 @@ func TestReconcileServiceBindingBindableClusterServiceClassNonbindablePlan(t *te
 
 	// There should only be one action that says binding was created
 	updatedServiceBinding := assertUpdateStatus(t, actions[0], binding)
-	assertServiceBindingErrorBeforeRequest(t, updatedServiceBinding, errorNonbindableClusterServiceClassReason, binding)
+	assertServiceBindingFailedBeforeRequest(t, updatedServiceBinding, errorNonbindableClusterServiceClassReason, binding)
 	assertServiceBindingOrphanMitigationSet(t, updatedServiceBinding, false)
 
 	events := getRecordedEvents(testController)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2274,6 +2274,15 @@ func assertServiceBindingErrorBeforeRequest(t *testing.T, obj runtime.Object, re
 	assertServiceBindingExternalPropertiesUnchanged(t, obj, originalBinding)
 }
 
+func assertServiceBindingFailedBeforeRequest(t *testing.T, obj runtime.Object, reason string, originalBinding *v1beta1.ServiceBinding) {
+	assertServiceBindingReadyFalse(t, obj, reason)
+	assertServiceBindingCurrentOperationClear(t, obj)
+	assertServiceBindingOperationStartTimeSet(t, obj, false)
+	assertServiceBindingReconciledGeneration(t, obj, originalBinding.Generation)
+	assertServiceBindingInProgressPropertiesNil(t, obj)
+	assertServiceBindingExternalPropertiesUnchanged(t, obj, originalBinding)
+}
+
 func assertServiceBindingOperationInProgress(t *testing.T, obj runtime.Object, operation v1beta1.ServiceBindingOperation, originalBinding *v1beta1.ServiceBinding) {
 	assertServiceBindingOperationInProgressWithParameters(t, obj, operation, nil, "", originalBinding)
 }


### PR DESCRIPTION
Relates to second point in https://github.com/kubernetes-incubator/service-catalog/issues/1423