### PR TITLE
fix docker volume mount when building with docker under SELinux (#1500)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ ifdef NO_DOCKER
 	scBuildImageTarget =
 else
 	# Mount .pkg as pkg so that we save our cached "go build" output files
-	DOCKER_CMD = docker run --rm -v $(PWD):/go/src/$(SC_PKG) \
+	DOCKER_CMD = docker run --security-opt label:disable --rm -v $(PWD):/go/src/$(SC_PKG) \
 	  -v $(PWD)/.pkg:/go/pkg scbuildimage
 	scBuildImageTarget = .scBuildImage
 endif


### PR DESCRIPTION
fixes #1500 

Tested under Fedora and Ubuntu where SELinux is enabled.  I have not tested specifically with SELinux disabled.  Docker added the z and Z options in 1.7.  From man docker-run:

> To change a label in the container context, you can add either of two suffixes :z or :Z to the volume mount. These suffixes tell Docker to relabel file objects on the shared volumes. The z option tells Docker that two containers share the volume content. As a result, Docker labels the content with a shared content label. Shared volume labels allow all containers to read/write content.  The Z option tells Docker to label the content with a private unshared label.  Only the current container can use a private volume.
