### PR TITLE
Send an empty object for Parameters when deleting all parameters of a ServiceInstance

### DIFF
--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -756,7 +756,11 @@ func (c *controller) reconcileServiceInstance(instance *v1beta1.ServiceInstance)
 		// Only send the parameters if they have changed from what the Broker has
 		if toUpdate.Status.ExternalProperties == nil ||
 			toUpdate.Status.InProgressProperties.ParametersChecksum != toUpdate.Status.ExternalProperties.ParametersChecksum {
-			updateRequest.Parameters = parameters
+			if parameters != nil {
+				updateRequest.Parameters = parameters
+			} else {
+				updateRequest.Parameters = make(map[string]interface{})
+			}
 		}
 		currentOperation = v1beta1.ServiceInstanceOperationUpdate
 		provisionOrUpdateText = "update"


### PR DESCRIPTION
Fixes #1554.

I have an integration test coming for this as part of my next round of integration test improvements.