### PR TITLE
Clear out plan ref when plan changed using k8s names

### DIFF
--- a/pkg/registry/servicecatalog/instance/strategy.go
+++ b/pkg/registry/servicecatalog/instance/strategy.go
@@ -156,7 +156,8 @@ func (instanceRESTStrategy) PrepareForUpdate(ctx genericapirequest.Context, new,
 	newServiceInstance.Spec.ClusterServicePlanRef = oldServiceInstance.Spec.ClusterServicePlanRef
 
 	// Clear out the ClusterServicePlanRef so that it is resolved during reconciliation
-	if newServiceInstance.Spec.ClusterServicePlanExternalName != oldServiceInstance.Spec.ClusterServicePlanExternalName {
+	if newServiceInstance.Spec.ClusterServicePlanExternalName != oldServiceInstance.Spec.ClusterServicePlanExternalName ||
+		newServiceInstance.Spec.ClusterServicePlanName != oldServiceInstance.Spec.ClusterServicePlanName {
 		newServiceInstance.Spec.ClusterServicePlanRef = nil
 	}
 

--- a/pkg/registry/servicecatalog/instance/strategy_test.go
+++ b/pkg/registry/servicecatalog/instance/strategy_test.go
@@ -103,6 +103,27 @@ func TestInstanceUpdate(t *testing.T) {
 			shouldGenerationIncrement: true,
 			shouldPlanRefClear:        true,
 		},
+		{
+			name: "plan change using k8s name",
+			older: func() *servicecatalog.ServiceInstance {
+				i := getTestInstance()
+				i.Spec.ClusterServiceClassExternalName = ""
+				i.Spec.ClusterServicePlanExternalName = ""
+				i.Spec.ClusterServiceClassName = "class-name"
+				i.Spec.ClusterServicePlanName = "old-plan-name"
+				return i
+			}(),
+			newer: func() *servicecatalog.ServiceInstance {
+				i := getTestInstance()
+				i.Spec.ClusterServiceClassExternalName = ""
+				i.Spec.ClusterServicePlanExternalName = ""
+				i.Spec.ClusterServiceClassName = "class-name"
+				i.Spec.ClusterServicePlanName = "new-plan-name"
+				return i
+			}(),
+			shouldGenerationIncrement: true,
+			shouldPlanRefClear:        true,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes #1552.

I have an integration test coming for this as part of my next round of integration test improvements.