### PR TITLE
Grant controller abilit to update service/plan status

### DIFF
--- a/charts/catalog/templates/rbac.yaml
+++ b/charts/catalog/templates/rbac.yaml
@@ -95,7 +95,7 @@ items:
     resources: ["clusterservicebrokers","serviceinstances","servicebindings"]
     verbs:     ["get","list","watch"]
   - apiGroups: ["servicecatalog.k8s.io"]
-    resources: ["clusterservicebrokers/status","serviceinstances/status","serviceinstances/reference","servicebindings/status"]
+    resources: ["clusterservicebrokers/status","clusterserviceclasses/status","clusterserviceplans/status","serviceinstances/status","serviceinstances/reference","servicebindings/status"]
     verbs:     ["update"]
 # give the controller-manager service account access to whats defined in its role.
 - apiVersion: {{template "rbacApiVersion" . }}


### PR DESCRIPTION
Fixes a bug where the controller, as deployed by the helm chart, could not update the status subresource of ClusterServiceClasses and ClusterServicePlans, meaning that handling of removed service/plans from broker catalog was not working correctly.