### PR TITLE
Do not block instance spec changes unless there is an on-going operation

### DIFF
--- a/pkg/apis/servicecatalog/validation/instance.go
+++ b/pkg/apis/servicecatalog/validation/instance.go
@@ -262,7 +262,7 @@ func validateServiceInstanceUpdate(instance *sc.ServiceInstance) field.ErrorList
 // to the spec to go through.
 func internalValidateServiceInstanceUpdateAllowed(new *sc.ServiceInstance, old *sc.ServiceInstance) field.ErrorList {
 	errors := field.ErrorList{}
-	if old.Generation != new.Generation && old.Status.ReconciledGeneration != old.Generation {
+	if old.Generation != new.Generation && old.Status.ReconciledGeneration != old.Generation && old.Status.CurrentOperation != "" {
 		errors = append(errors, field.Forbidden(field.NewPath("spec"), "Another update for this service instance is in progress"))
 	}
 	if old.Spec.ClusterServicePlanExternalName != new.Spec.ClusterServicePlanExternalName && new.Spec.ClusterServicePlanRef != nil {

--- a/pkg/apis/servicecatalog/validation/instance.go
+++ b/pkg/apis/servicecatalog/validation/instance.go
@@ -262,7 +262,7 @@ func validateServiceInstanceUpdate(instance *sc.ServiceInstance) field.ErrorList
 // to the spec to go through.
 func internalValidateServiceInstanceUpdateAllowed(new *sc.ServiceInstance, old *sc.ServiceInstance) field.ErrorList {
 	errors := field.ErrorList{}
-	if old.Generation != new.Generation && old.Status.ReconciledGeneration != old.Generation && old.Status.CurrentOperation != "" {
+	if old.Generation != new.Generation && old.Status.CurrentOperation != "" {
 		errors = append(errors, field.Forbidden(field.NewPath("spec"), "Another update for this service instance is in progress"))
 	}
 	if old.Spec.ClusterServicePlanExternalName != new.Spec.ClusterServicePlanExternalName && new.Spec.ClusterServicePlanRef != nil {

--- a/pkg/apis/servicecatalog/validation/instance_test.go
+++ b/pkg/apis/servicecatalog/validation/instance_test.go
@@ -631,30 +631,49 @@ func TestInternalValidateServiceInstanceUpdateAllowed(t *testing.T) {
 		name              string
 		newSpecChange     bool
 		onGoingSpecChange bool
+		onGoingOperation  bool
 		valid             bool
 	}{
 		{
 			name:              "spec change when no on-going spec change",
 			newSpecChange:     true,
 			onGoingSpecChange: false,
+			onGoingOperation:  false,
 			valid:             true,
 		},
 		{
-			name:              "spec change when on-going spec change",
+			name:              "spec change when on-going spec change but no on-going operation",
 			newSpecChange:     true,
 			onGoingSpecChange: true,
+			onGoingOperation:  false,
+			valid:             true,
+		},
+		{
+			name:              "spec change when on-going spec change and on-going operation",
+			newSpecChange:     true,
+			onGoingSpecChange: true,
+			onGoingOperation:  true,
 			valid:             false,
 		},
 		{
 			name:              "meta change when no on-going spec change",
 			newSpecChange:     false,
 			onGoingSpecChange: false,
+			onGoingOperation:  false,
 			valid:             true,
 		},
 		{
-			name:              "meta change when on-going spec change",
+			name:              "meta change when on-going spec change but no on-going operation",
 			newSpecChange:     false,
 			onGoingSpecChange: true,
+			onGoingOperation:  false,
+			valid:             true,
+		},
+		{
+			name:              "meta change when on-going spec change and on-going operation",
+			newSpecChange:     false,
+			onGoingSpecChange: true,
+			onGoingOperation:  true,
 			valid:             true,
 		},
 	}
@@ -678,6 +697,9 @@ func TestInternalValidateServiceInstanceUpdateAllowed(t *testing.T) {
 			oldInstance.Generation = 1
 		}
 		oldInstance.Status.ReconciledGeneration = 1
+		if tc.onGoingOperation {
+			oldInstance.Status.CurrentOperation = servicecatalog.ServiceInstanceOperationProvision
+		}
 
 		newInstance := &servicecatalog.ServiceInstance{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/servicecatalog/validation/instance_test.go
+++ b/pkg/apis/servicecatalog/validation/instance_test.go
@@ -628,53 +628,34 @@ func TestValidateServiceInstance(t *testing.T) {
 
 func TestInternalValidateServiceInstanceUpdateAllowed(t *testing.T) {
 	cases := []struct {
-		name              string
-		newSpecChange     bool
-		onGoingSpecChange bool
-		onGoingOperation  bool
-		valid             bool
+		name             string
+		specChange       bool
+		onGoingOperation bool
+		valid            bool
 	}{
 		{
-			name:              "spec change when no on-going spec change",
-			newSpecChange:     true,
-			onGoingSpecChange: false,
-			onGoingOperation:  false,
-			valid:             true,
+			name:             "spec change when no on-going operation",
+			specChange:       true,
+			onGoingOperation: false,
+			valid:            true,
 		},
 		{
-			name:              "spec change when on-going spec change but no on-going operation",
-			newSpecChange:     true,
-			onGoingSpecChange: true,
-			onGoingOperation:  false,
-			valid:             true,
+			name:             "spec change when on-going operation",
+			specChange:       true,
+			onGoingOperation: true,
+			valid:            false,
 		},
 		{
-			name:              "spec change when on-going spec change and on-going operation",
-			newSpecChange:     true,
-			onGoingSpecChange: true,
-			onGoingOperation:  true,
-			valid:             false,
+			name:             "meta change when no on-going operation",
+			specChange:       false,
+			onGoingOperation: false,
+			valid:            true,
 		},
 		{
-			name:              "meta change when no on-going spec change",
-			newSpecChange:     false,
-			onGoingSpecChange: false,
-			onGoingOperation:  false,
-			valid:             true,
-		},
-		{
-			name:              "meta change when on-going spec change but no on-going operation",
-			newSpecChange:     false,
-			onGoingSpecChange: true,
-			onGoingOperation:  false,
-			valid:             true,
-		},
-		{
-			name:              "meta change when on-going spec change and on-going operation",
-			newSpecChange:     false,
-			onGoingSpecChange: true,
-			onGoingOperation:  true,
-			valid:             true,
+			name:             "meta change when on-going operation",
+			specChange:       false,
+			onGoingOperation: true,
+			valid:            true,
 		},
 	}
 
@@ -691,12 +672,7 @@ func TestInternalValidateServiceInstanceUpdateAllowed(t *testing.T) {
 				},
 			},
 		}
-		if tc.onGoingSpecChange {
-			oldInstance.Generation = 2
-		} else {
-			oldInstance.Generation = 1
-		}
-		oldInstance.Status.ReconciledGeneration = 1
+		oldInstance.Generation = 1
 		if tc.onGoingOperation {
 			oldInstance.Status.CurrentOperation = servicecatalog.ServiceInstanceOperationProvision
 		}
@@ -708,17 +684,16 @@ func TestInternalValidateServiceInstanceUpdateAllowed(t *testing.T) {
 			},
 			Spec: servicecatalog.ServiceInstanceSpec{
 				PlanReference: servicecatalog.PlanReference{
-					ClusterServiceClassExternalName: "test-serviceclass",
-					ClusterServicePlanExternalName:  "test-plan",
+					ClusterServiceClassExternalName: clusterServiceClassExternalName,
+					ClusterServicePlanExternalName:  clusterServicePlanExternalName,
 				},
 			},
 		}
-		if tc.newSpecChange {
+		if tc.specChange {
 			newInstance.Generation = oldInstance.Generation + 1
 		} else {
 			newInstance.Generation = oldInstance.Generation
 		}
-		newInstance.Status.ReconciledGeneration = 1
 
 		errs := internalValidateServiceInstanceUpdateAllowed(newInstance, oldInstance)
 		if len(errs) != 0 && tc.valid {


### PR DESCRIPTION
Fixes #1533.

Change the validator for ServiceInstance so that it only blocks spec changes when there is an on-going operation. If the plan was changed to a non-existent plan, then there will not be an on-going operation for the ServiceInstance since the reconciliation of the pending change will fail when resolving the plan, prior to the point where the Controller sends a request to the broker.

Let's consider the case where the Controller is doing reconciliation on a ServiceInstance at the same time that the API Server is effecting a change to the same ServiceInstancee. In that case, the API Server will accept the requested spec change because the request from the Controller to the API Server to update the status of the ServiceInstance with the current operation has not been processed by the API Server yet. When the API Server processes the status change from the Controller, the API Server will reject the status change because the ServiceInstance used by the Controller will be out-of-date at that point. Since the status update will fail, the Controller will fail the reconciliation of the ServiceInstance. Later, the Controller will try reconciliation again with the new version of the ServiceInstance, with the updated spec.