### PR TITLE
fix bind injection failure not being persisted in API server

### DIFF
--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -586,6 +586,13 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 
 		// The Bind request has returned successfully from the Broker. Continue
 		// with the success case of creating the ServiceBinding.
+
+		// Save off the external properties here even if the subsequent
+		// credentials injection fails. The Broker has already processed the
+		// request, so this is what the Broker knows about the state of the
+		// binding.
+		toUpdate.Status.ExternalProperties = toUpdate.Status.InProgressProperties
+
 		err = c.injectServiceBinding(binding, response.Credentials)
 		if err != nil {
 			s := fmt.Sprintf(`Error injecting binding results: %s`, err)
@@ -619,7 +626,6 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 			return err
 		}
 
-		toUpdate.Status.ExternalProperties = toUpdate.Status.InProgressProperties
 		clearServiceBindingCurrentOperation(toUpdate)
 
 		setServiceBindingCondition(
@@ -1530,7 +1536,6 @@ func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
 		// Update the in progress/external properties, as the changes have been
 		// persisted in the broker
 		binding.Status.ExternalProperties = binding.Status.InProgressProperties
-		binding.Status.InProgressProperties = nil
 
 		getBindingRequest := &osb.GetBindingRequest{
 			InstanceID: instance.Spec.ExternalID,

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -586,14 +586,6 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 
 		// The Bind request has returned successfully from the Broker. Continue
 		// with the success case of creating the ServiceBinding.
-
-		// Save off the external properties here even if the subsequent
-		// credentials injection fails. The Broker has already processed the
-		// request, so this is what the Broker knows about the state of the
-		// binding.
-		toUpdate.Status.ExternalProperties = toUpdate.Status.InProgressProperties
-		toUpdate.Status.InProgressProperties = nil
-
 		err = c.injectServiceBinding(binding, response.Credentials)
 		if err != nil {
 			s := fmt.Sprintf(`Error injecting binding results: %s`, err)
@@ -627,6 +619,7 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 			return err
 		}
 
+		toUpdate.Status.ExternalProperties = toUpdate.Status.InProgressProperties
 		clearServiceBindingCurrentOperation(toUpdate)
 
 		setServiceBindingCondition(

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -339,7 +339,8 @@ func TestReconcileServiceBindingWithSecretConflict(t *testing.T) {
 	assertServiceBindingOperationStartTimeSet(t, updatedServiceBinding, true)
 	assertServiceBindingReconciledGeneration(t, updatedServiceBinding, binding.Status.ReconciledGeneration)
 	assertServiceBindingInProgressPropertiesParameters(t, updatedServiceBinding, nil, "")
-	assertServiceBindingExternalPropertiesNil(t, updatedServiceBinding)
+	// External properties are updated because the bind request with the Broker was successful
+	assertServiceBindingExternalPropertiesParameters(t, updatedServiceBinding, nil, "")
 	assertServiceBindingOrphanMitigationSet(t, updatedServiceBinding, false)
 
 	kubeActions := fakeKubeClient.Actions()
@@ -2115,6 +2116,7 @@ func TestReconcileBindingWithSecretConflictFailedAfterFinalRetry(t *testing.T) {
 	assertServiceBindingCondition(t, updatedServiceBinding, v1beta1.ServiceBindingConditionReady, v1beta1.ConditionFalse, errorServiceBindingOrphanMitigation)
 	assertServiceBindingCondition(t, updatedServiceBinding, v1beta1.ServiceBindingConditionFailed, v1beta1.ConditionTrue, errorReconciliationRetryTimeoutReason)
 	assertServiceBindingStartingOrphanMitigation(t, updatedServiceBinding, binding)
+	assertServiceBindingExternalPropertiesParameters(t, updatedServiceBinding, nil, "")
 
 	kubeActions := fakeKubeClient.Actions()
 	assertNumberOfActions(t, kubeActions, 2)
@@ -2475,13 +2477,14 @@ func TestReconcileBindingWithSetOrphanMitigation(t *testing.T) {
 
 			updatedServiceBinding = assertUpdateStatus(t, actions[1], binding).(*v1beta1.ServiceBinding)
 
+			assertServiceBindingExternalPropertiesNil(t, updatedServiceBinding)
+
 			if tc.setOrphanMitigation {
 				assertServiceBindingStartingOrphanMitigation(t, updatedServiceBinding, binding)
 			} else {
 				assertServiceBindingReadyFalse(t, updatedServiceBinding)
 				assertServiceBindingCondition(t, updatedServiceBinding, v1beta1.ServiceBindingConditionReady, v1beta1.ConditionFalse)
-				assertServiceBindingOrphanMitigationSet(t, updatedServiceBinding, tc.setOrphanMitigation)
-				assertServiceBindingExternalPropertiesNil(t, updatedServiceBinding)
+				assertServiceBindingOrphanMitigationSet(t, updatedServiceBinding, false)
 			}
 		})
 	}

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -338,9 +338,8 @@ func TestReconcileServiceBindingWithSecretConflict(t *testing.T) {
 	assertServiceBindingCurrentOperation(t, updatedServiceBinding, v1beta1.ServiceBindingOperationBind)
 	assertServiceBindingOperationStartTimeSet(t, updatedServiceBinding, true)
 	assertServiceBindingReconciledGeneration(t, updatedServiceBinding, binding.Status.ReconciledGeneration)
-	assertServiceBindingInProgressPropertiesNil(t, updatedServiceBinding)
-	// External properties are updated because the bind request with the Broker was successful
-	assertServiceBindingExternalPropertiesParameters(t, updatedServiceBinding, nil, "")
+	assertServiceBindingInProgressPropertiesParameters(t, updatedServiceBinding, nil, "")
+	assertServiceBindingExternalPropertiesNil(t, updatedServiceBinding)
 	assertServiceBindingOrphanMitigationSet(t, updatedServiceBinding, false)
 
 	kubeActions := fakeKubeClient.Actions()
@@ -2116,8 +2115,6 @@ func TestReconcileBindingWithSecretConflictFailedAfterFinalRetry(t *testing.T) {
 	assertServiceBindingCondition(t, updatedServiceBinding, v1beta1.ServiceBindingConditionReady, v1beta1.ConditionFalse, errorServiceBindingOrphanMitigation)
 	assertServiceBindingCondition(t, updatedServiceBinding, v1beta1.ServiceBindingConditionFailed, v1beta1.ConditionTrue, errorReconciliationRetryTimeoutReason)
 	assertServiceBindingStartingOrphanMitigation(t, updatedServiceBinding, binding)
-	assertServiceBindingInProgressPropertiesNil(t, updatedServiceBinding)
-	assertServiceBindingExternalPropertiesParameters(t, updatedServiceBinding, nil, "")
 
 	kubeActions := fakeKubeClient.Actions()
 	assertNumberOfActions(t, kubeActions, 2)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2490,6 +2490,8 @@ func assertServiceBindingStartingOrphanMitigation(t *testing.T, obj runtime.Obje
 	assertServiceBindingOperationStartTimeSet(t, obj, false)
 	assertServiceBindingReconciledGeneration(t, obj, originalBinding.Status.ReconciledGeneration)
 	assertServiceBindingOrphanMitigationSet(t, obj, true)
+	assertServiceBindingInProgressPropertiesParameters(t, obj, nil, "")
+	assertServiceBindingExternalPropertiesNil(t, obj)
 	assertServiceBindingUnbindStatus(t, obj, v1beta1.ServiceBindingUnbindStatusRequired)
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2491,7 +2491,6 @@ func assertServiceBindingStartingOrphanMitigation(t *testing.T, obj runtime.Obje
 	assertServiceBindingReconciledGeneration(t, obj, originalBinding.Status.ReconciledGeneration)
 	assertServiceBindingOrphanMitigationSet(t, obj, true)
 	assertServiceBindingInProgressPropertiesParameters(t, obj, nil, "")
-	assertServiceBindingExternalPropertiesNil(t, obj)
 	assertServiceBindingUnbindStatus(t, obj, v1beta1.ServiceBindingUnbindStatusRequired)
 }
 
@@ -2577,8 +2576,8 @@ func assertServiceBindingAsyncBindErrorAfterStateSucceeded(t *testing.T, obj run
 	assertServiceBindingOperationStartTimeSet(t, obj, false)
 	assertServiceBindingReconciledGeneration(t, obj, originalBinding.Status.ReconciledGeneration)
 	assertServiceBindingExternalPropertiesParameters(t, obj, nil, "")
-	assertServiceBindingInProgressPropertiesNil(t, obj)
 	assertServiceBindingUnbindStatus(t, obj, v1beta1.ServiceBindingUnbindStatusRequired)
+	assertServiceBindingInProgressPropertiesParameters(t, obj, nil, "")
 	assertCatalogFinalizerExists(t, obj)
 }
 


### PR DESCRIPTION
Follow-up to #1545. ~~Does not unset `InProgressProperties` or set `ExternalProperties` until bind has completely succeeded. This is more analogous to the treatment during orphan mitigation, and allows the validation in the API server to be stronger.~~

Does not unset `InProgressProperties` until bind has completely succeeded.

Closes: #1529 