### PR TITLE
Add an additional plan to ups-broker

### DIFF
--- a/contrib/pkg/broker/user_provided/controller/controller.go
+++ b/contrib/pkg/broker/user_provided/controller/controller.go
@@ -70,7 +70,7 @@ func (c *userProvidedController) Catalog() (*brokerapi.Catalog, error) {
 					Name:        "premium",
 					ID:          "cc0d7529-18e8-416d-8946-6f7456acd589",
 					Description: "Premium plan",
-					Free:        true,
+					Free:        false,
 				},
 				},
 				Bindable:       true,

--- a/contrib/pkg/broker/user_provided/controller/controller.go
+++ b/contrib/pkg/broker/user_provided/controller/controller.go
@@ -66,9 +66,15 @@ func (c *userProvidedController) Catalog() (*brokerapi.Catalog, error) {
 					ID:          "86064792-7ea2-467b-af93-ac9694d96d52",
 					Description: "Sample plan description",
 					Free:        true,
+				}, {
+					Name:        "premium",
+					ID:          "cc0d7529-18e8-416d-8946-6f7456acd589",
+					Description: "Premium plan",
+					Free:        true,
 				},
 				},
-				Bindable: true,
+				Bindable:       true,
+				PlanUpdateable: true,
 			},
 		},
 	}, nil


### PR DESCRIPTION
Add a second plan to the ups-broker. And allow plan updates with the ups-broker service. I found this useful when validating my changes in #1536.