### PR TITLE
Adding UnbindStatus to ServiceBindings

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -749,6 +749,9 @@ type ServiceBindingStatus struct {
 	// OrphanMitigationInProgress is a flag that represents whether orphan
 	// mitigation is in progress.
 	OrphanMitigationInProgress bool
+
+	// UnbindStatus describes what has been done to unbind a Binding
+	UnbindStatus ServiceBindingUnbindStatus
 }
 
 // ServiceBindingCondition condition information for a ServiceBinding.
@@ -816,6 +819,27 @@ type ServiceBindingPropertiesState struct {
 	// UserInfo is information about the user that made the request.
 	UserInfo *UserInfo
 }
+
+// ServiceBindingUnbindStatus is the status of unbinding a Binding
+type ServiceBindingUnbindStatus string
+
+const (
+	// ServiceBindingUnbindStatusNotRequired indicates that a binding request
+	// has not been sent for the ServiceBinding, so no unbinding request
+	// needs to be made.
+	ServiceBindingUnbindStatusNotRequired ServiceBindingUnbindStatus = "NotRequired"
+	// ServiceBindingUnbindStatusRequired indicates that a binding request has
+	// been sent for the ServiceBinding. An unbind request must be made before
+	// deleting the ServiceBinding.
+	ServiceBindingUnbindStatusRequired ServiceBindingUnbindStatus = "Required"
+	// ServiceBindingUnbindStatusSucceeded indicates that a unbind request
+	// has been sent for the ServiceBinding, and the request was successful.
+	ServiceBindingUnbindStatusSucceeded ServiceBindingUnbindStatus = "Succeeded"
+	// ServiceBindingUnbindStatusFailed indicates that unbind requests
+	// have been sent for the ServiceBinding but they failed. The controller
+	// has given up on sending more unbind requests.
+	ServiceBindingUnbindStatusFailed ServiceBindingUnbindStatus = "Failed"
+)
 
 // ParametersFromSource represents the source of a set of Parameters
 type ParametersFromSource struct {

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -750,7 +750,7 @@ type ServiceBindingStatus struct {
 	// mitigation is in progress.
 	OrphanMitigationInProgress bool
 
-	// UnbindStatus describes what has been done to unbind a Binding
+	// UnbindStatus describes what has been done to unbind a ServiceBinding
 	UnbindStatus ServiceBindingUnbindStatus
 }
 

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -772,6 +772,9 @@ type ServiceBindingStatus struct {
 	// OrphanMitigationInProgress is a flag that represents whether orphan
 	// mitigation is in progress.
 	OrphanMitigationInProgress bool `json:"orphanMitigationInProgress"`
+
+	// UnbindStatus describes what has been done to unbind the ServiceBinding.
+	UnbindStatus ServiceBindingUnbindStatus `json:"unbindStatus"`
 }
 
 // ServiceBindingCondition condition information for a ServiceBinding.
@@ -818,6 +821,27 @@ const (
 	// ServiceBindingOperationUnbind indicates that the
 	// ServiceBinding is being unbound.
 	ServiceBindingOperationUnbind ServiceBindingOperation = "Unbind"
+)
+
+// ServiceBindingUnbindStatus is the status of unbinding a Binding
+type ServiceBindingUnbindStatus string
+
+const (
+	// ServiceBindingUnbindStatusNotRequired indicates that a binding request
+	// has not been sent for the ServiceBinding, so no unbinding request
+	// needs to be made.
+	ServiceBindingUnbindStatusNotRequired ServiceBindingUnbindStatus = "NotRequired"
+	// ServiceBindingUnbindStatusRequired indicates that a binding request has
+	// been sent for the ServiceBinding. An unbind request must be made before
+	// deleting the ServiceBinding.
+	ServiceBindingUnbindStatusRequired ServiceBindingUnbindStatus = "Required"
+	// ServiceBindingUnbindStatusSucceeded indicates that a unbind request has
+	// been sent for the ServiceBinding, and the request was successful.
+	ServiceBindingUnbindStatusSucceeded ServiceBindingUnbindStatus = "Succeeded"
+	// ServiceBindingUnbindStatusFailed indicates that unbind requests have
+	// been sent for the ServiceBinding but they failed. The controller has
+	// given up on sending more unbind requests.
+	ServiceBindingUnbindStatusFailed ServiceBindingUnbindStatus = "Failed"
 )
 
 // These are external finalizer values to service catalog, must be qualified name.

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
@@ -767,6 +767,7 @@ func autoConvert_v1beta1_ServiceBindingStatus_To_servicecatalog_ServiceBindingSt
 	out.InProgressProperties = (*servicecatalog.ServiceBindingPropertiesState)(unsafe.Pointer(in.InProgressProperties))
 	out.ExternalProperties = (*servicecatalog.ServiceBindingPropertiesState)(unsafe.Pointer(in.ExternalProperties))
 	out.OrphanMitigationInProgress = in.OrphanMitigationInProgress
+	out.UnbindStatus = servicecatalog.ServiceBindingUnbindStatus(in.UnbindStatus)
 	return nil
 }
 
@@ -783,6 +784,7 @@ func autoConvert_servicecatalog_ServiceBindingStatus_To_v1beta1_ServiceBindingSt
 	out.InProgressProperties = (*ServiceBindingPropertiesState)(unsafe.Pointer(in.InProgressProperties))
 	out.ExternalProperties = (*ServiceBindingPropertiesState)(unsafe.Pointer(in.ExternalProperties))
 	out.OrphanMitigationInProgress = in.OrphanMitigationInProgress
+	out.UnbindStatus = ServiceBindingUnbindStatus(in.UnbindStatus)
 	return nil
 }
 

--- a/pkg/apis/servicecatalog/validation/binding_test.go
+++ b/pkg/apis/servicecatalog/validation/binding_test.go
@@ -37,6 +37,9 @@ func validServiceBinding() *servicecatalog.ServiceBinding {
 			},
 			SecretName: "test-secret",
 		},
+		Status: servicecatalog.ServiceBindingStatus{
+			UnbindStatus: servicecatalog.ServiceBindingUnbindStatusNotRequired,
+		},
 	}
 }
 
@@ -446,6 +449,72 @@ func TestValidateServiceBinding(t *testing.T) {
 						Status: servicecatalog.ConditionTrue,
 					},
 				}
+				return b
+			}(),
+			valid: true,
+		},
+		{
+			name: "required unbind status on create",
+			binding: func() *servicecatalog.ServiceBinding {
+				b := validServiceBinding()
+				b.Status.UnbindStatus = servicecatalog.ServiceBindingUnbindStatusRequired
+				return b
+			}(),
+			create: true,
+			valid:  false,
+		},
+		{
+			name: "succeeded unbind status on create",
+			binding: func() *servicecatalog.ServiceBinding {
+				b := validServiceBinding()
+				b.Status.UnbindStatus = servicecatalog.ServiceBindingUnbindStatusSucceeded
+				return b
+			}(),
+			create: true,
+			valid:  false,
+		},
+		{
+			name: "failed unbind status on create",
+			binding: func() *servicecatalog.ServiceBinding {
+				b := validServiceBinding()
+				b.Status.UnbindStatus = servicecatalog.ServiceBindingUnbindStatusFailed
+				return b
+			}(),
+			create: true,
+			valid:  false,
+		},
+		{
+			name: "invalid unbind status on update",
+			binding: func() *servicecatalog.ServiceBinding {
+				b := validServiceBinding()
+				b.Status.UnbindStatus = servicecatalog.ServiceBindingUnbindStatus("bad-unbind-status")
+				return b
+			}(),
+			valid: false,
+		},
+		{
+			name: "required unbind status on update",
+			binding: func() *servicecatalog.ServiceBinding {
+				b := validServiceBinding()
+				b.Status.UnbindStatus = servicecatalog.ServiceBindingUnbindStatusRequired
+				return b
+			}(),
+			valid: true,
+		},
+		{
+			name: "succeeded unbind status on update",
+			binding: func() *servicecatalog.ServiceBinding {
+				b := validServiceBinding()
+				b.Status.UnbindStatus = servicecatalog.ServiceBindingUnbindStatusSucceeded
+				return b
+			}(),
+			valid: true,
+		},
+		{
+			name: "failed unbind status on update",
+			binding: func() *servicecatalog.ServiceBinding {
+				b := validServiceBinding()
+				b.Status.UnbindStatus = servicecatalog.ServiceBindingUnbindStatusFailed
 				return b
 			}(),
 			valid: true,

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -632,8 +632,6 @@ func (c *controller) reconcileServiceBindingDelete(binding *v1beta1.ServiceBindi
 		finalizers.Delete(v1beta1.FinalizerServiceCatalog)
 		toUpdate.Finalizers = finalizers.List()
 
-		toUpdate.Status.ExternalProperties = nil
-		clearServiceBindingCurrentOperation(toUpdate)
 		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
 			return err
 		}

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -422,6 +422,8 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 			request.OriginatingIdentity = originatingIdentity
 		}
 
+		toUpdate.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusRequired
+
 		if toUpdate.Status.CurrentOperation == "" {
 			toUpdate, err = c.recordStartOfServiceBindingOperation(toUpdate, v1beta1.ServiceBindingOperationBind)
 			if err != nil {
@@ -430,8 +432,6 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 				return err
 			}
 		}
-
-		toUpdate.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusRequired
 
 		response, err := brokerClient.Bind(request)
 		// orphan mitigation: looking for timeout

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -207,16 +207,13 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 			return nil
 		}
 	}
-	if binding.DeletionTimestamp != nil || binding.Status.OrphanMitigationInProgress {
-		return c.reconcileServiceBindingDelete(binding)
-	}
-
-	glog.V(4).Info(pcb.Message("Processing"))
 
 	toUpdate, err := makeServiceBindingClone(binding)
 	if err != nil {
 		return err
 	}
+
+	glog.V(4).Info(pcb.Message("Processing"))
 
 	instance, err := c.instanceLister.ServiceInstances(binding.Namespace).Get(binding.Spec.ServiceInstanceRef.Name)
 	if err != nil {
@@ -291,7 +288,6 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 			s,
 		)
 		clearServiceBindingCurrentOperation(toUpdate)
-		toUpdate.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusNotRequired
 		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
 			return err
 		}
@@ -455,8 +451,6 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 			request.OriginatingIdentity = originatingIdentity
 		}
 
-		toUpdate.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusRequired
-
 		if toUpdate.Status.CurrentOperation == "" {
 			toUpdate, err = c.recordStartOfServiceBindingOperation(toUpdate, v1beta1.ServiceBindingOperationBind)
 			if err != nil {
@@ -513,7 +507,6 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 					errorBindCallReason,
 					"Bind call failed. "+s)
 				clearServiceBindingCurrentOperation(toUpdate)
-				toUpdate.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusNotRequired
 				if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
 					return err
 				}
@@ -543,7 +536,6 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 					errorReconciliationRetryTimeoutReason,
 					s)
 				clearServiceBindingCurrentOperation(toUpdate)
-				toUpdate.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusNotRequired
 				if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
 					return err
 				}
@@ -653,229 +645,119 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 		return nil
 	}
 
-	return nil
-}
-
-func (c *controller) reconcileServiceBindingDelete(binding *v1beta1.ServiceBinding) error {
-	// All updates having a DeletingTimestamp will have been handled here.
-	// We're dealing with an update that's actually a soft delete-- i.e. we
-	// have some finalization to do.
-
-	if binding.DeletionTimestamp == nil && !binding.Status.OrphanMitigationInProgress {
-		// nothing to do...
-		return nil
-	}
-
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
-	glog.V(4).Info(pcb.Message("Processing Delete"))
-
-	finalizerToken := v1beta1.FinalizerServiceCatalog
-	finalizers := sets.NewString(binding.Finalizers...)
-	if !finalizers.Has(finalizerToken) {
-		return nil
-	}
-
-	// If unbind has failed, do not do anything more
-	if binding.Status.UnbindStatus == v1beta1.ServiceBindingUnbindStatusFailed {
-		glog.V(4).Info(pcb.Message("Not processing delete event because unbinding has failed"))
-		return nil
-	}
-
-	toUpdate, err := makeServiceBindingClone(binding)
-	if err != nil {
-		return err
-	}
-
-	// If unbinding succeeded or is not needed, then clear out the finalizers
-	if binding.Status.UnbindStatus == v1beta1.ServiceBindingUnbindStatusNotRequired ||
-		binding.Status.UnbindStatus == v1beta1.ServiceBindingUnbindStatusSucceeded {
-
-		glog.V(5).Info(pcb.Message("Clearing catalog finalizer"))
-
-		// Clear the finalizer
-		finalizers.Delete(v1beta1.FinalizerServiceCatalog)
-		toUpdate.Finalizers = finalizers.List()
-
-		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-			return err
-		}
-		return nil
-	}
-
-	err = c.ejectServiceBinding(binding)
-	if err != nil {
-		s := fmt.Sprintf(`Error deleting secret: %s`, err)
-		glog.Warning(pcb.Message(s))
-		c.recorder.Eventf(binding, corev1.EventTypeWarning, errorEjectingBindReason, "%v %v", errorEjectingBindMessage, s)
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionUnknown,
-			errorEjectingBindReason,
-			errorEjectingBindMessage+s,
-		)
-		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-			return err
-		}
-		return err
-	}
-
-	if toUpdate.DeletionTimestamp == nil {
-		if toUpdate.Status.OperationStartTime == nil {
-			now := metav1.Now()
-			toUpdate.Status.OperationStartTime = &now
-		}
-	} else {
-		if toUpdate.Status.CurrentOperation != v1beta1.ServiceBindingOperationUnbind {
-			// Cancel any pending orphan mitigation since the resource is being deleted
-			toUpdate.Status.OrphanMitigationInProgress = false
-
-			toUpdate, err = c.recordStartOfServiceBindingOperation(toUpdate, v1beta1.ServiceBindingOperationUnbind)
-			if err != nil {
-				// There has been an update to the binding. Start reconciliation
-				// over with a fresh view of the binding.
-				return err
-			}
-		}
-	}
-
-	// Make unbinding request to broker
-	if ok, err := c.serviceBindingRequestUnbinding(binding, toUpdate, pcb); !ok || err != nil {
-		return err
-	}
-
-	if toUpdate.Status.OrphanMitigationInProgress {
-		s := "Orphan mitigation successful"
-		setServiceBindingCondition(toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionFalse,
-			successOrphanMitigationReason,
-			s)
-	} else {
-		s := "The binding was deleted successfully"
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionFalse,
-			successUnboundReason,
-			s,
-		)
-		// Clear the finalizer
-		finalizers.Delete(v1beta1.FinalizerServiceCatalog)
-		toUpdate.Finalizers = finalizers.List()
-	}
-
-	toUpdate.Status.ExternalProperties = nil
-	clearServiceBindingCurrentOperation(toUpdate)
-	if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-		return err
-	}
-
-	c.recorder.Event(binding, corev1.EventTypeNormal, successUnboundReason, "This binding was deleted successfully")
-	glog.V(5).Info(pcb.Message("Successfully deleted ServiceBinding"))
-
-	return nil
-}
-
-// serviceBindingRequestUnbinding validates and makes the binding request to the broker.
-// Returns if reconciliation should continue and any error produced.
-func (c *controller) serviceBindingRequestUnbinding(binding *v1beta1.ServiceBinding, toUpdate *v1beta1.ServiceBinding, pcb *pretty.ContextBuilder) (bool, error) {
-	glog.V(4).Info(pcb.Message("Going to make request to unbind"))
-	instance, err := c.instanceLister.ServiceInstances(binding.Namespace).Get(binding.Spec.ServiceInstanceRef.Name)
-	if err != nil {
-		s := fmt.Sprintf(
-			`References a non-existent %s "%s/%s"`,
-			pretty.ServiceInstance, binding.Namespace, binding.Spec.ServiceInstanceRef.Name,
-		)
-		glog.Warningf(pcb.Messagef("%s (%s)", s, err))
-		c.recorder.Event(binding, corev1.EventTypeWarning, errorNonexistentServiceInstanceReason, s)
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionFalse,
-			errorNonexistentServiceInstanceReason,
-			"The binding references an ServiceInstance that does not exist. "+s,
-		)
-		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-			return false, err
-		}
-		return false, err
-	}
-
-	if instance.Status.AsyncOpInProgress {
-		s := fmt.Sprintf(
-			`trying to unbind to %s "%s/%s" that has ongoing asynchronous operation`,
-			pretty.ServiceInstance, binding.Namespace, binding.Spec.ServiceInstanceRef.Name,
-		)
-		glog.Info(pcb.Message(s))
-		c.recorder.Event(binding, corev1.EventTypeWarning, errorWithOngoingAsyncOperation, s)
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionFalse,
-			errorWithOngoingAsyncOperation,
-			errorWithOngoingAsyncOperationMessage,
-		)
-		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-			return false, err
-		}
-		return false, fmt.Errorf("Ongoing Asynchronous operation")
-	}
-
-	if instance.Spec.ClusterServiceClassRef == nil || instance.Spec.ClusterServicePlanRef == nil {
-		return false, fmt.Errorf("ClusterServiceClass or ClusterServicePlan references for Instance have not been resolved yet")
-	}
-
-	serviceClass, servicePlan, brokerName, brokerClient, err := c.getClusterServiceClassPlanAndClusterServiceBrokerForServiceBinding(instance, binding)
-	if err != nil {
-		return false, err // retry later
-	}
-
-	unbindRequest := &osb.UnbindRequest{
-		BindingID:  binding.Spec.ExternalID,
-		InstanceID: instance.Spec.ExternalID,
-		ServiceID:  serviceClass.Spec.ExternalID,
-		PlanID:     servicePlan.Spec.ExternalID,
-	}
-
-	// Asynchronous binding operations is currently ALPHA and not
-	// enabled by default. To use this feature, you must enable the
-	// AsyncBindingOperations feature gate. This may be easily set
-	// by setting `asyncBindingOperationsEnabled=true` when
-	// deploying the Service Catalog via the Helm charts.
-	if serviceClass.Spec.BindingRetrievable &&
-		utilfeature.DefaultFeatureGate.Enabled(scfeatures.AsyncBindingOperations) {
-
-		unbindRequest.AcceptsIncomplete = true
-	}
-
-	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {
-		originatingIdentity, err := buildOriginatingIdentity(binding.Spec.UserInfo)
+	// All updates not having a DeletingTimestamp will have been handled above
+	// and returned early, except in the case of orphan mitigation. Otherwise,
+	// when we reach this point, we're dealing with an update that's actually
+	// a soft delete-- i.e. we have some finalization to do.
+	if finalizers := sets.NewString(binding.Finalizers...); finalizers.Has(v1beta1.FinalizerServiceCatalog) || binding.Status.OrphanMitigationInProgress {
+		err := c.ejectServiceBinding(binding)
 		if err != nil {
-			s := fmt.Sprintf(`Error building originating identity headers while unbinding: %v`, err)
+			s := fmt.Sprintf(`Error deleting secret: %s`, err)
 			glog.Warning(pcb.Message(s))
-			c.recorder.Event(binding, corev1.EventTypeWarning, errorWithOriginatingIdentity, s)
+			c.recorder.Eventf(binding, corev1.EventTypeWarning, errorEjectingBindReason, "%v %v", errorEjectingBindMessage, s)
 			setServiceBindingCondition(
 				toUpdate,
 				v1beta1.ServiceBindingConditionReady,
-				v1beta1.ConditionFalse,
-				errorWithOriginatingIdentity,
-				s,
+				v1beta1.ConditionUnknown,
+				errorEjectingBindReason,
+				errorEjectingBindMessage+s,
 			)
 			if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-				return false, err
+				return err
 			}
-			return false, err
+			return err
 		}
-		unbindRequest.OriginatingIdentity = originatingIdentity
-	}
 
-	response, err := brokerClient.Unbind(unbindRequest)
-	if err != nil {
-		if httpErr, ok := osb.IsHTTPError(err); ok {
+		unbindRequest := &osb.UnbindRequest{
+			BindingID:  binding.Spec.ExternalID,
+			InstanceID: instance.Spec.ExternalID,
+			ServiceID:  serviceClass.Spec.ExternalID,
+			PlanID:     servicePlan.Spec.ExternalID,
+		}
+
+		// Asynchronous binding operations is currently ALPHA and not
+		// enabled by default. To use this feature, you must enable the
+		// AsyncBindingOperations feature gate. This may be easily set
+		// by setting `asyncBindingOperationsEnabled=true` when
+		// deploying the Service Catalog via the Helm charts.
+		if serviceClass.Spec.BindingRetrievable &&
+			utilfeature.DefaultFeatureGate.Enabled(scfeatures.AsyncBindingOperations) {
+
+			unbindRequest.AcceptsIncomplete = true
+		}
+
+		if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {
+			originatingIdentity, err := buildOriginatingIdentity(binding.Spec.UserInfo)
+			if err != nil {
+				s := fmt.Sprintf(`Error building originating identity headers while unbinding: %v`, err)
+				glog.Warning(pcb.Message(s))
+				c.recorder.Event(binding, corev1.EventTypeWarning, errorWithOriginatingIdentity, s)
+				setServiceBindingCondition(
+					toUpdate,
+					v1beta1.ServiceBindingConditionReady,
+					v1beta1.ConditionFalse,
+					errorWithOriginatingIdentity,
+					s,
+				)
+				if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
+					return err
+				}
+				return err
+			}
+			unbindRequest.OriginatingIdentity = originatingIdentity
+		}
+
+		if toUpdate.DeletionTimestamp == nil {
+			if toUpdate.Status.OperationStartTime == nil {
+				now := metav1.Now()
+				toUpdate.Status.OperationStartTime = &now
+			}
+		} else {
+			if toUpdate.Status.CurrentOperation != v1beta1.ServiceBindingOperationUnbind {
+				// Cancel any pending orphan mitigation since the resource is being deleted
+				toUpdate.Status.OrphanMitigationInProgress = false
+
+				toUpdate, err = c.recordStartOfServiceBindingOperation(toUpdate, v1beta1.ServiceBindingOperationUnbind)
+				if err != nil {
+					// There has been an update to the binding. Start reconciliation
+					// over with a fresh view of the binding.
+					return err
+				}
+			}
+		}
+
+		response, err := brokerClient.Unbind(unbindRequest)
+		if err != nil {
+			if httpErr, ok := osb.IsHTTPError(err); ok {
+				s := fmt.Sprintf(
+					`Error unbinding from %s: %s`,
+					pretty.FromServiceInstanceOfClusterServiceClassAtBrokerName(instance, serviceClass, brokerName), httpErr.Error(),
+				)
+				glog.Warning(pcb.Message(s))
+				c.recorder.Event(binding, corev1.EventTypeWarning, errorUnbindCallReason, s)
+				setServiceBindingCondition(
+					toUpdate,
+					v1beta1.ServiceBindingConditionReady,
+					v1beta1.ConditionUnknown,
+					errorUnbindCallReason,
+					"Unbind call failed. "+s)
+				if !toUpdate.Status.OrphanMitigationInProgress {
+					setServiceBindingCondition(
+						toUpdate,
+						v1beta1.ServiceBindingConditionFailed,
+						v1beta1.ConditionTrue,
+						errorUnbindCallReason,
+						"Unbind call failed. "+s)
+				}
+				clearServiceBindingCurrentOperation(toUpdate)
+				if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
+					return err
+				}
+				return nil
+			}
 			s := fmt.Sprintf(
 				`Error unbinding from %s: %s`,
-				pretty.FromServiceInstanceOfClusterServiceClassAtBrokerName(instance, serviceClass, brokerName), httpErr.Error(),
+				pretty.FromServiceInstanceOfClusterServiceClassAtBrokerName(instance, serviceClass, brokerName), err,
 			)
 			glog.Warning(pcb.Message(s))
 			c.recorder.Event(binding, corev1.EventTypeWarning, errorUnbindCallReason, s)
@@ -885,33 +767,34 @@ func (c *controller) serviceBindingRequestUnbinding(binding *v1beta1.ServiceBind
 				v1beta1.ConditionUnknown,
 				errorUnbindCallReason,
 				"Unbind call failed. "+s)
-			if !toUpdate.Status.OrphanMitigationInProgress {
-				setServiceBindingCondition(
-					toUpdate,
-					v1beta1.ServiceBindingConditionFailed,
-					v1beta1.ConditionTrue,
-					errorUnbindCallReason,
-					"Unbind call failed. "+s)
+
+			if !time.Now().Before(toUpdate.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
+				if toUpdate.Status.OrphanMitigationInProgress {
+					s := "Stopping reconciliation retries, too much time has elapsed during orphan mitigation"
+					glog.Info(pcb.Message(s))
+					c.recorder.Event(binding, corev1.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
+				} else {
+					s := "Stopping reconciliation retries, too much time has elapsed"
+					glog.Info(pcb.Message(s))
+					c.recorder.Event(binding, corev1.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
+					setServiceBindingCondition(toUpdate,
+						v1beta1.ServiceBindingConditionFailed,
+						v1beta1.ConditionTrue,
+						errorReconciliationRetryTimeoutReason,
+						s)
+				}
+				clearServiceBindingCurrentOperation(toUpdate)
+				if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
+					return err
+				}
+				return nil
 			}
-			clearServiceBindingCurrentOperation(toUpdate)
-			toUpdate.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusFailed
+
 			if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-				return false, err
+				return err
 			}
-			return false, nil
+			return err
 		}
-		s := fmt.Sprintf(
-			`Error unbinding from %s: %s`,
-			pretty.FromServiceInstanceOfClusterServiceClassAtBrokerName(instance, serviceClass, brokerName), err,
-		)
-		glog.Warning(pcb.Message(s))
-		c.recorder.Event(binding, corev1.EventTypeWarning, errorUnbindCallReason, s)
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionUnknown,
-			errorUnbindCallReason,
-			"Unbind call failed. "+s)
 
 		if response.Async {
 			glog.Info(pcb.Message("Received asynchronous unbind response"))
@@ -932,48 +815,52 @@ func (c *controller) serviceBindingRequestUnbinding(binding *v1beta1.ServiceBind
 			)
 
 			if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-				return false, err
+				return err
 			}
 
 			if err := c.beginPollingServiceBinding(binding); err != nil {
-				return false, err
+				return err
 			}
 
 			c.recorder.Eventf(binding, corev1.EventTypeNormal, asyncUnbindingReason, asyncUnbindingMessage)
 
-			return false, nil
+			return nil
 		}
 
-		if !time.Now().Before(toUpdate.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
-			if toUpdate.Status.OrphanMitigationInProgress {
-				s := "Stopping reconciliation retries, too much time has elapsed during orphan mitigation"
-				glog.Info(pcb.Message(s))
-				c.recorder.Event(binding, corev1.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
-			} else {
-				s := "Stopping reconciliation retries, too much time has elapsed"
-				glog.Info(pcb.Message(s))
-				c.recorder.Event(binding, corev1.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
-				setServiceBindingCondition(toUpdate,
-					v1beta1.ServiceBindingConditionFailed,
-					v1beta1.ConditionTrue,
-					errorReconciliationRetryTimeoutReason,
-					s)
-			}
-			clearServiceBindingCurrentOperation(toUpdate)
-			toUpdate.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusFailed
-			if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-				return false, err
-			}
-			return false, nil
+		if toUpdate.Status.OrphanMitigationInProgress {
+			s := "Orphan mitigation successful"
+			setServiceBindingCondition(toUpdate,
+				v1beta1.ServiceBindingConditionReady,
+				v1beta1.ConditionFalse,
+				successOrphanMitigationReason,
+				s)
+		} else {
+			s := "The binding was deleted successfully"
+			setServiceBindingCondition(
+				toUpdate,
+				v1beta1.ServiceBindingConditionReady,
+				v1beta1.ConditionFalse,
+				successUnboundReason,
+				s,
+			)
+			// Clear the finalizer
+			finalizers.Delete(v1beta1.FinalizerServiceCatalog)
+			toUpdate.Finalizers = finalizers.List()
 		}
 
+		toUpdate.Status.ExternalProperties = nil
+		clearServiceBindingCurrentOperation(toUpdate)
 		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-			return false, err
+			return err
 		}
-		return false, err
+
+		c.recorder.Event(binding, corev1.EventTypeNormal, successUnboundReason, "This binding was deleted successfully")
+		glog.V(5).Info(pcb.Messagef(
+			"Successfully deleted ServiceBinding of %s",
+			pretty.FromServiceInstanceOfClusterServiceClassAtBrokerName(instance, serviceClass, brokerName),
+		))
 	}
-	toUpdate.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusSucceeded
-	return true, nil
+	return nil
 }
 
 // isPlanBindable returns whether the given ClusterServiceClass and ClusterServicePlan

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -637,6 +637,7 @@ func (c *controller) reconcileServiceBindingDelete(binding *v1beta1.ServiceBindi
 		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
 			return err
 		}
+		return nil
 	}
 
 	err = c.ejectServiceBinding(binding)

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -231,6 +231,13 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 	}
 
 	if instance.Spec.ClusterServiceClassRef == nil || instance.Spec.ClusterServicePlanRef == nil {
+		// Do not retry if the user wants to cancel/abort a binding request.
+		// This is a special case where no service class is resolved and a binding delete request
+		// has come in in the mean time. In general this should be fixed more generally per issue #1524.
+		if shouldServiceBindingAbort(binding) {
+			return c.serviceBindingAbort(binding, toUpdate, pcb)
+		}
+
 		// retry later
 		return fmt.Errorf("ClusterServiceClass or ClusterServicePlan references for Instance have not been resolved yet")
 	}
@@ -758,6 +765,90 @@ func isPlanBindable(serviceClass *v1beta1.ClusterServiceClass, plan *v1beta1.Clu
 	}
 
 	return serviceClass.Spec.Bindable
+}
+
+// shouldServiceBindingAbort tests to see if we have a service binding
+// request that never was able to bind, and then was deleted. This is a
+// special case meaning the user would like to abort the bind.
+func shouldServiceBindingAbort(binding *v1beta1.ServiceBinding) bool {
+	if binding.Generation == 1 && binding.DeletionTimestamp != nil {
+		return true
+	}
+	return false
+}
+
+// serviceBindingAbort will remove the service binding request from the reconciliation queue
+// before operations have been sent to the broker.
+func (c *controller) serviceBindingAbort(binding *v1beta1.ServiceBinding, toUpdate *v1beta1.ServiceBinding, pcb *pretty.ContextBuilder) error {
+	if finalizers := sets.NewString(binding.Finalizers...); finalizers.Has(v1beta1.FinalizerServiceCatalog) || binding.Status.OrphanMitigationInProgress {
+		err := c.ejectServiceBinding(binding)
+		if err != nil {
+			s := fmt.Sprintf(`Error deleting secret: %s`, err)
+			glog.Warning(pcb.Message(s))
+			c.recorder.Eventf(binding, corev1.EventTypeWarning, errorEjectingBindReason, "%v %v", errorEjectingBindMessage, s)
+			setServiceBindingCondition(
+				toUpdate,
+				v1beta1.ServiceBindingConditionReady,
+				v1beta1.ConditionUnknown,
+				errorEjectingBindReason,
+				errorEjectingBindMessage+s,
+			)
+			if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
+				return err
+			}
+			return err
+		}
+
+		if toUpdate.DeletionTimestamp == nil {
+			if toUpdate.Status.OperationStartTime == nil {
+				now := metav1.Now()
+				toUpdate.Status.OperationStartTime = &now
+			}
+		} else {
+			if toUpdate.Status.CurrentOperation != v1beta1.ServiceBindingOperationUnbind {
+				// Cancel any pending orphan mitigation since the resource is being deleted
+				toUpdate.Status.OrphanMitigationInProgress = false
+
+				toUpdate, err = c.recordStartOfServiceBindingOperation(toUpdate, v1beta1.ServiceBindingOperationUnbind)
+				if err != nil {
+					// There has been an update to the binding. Start reconciliation
+					// over with a fresh view of the binding.
+					return err
+				}
+			}
+		}
+
+		if toUpdate.Status.OrphanMitigationInProgress {
+			s := "Orphan mitigation successful"
+			setServiceBindingCondition(toUpdate,
+				v1beta1.ServiceBindingConditionReady,
+				v1beta1.ConditionFalse,
+				successOrphanMitigationReason,
+				s)
+		} else {
+			s := "The binding was deleted successfully"
+			setServiceBindingCondition(
+				toUpdate,
+				v1beta1.ServiceBindingConditionReady,
+				v1beta1.ConditionFalse,
+				successUnboundReason,
+				s,
+			)
+			// Clear the finalizer
+			finalizers.Delete(v1beta1.FinalizerServiceCatalog)
+			toUpdate.Finalizers = finalizers.List()
+		}
+
+		toUpdate.Status.ExternalProperties = nil
+		c.clearServiceBindingCurrentOperation(toUpdate)
+		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
+			return err
+		}
+
+		c.recorder.Event(binding, corev1.EventTypeNormal, successUnboundReason, "This binding was deleted successfully")
+		glog.V(5).Info(pcb.Message("Successfully aborted ServiceBinding"))
+	}
+	return nil
 }
 
 func (c *controller) injectServiceBinding(binding *v1beta1.ServiceBinding, credentials map[string]interface{}) error {

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -2763,8 +2763,9 @@ func TestReconcileServiceBindingDeleteDuringOrphanMitigation(t *testing.T) {
 	actions := fakeCatalogClient.Actions()
 	// The actions should be:
 	// 0. Updating the current operation
-	// 1. Updating the ready condition
-	assertNumberOfActions(t, actions, 2)
+	// 1. Update the unbind status
+	// 2. Updating the ready condition
+	assertNumberOfActions(t, actions, 3)
 
 	updatedServiceBinding := assertUpdateStatus(t, actions[0], binding).(*v1beta1.ServiceBinding)
 	assertServiceBindingOperationInProgress(t, updatedServiceBinding, v1beta1.ServiceBindingOperationUnbind, binding)

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -899,6 +899,7 @@ func TestReconcileServiceBindingDelete(t *testing.T) {
 		Status: v1beta1.ServiceBindingStatus{
 			ReconciledGeneration: 1,
 			ExternalProperties:   &v1beta1.ServiceBindingPropertiesState{},
+			UnbindStatus:         v1beta1.ServiceBindingUnbindStatusRequired,
 		},
 	}
 
@@ -988,6 +989,9 @@ func TestReconcileServiceBindingDeleteUnresolvedClusterServiceClassReference(t *
 			ServiceInstanceRef: v1beta1.LocalObjectReference{Name: testServiceInstanceName},
 			ExternalID:         testServiceBindingGUID,
 		},
+		Status: v1beta1.ServiceBindingStatus{
+			UnbindStatus: v1beta1.ServiceBindingUnbindStatusNotRequired,
+		},
 	}
 
 	err := testController.reconcileServiceBinding(binding)
@@ -1027,7 +1031,8 @@ func TestSetServiceBindingCondition(t *testing.T) {
 	bindingWithCondition := func(condition *v1beta1.ServiceBindingCondition) *v1beta1.ServiceBinding {
 		binding := getTestServiceBinding()
 		binding.Status = v1beta1.ServiceBindingStatus{
-			Conditions: []v1beta1.ServiceBindingCondition{*condition},
+			Conditions:   []v1beta1.ServiceBindingCondition{*condition},
+			UnbindStatus: v1beta1.ServiceBindingUnbindStatusRequired,
 		}
 
 		return binding
@@ -1174,6 +1179,7 @@ func TestReconcileServiceBindingDeleteFailedServiceBinding(t *testing.T) {
 	binding.ObjectMeta.DeletionTimestamp = &metav1.Time{}
 	binding.ObjectMeta.Finalizers = []string{v1beta1.FinalizerServiceCatalog}
 	binding.Status.ExternalProperties = &v1beta1.ServiceBindingPropertiesState{}
+	binding.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusRequired
 
 	binding.ObjectMeta.Generation = 2
 	binding.Status.ReconciledGeneration = 1
@@ -1263,6 +1269,9 @@ func TestReconcileServiceBindingWithClusterServiceBrokerError(t *testing.T) {
 			ExternalID:         testServiceBindingGUID,
 			SecretName:         testServiceBindingSecretName,
 		},
+		Status: v1beta1.ServiceBindingStatus{
+			UnbindStatus: v1beta1.ServiceBindingUnbindStatusNotRequired,
+		},
 	}
 
 	err := testController.reconcileServiceBinding(binding)
@@ -1322,6 +1331,9 @@ func TestReconcileServiceBindingWithClusterServiceBrokerHTTPError(t *testing.T) 
 			ServiceInstanceRef: v1beta1.LocalObjectReference{Name: testServiceInstanceName},
 			ExternalID:         testServiceBindingGUID,
 			SecretName:         testServiceBindingSecretName,
+		},
+		Status: v1beta1.ServiceBindingStatus{
+			UnbindStatus: v1beta1.ServiceBindingUnbindStatusNotRequired,
 		},
 	}
 
@@ -1698,6 +1710,7 @@ func TestReconcileUnbindingWithClusterServiceBrokerError(t *testing.T) {
 		},
 		Status: v1beta1.ServiceBindingStatus{
 			ExternalProperties: &v1beta1.ServiceBindingPropertiesState{},
+			UnbindStatus:       v1beta1.ServiceBindingUnbindStatusRequired,
 		},
 	}
 	if err := scmeta.AddFinalizer(binding, v1beta1.FinalizerServiceCatalog); err != nil {
@@ -1762,6 +1775,7 @@ func TestReconcileUnbindingWithClusterServiceBrokerHTTPError(t *testing.T) {
 		},
 		Status: v1beta1.ServiceBindingStatus{
 			ExternalProperties: &v1beta1.ServiceBindingPropertiesState{},
+			UnbindStatus:       v1beta1.ServiceBindingUnbindStatusRequired,
 		},
 	}
 	if err := scmeta.AddFinalizer(binding, v1beta1.FinalizerServiceCatalog); err != nil {
@@ -2454,6 +2468,9 @@ func TestReconcileBindingWithOrphanMitigationInProgress(t *testing.T) {
 			ExternalID:         testServiceBindingGUID,
 			SecretName:         testServiceBindingSecretName,
 		},
+		Status: v1beta1.ServiceBindingStatus{
+			UnbindStatus: v1beta1.ServiceBindingUnbindStatusRequired,
+		},
 	}
 	binding.Status.CurrentOperation = v1beta1.ServiceBindingOperationBind
 	binding.Status.OperationStartTime = nil
@@ -2532,6 +2549,7 @@ func TestReconcileBindingWithOrphanMitigationReconciliationRetryTimeOut(t *testi
 					Reason: "reason-orphan-mitigation-began",
 				},
 			},
+			UnbindStatus: v1beta1.ServiceBindingUnbindStatusRequired,
 		},
 	}
 	startTime := metav1.NewTime(time.Now().Add(-7 * 24 * time.Hour))
@@ -2611,6 +2629,7 @@ func TestReconcileServiceBindingDeleteDuringOngoingOperation(t *testing.T) {
 		Status: v1beta1.ServiceBindingStatus{
 			CurrentOperation:   v1beta1.ServiceBindingOperationBind,
 			OperationStartTime: &startTime,
+			UnbindStatus:       v1beta1.ServiceBindingUnbindStatusRequired,
 		},
 	}
 
@@ -2707,6 +2726,7 @@ func TestReconcileServiceBindingDeleteDuringOrphanMitigation(t *testing.T) {
 			CurrentOperation:           v1beta1.ServiceBindingOperationBind,
 			OperationStartTime:         &startTime,
 			OrphanMitigationInProgress: true,
+			UnbindStatus:               v1beta1.ServiceBindingUnbindStatusRequired,
 		},
 	}
 

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -1005,23 +1005,10 @@ func TestReconcileServiceBindingDeleteUnresolvedClusterServiceClassReference(t *
 	actions := fakeCatalogClient.Actions()
 	// The actions should be:
 	// 0. Updating the current operation
-	// 1. Updating the ready condition
-	assertNumberOfActions(t, actions, 2)
-
-	updatedServiceBinding := assertUpdateStatus(t, actions[0], binding)
-	assertServiceBindingOperationInProgress(t, updatedServiceBinding, v1beta1.ServiceBindingOperationUnbind, binding)
-	assertServiceBindingOrphanMitigationSet(t, updatedServiceBinding, false)
-
-	updatedServiceBinding = assertUpdateStatus(t, actions[1], binding)
-	assertServiceBindingOperationSuccess(t, updatedServiceBinding, v1beta1.ServiceBindingOperationUnbind, binding)
-	assertServiceBindingOrphanMitigationSet(t, updatedServiceBinding, false)
+	assertNumberOfActions(t, actions, 1)
 
 	events := getRecordedEvents(testController)
-
-	expectedEvent := normalEventBuilder(successUnboundReason).msg("This binding was deleted successfully")
-	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
-		t.Fatal(err)
-	}
+	assertNumEvents(t, events, 0)
 }
 
 // TestSetServiceBindingCondition verifies setting a condition on a binding yields
@@ -2763,9 +2750,8 @@ func TestReconcileServiceBindingDeleteDuringOrphanMitigation(t *testing.T) {
 	actions := fakeCatalogClient.Actions()
 	// The actions should be:
 	// 0. Updating the current operation
-	// 1. Update the unbind status
-	// 2. Updating the ready condition
-	assertNumberOfActions(t, actions, 3)
+	// 1. Updating the ready condition
+	assertNumberOfActions(t, actions, 2)
 
 	updatedServiceBinding := assertUpdateStatus(t, actions[0], binding).(*v1beta1.ServiceBinding)
 	assertServiceBindingOperationInProgress(t, updatedServiceBinding, v1beta1.ServiceBindingOperationUnbind, binding)

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -948,7 +948,71 @@ func TestReconcileServiceBindingDelete(t *testing.T) {
 	assertServiceBindingOrphanMitigationSet(t, updatedServiceBinding, false)
 
 	events := getRecordedEvents(testController)
-	assertNumEvents(t, events, 1)
+
+	expectedEvent := normalEventBuilder(successUnboundReason).msg("This binding was deleted successfully")
+	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestReconcileServiceBindingDeleteUnresolvedClusterServiceClassReference
+// tests reconcileBinding to ensure a binding delete succeeds when a ClusterServiceClassRef
+// has not been resolved and no action has accrued for the binding.
+func TestReconcileServiceBindingDeleteUnresolvedClusterServiceClassReference(t *testing.T) {
+	_, fakeCatalogClient, fakeClusterServiceBrokerClient, testController, sharedInformers := newTestController(t, noFakeActions())
+
+	sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(getTestClusterServiceBroker())
+	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(getTestClusterServiceClass())
+	instance := &v1beta1.ServiceInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: testServiceInstanceName, Namespace: testNamespace},
+		Spec: v1beta1.ServiceInstanceSpec{
+			PlanReference: v1beta1.PlanReference{
+				ClusterServiceClassExternalName: testNonExistentClusterServiceClassName,
+				ClusterServicePlanExternalName:  testClusterServicePlanName,
+			},
+			ExternalID: testServiceInstanceGUID,
+		},
+	}
+	sharedInformers.ServiceInstances().Informer().GetStore().Add(instance)
+	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
+
+	binding := &v1beta1.ServiceBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              testServiceBindingName,
+			Namespace:         testNamespace,
+			DeletionTimestamp: &metav1.Time{},
+			Finalizers:        []string{v1beta1.FinalizerServiceCatalog},
+			Generation:        1,
+		},
+		Spec: v1beta1.ServiceBindingSpec{
+			ServiceInstanceRef: v1beta1.LocalObjectReference{Name: testServiceInstanceName},
+			ExternalID:         testServiceBindingGUID,
+		},
+	}
+
+	err := testController.reconcileServiceBinding(binding)
+	if err != nil {
+		t.Fatal("serviceclassref was nil + generation was 1: reconcile should abort the binding")
+	}
+
+	brokerActions := fakeClusterServiceBrokerClient.Actions()
+	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 0)
+
+	actions := fakeCatalogClient.Actions()
+	// The actions should be:
+	// 0. Updating the current operation
+	// 1. Updating the ready condition
+	assertNumberOfActions(t, actions, 2)
+
+	updatedServiceBinding := assertUpdateStatus(t, actions[0], binding)
+	assertServiceBindingOperationInProgress(t, updatedServiceBinding, v1beta1.ServiceBindingOperationUnbind, binding)
+	assertServiceBindingOrphanMitigationSet(t, updatedServiceBinding, false)
+
+	updatedServiceBinding = assertUpdateStatus(t, actions[1], binding)
+	assertServiceBindingOperationSuccess(t, updatedServiceBinding, v1beta1.ServiceBindingOperationUnbind, binding)
+	assertServiceBindingOrphanMitigationSet(t, updatedServiceBinding, false)
+
+	events := getRecordedEvents(testController)
 
 	expectedEvent := normalEventBuilder(successUnboundReason).msg("This binding was deleted successfully")
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {

--- a/pkg/controller/controller_events_test.go
+++ b/pkg/controller/controller_events_test.go
@@ -23,7 +23,7 @@ import (
 
 func checkEventCounts(actual, expected []string) error {
 	if len(actual) != len(expected) {
-		return fmt.Errorf(expectedGot(len(expected), len(actual)))
+		return fmt.Errorf("Checking event count: %s", expectedGot(len(expected), len(actual)))
 	}
 	return nil
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -847,6 +847,9 @@ func getTestServiceBinding() *v1beta1.ServiceBinding {
 			ServiceInstanceRef: v1beta1.LocalObjectReference{Name: testServiceInstanceName},
 			ExternalID:         testServiceBindingGUID,
 		},
+		Status: v1beta1.ServiceBindingStatus{
+			UnbindStatus: v1beta1.ServiceBindingUnbindStatusRequired,
+		},
 	}
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -205,7 +205,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"relistDuration": {
 							SchemaProps: spec.SchemaProps{
-								Description: "RelistDuration is the frequency by which a controller will relist the broker when the RelistBehavior is set to ServiceBrokerRelistBehaviorDuration.",
+								Description: "RelistDuration is the frequency by which a controller will relist the broker when the RelistBehavior is set to ServiceBrokerRelistBehaviorDuration. Users are cautioned against configuring low values for the RelistDuration, as this can easily overload the controller manager in an environment with many brokers. The actual interval is intrinsically governed by the configured resync interval of the controller, which acts as a minimum bound. For example, with a resync interval of 5m and a RelistDuration of 2m, relists will occur at the resync interval of 5m.",
 								Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 							},
 						},
@@ -1036,8 +1036,15 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "",
 							},
 						},
+						"unbindStatus": {
+							SchemaProps: spec.SchemaProps{
+								Description: "UnbindStatus describes what has been done to unbind the ServiceBinding.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 					},
-					Required: []string{"conditions", "reconciledGeneration", "orphanMitigationInProgress"},
+					Required: []string{"conditions", "reconciledGeneration", "orphanMitigationInProgress", "unbindStatus"},
 				},
 			},
 			Dependencies: []string{

--- a/pkg/registry/servicecatalog/binding/strategy.go
+++ b/pkg/registry/servicecatalog/binding/strategy.go
@@ -100,7 +100,9 @@ func (bindingRESTStrategy) PrepareForCreate(ctx genericapirequest.Context, obj r
 	// Creating a brand new object, thus it must have no
 	// status. We can't fail here if they passed a status in, so
 	// we just wipe it clean.
-	binding.Status = sc.ServiceBindingStatus{}
+	binding.Status = sc.ServiceBindingStatus{
+		UnbindStatus: sc.ServiceBindingUnbindStatusNotRequired,
+	}
 	// Fill in the first entry set to "creating"?
 	binding.Status.Conditions = []sc.ServiceBindingCondition{}
 	binding.Finalizers = []string{sc.FinalizerServiceCatalog}

--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -1087,6 +1087,9 @@ func testBindingClient(sType server.StorageType, client servicecatalogclient.Int
 			Parameters: &runtime.RawExtension{Raw: []byte(bindingParameter)},
 			ExternalID: "UUID-string",
 		},
+		Status: v1beta1.ServiceBindingStatus{
+			UnbindStatus: v1beta1.ServiceBindingUnbindStatusNotRequired,
+		},
 	}
 
 	bindings, err := bindingClient.List(metav1.ListOptions{})
@@ -1183,7 +1186,8 @@ func testBindingClient(sType server.StorageType, client servicecatalogclient.Int
 		Message: "ConditionMessage",
 	}
 	bindingServer.Status = v1beta1.ServiceBindingStatus{
-		Conditions: []v1beta1.ServiceBindingCondition{readyConditionTrue},
+		Conditions:   []v1beta1.ServiceBindingCondition{readyConditionTrue},
+		UnbindStatus: v1beta1.ServiceBindingUnbindStatusNotRequired,
 	}
 	if _, err = bindingClient.UpdateStatus(bindingServer); err != nil {
 		return fmt.Errorf("Error updating binding: %v", err)


### PR DESCRIPTION
Add a UnbindStatus field to ServiceBindingStatus. The field tracks the status of the ServiceBinding with respect to what needs to be done or has been done for unbinding the ServiceBinding.

When a BindingInstance is created, the UnbindStatus is set to Not Required. This indicates that an unbind request does not need to be made for the ServiceBinding when it is deleted.

When a unbind request is made for a ServiceBinding, the UnbindStatus is set to Required. This indicates that an unbind request does need to be made for the ServiceBinding when it is deleted.

When a unbind request is successful for a ServiceBinding, the UnbindStatus is set to Succeeded. This indicates that no further unbind requests need to be made for the ServiceBinding, and it unblocks the controller from removing the finalizer for the ServiceBinding.

When the controller gives up on sending unbind requests due to failures, the UnbindStatus is set to Failed. This indicates that no further unbind requests need to be made for the ServiceBinding, but it blocks the controller from removing the finalizer for the ServiceBinding. This keeps the resource around so that the user can negotiate unbind directly with the broker. The user must force-delete the ServiceBinding to remove it.

Relates to first point in #1423