### PR TITLE
Clear out current operation when starting reconciliation of a delete

### DIFF
--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -677,8 +677,11 @@ func (c *controller) reconcileServiceBindingDelete(binding *v1beta1.ServiceBindi
 		}
 	} else {
 		if toUpdate.Status.CurrentOperation != v1beta1.ServiceBindingOperationUnbind {
-			// Cancel any pending orphan mitigation since the resource is being deleted
-			toUpdate.Status.OrphanMitigationInProgress = false
+			// Cancel any in-progress operation or pending orphan mitigation since the resource is being deleted.
+			// Do not update the reconciled generation since the operation was aborted and not finished.
+			currentReconciledGeneration := toUpdate.Status.ReconciledGeneration
+			clearServiceBindingCurrentOperation(toUpdate)
+			toUpdate.Status.ReconciledGeneration = currentReconciledGeneration
 
 			toUpdate, err = c.recordStartOfServiceBindingOperation(toUpdate, v1beta1.ServiceBindingOperationUnbind)
 			if err != nil {

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -2681,9 +2681,10 @@ func TestReconcileServiceBindingDeleteDuringOngoingOperation(t *testing.T) {
 			SecretName:         testServiceBindingSecretName,
 		},
 		Status: v1beta1.ServiceBindingStatus{
-			CurrentOperation:   v1beta1.ServiceBindingOperationBind,
-			OperationStartTime: &startTime,
-			UnbindStatus:       v1beta1.ServiceBindingUnbindStatusRequired,
+			CurrentOperation:     v1beta1.ServiceBindingOperationBind,
+			OperationStartTime:   &startTime,
+			InProgressProperties: &v1beta1.ServiceBindingPropertiesState{},
+			UnbindStatus:         v1beta1.ServiceBindingUnbindStatusRequired,
 		},
 	}
 

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -408,8 +408,11 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1beta1.ServiceIns
 		}
 	} else {
 		if toUpdate.Status.CurrentOperation != v1beta1.ServiceInstanceOperationDeprovision {
-			// Cancel any pending orphan mitigation since the resource is being deleted
-			toUpdate.Status.OrphanMitigationInProgress = false
+			// Cancel any in-progress operation or pending orphan mitigation since the resource is being deleted.
+			// Do not update the reconciled generation since the operation was aborted and not finished.
+			currentReconciledGeneration := toUpdate.Status.ReconciledGeneration
+			clearServiceInstanceCurrentOperation(toUpdate)
+			toUpdate.Status.ReconciledGeneration = currentReconciledGeneration
 
 			toUpdate, err = c.recordStartOfServiceInstanceOperation(toUpdate, v1beta1.ServiceInstanceOperationDeprovision)
 			if err != nil {

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -4813,6 +4813,7 @@ func TestReconcileServiceInstanceDeleteDuringOngoingOperation(t *testing.T) {
 	instance.Status.CurrentOperation = v1beta1.ServiceInstanceOperationProvision
 	startTime := metav1.NewTime(time.Now().Add(-1 * time.Hour))
 	instance.Status.OperationStartTime = &startTime
+	instance.Status.InProgressProperties = &v1beta1.ServiceInstancePropertiesState{}
 
 	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		return true, instance, nil


### PR DESCRIPTION
Fixes #1563.

I have an integration test coming for this as part of my next round of integration test improvements.