### PR TITLE
Allow for changes to fake broker responses during a test

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 38f3b63d31dba3a1610768b533a3fb1efb3318c42f6993bc2ff7f91e3f8541c2
-updated: 2017-11-09T10:01:45.543223759-05:00
+hash: ee8643441675c68b31a407670ad2549ecec1822964130fc7d618306a89471fa6
+updated: 2017-11-09T17:12:48.919866503-05:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -253,7 +253,7 @@ imports:
 - name: github.com/pkg/errors
   version: a22138067af1c4942683050411a841ade67fe1eb
 - name: github.com/pmorie/go-open-service-broker-client
-  version: 9e257974620c1db53c4d3549fd9eddaa2d2d653e
+  version: 31d8027f493f8f23f850415d171c7c52a972a6f2
   subpackages:
   - v2
   - v2/fake

--- a/glide.yaml
+++ b/glide.yaml
@@ -93,4 +93,4 @@ import:
 - package: github.com/gorilla/context
   version: 215affda49addc4c8ef7e2534915df2c8c35c6cd
 - package: github.com/pmorie/go-open-service-broker-client
-  version: 9e257974620c1db53c4d3549fd9eddaa2d2d653e 
+  version: 31d8027f493f8f23f850415d171c7c52a972a6f2

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -66,7 +66,7 @@ const (
 	testDeleterUsername          = "delete-username"
 )
 
-// TestBasicFlowsSync tests:
+// TestBasicFlows tests:
 //
 // - add Broker
 // - verify ClusterServiceClasses added
@@ -76,397 +76,207 @@ const (
 // - unbind
 // - deprovision
 // - delete broker
-//
-// ...using purely synchronous provision/deprovision.
-func TestBasicFlowsSync(t *testing.T) {
-	_, catalogClient, _, _, _, _, shutdownServer, shutdownController := newTestController(t, fakeosb.FakeClientConfiguration{
-		CatalogReaction: &fakeosb.CatalogReaction{
-			Response: getTestCatalogResponse(),
+func TestBasicFlows(t *testing.T) {
+	cases := []struct {
+		name              string
+		asyncForInstances bool
+		asyncForBindings  bool
+	}{
+		{
+			name: "sync",
 		},
-		ProvisionReaction: &fakeosb.ProvisionReaction{
-			Response: &osb.ProvisionResponse{
-				Async: false,
-			},
+		{
+			name:              "async instances",
+			asyncForInstances: true,
 		},
-		UpdateInstanceReaction: &fakeosb.UpdateInstanceReaction{
-			Response: &osb.UpdateInstanceResponse{
-				Async: false,
-			},
+		{
+			name:             "async bindings",
+			asyncForBindings: true,
 		},
-		BindReaction: &fakeosb.BindReaction{
-			Response: &osb.BindResponse{
-				Credentials: map[string]interface{}{
-					"foo": "bar",
-					"baz": "zap",
+		{
+			name:              "async instances and bindings",
+			asyncForInstances: true,
+			asyncForBindings:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.asyncForBindings {
+				// Enable the AsyncBindingOperations feature
+				utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.AsyncBindingOperations))
+				defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.AsyncBindingOperations))
+			}
+
+			_, catalogClient, _, osbClient, _, _, shutdownServer, shutdownController := newTestController(t)
+			defer shutdownController()
+			defer shutdownServer()
+
+			if tc.asyncForInstances {
+				osbClient.ProvisionReaction.(*fakeosb.ProvisionReaction).Response.Async = true
+				osbClient.UpdateInstanceReaction.(*fakeosb.UpdateInstanceReaction).Response.Async = true
+				osbClient.DeprovisionReaction.(*fakeosb.DeprovisionReaction).Response.Async = true
+			}
+
+			if tc.asyncForBindings {
+				osbClient.BindReaction.(*fakeosb.BindReaction).Response.Async = true
+				osbClient.UnbindReaction.(*fakeosb.UnbindReaction).Response.Async = true
+			}
+
+			client := catalogClient.ServicecatalogV1beta1()
+
+			broker := &v1beta1.ClusterServiceBroker{
+				ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
+				Spec: v1beta1.ClusterServiceBrokerSpec{
+					URL: testBrokerURL,
 				},
-			},
-		},
-		UnbindReaction: &fakeosb.UnbindReaction{
-			Response: &osb.UnbindResponse{
-				Async: false,
-			},
-		},
-		DeprovisionReaction: &fakeosb.DeprovisionReaction{
-			Response: &osb.DeprovisionResponse{
-				Async: false,
-			},
-		},
-	})
-	defer shutdownController()
-	defer shutdownServer()
+			}
 
-	client := catalogClient.ServicecatalogV1beta1()
+			_, err := client.ClusterServiceBrokers().Create(broker)
+			if nil != err {
+				t.Fatalf("error creating the broker %q (%q)", broker.Name, err)
+			}
 
-	broker := &v1beta1.ClusterServiceBroker{
-		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
-		Spec: v1beta1.ClusterServiceBrokerSpec{
-			URL: testBrokerURL,
-		},
-	}
+			err = util.WaitForBrokerCondition(client,
+				testClusterServiceBrokerName,
+				v1beta1.ServiceBrokerCondition{
+					Type:   v1beta1.ServiceBrokerConditionReady,
+					Status: v1beta1.ConditionTrue,
+				})
+			if err != nil {
+				t.Fatalf("error waiting for broker to become ready: %v", err)
+			}
 
-	_, err := client.ClusterServiceBrokers().Create(broker)
-	if nil != err {
-		t.Fatalf("error creating the broker %q (%q)", broker.Name, err)
-	}
+			err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
+			if nil != err {
+				t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
+			}
 
-	err = util.WaitForBrokerCondition(client,
-		testClusterServiceBrokerName,
-		v1beta1.ServiceBrokerCondition{
-			Type:   v1beta1.ServiceBrokerConditionReady,
-			Status: v1beta1.ConditionTrue,
-		})
-	if err != nil {
-		t.Fatalf("error waiting for broker to become ready: %v", err)
-	}
+			// TODO: find some way to compose scenarios; extract method here for real
+			// logic for this test.
 
-	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
-	if nil != err {
-		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
-	}
+			//-----------------
 
-	// TODO: find some way to compose scenarios; extract method here for real
-	// logic for this test.
-
-	//-----------------
-
-	instance := &v1beta1.ServiceInstance{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
-		Spec: v1beta1.ServiceInstanceSpec{
-			PlanReference: v1beta1.PlanReference{
-				ClusterServiceClassExternalName: testClusterServiceClassName,
-				ClusterServicePlanExternalName:  testClusterServicePlanName,
-			},
-			ExternalID: testExternalID,
-		},
-	}
-
-	if _, err := client.ServiceInstances(testNamespace).Create(instance); err != nil {
-		t.Fatalf("error creating Instance: %v", err)
-	}
-
-	if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
-		Type:   v1beta1.ServiceInstanceConditionReady,
-		Status: v1beta1.ConditionTrue,
-	}); err != nil {
-		t.Fatalf("error waiting for instance to become ready: %v", err)
-	}
-
-	retInst, err := client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-	}
-	if retInst.Spec.ExternalID != instance.Spec.ExternalID {
-		t.Fatalf(
-			"returned OSB GUID '%s' doesn't match original '%s'",
-			retInst.Spec.ExternalID,
-			instance.Spec.ExternalID,
-		)
-	}
-
-	// Update Instance
-	updateRequests := retInst.Spec.UpdateRequests + 1
-	retInst.Spec.UpdateRequests = updateRequests
-	if _, err := client.ServiceInstances(testNamespace).Update(retInst); err != nil {
-		t.Fatalf("error updating Instance: %v", err)
-	}
-
-	if err := util.WaitForInstanceReconciledGeneration(client, testNamespace, testInstanceName, retInst.Status.ReconciledGeneration+1); err != nil {
-		t.Fatalf("error waiting for instance to reconcile: %v", err)
-	}
-
-	retInst, err = client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-	}
-	if e, a := updateRequests, retInst.Spec.UpdateRequests; e != a {
-		t.Fatalf("unexpected updateRequets in instance spec: expected %v, got %v", e, a)
-	}
-
-	// Binding test begins here
-	//-----------------
-
-	binding := &v1beta1.ServiceBinding{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testBindingName},
-		Spec: v1beta1.ServiceBindingSpec{
-			ServiceInstanceRef: v1beta1.LocalObjectReference{
-				Name: testInstanceName,
-			},
-		},
-	}
-
-	_, err = client.ServiceBindings(testNamespace).Create(binding)
-	if err != nil {
-		t.Fatalf("error creating Binding: %v", binding)
-	}
-
-	err = util.WaitForBindingCondition(client, testNamespace, testBindingName, v1beta1.ServiceBindingCondition{
-		Type:   v1beta1.ServiceBindingConditionReady,
-		Status: v1beta1.ConditionTrue,
-	})
-	if err != nil {
-		t.Fatalf("error waiting for binding to become ready: %v", err)
-	}
-
-	err = client.ServiceBindings(testNamespace).Delete(testBindingName, &metav1.DeleteOptions{})
-	if err != nil {
-		t.Fatalf("binding delete should have been accepted: %v", err)
-	}
-
-	err = util.WaitForBindingToNotExist(client, testNamespace, testBindingName)
-	if err != nil {
-		t.Fatalf("error waiting for binding to not exist: %v", err)
-	}
-
-	//-----------------
-	// End binding test
-
-	err = client.ServiceInstances(testNamespace).Delete(testInstanceName, &metav1.DeleteOptions{})
-	if nil != err {
-		t.Fatalf("instance delete should have been accepted: %v", err)
-	}
-
-	err = util.WaitForInstanceToNotExist(client, testNamespace, testInstanceName)
-	if err != nil {
-		t.Fatalf("error waiting for instance to be deleted: %v", err)
-	}
-
-	//-----------------
-	// End provision test
-
-	// Delete the broker
-	err = client.ClusterServiceBrokers().Delete(testClusterServiceBrokerName, &metav1.DeleteOptions{})
-	if nil != err {
-		t.Fatalf("broker should be deleted (%s)", err)
-	}
-
-	err = util.WaitForClusterServiceClassToNotExist(client, testClusterServiceClassName)
-	if err != nil {
-		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
-	}
-
-	err = util.WaitForBrokerToNotExist(client, testClusterServiceBrokerName)
-	if err != nil {
-		t.Fatalf("error waiting for Broker to not exist: %v", err)
-	}
-}
-
-// TestBasicFlowsAsync tests the same flows as TestBasicFlowsSync, using
-// asynchronous provision/deprovision (but not asynchronous bind/unbind, as
-// they are alpha features).
-func TestBasicFlowsAsync(t *testing.T) {
-	_, catalogClient, _, _, _, _, shutdownServer, shutdownController := newTestController(t, fakeosb.FakeClientConfiguration{
-		CatalogReaction: &fakeosb.CatalogReaction{
-			Response: getTestCatalogResponse(),
-		},
-		ProvisionReaction: &fakeosb.ProvisionReaction{
-			Response: &osb.ProvisionResponse{
-				Async: true,
-			},
-		},
-		PollLastOperationReaction: &fakeosb.PollLastOperationReaction{
-			Response: &osb.LastOperationResponse{
-				State: osb.StateSucceeded,
-			},
-		},
-		UpdateInstanceReaction: &fakeosb.UpdateInstanceReaction{
-			Response: &osb.UpdateInstanceResponse{
-				Async: true,
-			},
-		},
-		BindReaction: &fakeosb.BindReaction{
-			Response: &osb.BindResponse{
-				Credentials: map[string]interface{}{
-					"foo": "bar",
-					"baz": "zap",
+			instance := &v1beta1.ServiceInstance{
+				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
+				Spec: v1beta1.ServiceInstanceSpec{
+					PlanReference: v1beta1.PlanReference{
+						ClusterServiceClassExternalName: testClusterServiceClassName,
+						ClusterServicePlanExternalName:  testClusterServicePlanName,
+					},
+					ExternalID: testExternalID,
 				},
-			},
-		},
-		UnbindReaction: &fakeosb.UnbindReaction{
-			Response: &osb.UnbindResponse{
-				Async: false,
-			},
-		},
-		DeprovisionReaction: &fakeosb.DeprovisionReaction{
-			Response: &osb.DeprovisionResponse{
-				Async: true,
-			},
-		},
-	})
-	defer shutdownController()
-	defer shutdownServer()
+			}
 
-	client := catalogClient.ServicecatalogV1beta1()
+			if _, err := client.ServiceInstances(testNamespace).Create(instance); err != nil {
+				t.Fatalf("error creating Instance: %v", err)
+			}
 
-	broker := &v1beta1.ClusterServiceBroker{
-		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
-		Spec: v1beta1.ClusterServiceBrokerSpec{
-			URL: testBrokerURL,
-		},
-	}
+			if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
+				Type:   v1beta1.ServiceInstanceConditionReady,
+				Status: v1beta1.ConditionTrue,
+			}); err != nil {
+				t.Fatalf("error waiting for instance to become ready: %v", err)
+			}
 
-	_, err := client.ClusterServiceBrokers().Create(broker)
-	if nil != err {
-		t.Fatalf("error creating the broker %q (%q)", broker.Name, err)
-	}
+			retInst, err := client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
+			}
+			if retInst.Spec.ExternalID != instance.Spec.ExternalID {
+				t.Fatalf(
+					"returned OSB GUID '%s' doesn't match original '%s'",
+					retInst.Spec.ExternalID,
+					instance.Spec.ExternalID,
+				)
+			}
 
-	err = util.WaitForBrokerCondition(client,
-		testClusterServiceBrokerName,
-		v1beta1.ServiceBrokerCondition{
-			Type:   v1beta1.ServiceBrokerConditionReady,
-			Status: v1beta1.ConditionTrue,
+			// Update Instance
+			updateRequests := retInst.Spec.UpdateRequests + 1
+			retInst.Spec.UpdateRequests = updateRequests
+			if _, err := client.ServiceInstances(testNamespace).Update(retInst); err != nil {
+				t.Fatalf("error updating Instance: %v", err)
+			}
+
+			if err := util.WaitForInstanceReconciledGeneration(client, testNamespace, testInstanceName, retInst.Status.ReconciledGeneration+1); err != nil {
+				t.Fatalf("error waiting for instance to reconcile: %v", err)
+			}
+
+			retInst, err = client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
+			}
+			if e, a := updateRequests, retInst.Spec.UpdateRequests; e != a {
+				t.Fatalf("unexpected updateRequets in instance spec: expected %v, got %v", e, a)
+			}
+
+			// Binding test begins here
+			//-----------------
+
+			binding := &v1beta1.ServiceBinding{
+				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testBindingName},
+				Spec: v1beta1.ServiceBindingSpec{
+					ServiceInstanceRef: v1beta1.LocalObjectReference{
+						Name: testInstanceName,
+					},
+				},
+			}
+
+			_, err = client.ServiceBindings(testNamespace).Create(binding)
+			if err != nil {
+				t.Fatalf("error creating Binding: %v", binding)
+			}
+
+			err = util.WaitForBindingCondition(client, testNamespace, testBindingName, v1beta1.ServiceBindingCondition{
+				Type:   v1beta1.ServiceBindingConditionReady,
+				Status: v1beta1.ConditionTrue,
+			})
+			if err != nil {
+				t.Fatalf("error waiting for binding to become ready: %v", err)
+			}
+
+			err = client.ServiceBindings(testNamespace).Delete(testBindingName, &metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("binding delete should have been accepted: %v", err)
+			}
+
+			err = util.WaitForBindingToNotExist(client, testNamespace, testBindingName)
+			if err != nil {
+				t.Fatalf("error waiting for binding to not exist: %v", err)
+			}
+
+			//-----------------
+			// End binding test
+
+			err = client.ServiceInstances(testNamespace).Delete(testInstanceName, &metav1.DeleteOptions{})
+			if nil != err {
+				t.Fatalf("instance delete should have been accepted: %v", err)
+			}
+
+			err = util.WaitForInstanceToNotExist(client, testNamespace, testInstanceName)
+			if err != nil {
+				t.Fatalf("error waiting for instance to be deleted: %v", err)
+			}
+
+			//-----------------
+			// End provision test
+
+			// Delete the broker
+			err = client.ClusterServiceBrokers().Delete(testClusterServiceBrokerName, &metav1.DeleteOptions{})
+			if nil != err {
+				t.Fatalf("broker should be deleted (%s)", err)
+			}
+
+			err = util.WaitForClusterServiceClassToNotExist(client, testClusterServiceClassName)
+			if err != nil {
+				t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
+			}
+
+			err = util.WaitForBrokerToNotExist(client, testClusterServiceBrokerName)
+			if err != nil {
+				t.Fatalf("error waiting for Broker to not exist: %v", err)
+			}
 		})
-	if err != nil {
-		t.Fatalf("error waiting for broker to become ready: %v", err)
-	}
-
-	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
-	if nil != err {
-		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
-	}
-
-	// TODO: find some way to compose scenarios; extract method here for real
-	// logic for this test.
-
-	//-----------------
-
-	instance := &v1beta1.ServiceInstance{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
-		Spec: v1beta1.ServiceInstanceSpec{
-			PlanReference: v1beta1.PlanReference{
-				ClusterServiceClassExternalName: testClusterServiceClassName,
-				ClusterServicePlanExternalName:  testClusterServicePlanName,
-			},
-			ExternalID: testExternalID,
-		},
-	}
-
-	if _, err := client.ServiceInstances(testNamespace).Create(instance); err != nil {
-		t.Fatalf("error creating Instance: %v", err)
-	}
-
-	if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
-		Type:   v1beta1.ServiceInstanceConditionReady,
-		Status: v1beta1.ConditionTrue,
-	}); err != nil {
-		t.Fatalf("error waiting for instance to become ready: %v", err)
-	}
-
-	retInst, err := client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-	}
-	if retInst.Spec.ExternalID != instance.Spec.ExternalID {
-		t.Fatalf(
-			"returned OSB GUID '%s' doesn't match original '%s'",
-			retInst.Spec.ExternalID,
-			instance.Spec.ExternalID,
-		)
-	}
-
-	// Update Instance
-	updateRequests := retInst.Spec.UpdateRequests + 1
-	retInst.Spec.UpdateRequests = updateRequests
-	if _, err := client.ServiceInstances(testNamespace).Update(retInst); err != nil {
-		t.Fatalf("error updating Instance: %v", err)
-	}
-
-	if err := util.WaitForInstanceReconciledGeneration(client, testNamespace, testInstanceName, retInst.Status.ReconciledGeneration+1); err != nil {
-		t.Fatalf("error waiting for instance to reconcile: %v", err)
-	}
-
-	retInst, err = client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-	}
-	if e, a := updateRequests, retInst.Spec.UpdateRequests; e != a {
-		t.Fatalf("unexpected updateRequets in instance spec: expected %v, got %v", e, a)
-	}
-
-	// Binding test begins here
-	//-----------------
-
-	binding := &v1beta1.ServiceBinding{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testBindingName},
-		Spec: v1beta1.ServiceBindingSpec{
-			ServiceInstanceRef: v1beta1.LocalObjectReference{
-				Name: testInstanceName,
-			},
-		},
-	}
-
-	_, err = client.ServiceBindings(testNamespace).Create(binding)
-	if err != nil {
-		t.Fatalf("error creating Binding: %v", binding)
-	}
-
-	err = util.WaitForBindingCondition(client, testNamespace, testBindingName, v1beta1.ServiceBindingCondition{
-		Type:   v1beta1.ServiceBindingConditionReady,
-		Status: v1beta1.ConditionTrue,
-	})
-	if err != nil {
-		t.Fatalf("error waiting for binding to become ready: %v", err)
-	}
-
-	err = client.ServiceBindings(testNamespace).Delete(testBindingName, &metav1.DeleteOptions{})
-	if err != nil {
-		t.Fatalf("binding delete should have been accepted: %v", err)
-	}
-
-	err = util.WaitForBindingToNotExist(client, testNamespace, testBindingName)
-	if err != nil {
-		t.Fatalf("error waiting for binding to not exist: %v", err)
-	}
-
-	//-----------------
-	// End binding test
-
-	err = client.ServiceInstances(testNamespace).Delete(testInstanceName, &metav1.DeleteOptions{})
-	if nil != err {
-		t.Fatalf("instance delete should have been accepted: %v", err)
-	}
-
-	err = util.WaitForInstanceToNotExist(client, testNamespace, testInstanceName)
-	if err != nil {
-		t.Fatalf("error waiting for instance to be deleted: %v", err)
-	}
-
-	//-----------------
-	// End provision test
-
-	// Delete the broker
-	err = client.ClusterServiceBrokers().Delete(testClusterServiceBrokerName, &metav1.DeleteOptions{})
-	if nil != err {
-		t.Fatalf("broker should be deleted (%s)", err)
-	}
-
-	err = util.WaitForClusterServiceClassToNotExist(client, testClusterServiceClassName)
-	if err != nil {
-		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
-	}
-
-	err = util.WaitForBrokerToNotExist(client, testClusterServiceBrokerName)
-	if err != nil {
-		t.Fatalf("error waiting for Broker to not exist: %v", err)
 	}
 }
 
@@ -476,25 +286,17 @@ func TestBasicFlowsAsync(t *testing.T) {
 // TODO: additional tests for scenarios like this will be needed once we
 // implement orphan mitigation.
 func TestProvisionFailure(t *testing.T) {
-	_, catalogClient, _, _, _, _, shutdownServer, shutdownController := newTestController(t, fakeosb.FakeClientConfiguration{
-		CatalogReaction: &fakeosb.CatalogReaction{
-			Response: getTestCatalogResponse(),
-		},
-		ProvisionReaction: &fakeosb.ProvisionReaction{
-			Error: osb.HTTPStatusCodeError{
-				StatusCode:   http.StatusConflict,
-				ErrorMessage: strPtr("OutOfQuota"),
-				Description:  strPtr("You're out of quota!"),
-			},
-		},
-		DeprovisionReaction: &fakeosb.DeprovisionReaction{
-			Response: &osb.DeprovisionResponse{
-				Async: false,
-			},
-		},
-	})
+	_, catalogClient, _, osbClient, _, _, shutdownServer, shutdownController := newTestController(t)
 	defer shutdownController()
 	defer shutdownServer()
+
+	osbClient.ProvisionReaction = &fakeosb.ProvisionReaction{
+		Error: osb.HTTPStatusCodeError{
+			StatusCode:   http.StatusConflict,
+			ErrorMessage: strPtr("OutOfQuota"),
+			Description:  strPtr("You're out of quota!"),
+		},
+	}
 
 	client := catalogClient.ServicecatalogV1beta1()
 
@@ -597,35 +399,17 @@ func TestProvisionFailure(t *testing.T) {
 // TestBindingFailure tests that a binding gets a failure condition when the
 // broker returns a failure response for a bind operation.
 func TestBindingFailure(t *testing.T) {
-	_, fakeCatalogClient, _, _, _, _, shutdownServer, shutdownController := newTestController(t, fakeosb.FakeClientConfiguration{
-		CatalogReaction: &fakeosb.CatalogReaction{
-			Response: getTestCatalogResponse(),
-		},
-		BindReaction: &fakeosb.BindReaction{
-			Error: osb.HTTPStatusCodeError{
-				StatusCode:   http.StatusConflict,
-				ErrorMessage: strPtr("ServiceBindingExists"),
-				Description:  strPtr("Service binding with the same id, for the same service instance already exists."),
-			},
-		},
-		UnbindReaction: &fakeosb.UnbindReaction{
-			Response: &osb.UnbindResponse{
-				Async:false,
-			},
-		},
-		ProvisionReaction: &fakeosb.ProvisionReaction{
-			Response: &osb.ProvisionResponse{
-				Async: false,
-			},
-		},
-		DeprovisionReaction: &fakeosb.DeprovisionReaction{
-			Response: &osb.DeprovisionResponse{
-				Async: false,
-			},
-		},
-	})
+	_, fakeCatalogClient, _, osbClient, _, _, shutdownServer, shutdownController := newTestController(t)
 	defer shutdownController()
 	defer shutdownServer()
+
+	osbClient.BindReaction = &fakeosb.BindReaction{
+		Error: osb.HTTPStatusCodeError{
+			StatusCode:   http.StatusConflict,
+			ErrorMessage: strPtr("ServiceBindingExists"),
+			Description:  strPtr("Service binding with the same id, for the same service instance already exists."),
+		},
+	}
 
 	client := fakeCatalogClient.ServicecatalogV1beta1()
 
@@ -770,56 +554,7 @@ func TestBasicFlowsWithOriginatingIdentity(t *testing.T) {
 	utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.OriginatingIdentity))
 	defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.OriginatingIdentity))
 
-	_, catalogClient, catalogClientConfig, _, _, _, shutdownServer, shutdownController := newTestController(t, fakeosb.FakeClientConfiguration{
-		CatalogReaction: &fakeosb.CatalogReaction{
-			Response: &osb.CatalogResponse{
-				Services: []osb.Service{
-					{
-						Name:        testClusterServiceClassName,
-						ID:          "12345",
-						Description: "a test service",
-						Bindable:    true,
-						Plans: []osb.Plan{
-							{
-								Name:        testClusterServicePlanName,
-								Free:        truePtr(),
-								ID:          "34567",
-								Description: "a test plan",
-							},
-						},
-					},
-				},
-			},
-		},
-		ProvisionReaction: &fakeosb.ProvisionReaction{
-			Response: &osb.ProvisionResponse{
-				Async: false,
-			},
-		},
-		UpdateInstanceReaction: &fakeosb.UpdateInstanceReaction{
-			Response: &osb.UpdateInstanceResponse{
-				Async: false,
-			},
-		},
-		BindReaction: &fakeosb.BindReaction{
-			Response: &osb.BindResponse{
-				Credentials: map[string]interface{}{
-					"foo": "bar",
-					"baz": "zap",
-				},
-			},
-		},
-		UnbindReaction: &fakeosb.UnbindReaction{
-			Response: &osb.UnbindResponse{
-				Async: false,
-			},
-		},
-		DeprovisionReaction: &fakeosb.DeprovisionReaction{
-			Response: &osb.DeprovisionResponse{
-				Async: false,
-			},
-		},
-	})
+	_, catalogClient, catalogClientConfig, _, _, _, shutdownServer, shutdownController := newTestController(t)
 	defer shutdownController()
 	defer shutdownServer()
 
@@ -1026,21 +761,15 @@ func TestBasicFlowsWithOriginatingIdentity(t *testing.T) {
 // successfully deprovisioned after a provision request returns a status code
 // that should trigger orphan mitigation.
 func TestServiceInstanceOrphanMitigation(t *testing.T) {
-	_, catalogClient, _, _, _, _, shutdownServer, shutdownController := newTestController(t, fakeosb.FakeClientConfiguration{
-		CatalogReaction: &fakeosb.CatalogReaction{
-			Response: getTestCatalogResponse(),
-		},
-		ProvisionReaction: &fakeosb.ProvisionReaction{
-			Error: osb.HTTPStatusCodeError{
-				StatusCode: http.StatusInternalServerError,
-			},
-		},
-		DeprovisionReaction: &fakeosb.DeprovisionReaction{
-			Response: &osb.DeprovisionResponse{},
-		},
-	})
+	_, catalogClient, _, osbClient, _, _, shutdownServer, shutdownController := newTestController(t)
 	defer shutdownController()
 	defer shutdownServer()
+
+	osbClient.ProvisionReaction = &fakeosb.ProvisionReaction{
+		Error: osb.HTTPStatusCodeError{
+			StatusCode: http.StatusInternalServerError,
+		},
+	}
 
 	client := catalogClient.ServicecatalogV1beta1()
 
@@ -1149,27 +878,15 @@ func TestServiceInstanceOrphanMitigation(t *testing.T) {
 // successfully deleted after a bind request returns a status code
 // that should trigger orphan mitigation.
 func TestServiceBindingOrphanMitigation(t *testing.T) {
-	_, fakeCatalogClient, _, _, _, _, shutdownServer, shutdownController := newTestController(t, fakeosb.FakeClientConfiguration{
-		CatalogReaction: &fakeosb.CatalogReaction{
-			Response: getTestCatalogResponse(),
-		},
-		BindReaction: &fakeosb.BindReaction{
-			Error: osb.HTTPStatusCodeError{
-				StatusCode: http.StatusInternalServerError,
-			},
-		},
-		UnbindReaction: &fakeosb.UnbindReaction{
-			Response: &osb.UnbindResponse{},
-		},
-		ProvisionReaction: &fakeosb.ProvisionReaction{
-			Response: &osb.ProvisionResponse{},
-		},
-		DeprovisionReaction: &fakeosb.DeprovisionReaction{
-			Response: &osb.DeprovisionResponse{},
-		},
-	})
+	_, fakeCatalogClient, _, osbClient, _, _, shutdownServer, shutdownController := newTestController(t)
 	defer shutdownController()
 	defer shutdownServer()
+
+	osbClient.BindReaction = &fakeosb.BindReaction{
+		Error: osb.HTTPStatusCodeError{
+			StatusCode: http.StatusInternalServerError,
+		},
+	}
 
 	client := fakeCatalogClient.ServicecatalogV1beta1()
 
@@ -1315,63 +1032,26 @@ func TestServiceBindingOrphanMitigation(t *testing.T) {
 	}
 }
 
-// TestBasicFlowsAsyncBinding tests the same flows as TestBasicFlowsAsync, using
-// asynchronous binding/unbindg as well.
-func TestBasicFlowsAsyncBinding(t *testing.T) {
-	// Enable the AsyncBindingOperations feature
-	utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.AsyncBindingOperations))
-	defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.AsyncBindingOperations))
-
-	_, catalogClient, _, _, _, _, shutdownServer, shutdownController := newTestController(t, fakeosb.FakeClientConfiguration{
-		CatalogReaction: &fakeosb.CatalogReaction{
-			Response: getTestCatalogResponse(),
-		},
-		ProvisionReaction: &fakeosb.ProvisionReaction{
-			Response: &osb.ProvisionResponse{
-				Async: true,
-			},
-		},
-		PollLastOperationReaction: &fakeosb.PollLastOperationReaction{
-			Response: &osb.LastOperationResponse{
-				State: osb.StateSucceeded,
-			},
-		},
-		PollBindingLastOperationReaction: &fakeosb.PollBindingLastOperationReaction{
-			Response: &osb.LastOperationResponse{
-				State: osb.StateSucceeded,
-			},
-		},
-		UpdateInstanceReaction: &fakeosb.UpdateInstanceReaction{
-			Response: &osb.UpdateInstanceResponse{
-				Async: true,
-			},
-		},
-		BindReaction: &fakeosb.BindReaction{
-			Response: &osb.BindResponse{
-				Async: true,
-			},
-		},
-		GetBindingReaction: &fakeosb.GetBindingReaction{
-			Response: &osb.GetBindingResponse{
-				Credentials: map[string]interface{}{
-					"foo": "bar",
-					"baz": "zap",
-				},
-			},
-		},
-		UnbindReaction: &fakeosb.UnbindReaction{
-			Response: &osb.UnbindResponse{
-				Async: true,
-			},
-		},
-		DeprovisionReaction: &fakeosb.DeprovisionReaction{
-			Response: &osb.DeprovisionResponse{
-				Async: true,
-			},
-		},
-	})
+// TestAsyncProvisionWithMultiplePolls tests an async instance provisioning
+// where the first few last-operation polls respond still in-progress.
+func TestAsyncProvisionWithMultiplePolls(t *testing.T) {
+	_, catalogClient, _, osbClient, _, _, shutdownServer, shutdownController := newTestController(t)
 	defer shutdownController()
 	defer shutdownServer()
+
+	osbClient.ProvisionReaction.(*fakeosb.ProvisionReaction).Response.Async = true
+
+	const NumberOfInProgressResponses = 2
+	numberOfPolls := 0
+	osbClient.PollLastOperationReaction = fakeosb.DynamicPollLastOperationReaction(
+		func(_ *osb.LastOperationRequest) (*osb.LastOperationResponse, error) {
+			numberOfPolls++
+			state := osb.StateInProgress
+			if numberOfPolls > NumberOfInProgressResponses {
+				state = osb.StateSucceeded
+			}
+			return &osb.LastOperationResponse{State: state}, nil
+		})
 
 	client := catalogClient.ServicecatalogV1beta1()
 
@@ -1422,6 +1102,11 @@ func TestBasicFlowsAsyncBinding(t *testing.T) {
 		t.Fatalf("error creating Instance: %v", err)
 	}
 
+	// Polling is going to take at least 3 seconds, with a 1-second break between the first poll and the second
+	// and a 2-second break between the second poll and the third. Let's sleep here so that we don't risk
+	// timing out while waiting for the instance condition to be ready in the following wait.
+	time.Sleep(3 * time.Second)
+
 	if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
 		Type:   v1beta1.ServiceInstanceConditionReady,
 		Status: v1beta1.ConditionTrue,
@@ -1440,63 +1125,6 @@ func TestBasicFlowsAsyncBinding(t *testing.T) {
 			instance.Spec.ExternalID,
 		)
 	}
-
-	// Update Instance
-	updateRequests := retInst.Spec.UpdateRequests + 1
-	retInst.Spec.UpdateRequests = updateRequests
-	if _, err := client.ServiceInstances(testNamespace).Update(retInst); err != nil {
-		t.Fatalf("error updating Instance: %v", err)
-	}
-
-	if err := util.WaitForInstanceReconciledGeneration(client, testNamespace, testInstanceName, retInst.Status.ReconciledGeneration+1); err != nil {
-		t.Fatalf("error waiting for instance to reconcile: %v", err)
-	}
-
-	retInst, err = client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-	}
-	if e, a := updateRequests, retInst.Spec.UpdateRequests; e != a {
-		t.Fatalf("unexpected updateRequets in instance spec: expected %v, got %v", e, a)
-	}
-
-	// Binding test begins here
-	//-----------------
-
-	binding := &v1beta1.ServiceBinding{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testBindingName},
-		Spec: v1beta1.ServiceBindingSpec{
-			ServiceInstanceRef: v1beta1.LocalObjectReference{
-				Name: testInstanceName,
-			},
-		},
-	}
-
-	_, err = client.ServiceBindings(testNamespace).Create(binding)
-	if err != nil {
-		t.Fatalf("error creating Binding: %v", binding)
-	}
-
-	err = util.WaitForBindingCondition(client, testNamespace, testBindingName, v1beta1.ServiceBindingCondition{
-		Type:   v1beta1.ServiceBindingConditionReady,
-		Status: v1beta1.ConditionTrue,
-	})
-	if err != nil {
-		t.Fatalf("error waiting for binding to become ready: %v", err)
-	}
-
-	err = client.ServiceBindings(testNamespace).Delete(testBindingName, &metav1.DeleteOptions{})
-	if err != nil {
-		t.Fatalf("binding delete should have been accepted: %v", err)
-	}
-
-	err = util.WaitForBindingToNotExist(client, testNamespace, testBindingName)
-	if err != nil {
-		t.Fatalf("error waiting for binding to not exist: %v", err)
-	}
-
-	//-----------------
-	// End binding test
 
 	err = client.ServiceInstances(testNamespace).Delete(testInstanceName, &metav1.DeleteOptions{})
 	if nil != err {
@@ -1533,13 +1161,13 @@ func TestBasicFlowsAsyncBinding(t *testing.T) {
 //
 // - a fake kubernetes core api client
 // - a fake service catalog api client
-// - a fake osb client
+// - a fake osb client, with configuration for happy path testing
 // - a test controller
 // - the shared informers for the service catalog v1beta1 api
 //
 // If there is an error, newTestController calls 'Fatal' on the injected
 // testing.T.
-func newTestController(t *testing.T, config fakeosb.FakeClientConfiguration) (
+func newTestController(t *testing.T) (
 	*fake.Clientset,
 	clientset.Interface,
 	*restclient.Config,
@@ -1558,7 +1186,7 @@ func newTestController(t *testing.T, config fakeosb.FakeClientConfiguration) (
 		return &servicecatalog.ClusterServiceBroker{}
 	})
 
-	fakeOSBClient := fakeosb.NewFakeClient(config) // error should always be nil
+	fakeOSBClient := fakeosb.NewFakeClient(getTestHappyPathBrokerClientConfig())
 	brokerClFunc := fakeosb.ReturnFakeClientFunc(fakeOSBClient)
 
 	// create informers
@@ -1638,6 +1266,55 @@ func getTestCatalogResponse() *osb.CatalogResponse {
 						Description: "a test plan",
 					},
 				},
+			},
+		},
+	}
+}
+
+func getTestBindCredentials() map[string]interface{} {
+	return map[string]interface{}{
+		"foo": "bar",
+		"baz": "zap",
+	}
+}
+
+// getTestHappyPathBrokerClientConfig returns configuration for the fake
+// broker client that is appropriate for testing the synchronous happy path.
+func getTestHappyPathBrokerClientConfig() fakeosb.FakeClientConfiguration {
+	return fakeosb.FakeClientConfiguration{
+		CatalogReaction: &fakeosb.CatalogReaction{
+			Response: getTestCatalogResponse(),
+		},
+		ProvisionReaction: &fakeosb.ProvisionReaction{
+			Response: &osb.ProvisionResponse{},
+		},
+		UpdateInstanceReaction: &fakeosb.UpdateInstanceReaction{
+			Response: &osb.UpdateInstanceResponse{},
+		},
+		DeprovisionReaction: &fakeosb.DeprovisionReaction{
+			Response: &osb.DeprovisionResponse{},
+		},
+		BindReaction: &fakeosb.BindReaction{
+			Response: &osb.BindResponse{
+				Credentials: getTestBindCredentials(),
+			},
+		},
+		UnbindReaction: &fakeosb.UnbindReaction{
+			Response: &osb.UnbindResponse{},
+		},
+		PollLastOperationReaction: &fakeosb.PollLastOperationReaction{
+			Response: &osb.LastOperationResponse{
+				State: osb.StateSucceeded,
+			},
+		},
+		PollBindingLastOperationReaction: &fakeosb.PollBindingLastOperationReaction{
+			Response: &osb.LastOperationResponse{
+				State: osb.StateSucceeded,
+			},
+		},
+		GetBindingReaction: &fakeosb.GetBindingReaction{
+			Response: &osb.GetBindingResponse{
+				Credentials: getTestBindCredentials(),
 			},
 		},
 	}

--- a/test/integration/deleted_services_and_plans_test.go
+++ b/test/integration/deleted_services_and_plans_test.go
@@ -24,18 +24,12 @@ import (
 	// avoid error `servicecatalog/v1beta1 is not enabled`
 	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
 
-	fakeosb "github.com/pmorie/go-open-service-broker-client/v2/fake"
-
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-incubator/service-catalog/test/util"
 )
 
 func TestClusterServicePlanRemovedFromCatalogWithoutInstances(t *testing.T) {
-	_, catalogClient, _, _, _, _, shutdownServer, shutdownController := newTestController(t, fakeosb.FakeClientConfiguration{
-		CatalogReaction: &fakeosb.CatalogReaction{
-			Response: getTestCatalogResponse(),
-		},
-	})
+	_, catalogClient, _, _, _, _, shutdownServer, shutdownController := newTestController(t)
 	defer shutdownController()
 	defer shutdownServer()
 
@@ -117,11 +111,7 @@ func getTestClusterServicePlanRemoved() *v1beta1.ClusterServicePlan {
 }
 
 func TestClusterServiceClassRemovedFromCatalogWithoutInstances(t *testing.T) {
-	_, catalogClient, _, _, _, _, shutdownServer, shutdownController := newTestController(t, fakeosb.FakeClientConfiguration{
-		CatalogReaction: &fakeosb.CatalogReaction{
-			Response: getTestCatalogResponse(),
-		},
-	})
+	_, catalogClient, _, _, _, _, shutdownServer, shutdownController := newTestController(t)
 	defer shutdownController()
 	defer shutdownServer()
 

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/fake/fake_test.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/fake/fake_test.go
@@ -58,7 +58,7 @@ func truePtr() *bool {
 func TestGetCatalog(t *testing.T) {
 	cases := []struct {
 		name     string
-		reaction *fake.CatalogReaction
+		reaction fake.CatalogReactionInterface
 		response *v2.CatalogResponse
 		err      error
 	}{
@@ -79,6 +79,28 @@ func TestGetCatalog(t *testing.T) {
 				Error: errors.New("oops"),
 			},
 			err: errors.New("oops"),
+		},
+		{
+			name: "dynamic response",
+			reaction: fake.DynamicCatalogReaction(func() (*v2.CatalogResponse, error) {
+				return catalogResponse(), nil
+			}),
+			response: catalogResponse(),
+		},
+		{
+			name: "dynamic error",
+			reaction: fake.DynamicCatalogReaction(func() (*v2.CatalogResponse, error) {
+				return nil, errors.New("oops")
+			}),
+			err: errors.New("oops"),
+		},
+		{
+			name: "nil static reaction",
+			reaction: func() fake.CatalogReactionInterface {
+				var nilStaticReaction *fake.CatalogReaction
+				return nilStaticReaction
+			}(),
+			err: fake.UnexpectedActionError(),
 		},
 	}
 
@@ -118,7 +140,7 @@ func provisionResponse() *v2.ProvisionResponse {
 func TestProvisionInstance(t *testing.T) {
 	cases := []struct {
 		name     string
-		reaction *fake.ProvisionReaction
+		reaction fake.ProvisionReactionInterface
 		response *v2.ProvisionResponse
 		err      error
 	}{
@@ -139,6 +161,28 @@ func TestProvisionInstance(t *testing.T) {
 				Error: errors.New("oops"),
 			},
 			err: errors.New("oops"),
+		},
+		{
+			name: "dynamic response",
+			reaction: fake.DynamicProvisionReaction(func(_ *v2.ProvisionRequest) (*v2.ProvisionResponse, error) {
+				return provisionResponse(), nil
+			}),
+			response: provisionResponse(),
+		},
+		{
+			name: "dynamic error",
+			reaction: fake.DynamicProvisionReaction(func(_ *v2.ProvisionRequest) (*v2.ProvisionResponse, error) {
+				return nil, errors.New("oops")
+			}),
+			err: errors.New("oops"),
+		},
+		{
+			name: "nil static reaction",
+			reaction: func() fake.ProvisionReactionInterface {
+				var nilStaticReaction *fake.ProvisionReaction
+				return nilStaticReaction
+			}(),
+			err: fake.UnexpectedActionError(),
 		},
 	}
 
@@ -176,7 +220,7 @@ func updateInstanceResponse() *v2.UpdateInstanceResponse {
 func TestUpdateInstance(t *testing.T) {
 	cases := []struct {
 		name     string
-		reaction *fake.UpdateInstanceReaction
+		reaction fake.UpdateInstanceReactionInterface
 		response *v2.UpdateInstanceResponse
 		err      error
 	}{
@@ -197,6 +241,28 @@ func TestUpdateInstance(t *testing.T) {
 				Error: errors.New("oops"),
 			},
 			err: errors.New("oops"),
+		},
+		{
+			name: "dynamic response",
+			reaction: fake.DynamicUpdateInstanceReaction(func(_ *v2.UpdateInstanceRequest) (*v2.UpdateInstanceResponse, error) {
+				return updateInstanceResponse(), nil
+			}),
+			response: updateInstanceResponse(),
+		},
+		{
+			name: "dynamic error",
+			reaction: fake.DynamicUpdateInstanceReaction(func(_ *v2.UpdateInstanceRequest) (*v2.UpdateInstanceResponse, error) {
+				return nil, errors.New("oops")
+			}),
+			err: errors.New("oops"),
+		},
+		{
+			name: "nil static reaction",
+			reaction: func() fake.UpdateInstanceReactionInterface {
+				var nilStaticReaction *fake.UpdateInstanceReaction
+				return nilStaticReaction
+			}(),
+			err: fake.UnexpectedActionError(),
 		},
 	}
 
@@ -234,7 +300,7 @@ func deprovisionResponse() *v2.DeprovisionResponse {
 func TestDeprovisionInstance(t *testing.T) {
 	cases := []struct {
 		name     string
-		reaction *fake.DeprovisionReaction
+		reaction fake.DeprovisionReactionInterface
 		response *v2.DeprovisionResponse
 		err      error
 	}{
@@ -255,6 +321,28 @@ func TestDeprovisionInstance(t *testing.T) {
 				Error: errors.New("oops"),
 			},
 			err: errors.New("oops"),
+		},
+		{
+			name: "dynamic response",
+			reaction: fake.DynamicDeprovisionReaction(func(_ *v2.DeprovisionRequest) (*v2.DeprovisionResponse, error) {
+				return deprovisionResponse(), nil
+			}),
+			response: deprovisionResponse(),
+		},
+		{
+			name: "dynamic error",
+			reaction: fake.DynamicDeprovisionReaction(func(_ *v2.DeprovisionRequest) (*v2.DeprovisionResponse, error) {
+				return nil, errors.New("oops")
+			}),
+			err: errors.New("oops"),
+		},
+		{
+			name: "nil static reaction",
+			reaction: func() fake.DeprovisionReactionInterface {
+				var nilStaticReaction *fake.DeprovisionReaction
+				return nilStaticReaction
+			}(),
+			err: fake.UnexpectedActionError(),
 		},
 	}
 
@@ -292,7 +380,7 @@ func lastOperationResponse() *v2.LastOperationResponse {
 func TestPollLastOperation(t *testing.T) {
 	cases := []struct {
 		name     string
-		reaction *fake.PollLastOperationReaction
+		reaction fake.PollLastOperationReactionInterface
 		response *v2.LastOperationResponse
 		err      error
 	}{
@@ -313,6 +401,28 @@ func TestPollLastOperation(t *testing.T) {
 				Error: errors.New("oops"),
 			},
 			err: errors.New("oops"),
+		},
+		{
+			name: "dynamic response",
+			reaction: fake.DynamicPollLastOperationReaction(func(_ *v2.LastOperationRequest) (*v2.LastOperationResponse, error) {
+				return lastOperationResponse(), nil
+			}),
+			response: lastOperationResponse(),
+		},
+		{
+			name: "dynamic error",
+			reaction: fake.DynamicPollLastOperationReaction(func(_ *v2.LastOperationRequest) (*v2.LastOperationResponse, error) {
+				return nil, errors.New("oops")
+			}),
+			err: errors.New("oops"),
+		},
+		{
+			name: "nil static reaction",
+			reaction: func() fake.PollLastOperationReactionInterface {
+				var nilStaticReaction *fake.PollLastOperationReaction
+				return nilStaticReaction
+			}(),
+			err: fake.UnexpectedActionError(),
 		},
 	}
 
@@ -347,7 +457,7 @@ func TestPollLastOperations(t *testing.T) {
 	cases := []struct {
 		name         string
 		operationKey *v2.OperationKey
-		reaction     *fake.PollLastOperationReaction
+		reaction     fake.PollLastOperationReactionInterface
 		reactions    map[v2.OperationKey]*fake.PollLastOperationReaction
 		response     *v2.LastOperationResponse
 		err          error
@@ -433,7 +543,7 @@ func TestPollLastOperations(t *testing.T) {
 func TestPollBindingLastOperation(t *testing.T) {
 	cases := []struct {
 		name     string
-		reaction *fake.PollBindingLastOperationReaction
+		reaction fake.PollBindingLastOperationReactionInterface
 		response *v2.LastOperationResponse
 		err      error
 	}{
@@ -454,6 +564,28 @@ func TestPollBindingLastOperation(t *testing.T) {
 				Error: errors.New("oops"),
 			},
 			err: errors.New("oops"),
+		},
+		{
+			name: "dynamic response",
+			reaction: fake.DynamicPollBindingLastOperationReaction(func(_ *v2.BindingLastOperationRequest) (*v2.LastOperationResponse, error) {
+				return lastOperationResponse(), nil
+			}),
+			response: lastOperationResponse(),
+		},
+		{
+			name: "dynamic error",
+			reaction: fake.DynamicPollBindingLastOperationReaction(func(_ *v2.BindingLastOperationRequest) (*v2.LastOperationResponse, error) {
+				return nil, errors.New("oops")
+			}),
+			err: errors.New("oops"),
+		},
+		{
+			name: "nil static reaction",
+			reaction: func() fake.PollBindingLastOperationReactionInterface {
+				var nilStaticReaction *fake.PollBindingLastOperationReaction
+				return nilStaticReaction
+			}(),
+			err: fake.UnexpectedActionError(),
 		},
 	}
 
@@ -493,7 +625,7 @@ func bindResponse() *v2.BindResponse {
 func TestBind(t *testing.T) {
 	cases := []struct {
 		name     string
-		reaction *fake.BindReaction
+		reaction fake.BindReactionInterface
 		response *v2.BindResponse
 		err      error
 	}{
@@ -514,6 +646,28 @@ func TestBind(t *testing.T) {
 				Error: errors.New("oops"),
 			},
 			err: errors.New("oops"),
+		},
+		{
+			name: "dynamic response",
+			reaction: fake.DynamicBindReaction(func(_ *v2.BindRequest) (*v2.BindResponse, error) {
+				return bindResponse(), nil
+			}),
+			response: bindResponse(),
+		},
+		{
+			name: "dynamic error",
+			reaction: fake.DynamicBindReaction(func(_ *v2.BindRequest) (*v2.BindResponse, error) {
+				return nil, errors.New("oops")
+			}),
+			err: errors.New("oops"),
+		},
+		{
+			name: "nil static reaction",
+			reaction: func() fake.BindReactionInterface {
+				var nilStaticReaction *fake.BindReaction
+				return nilStaticReaction
+			}(),
+			err: fake.UnexpectedActionError(),
 		},
 	}
 
@@ -549,7 +703,7 @@ func unbindResponse() *v2.UnbindResponse {
 func TestUnbind(t *testing.T) {
 	cases := []struct {
 		name     string
-		reaction *fake.UnbindReaction
+		reaction fake.UnbindReactionInterface
 		response *v2.UnbindResponse
 		err      error
 	}{
@@ -570,6 +724,28 @@ func TestUnbind(t *testing.T) {
 				Error: errors.New("oops"),
 			},
 			err: errors.New("oops"),
+		},
+		{
+			name: "dynamic response",
+			reaction: fake.DynamicUnbindReaction(func(_ *v2.UnbindRequest) (*v2.UnbindResponse, error) {
+				return unbindResponse(), nil
+			}),
+			response: unbindResponse(),
+		},
+		{
+			name: "dynamic error",
+			reaction: fake.DynamicUnbindReaction(func(_ *v2.UnbindRequest) (*v2.UnbindResponse, error) {
+				return nil, errors.New("oops")
+			}),
+			err: errors.New("oops"),
+		},
+		{
+			name: "nil static reaction",
+			reaction: func() fake.UnbindReactionInterface {
+				var nilStaticReaction *fake.UnbindReaction
+				return nilStaticReaction
+			}(),
+			err: fake.UnexpectedActionError(),
 		},
 	}
 
@@ -609,7 +785,7 @@ func getBindingResponse() *v2.GetBindingResponse {
 func TestGetBinding(t *testing.T) {
 	cases := []struct {
 		name     string
-		reaction *fake.GetBindingReaction
+		reaction fake.GetBindingReactionInterface
 		response *v2.GetBindingResponse
 		err      error
 	}{
@@ -630,6 +806,28 @@ func TestGetBinding(t *testing.T) {
 				Error: errors.New("oops"),
 			},
 			err: errors.New("oops"),
+		},
+		{
+			name: "dynamic response",
+			reaction: fake.DynamicGetBindingReaction(func() (*v2.GetBindingResponse, error) {
+				return getBindingResponse(), nil
+			}),
+			response: getBindingResponse(),
+		},
+		{
+			name: "dynamic error",
+			reaction: fake.DynamicGetBindingReaction(func() (*v2.GetBindingResponse, error) {
+				return nil, errors.New("oops")
+			}),
+			err: errors.New("oops"),
+		},
+		{
+			name: "nil static reaction",
+			reaction: func() fake.GetBindingReactionInterface {
+				var nilStaticReaction *fake.GetBindingReaction
+				return nilStaticReaction
+			}(),
+			err: fake.UnexpectedActionError(),
 		},
 	}
 


### PR DESCRIPTION
* Change the fake OSB client so that it is configured with functions for reactions rather than static responses and errors. The function reactions can be used to adjust the response from the fake broker as the tests proceed. As an example, there is a new test `TestAsyncProvisionWithMultiplePolls` that responds to the first 2 last operation polls with "in-progress" before responding with "success" on subsequent polls.
* Add functions that can be used to easily configure the fake broker client for the happy paths. This keeps the same big block of code from having to be duplicated in each test. When unhappy paths are being tested, a happy path response can be used as a base with adjustments made as needed.
* Bring the sync and async basic flow tests together into a single test with sub-tests.
