### PR TITLE
fix bind injection failure not being persisted in API server

### DIFF
--- a/pkg/apis/servicecatalog/validation/binding.go
+++ b/pkg/apis/servicecatalog/validation/binding.go
@@ -109,17 +109,15 @@ func validateServiceBindingStatus(status *sc.ServiceBindingStatus, fldPath *fiel
 		}
 	}
 
-	if status.CurrentOperation == sc.ServiceBindingOperationBind {
-		if status.InProgressProperties == nil {
-			allErrs = append(allErrs, field.Required(fldPath.Child("inProgressProperties"), `inProgressProperties is required when currentOperation is "Bind"`))
-		}
-	} else {
-		if status.InProgressProperties != nil {
+	if status.InProgressProperties != nil {
+		if status.CurrentOperation != sc.ServiceBindingOperationBind {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("inProgressProperties"), `inProgressProperties must not be present when currentOperation is not "Bind"`))
 		}
-	}
 
-	if status.InProgressProperties != nil {
+		if status.ExternalProperties != nil {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("inProgressProperties"), `inProgressProperties and externalProperties cannot both be present`))
+		}
+
 		allErrs = append(allErrs, validateServiceBindingPropertiesState(status.InProgressProperties, fldPath.Child("inProgressProperties"), create)...)
 	}
 

--- a/pkg/apis/servicecatalog/validation/binding_test.go
+++ b/pkg/apis/servicecatalog/validation/binding_test.go
@@ -196,10 +196,10 @@ func TestValidateServiceBinding(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "in-progress bind with missing InProgressParameters",
+			name: "in-progress bind with existing externalProperties",
 			binding: func() *servicecatalog.ServiceBinding {
 				b := validServiceBindingWithInProgressBind()
-				b.Status.InProgressProperties = nil
+				b.Status.ExternalProperties = validServiceBindingPropertiesState()
 				return b
 			}(),
 			valid: false,


### PR DESCRIPTION
When a bind request succeeds, we unset `InProgressProperties` and set `ExternalProperties`, as we know that is the true state of the world. However, if we fail to inject, we need to update the status but continue reconciliation for the bind. The API server currently blocks this update because we assumed if the `InProgressProperties` are unset, the bind operation has completed.