### PR TITLE
(WIP) Add integration tests for creating and updating ServiceInstances

### DIFF
--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -677,8 +677,11 @@ func (c *controller) reconcileServiceBindingDelete(binding *v1beta1.ServiceBindi
 		}
 	} else {
 		if toUpdate.Status.CurrentOperation != v1beta1.ServiceBindingOperationUnbind {
-			// Cancel any pending orphan mitigation since the resource is being deleted
-			toUpdate.Status.OrphanMitigationInProgress = false
+			// Cancel any in-progress operation or pending orphan mitigation since the resource is being deleted.
+			// Do not update the reconciled generation since the operation was aborted and not finished.
+			currentReconciledGeneration := toUpdate.Status.ReconciledGeneration
+			clearServiceBindingCurrentOperation(toUpdate)
+			toUpdate.Status.ReconciledGeneration = currentReconciledGeneration
 
 			toUpdate, err = c.recordStartOfServiceBindingOperation(toUpdate, v1beta1.ServiceBindingOperationUnbind)
 			if err != nil {

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -2681,9 +2681,10 @@ func TestReconcileServiceBindingDeleteDuringOngoingOperation(t *testing.T) {
 			SecretName:         testServiceBindingSecretName,
 		},
 		Status: v1beta1.ServiceBindingStatus{
-			CurrentOperation:   v1beta1.ServiceBindingOperationBind,
-			OperationStartTime: &startTime,
-			UnbindStatus:       v1beta1.ServiceBindingUnbindStatusRequired,
+			CurrentOperation:     v1beta1.ServiceBindingOperationBind,
+			OperationStartTime:   &startTime,
+			InProgressProperties: &v1beta1.ServiceBindingPropertiesState{},
+			UnbindStatus:         v1beta1.ServiceBindingUnbindStatusRequired,
 		},
 	}
 

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -756,7 +756,11 @@ func (c *controller) reconcileServiceInstance(instance *v1beta1.ServiceInstance)
 		// Only send the parameters if they have changed from what the Broker has
 		if toUpdate.Status.ExternalProperties == nil ||
 			toUpdate.Status.InProgressProperties.ParametersChecksum != toUpdate.Status.ExternalProperties.ParametersChecksum {
-			updateRequest.Parameters = parameters
+			if parameters != nil {
+				updateRequest.Parameters = parameters
+			} else {
+				updateRequest.Parameters = make(map[string]interface{})
+			}
 		}
 		currentOperation = v1beta1.ServiceInstanceOperationUpdate
 		provisionOrUpdateText = "update"

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -408,8 +408,11 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1beta1.ServiceIns
 		}
 	} else {
 		if toUpdate.Status.CurrentOperation != v1beta1.ServiceInstanceOperationDeprovision {
-			// Cancel any pending orphan mitigation since the resource is being deleted
-			toUpdate.Status.OrphanMitigationInProgress = false
+			// Cancel any in-progress operation or pending orphan mitigation since the resource is being deleted.
+			// Do not update the reconciled generation since the operation was aborted and not finished.
+			currentReconciledGeneration := toUpdate.Status.ReconciledGeneration
+			clearServiceInstanceCurrentOperation(toUpdate)
+			toUpdate.Status.ReconciledGeneration = currentReconciledGeneration
 
 			toUpdate, err = c.recordStartOfServiceInstanceOperation(toUpdate, v1beta1.ServiceInstanceOperationDeprovision)
 			if err != nil {

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -354,97 +355,340 @@ func TestReconcileServiceInstanceNonExistentClusterServicePlanK8SName(t *testing
 
 // TestReconcileServiceInstanceWithParameters tests a simple successful reconciliation
 func TestReconcileServiceInstanceWithParameters(t *testing.T) {
-	fakeKubeClient, fakeCatalogClient, fakeClusterServiceBrokerClient, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
-		ProvisionReaction: &fakeosb.ProvisionReaction{
-			Response: &osb.ProvisionResponse{},
-		},
-	})
-
-	sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(getTestClusterServiceBroker())
-	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(getTestClusterServiceClass())
-	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
-
-	instance := getTestServiceInstanceWithRefs()
-
-	parameters := instanceParameters{Name: "test-param", Args: make(map[string]string)}
-	parameters.Args["first"] = "first-arg"
-	parameters.Args["second"] = "second-arg"
-
-	b, err := json.Marshal(parameters)
-	if err != nil {
-		t.Fatalf("Failed to marshal parameters %v : %v", parameters, err)
+	type secretDef struct {
+		name string
+		data map[string][]byte
 	}
-	instance.Spec.Parameters = &runtime.RawExtension{Raw: b}
-
-	if err = testController.reconcileServiceInstance(instance); err != nil {
-		t.Fatalf("This should not fail : %v", err)
-	}
-
-	brokerActions := fakeClusterServiceBrokerClient.Actions()
-	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
-	assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
-		AcceptsIncomplete: true,
-		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testClusterServiceClassGUID,
-		PlanID:            testClusterServicePlanGUID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
+	cases := []struct {
+		name                              string
+		params                            []byte
+		paramsFrom                        []v1beta1.ParametersFromSource
+		secrets                           []secretDef
+		expectedParams                    map[string]interface{}
+		expectedParamsWithSecretsRedacted map[string]interface{}
+		expectedError                     bool
+	}{
+		{
+			name:           "no params",
+			expectedParams: nil,
 		},
-		Parameters: map[string]interface{}{
-			"args": map[string]interface{}{
-				"first":  "first-arg",
-				"second": "second-arg",
+		{
+			name:   "plain params",
+			params: []byte(`{"Name":"test-param","Args":{"first":"first-arg","second":"second-arg"}}`),
+			expectedParams: map[string]interface{}{
+				"Name": "test-param",
+				"Args": map[string]interface{}{
+					"first":  "first-arg",
+					"second": "second-arg",
+				},
 			},
-			"name": "test-param",
+			expectedParamsWithSecretsRedacted: map[string]interface{}{
+				"Name": "test-param",
+				"Args": map[string]interface{}{
+					"first":  "first-arg",
+					"second": "second-arg",
+				},
+			},
 		},
-	})
-
-	expectedParameters := map[string]interface{}{
-		"args": map[string]interface{}{
-			"first":  "first-arg",
-			"second": "second-arg",
+		{
+			name: "secret params",
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			secrets: []secretDef{
+				{
+					name: "secret-name",
+					data: map[string][]byte{
+						"secret-key": []byte(`{"A":"B","C":{"D":"E","F":"G"}}`),
+					},
+				},
+			},
+			expectedParams: map[string]interface{}{
+				"A": "B",
+				"C": map[string]interface{}{
+					"D": "E",
+					"F": "G",
+				},
+			},
+			expectedParamsWithSecretsRedacted: map[string]interface{}{
+				"A": "<redacted>",
+				"C": "<redacted>",
+			},
 		},
-		"name": "test-param",
+		{
+			name:   "plain and secret params",
+			params: []byte(`{"Name":"test-param","Args":{"first":"first-arg","second":"second-arg"}}`),
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			secrets: []secretDef{
+				{
+					name: "secret-name",
+					data: map[string][]byte{
+						"secret-key": []byte(`{"A":"B","C":{"D":"E","F":"G"}}`),
+					},
+				},
+			},
+			expectedParams: map[string]interface{}{
+				"Name": "test-param",
+				"Args": map[string]interface{}{
+					"first":  "first-arg",
+					"second": "second-arg",
+				},
+				"A": "B",
+				"C": map[string]interface{}{
+					"D": "E",
+					"F": "G",
+				},
+			},
+			expectedParamsWithSecretsRedacted: map[string]interface{}{
+				"Name": "test-param",
+				"Args": map[string]interface{}{
+					"first":  "first-arg",
+					"second": "second-arg",
+				},
+				"A": "<redacted>",
+				"C": "<redacted>",
+			},
+		},
+		{
+			name:          "bad params",
+			params:        []byte("bad"),
+			expectedError: true,
+		},
+		{
+			name: "missing secret",
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "missing secret key",
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "other-secret-key",
+					},
+				},
+			},
+			secrets: []secretDef{
+				{
+					name: "secret-name",
+					data: map[string][]byte{
+						"secret-key": []byte(`bad`),
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "empty secret data",
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			secrets: []secretDef{
+				{
+					name: "secret-name",
+					data: map[string][]byte{},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "bad secret data",
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			secrets: []secretDef{
+				{
+					name: "secret-name",
+					data: map[string][]byte{
+						"secret-key": []byte(`bad`),
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "no params in secret data",
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			secrets: []secretDef{
+				{
+					name: "secret-name",
+					data: map[string][]byte{
+						"secret-key": []byte(`{}`),
+					},
+				},
+			},
+		},
 	}
-	expectedParametersChecksum, err := generateChecksumOfParameters(expectedParameters)
-	if err != nil {
-		t.Fatalf("Failed to generate parameters checksum: %v", err)
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeKubeClient, fakeCatalogClient, fakeClusterServiceBrokerClient, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
+				ProvisionReaction: &fakeosb.ProvisionReaction{
+					Response: &osb.ProvisionResponse{},
+				},
+			})
 
-	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 2)
+			sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(getTestClusterServiceBroker())
+			sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(getTestClusterServiceClass())
+			sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
 
-	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceOperationInProgressWithParameters(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationProvision, testClusterServicePlanName, testClusterServicePlanGUID, expectedParameters, expectedParametersChecksum, instance)
+			for _, s := range tc.secrets {
+				fakeKubeClient.PrependReactor("get", "secrets", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+					getAction, ok := action.(clientgotesting.GetAction)
+					if !ok {
+						return true, nil, apierrors.NewInternalError(fmt.Errorf("could not convert get secrets action to a GetAction: %T", action))
+					}
+					if getAction.GetName() != s.name {
+						return false, nil, nil
+					}
+					secret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: testNamespace,
+							Name:      s.name,
+						},
+						Data: s.data,
+					}
+					return true, secret, nil
+				})
+			}
 
-	updatedServiceInstance = assertUpdateStatus(t, actions[1], instance)
-	assertServiceInstanceOperationSuccessWithParameters(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationProvision, testClusterServicePlanName, testClusterServicePlanGUID, expectedParameters, expectedParametersChecksum, instance)
+			instance := getTestServiceInstanceWithRefs()
 
-	updateObject, ok := updatedServiceInstance.(*v1beta1.ServiceInstance)
-	if !ok {
-		t.Fatalf("couldn't convert to *v1beta1.ServiceInstance")
-	}
+			if tc.params != nil {
+				instance.Spec.Parameters = &runtime.RawExtension{Raw: tc.params}
+			}
 
-	// Verify parameters are what we'd expect them to be, basically name, map with two values in it.
-	if len(updateObject.Spec.Parameters.Raw) == 0 {
-		t.Fatalf("Parameters was unexpectedly empty")
-	}
+			instance.Spec.ParametersFrom = tc.paramsFrom
 
-	// verify no kube resources created
-	// One single action comes from getting namespace uid
-	kubeActions := fakeKubeClient.Actions()
-	if err := checkKubeClientActions(kubeActions, []kubeClientAction{
-		{verb: "get", resourceName: "namespaces", checkType: checkGetActionType},
-	}); err != nil {
-		t.Fatal(err)
-	}
+			err := testController.reconcileServiceInstance(instance)
+			if tc.expectedError {
+				if err == nil {
+					t.Fatalf("Reconcile expected to fail")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Reconcile not expected to fail : %v", err)
+				}
+			}
 
-	events := getRecordedEvents(testController)
+			brokerActions := fakeClusterServiceBrokerClient.Actions()
+			if tc.expectedError {
+				assertNumberOfClusterServiceBrokerActions(t, brokerActions, 0)
+			} else {
+				assertNumberOfClusterServiceBrokerActions(t, brokerActions, 1)
+				assertProvision(t, brokerActions[0], &osb.ProvisionRequest{
+					AcceptsIncomplete: true,
+					InstanceID:        testServiceInstanceGUID,
+					ServiceID:         testClusterServiceClassGUID,
+					PlanID:            testClusterServicePlanGUID,
+					Context: map[string]interface{}{
+						"platform":  "kubernetes",
+						"namespace": "test-ns",
+					},
+					Parameters: tc.expectedParams,
+				})
+			}
 
-	expectedEvent := normalEventBuilder(successProvisionReason).msg("The instance was provisioned successfully")
-	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
-		t.Fatal(err)
+			actions := fakeCatalogClient.Actions()
+			if tc.expectedError {
+				assertNumberOfActions(t, actions, 1)
+				updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
+				assertServiceInstanceErrorBeforeRequest(t, updatedServiceInstance, errorWithParameters, instance)
+			} else {
+				expectedParametersChecksum, err := generateChecksumOfParameters(tc.expectedParams)
+				if err != nil {
+					t.Fatalf("Failed to generate parameters checksum: %v", err)
+				}
+
+				assertNumberOfActions(t, actions, 2)
+
+				updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
+				assertServiceInstanceOperationInProgressWithParameters(t,
+					updatedServiceInstance,
+					v1beta1.ServiceInstanceOperationProvision,
+					testClusterServicePlanName,
+					testClusterServicePlanGUID,
+					tc.expectedParamsWithSecretsRedacted,
+					expectedParametersChecksum,
+					instance,
+				)
+
+				updatedServiceInstance = assertUpdateStatus(t, actions[1], instance)
+				assertServiceInstanceOperationSuccessWithParameters(t,
+					updatedServiceInstance,
+					v1beta1.ServiceInstanceOperationProvision,
+					testClusterServicePlanName,
+					testClusterServicePlanGUID,
+					tc.expectedParamsWithSecretsRedacted,
+					expectedParametersChecksum,
+					instance,
+				)
+			}
+
+			// verify one action comes from getting namespace uid and one
+			// action for each secret referenced in paramsFrom
+			expectedActions := []kubeClientAction{
+				{verb: "get", resourceName: "namespaces", checkType: checkGetActionType},
+			}
+			for range tc.paramsFrom {
+				expectedActions = append(expectedActions,
+					kubeClientAction{verb: "get", resourceName: "secrets", checkType: checkGetActionType})
+			}
+			kubeActions := fakeKubeClient.Actions()
+			if err := checkKubeClientActions(kubeActions, expectedActions); err != nil {
+				t.Fatal(err)
+			}
+
+			events := getRecordedEvents(testController)
+
+			if tc.expectedError {
+				expectedEvent := warningEventBuilder(errorWithParameters).msg("failed to prepare parameters")
+				if err := checkEventPrefixes(events, expectedEvent.stringArr()); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				expectedEvent := normalEventBuilder(successProvisionReason).msg("The instance was provisioned successfully")
+				if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
 	}
 }
 
@@ -648,54 +892,6 @@ func TestReconcileServiceInstanceResolvesReferencesClusterServiceClassRefAlready
 
 	expectedEvent := normalEventBuilder(successProvisionReason).msg("The instance was provisioned successfully")
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
-		t.Fatal(err)
-	}
-}
-
-// TestReconcileServiceInstanceWithInvalidParameters tests that reconcileInstance
-// fails with an error when the service parameters are invalid
-func TestReconcileServiceInstanceWithInvalidParameters(t *testing.T) {
-	fakeKubeClient, fakeCatalogClient, fakeClusterServiceBrokerClient, testController, sharedInformers := newTestController(t, noFakeActions())
-
-	sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(getTestClusterServiceBroker())
-	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(getTestClusterServiceClass())
-	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
-
-	instance := getTestServiceInstanceWithRefs()
-	parameters := instanceParameters{Name: "test-param", Args: make(map[string]string)}
-	parameters.Args["first"] = "first-arg"
-	parameters.Args["second"] = "second-arg"
-
-	b, err := json.Marshal(parameters)
-	if err != nil {
-		t.Fatalf("Failed to marshal parameters %v : %v", parameters, err)
-	}
-	// corrupt the byte slice to begin with a '!' instead of an opening JSON bracket '{'
-	b[0] = 0x21
-	instance.Spec.Parameters = &runtime.RawExtension{Raw: b}
-
-	if err = testController.reconcileServiceInstance(instance); err == nil {
-		t.Fatalf("this should fail due to a parse error")
-	}
-
-	brokerActions := fakeClusterServiceBrokerClient.Actions()
-	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 0)
-
-	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
-
-	// There should only be one action that says that the parameters were invalid.
-	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceErrorBeforeRequest(t, updatedServiceInstance, errorWithParameters, instance)
-
-	// only action should be a get on the namespace
-	kubeActions := fakeKubeClient.Actions()
-	assertNumberOfActions(t, kubeActions, 1)
-
-	events := getRecordedEvents(testController)
-
-	expectedEvent := warningEventBuilder(errorWithParameters).msg("failed to prepare parameters")
-	if err := checkEventContains(events[0], expectedEvent.String()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -4911,6 +4911,7 @@ func TestReconcileServiceInstanceDeleteDuringOngoingOperation(t *testing.T) {
 	instance.Status.CurrentOperation = v1beta1.ServiceInstanceOperationProvision
 	startTime := metav1.NewTime(time.Now().Add(-1 * time.Hour))
 	instance.Status.OperationStartTime = &startTime
+	instance.Status.InProgressProperties = &v1beta1.ServiceInstancePropertiesState{}
 
 	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		return true, instance, nil

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -1,0 +1,994 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+	fakeosb "github.com/pmorie/go-open-service-broker-client/v2/fake"
+
+	// avoid error `servicecatalog/v1beta1 is not enabled`
+	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/test/util"
+)
+
+// TestCreateServiceInstanceNonExistentClusterServiceClassOrPlan tests that a ServiceInstance gets
+// a Failed condition when the service class or service plan it references does not exist.
+func TestCreateServiceInstanceNonExistentClusterServiceClassOrPlan(t *testing.T) {
+	cases := []struct {
+		name                string
+		classExternalName   string
+		planExternalName    string
+		classK8sName        string
+		planK8sName         string
+		expectedErrorReason string
+	}{
+		{
+			name:                "existent external class and plan name",
+			classExternalName:   testClusterServiceClassName,
+			planExternalName:    testClusterServicePlanName,
+			expectedErrorReason: "",
+		},
+		{
+			name:                "non-existent external class name",
+			classExternalName:   "nothereclass",
+			planExternalName:    testClusterServicePlanName,
+			expectedErrorReason: "ReferencesNonexistentServiceClass",
+		},
+		{
+			name:                "non-existent external plan name",
+			classExternalName:   testClusterServiceClassName,
+			planExternalName:    "nothereplan",
+			expectedErrorReason: "ReferencesNonexistentServicePlan",
+		},
+		{
+			name:                "non-existent external class and plan name",
+			classExternalName:   "nothereclass",
+			planExternalName:    "nothereplan",
+			expectedErrorReason: "ReferencesNonexistentServiceClass",
+		},
+		{
+			name:                "existent k8s class and plan name",
+			classK8sName:        testClusterServiceClassGUID,
+			planK8sName:         testPlanExternalID,
+			expectedErrorReason: "",
+		},
+		{
+			name:                "non-existent k8s class name",
+			classK8sName:        "nothereclass",
+			planK8sName:         testPlanExternalID,
+			expectedErrorReason: "ReferencesNonexistentServiceClass",
+		},
+		{
+			name:                "non-existent k8s plan name",
+			classK8sName:        testClusterServiceClassGUID,
+			planK8sName:         "nothereplan",
+			expectedErrorReason: "ReferencesNonexistentServicePlan",
+		},
+		{
+			name:                "non-existent k8s class and plan name",
+			classK8sName:        "nothereclass",
+			planK8sName:         "nothereplan",
+			expectedErrorReason: "ReferencesNonexistentServiceClass",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ct := &controllerTest{
+				t:      t,
+				broker: getTestBroker(),
+				instance: func() *v1beta1.ServiceInstance {
+					i := getTestInstance()
+					i.Spec.PlanReference.ClusterServiceClassExternalName = tc.classExternalName
+					i.Spec.PlanReference.ClusterServicePlanExternalName = tc.planExternalName
+					i.Spec.PlanReference.ClusterServiceClassName = tc.classK8sName
+					i.Spec.PlanReference.ClusterServicePlanName = tc.planK8sName
+					return i
+				}(),
+				skipVerifyingInstanceSuccess: tc.expectedErrorReason != "",
+			}
+			ct.run(func(ct *controllerTest) {
+				status := v1beta1.ConditionTrue
+				if tc.expectedErrorReason != "" {
+					status = v1beta1.ConditionFalse
+				}
+				condition := v1beta1.ServiceInstanceCondition{
+					Type:   v1beta1.ServiceInstanceConditionReady,
+					Status: status,
+					Reason: tc.expectedErrorReason,
+				}
+				if err := util.WaitForInstanceCondition(ct.client, testNamespace, testInstanceName, condition); err != nil {
+					t.Fatalf("error waiting for instance condition: %v", err)
+				}
+			})
+		})
+	}
+}
+
+// TestCreateServiceInstanceNonExistsentClusterServiceBroker tests creating a
+// ServiceInstance whose broker does not exist.
+func TestCreateServiceInstanceNonExistentClusterServiceBroker(t *testing.T) {
+	ct := &controllerTest{
+		t:                            t,
+		instance:                     getTestInstance(),
+		skipVerifyingInstanceSuccess: true,
+		preCreateInstance: func(ct *controllerTest) {
+			serviceClass := &v1beta1.ClusterServiceClass{
+				ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceClassGUID},
+				Spec: v1beta1.ClusterServiceClassSpec{
+					ClusterServiceBrokerName: testClusterServiceBrokerName,
+					ExternalID:               testClusterServiceClassGUID,
+					ExternalName:             testClusterServiceClassName,
+					Description:              "a test service",
+					Bindable:                 true,
+				},
+			}
+			if _, err := ct.client.ClusterServiceClasses().Create(serviceClass); err != nil {
+				t.Fatalf("error creating ClusterServiceClass: %v", err)
+			}
+
+			if err := util.WaitForClusterServiceClassToExist(ct.client, testClusterServiceClassGUID); err != nil {
+				t.Fatalf("error waiting for ClusterServiceClass to exist: %v", err)
+			}
+
+			servicePlan := &v1beta1.ClusterServicePlan{
+				ObjectMeta: metav1.ObjectMeta{Name: testPlanExternalID},
+				Spec: v1beta1.ClusterServicePlanSpec{
+					ClusterServiceBrokerName: testClusterServiceBrokerName,
+					ExternalID:               testPlanExternalID,
+					ExternalName:             testClusterServicePlanName,
+					Description:              "a test plan",
+					ClusterServiceClassRef: v1beta1.ClusterObjectReference{
+						Name: testClusterServiceClassGUID,
+					},
+				},
+			}
+			if _, err := ct.client.ClusterServicePlans().Create(servicePlan); err != nil {
+				t.Fatalf("error creating ClusterServicePlan: %v", err)
+			}
+			if err := util.WaitForClusterServicePlanToExist(ct.client, testPlanExternalID); err != nil {
+				t.Fatalf("error waiting for ClusterServicePlan to exist: %v", err)
+			}
+		},
+	}
+	ct.run(func(ct *controllerTest) {
+		if err := util.WaitForInstanceCondition(ct.client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
+			Type:   v1beta1.ServiceInstanceConditionReady,
+			Status: v1beta1.ConditionFalse,
+			Reason: "ReferencesNonexistentBroker",
+		}); err != nil {
+			t.Fatalf("error waiting for instance reconciliation to fail: %v", err)
+		}
+	})
+}
+
+// TestCreateServiceInstanceWithAuthError tests creating a SerivceInstance when
+// the secret containing the broker authorization info cannot be found.
+func TestCreateServiceInstanceWithAuthError(t *testing.T) {
+	ct := &controllerTest{
+		t: t,
+		broker: func() *v1beta1.ClusterServiceBroker {
+			b := getTestBroker()
+			b.Spec.AuthInfo = &v1beta1.ServiceBrokerAuthInfo{
+				Basic: &v1beta1.BasicAuthConfig{
+					SecretRef: &v1beta1.ObjectReference{
+						Namespace: testNamespace,
+						Name:      "secret-name",
+					},
+				},
+			}
+			return b
+		}(),
+		instance:                     getTestInstance(),
+		skipVerifyingInstanceSuccess: true,
+		preCreateBroker: func(ct *controllerTest) {
+			prependGetSecretReaction(ct.kubeClient, "secret-name", map[string][]byte{
+				"username": []byte("user"),
+				"password": []byte("pass"),
+			})
+		},
+		preCreateInstance: func(ct *controllerTest) {
+			prependGetSecretNotFoundReaction(ct.kubeClient)
+		},
+	}
+	ct.run(func(ct *controllerTest) {
+		if err := util.WaitForInstanceCondition(ct.client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
+			Type:   v1beta1.ServiceInstanceConditionReady,
+			Status: v1beta1.ConditionFalse,
+			Reason: "ErrorGettingAuthCredentials",
+		}); err != nil {
+			t.Fatalf("error waiting for instance reconciliation to fail: %v", err)
+		}
+	})
+}
+
+// TestCreateServiceInstanceWithParameters tests creating a ServiceInstance
+// with parameters.
+func TestCreateServiceInstanceWithParameters(t *testing.T) {
+	type secretDef struct {
+		name string
+		data map[string][]byte
+	}
+	cases := []struct {
+		name           string
+		params         map[string]interface{}
+		paramsFrom     []v1beta1.ParametersFromSource
+		secrets        []secretDef
+		expectedParams map[string]interface{}
+		expectedError  bool
+	}{
+		{
+			name:           "no params",
+			expectedParams: nil,
+		},
+		{
+			name: "plain params",
+			params: map[string]interface{}{
+				"Name": "test-param",
+				"Args": map[string]interface{}{
+					"first":  "first-arg",
+					"second": "second-arg",
+				},
+			},
+			expectedParams: map[string]interface{}{
+				"Name": "test-param",
+				"Args": map[string]interface{}{
+					"first":  "first-arg",
+					"second": "second-arg",
+				},
+			},
+		},
+		{
+			name: "secret params",
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			secrets: []secretDef{
+				{
+					name: "secret-name",
+					data: map[string][]byte{
+						"secret-key": []byte(`{"A":"B","C":{"D":"E","F":"G"}}`),
+					},
+				},
+			},
+			expectedParams: map[string]interface{}{
+				"A": "B",
+				"C": map[string]interface{}{
+					"D": "E",
+					"F": "G",
+				},
+			},
+		},
+		{
+			name: "plain and secret params",
+			params: map[string]interface{}{
+				"Name": "test-param",
+				"Args": map[string]interface{}{
+					"first":  "first-arg",
+					"second": "second-arg",
+				},
+			},
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			secrets: []secretDef{
+				{
+					name: "secret-name",
+					data: map[string][]byte{
+						"secret-key": []byte(`{"A":"B","C":{"D":"E","F":"G"}}`),
+					},
+				},
+			},
+			expectedParams: map[string]interface{}{
+				"Name": "test-param",
+				"Args": map[string]interface{}{
+					"first":  "first-arg",
+					"second": "second-arg",
+				},
+				"A": "B",
+				"C": map[string]interface{}{
+					"D": "E",
+					"F": "G",
+				},
+			},
+		},
+		{
+			name: "missing secret",
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "missing secret key",
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "other-secret-key",
+					},
+				},
+			},
+			secrets: []secretDef{
+				{
+					name: "secret-name",
+					data: map[string][]byte{
+						"secret-key": []byte(`bad`),
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "empty secret data",
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			secrets: []secretDef{
+				{
+					name: "secret-name",
+					data: map[string][]byte{},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "bad secret data",
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			secrets: []secretDef{
+				{
+					name: "secret-name",
+					data: map[string][]byte{
+						"secret-key": []byte(`bad`),
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "no params in secret data",
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			secrets: []secretDef{
+				{
+					name: "secret-name",
+					data: map[string][]byte{
+						"secret-key": []byte(`{}`),
+					},
+				},
+			},
+			expectedParams: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ct := &controllerTest{
+				t:      t,
+				broker: getTestBroker(),
+				instance: func() *v1beta1.ServiceInstance {
+					i := getTestInstance()
+					if tc.params != nil {
+						i.Spec.Parameters = convertParametersIntoRawExtension(t, tc.params)
+					}
+					i.Spec.ParametersFrom = tc.paramsFrom
+					return i
+				}(),
+				skipVerifyingInstanceSuccess: tc.expectedError,
+				setup: func(ct *controllerTest) {
+					for _, secret := range tc.secrets {
+						prependGetSecretReaction(ct.kubeClient, secret.name, secret.data)
+					}
+				},
+			}
+			ct.run(func(ct *controllerTest) {
+				if tc.expectedError {
+					if err := util.WaitForInstanceCondition(ct.client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
+						Type:   v1beta1.ServiceInstanceConditionReady,
+						Status: v1beta1.ConditionFalse,
+						Reason: "ErrorWithParameters",
+					}); err != nil {
+						t.Fatalf("error waiting for instance reconciliation to fail: %v", err)
+					}
+				} else {
+					brokerAction := getLastBrokerAction(t, ct.osbClient, fakeosb.ProvisionInstance)
+					if e, a := tc.expectedParams, brokerAction.Request.(*osb.ProvisionRequest).Parameters; !reflect.DeepEqual(e, a) {
+						t.Fatalf("unexpected diff in provision parameters: expected %v, got %v", e, a)
+					}
+				}
+			})
+		})
+	}
+}
+
+// TestUpdateServiceInstanceChangePlans tests changing plans for an existing
+// ServiceInstance.
+func TestUpdateServiceInstanceChangePlans(t *testing.T) {
+	otherPlanName := "otherplanname"
+	otherPlanID := "other-plan-id"
+	cases := []struct {
+		name             string
+		useExternalNames bool
+	}{
+		{
+			name:             "external",
+			useExternalNames: true,
+		},
+		{
+			name:             "k8s",
+			useExternalNames: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ct := &controllerTest{
+				t:      t,
+				broker: getTestBroker(),
+				instance: func() *v1beta1.ServiceInstance {
+					i := getTestInstance()
+					if !tc.useExternalNames {
+						i.Spec.ClusterServiceClassExternalName = ""
+						i.Spec.ClusterServicePlanExternalName = ""
+						i.Spec.ClusterServiceClassName = testClusterServiceClassGUID
+						i.Spec.ClusterServicePlanName = testPlanExternalID
+					}
+					return i
+				}(),
+				setup: func(ct *controllerTest) {
+					catalogResponse := ct.osbClient.CatalogReaction.(*fakeosb.CatalogReaction).Response
+					catalogResponse.Services[0].PlanUpdatable = truePtr()
+					catalogResponse.Services[0].Plans = append(catalogResponse.Services[0].Plans, osb.Plan{
+						Name:        otherPlanName,
+						Free:        truePtr(),
+						ID:          otherPlanID,
+						Description: "another test plan",
+					})
+				},
+			}
+			ct.run(func(ct *controllerTest) {
+				if tc.useExternalNames {
+					ct.instance.Spec.ClusterServicePlanExternalName = otherPlanName
+				} else {
+					ct.instance.Spec.ClusterServicePlanName = otherPlanID
+				}
+
+				if _, err := ct.client.ServiceInstances(testNamespace).Update(ct.instance); err != nil {
+					t.Fatalf("error updating Instance: %v", err)
+				}
+
+				if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Status.ReconciledGeneration+1); err != nil {
+					t.Fatalf("error waiting for instance to reconcile: %v", err)
+				}
+
+				brokerAction := getLastBrokerAction(t, ct.osbClient, fakeosb.UpdateInstance)
+				request := brokerAction.Request.(*osb.UpdateInstanceRequest)
+				if request.PlanID == nil {
+					t.Fatalf("plan ID not sent in update instance request: request = %+v", request)
+				}
+				if e, a := otherPlanID, *request.PlanID; e != a {
+					t.Fatalf("unexpected plan ID: expected %s, got %s", e, a)
+				}
+			})
+		})
+	}
+}
+
+// TestUpdateServiceInstanceChangePlansToNonexistentPlan tests changing plans
+// to a non-existent plan.
+func TestUpdateServiceInstanceChangePlansToNonexistentPlan(t *testing.T) {
+	cases := []struct {
+		name             string
+		useExternalNames bool
+	}{
+		{
+			name:             "external",
+			useExternalNames: true,
+		},
+		{
+			name:             "k8s",
+			useExternalNames: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ct := &controllerTest{
+				t:      t,
+				broker: getTestBroker(),
+				instance: func() *v1beta1.ServiceInstance {
+					i := getTestInstance()
+					if !tc.useExternalNames {
+						i.Spec.ClusterServiceClassExternalName = ""
+						i.Spec.ClusterServicePlanExternalName = ""
+						i.Spec.ClusterServiceClassName = testClusterServiceClassGUID
+						i.Spec.ClusterServicePlanName = testPlanExternalID
+					}
+					return i
+				}(),
+				setup: func(ct *controllerTest) {
+					ct.osbClient.CatalogReaction.(*fakeosb.CatalogReaction).Response.Services[0].PlanUpdatable = truePtr()
+				},
+			}
+			ct.run(func(ct *controllerTest) {
+				if tc.useExternalNames {
+					ct.instance.Spec.ClusterServicePlanExternalName = "other-plan-name"
+				} else {
+					ct.instance.Spec.ClusterServicePlanName = "other-plan-id"
+				}
+
+				if _, err := ct.client.ServiceInstances(testNamespace).Update(ct.instance); err != nil {
+					t.Fatalf("error updating Instance: %v", err)
+				}
+
+				if err := util.WaitForInstanceCondition(ct.client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
+					Type:   v1beta1.ServiceInstanceConditionReady,
+					Status: v1beta1.ConditionFalse,
+					Reason: "ReferencesNonexistentServicePlan",
+				}); err != nil {
+					t.Fatalf("error waiting for instance reconciliation to fail: %v", err)
+				}
+
+			})
+		})
+	}
+}
+
+// TestUpdateServiceInstanceUpdateParameters tests updating the parameters
+// of an existing ServiceInstance.
+func TestUpdateServiceInstanceUpdateParameters(t *testing.T) {
+	cases := []struct {
+		name                        string
+		createdWithParams           bool
+		createdWithParamsFromSecret bool
+		updateParams                bool
+		updateParamsFromSecret      bool
+		updateSecret                bool
+		deleteParams                bool
+		deleteParamsFromSecret      bool
+	}{
+		{
+			name:              "add param",
+			createdWithParams: false,
+			updateParams:      true,
+		},
+		{
+			name:              "update param",
+			createdWithParams: true,
+			updateParams:      true,
+		},
+		{
+			name:              "delete param",
+			createdWithParams: true,
+			deleteParams:      true,
+		},
+		{
+			name:                        "add param with secret",
+			createdWithParams:           false,
+			createdWithParamsFromSecret: true,
+			updateParams:                true,
+		},
+		{
+			name:                        "update param with secret",
+			createdWithParams:           true,
+			createdWithParamsFromSecret: true,
+			updateParams:                true,
+		},
+		{
+			name:                        "delete param with secret",
+			createdWithParams:           true,
+			createdWithParamsFromSecret: true,
+			deleteParams:                true,
+		},
+		{
+			name: "add secret param",
+			createdWithParamsFromSecret: false,
+			updateParamsFromSecret:      true,
+		},
+		{
+			name: "update secret param",
+			createdWithParamsFromSecret: true,
+			updateParamsFromSecret:      true,
+		},
+		{
+			name: "delete secret param",
+			createdWithParamsFromSecret: true,
+			deleteParamsFromSecret:      true,
+		},
+		{
+			name:                        "add secret param with plain param",
+			createdWithParams:           true,
+			createdWithParamsFromSecret: false,
+			updateParamsFromSecret:      true,
+		},
+		{
+			name:                        "update secret param with plain param",
+			createdWithParams:           true,
+			createdWithParamsFromSecret: true,
+			updateParamsFromSecret:      true,
+		},
+		{
+			name:                        "delete secret param with plain param",
+			createdWithParams:           true,
+			createdWithParamsFromSecret: true,
+			deleteParamsFromSecret:      true,
+		},
+		{
+			name: "update secret",
+			createdWithParamsFromSecret: true,
+			updateSecret:                true,
+		},
+		{
+			name:                        "update secret with plain param",
+			createdWithParams:           true,
+			createdWithParamsFromSecret: true,
+			updateSecret:                true,
+		},
+		{
+			name:                        "add plain and secret param",
+			createdWithParams:           false,
+			createdWithParamsFromSecret: false,
+			updateParams:                true,
+			updateParamsFromSecret:      true,
+		},
+		{
+			name:                        "update plain and secret param",
+			createdWithParams:           true,
+			createdWithParamsFromSecret: true,
+			updateParams:                true,
+			updateParamsFromSecret:      true,
+		},
+		{
+			name:                        "delete plain and secret param",
+			createdWithParams:           true,
+			createdWithParamsFromSecret: true,
+			deleteParams:                true,
+			deleteParamsFromSecret:      true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ct := &controllerTest{
+				t:      t,
+				broker: getTestBroker(),
+				instance: func() *v1beta1.ServiceInstance {
+					i := getTestInstance()
+					if tc.createdWithParams {
+						i.Spec.Parameters = convertParametersIntoRawExtension(t,
+							map[string]interface{}{
+								"param-key": "param-value",
+							})
+					}
+					if tc.createdWithParamsFromSecret {
+						i.Spec.ParametersFrom = []v1beta1.ParametersFromSource{
+							{
+								SecretKeyRef: &v1beta1.SecretKeyReference{
+									Name: "secret-name",
+									Key:  "secret-key",
+								},
+							},
+						}
+					}
+					return i
+				}(),
+				setup: func(ct *controllerTest) {
+					prependGetSecretReaction(ct.kubeClient, "secret-name", map[string][]byte{
+						"secret-key": []byte(`{"secret-param-key":"secret-param-value"}`),
+					})
+					prependGetSecretReaction(ct.kubeClient, "other-secret-name", map[string][]byte{
+						"other-secret-key": []byte(`{"other-secret-param-key":"other-secret-param-value"}`),
+					})
+				},
+			}
+			ct.run(func(ct *controllerTest) {
+				if tc.updateParams {
+					ct.instance.Spec.Parameters = convertParametersIntoRawExtension(t,
+						map[string]interface{}{
+							"param-key": "new-param-value",
+						})
+				} else if tc.deleteParams {
+					ct.instance.Spec.Parameters = nil
+				}
+
+				if tc.updateParamsFromSecret {
+					ct.instance.Spec.ParametersFrom = []v1beta1.ParametersFromSource{
+						{
+							SecretKeyRef: &v1beta1.SecretKeyReference{
+								Name: "other-secret-name",
+								Key:  "other-secret-key",
+							},
+						},
+					}
+				} else if tc.deleteParamsFromSecret {
+					ct.instance.Spec.ParametersFrom = nil
+				}
+
+				if tc.updateSecret {
+					prependGetSecretReaction(ct.kubeClient, "secret-name", map[string][]byte{
+						"secret-key": []byte(`{"new-secret-param-key":"new-secret-param-value"}`),
+					})
+					ct.instance.Spec.UpdateRequests++
+				}
+
+				if _, err := ct.client.ServiceInstances(testNamespace).Update(ct.instance); err != nil {
+					t.Fatalf("error updating Instance: %v", err)
+				}
+
+				if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Status.ReconciledGeneration+1); err != nil {
+					t.Fatalf("error waiting for instance to reconcile: %v", err)
+				}
+
+				expectedParameters := make(map[string]interface{})
+
+				if tc.updateParams {
+					expectedParameters["param-key"] = "new-param-value"
+				} else if tc.createdWithParams && !tc.deleteParams {
+					expectedParameters["param-key"] = "param-value"
+				}
+
+				if tc.updateParamsFromSecret {
+					expectedParameters["other-secret-param-key"] = "other-secret-param-value"
+				} else if tc.updateSecret {
+					expectedParameters["new-secret-param-key"] = "new-secret-param-value"
+				} else if tc.createdWithParamsFromSecret && !tc.deleteParamsFromSecret {
+					expectedParameters["secret-param-key"] = "secret-param-value"
+				}
+
+				brokerAction := getLastBrokerAction(t, ct.osbClient, fakeosb.UpdateInstance)
+				request := brokerAction.Request.(*osb.UpdateInstanceRequest)
+				if e, a := expectedParameters, request.Parameters; !reflect.DeepEqual(e, a) {
+					t.Fatalf("unexpected parameters: expected %v, got %v", e, a)
+				}
+			})
+		})
+	}
+}
+
+// TestCreateServiceInstanceWithInvalidParameters tests creating a ServiceInstance
+// with invalid parameters.
+func TestCreateServiceInstanceWithInvalidParameters(t *testing.T) {
+	ct := &controllerTest{
+		t:      t,
+		broker: getTestBroker(),
+	}
+	ct.run(func(ct *controllerTest) {
+		instance := getTestInstance()
+		instance.Spec.Parameters = convertParametersIntoRawExtension(t,
+			map[string]interface{}{
+				"Name": "test-param",
+				"Args": map[string]interface{}{
+					"first":  "first-arg",
+					"second": "second-arg",
+				},
+			})
+		instance.Spec.Parameters.Raw[0] = 0x21
+		if _, err := ct.client.ServiceInstances(instance.Namespace).Create(instance); err == nil {
+			t.Fatalf("expected instance to fail to be created due to invalid parameters")
+		}
+	})
+}
+
+// TimeoutError is an error sent back in a url.Error from the broker when
+// the request has timed out at the network layer.
+type TimeoutError string
+
+// Timeout returns true since TimeoutError indicates that there was a timeout.
+// This method is so that TimeoutError implements the url.timeout interface.
+func (e TimeoutError) Timeout() bool {
+	return true
+}
+
+// Error returns the TimeoutError as a string
+func (e TimeoutError) Error() string {
+	return string(e)
+}
+
+// TestCreateServiceInstanceWithProvisionFailure tests creating a ServiceInstance
+// with various failure results in response to the provision request.
+func TestCreateServiceInstanceWithProvisionFailure(t *testing.T) {
+	cases := []struct {
+		name                     string
+		statusCode               int
+		nonHttpResponseError     error
+		conditionReason          string
+		expectFailCondition      bool
+		triggersOrphanMitigation bool
+	}{
+		{
+			name:                "Status OK",
+			statusCode:          http.StatusOK,
+			conditionReason:     "ClusterServiceBrokerReturnedFailure",
+			expectFailCondition: true,
+		},
+		{
+			name:                     "Status Created",
+			statusCode:               http.StatusCreated,
+			conditionReason:          "ClusterServiceBrokerReturnedFailure",
+			expectFailCondition:      true,
+			triggersOrphanMitigation: true,
+		},
+		{
+			name:                     "other 2xx",
+			statusCode:               http.StatusNoContent,
+			conditionReason:          "ClusterServiceBrokerReturnedFailure",
+			expectFailCondition:      true,
+			triggersOrphanMitigation: true,
+		},
+		{
+			name:                "3XX",
+			statusCode:          300,
+			conditionReason:     "ClusterServiceBrokerReturnedFailure",
+			expectFailCondition: true,
+		},
+		{
+			name:                     "Status Request Timeout",
+			statusCode:               http.StatusRequestTimeout,
+			conditionReason:          "ClusterServiceBrokerReturnedFailure",
+			expectFailCondition:      true,
+			triggersOrphanMitigation: true,
+		},
+		{
+			name:                "other 4XX",
+			statusCode:          400,
+			conditionReason:     "ClusterServiceBrokerReturnedFailure",
+			expectFailCondition: true,
+		},
+		{
+			name:                     "5XX",
+			statusCode:               500,
+			conditionReason:          "ClusterServiceBrokerReturnedFailure",
+			expectFailCondition:      true,
+			triggersOrphanMitigation: true,
+		},
+		{
+			name:                 "non-url transport error",
+			nonHttpResponseError: fmt.Errorf("non-url error"),
+			conditionReason:      "ErrorCallingProvision",
+		},
+		{
+			name: "non-timeout url error",
+			nonHttpResponseError: &url.Error{
+				Op:  "Put",
+				URL: "https://fakebroker.com/v2/service_instances/instance_id",
+				Err: fmt.Errorf("non-timeout error"),
+			},
+			conditionReason: "ErrorCallingProvision",
+		},
+		{
+			name: "network timeout",
+			nonHttpResponseError: &url.Error{
+				Op:  "Put",
+				URL: "https://fakebroker.com/v2/service_instances/instance_id",
+				Err: TimeoutError("timeout error"),
+			},
+			conditionReason:          "ErrorCallingProvision",
+			expectFailCondition:      true,
+			triggersOrphanMitigation: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ct := &controllerTest{
+				t:                            t,
+				broker:                       getTestBroker(),
+				instance:                     getTestInstance(),
+				skipVerifyingInstanceSuccess: true,
+				setup: func(ct *controllerTest) {
+					reactionError := tc.nonHttpResponseError
+					if reactionError == nil {
+						reactionError = osb.HTTPStatusCodeError{
+							StatusCode:   tc.statusCode,
+							ErrorMessage: strPtr("error message"),
+							Description:  strPtr("response description"),
+						}
+					}
+					ct.osbClient.ProvisionReaction = &fakeosb.ProvisionReaction{
+						Error: reactionError,
+					}
+				},
+			}
+			ct.run(func(ct *controllerTest) {
+				var condition v1beta1.ServiceInstanceCondition
+				if tc.expectFailCondition {
+					condition = v1beta1.ServiceInstanceCondition{
+						Type:   v1beta1.ServiceInstanceConditionFailed,
+						Status: v1beta1.ConditionTrue,
+						Reason: tc.conditionReason,
+					}
+				} else {
+					condition = v1beta1.ServiceInstanceCondition{
+						Type:   v1beta1.ServiceInstanceConditionReady,
+						Status: v1beta1.ConditionFalse,
+						Reason: tc.conditionReason,
+					}
+				}
+				if err := util.WaitForInstanceCondition(ct.client, testNamespace, testInstanceName, condition); err != nil {
+					t.Fatalf("error waiting for instance condition: %v", err)
+				}
+
+				if tc.expectFailCondition {
+					if err := util.WaitForInstanceReconciledGeneration(ct.client, ct.instance.Namespace, ct.instance.Name, 1); err != nil {
+						t.Fatalf("error waiting for instance reconciliation to complete: %v", err)
+					}
+				}
+
+				expectedLastActionType := fakeosb.ProvisionInstance
+				if tc.triggersOrphanMitigation {
+					expectedLastActionType = fakeosb.DeprovisionInstance
+				}
+				// Ensure that the last request made to the broker was of the expected type
+				getLastBrokerAction(t, ct.osbClient, expectedLastActionType)
+
+				if tc.triggersOrphanMitigation {
+					instance, err := ct.client.ServiceInstances(ct.instance.Namespace).Get(ct.instance.Name, metav1.GetOptions{})
+					if err != nil {
+						t.Fatalf("error getting instance %s/%s back", ct.instance.Namespace, ct.instance.Name)
+					}
+					util.AssertServiceInstanceCondition(
+						t,
+						instance,
+						v1beta1.ServiceInstanceConditionReady,
+						v1beta1.ConditionFalse,
+						"OrphanMitigationSuccessful",
+					)
+					if e, a := v1beta1.ServiceInstanceDeprovisionStatusSucceeded, instance.Status.DeprovisionStatus; e != a {
+						t.Fatalf("unexpected deprovision status: expected %v, got %v", e, a)
+					}
+				}
+			})
+		})
+	}
+}

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package integration
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,6 +42,7 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
+	clientsetsc "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1beta1"
 	scinformers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/externalversions"
 	informers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/externalversions/servicecatalog/v1beta1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/controller"
@@ -61,9 +64,6 @@ const (
 	testBrokerURL                = "https://example.com"
 	testExternalID               = "9737b6ed-ca95-4439-8219-c53fcad118ab"
 	testDashboardURL             = "http://test-dashboard.example.com"
-	testCreatorUsername          = "create-username"
-	testUpdaterUsername          = "update-username"
-	testDeleterUsername          = "delete-username"
 )
 
 // TestBasicFlows tests:
@@ -108,1052 +108,243 @@ func TestBasicFlows(t *testing.T) {
 				defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.AsyncBindingOperations))
 			}
 
-			_, catalogClient, _, osbClient, _, _, shutdownServer, shutdownController := newTestController(t)
-			defer shutdownController()
-			defer shutdownServer()
+			ct := &controllerTest{
+				t:        t,
+				broker:   getTestBroker(),
+				instance: getTestInstance(),
+				binding:  getTestBinding(),
+				setup: func(ct *controllerTest) {
+					if tc.asyncForInstances {
+						ct.osbClient.ProvisionReaction.(*fakeosb.ProvisionReaction).Response.Async = true
+						ct.osbClient.UpdateInstanceReaction.(*fakeosb.UpdateInstanceReaction).Response.Async = true
+						ct.osbClient.DeprovisionReaction.(*fakeosb.DeprovisionReaction).Response.Async = true
+					}
 
-			if tc.asyncForInstances {
-				osbClient.ProvisionReaction.(*fakeosb.ProvisionReaction).Response.Async = true
-				osbClient.UpdateInstanceReaction.(*fakeosb.UpdateInstanceReaction).Response.Async = true
-				osbClient.DeprovisionReaction.(*fakeosb.DeprovisionReaction).Response.Async = true
-			}
-
-			if tc.asyncForBindings {
-				osbClient.BindReaction.(*fakeosb.BindReaction).Response.Async = true
-				osbClient.UnbindReaction.(*fakeosb.UnbindReaction).Response.Async = true
-			}
-
-			client := catalogClient.ServicecatalogV1beta1()
-
-			broker := &v1beta1.ClusterServiceBroker{
-				ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
-				Spec: v1beta1.ClusterServiceBrokerSpec{
-					URL: testBrokerURL,
+					if tc.asyncForBindings {
+						ct.osbClient.BindReaction.(*fakeosb.BindReaction).Response.Async = true
+						ct.osbClient.UnbindReaction.(*fakeosb.UnbindReaction).Response.Async = true
+					}
 				},
 			}
+			ct.run(func(ct *controllerTest) {
+				// Update instance
+				updateRequests := ct.instance.Spec.UpdateRequests + 1
+				ct.instance.Spec.UpdateRequests = updateRequests
+				if _, err := ct.client.ServiceInstances(testNamespace).Update(ct.instance); err != nil {
+					t.Fatalf("error updating Instance: %v", err)
+				}
 
-			_, err := client.ClusterServiceBrokers().Create(broker)
-			if nil != err {
-				t.Fatalf("error creating the broker %q (%q)", broker.Name, err)
-			}
+				if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Status.ReconciledGeneration+1); err != nil {
+					t.Fatalf("error waiting for instance to reconcile: %v", err)
+				}
 
-			err = util.WaitForBrokerCondition(client,
-				testClusterServiceBrokerName,
-				v1beta1.ServiceBrokerCondition{
-					Type:   v1beta1.ServiceBrokerConditionReady,
-					Status: v1beta1.ConditionTrue,
-				})
-			if err != nil {
-				t.Fatalf("error waiting for broker to become ready: %v", err)
-			}
-
-			err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
-			if nil != err {
-				t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
-			}
-
-			// TODO: find some way to compose scenarios; extract method here for real
-			// logic for this test.
-
-			//-----------------
-
-			instance := &v1beta1.ServiceInstance{
-				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
-				Spec: v1beta1.ServiceInstanceSpec{
-					PlanReference: v1beta1.PlanReference{
-						ClusterServiceClassExternalName: testClusterServiceClassName,
-						ClusterServicePlanExternalName:  testClusterServicePlanName,
-					},
-					ExternalID: testExternalID,
-				},
-			}
-
-			if _, err := client.ServiceInstances(testNamespace).Create(instance); err != nil {
-				t.Fatalf("error creating Instance: %v", err)
-			}
-
-			if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
-				Type:   v1beta1.ServiceInstanceConditionReady,
-				Status: v1beta1.ConditionTrue,
-			}); err != nil {
-				t.Fatalf("error waiting for instance to become ready: %v", err)
-			}
-
-			retInst, err := client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-			if err != nil {
-				t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-			}
-			if retInst.Spec.ExternalID != instance.Spec.ExternalID {
-				t.Fatalf(
-					"returned OSB GUID '%s' doesn't match original '%s'",
-					retInst.Spec.ExternalID,
-					instance.Spec.ExternalID,
-				)
-			}
-
-			// Update Instance
-			updateRequests := retInst.Spec.UpdateRequests + 1
-			retInst.Spec.UpdateRequests = updateRequests
-			if _, err := client.ServiceInstances(testNamespace).Update(retInst); err != nil {
-				t.Fatalf("error updating Instance: %v", err)
-			}
-
-			if err := util.WaitForInstanceReconciledGeneration(client, testNamespace, testInstanceName, retInst.Status.ReconciledGeneration+1); err != nil {
-				t.Fatalf("error waiting for instance to reconcile: %v", err)
-			}
-
-			retInst, err = client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-			if err != nil {
-				t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-			}
-			if e, a := updateRequests, retInst.Spec.UpdateRequests; e != a {
-				t.Fatalf("unexpected updateRequets in instance spec: expected %v, got %v", e, a)
-			}
-
-			// Binding test begins here
-			//-----------------
-
-			binding := &v1beta1.ServiceBinding{
-				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testBindingName},
-				Spec: v1beta1.ServiceBindingSpec{
-					ServiceInstanceRef: v1beta1.LocalObjectReference{
-						Name: testInstanceName,
-					},
-				},
-			}
-
-			_, err = client.ServiceBindings(testNamespace).Create(binding)
-			if err != nil {
-				t.Fatalf("error creating Binding: %v", binding)
-			}
-
-			err = util.WaitForBindingCondition(client, testNamespace, testBindingName, v1beta1.ServiceBindingCondition{
-				Type:   v1beta1.ServiceBindingConditionReady,
-				Status: v1beta1.ConditionTrue,
+				retInst, err := ct.client.ServiceInstances(ct.instance.Namespace).Get(ct.instance.Name, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("error getting instance %s/%s back", ct.instance.Namespace, ct.instance.Name)
+				}
+				if e, a := updateRequests, retInst.Spec.UpdateRequests; e != a {
+					t.Fatalf("unexpected updateRequets in instance spec: expected %v, got %v", e, a)
+				}
 			})
-			if err != nil {
-				t.Fatalf("error waiting for binding to become ready: %v", err)
-			}
-
-			err = client.ServiceBindings(testNamespace).Delete(testBindingName, &metav1.DeleteOptions{})
-			if err != nil {
-				t.Fatalf("binding delete should have been accepted: %v", err)
-			}
-
-			err = util.WaitForBindingToNotExist(client, testNamespace, testBindingName)
-			if err != nil {
-				t.Fatalf("error waiting for binding to not exist: %v", err)
-			}
-
-			//-----------------
-			// End binding test
-
-			err = client.ServiceInstances(testNamespace).Delete(testInstanceName, &metav1.DeleteOptions{})
-			if nil != err {
-				t.Fatalf("instance delete should have been accepted: %v", err)
-			}
-
-			err = util.WaitForInstanceToNotExist(client, testNamespace, testInstanceName)
-			if err != nil {
-				t.Fatalf("error waiting for instance to be deleted: %v", err)
-			}
-
-			//-----------------
-			// End provision test
-
-			// Delete the broker
-			err = client.ClusterServiceBrokers().Delete(testClusterServiceBrokerName, &metav1.DeleteOptions{})
-			if nil != err {
-				t.Fatalf("broker should be deleted (%s)", err)
-			}
-
-			err = util.WaitForClusterServiceClassToNotExist(client, testClusterServiceClassName)
-			if err != nil {
-				t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
-			}
-
-			err = util.WaitForBrokerToNotExist(client, testClusterServiceBrokerName)
-			if err != nil {
-				t.Fatalf("error waiting for Broker to not exist: %v", err)
-			}
 		})
-	}
-}
-
-// TestProvisionFailure tests that the controller correctly handles errors
-// from the broker that indicate the a provision operation failed.
-//
-// TODO: additional tests for scenarios like this will be needed once we
-// implement orphan mitigation.
-func TestProvisionFailure(t *testing.T) {
-	_, catalogClient, _, osbClient, _, _, shutdownServer, shutdownController := newTestController(t)
-	defer shutdownController()
-	defer shutdownServer()
-
-	osbClient.ProvisionReaction = &fakeosb.ProvisionReaction{
-		Error: osb.HTTPStatusCodeError{
-			StatusCode:   http.StatusConflict,
-			ErrorMessage: strPtr("OutOfQuota"),
-			Description:  strPtr("You're out of quota!"),
-		},
-	}
-
-	client := catalogClient.ServicecatalogV1beta1()
-
-	broker := &v1beta1.ClusterServiceBroker{
-		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
-		Spec: v1beta1.ClusterServiceBrokerSpec{
-			URL: testBrokerURL,
-		},
-	}
-
-	_, err := client.ClusterServiceBrokers().Create(broker)
-	if nil != err {
-		t.Fatalf("error creating the broker %q (%q)", broker.Name, err)
-	}
-
-	err = util.WaitForBrokerCondition(client,
-		testClusterServiceBrokerName,
-		v1beta1.ServiceBrokerCondition{
-			Type:   v1beta1.ServiceBrokerConditionReady,
-			Status: v1beta1.ConditionTrue,
-		})
-	if err != nil {
-		t.Fatalf("error waiting for broker to become ready: %v", err)
-	}
-
-	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
-	if nil != err {
-		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
-	}
-
-	// TODO: find some way to compose scenarios; extract method here for real
-	// logic for this test.
-
-	//-----------------
-
-	instance := &v1beta1.ServiceInstance{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
-		Spec: v1beta1.ServiceInstanceSpec{
-			PlanReference: v1beta1.PlanReference{
-				ClusterServiceClassExternalName: testClusterServiceClassName,
-				ClusterServicePlanExternalName:  testClusterServicePlanName,
-			},
-			ExternalID: testExternalID,
-		},
-	}
-
-	if _, err := client.ServiceInstances(testNamespace).Create(instance); err != nil {
-		t.Fatalf("error creating Instance: %v", err)
-	}
-
-	if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
-		Type:   v1beta1.ServiceInstanceConditionFailed,
-		Status: v1beta1.ConditionTrue,
-	}); err != nil {
-		t.Fatalf("error waiting for instance to become failed: %v", err)
-	}
-
-	retInst, err := client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-	}
-	if retInst.Spec.ExternalID != instance.Spec.ExternalID {
-		t.Fatalf(
-			"returned OSB GUID '%s' doesn't match original '%s'",
-			retInst.Spec.ExternalID,
-			instance.Spec.ExternalID,
-		)
-	}
-
-	err = client.ServiceInstances(testNamespace).Delete(testInstanceName, &metav1.DeleteOptions{})
-	if nil != err {
-		t.Fatalf("instance delete should have been accepted: %v", err)
-	}
-
-	err = util.WaitForInstanceToNotExist(client, testNamespace, testInstanceName)
-	if err != nil {
-		t.Fatalf("error waiting for instance to be deleted: %v", err)
-	}
-
-	//-----------------
-	// End provision test
-
-	// Delete the broker
-	err = client.ClusterServiceBrokers().Delete(testClusterServiceBrokerName, &metav1.DeleteOptions{})
-	if nil != err {
-		t.Fatalf("broker should be deleted (%s)", err)
-	}
-
-	err = util.WaitForClusterServiceClassToNotExist(client, testClusterServiceClassName)
-	if err != nil {
-		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
-	}
-
-	err = util.WaitForBrokerToNotExist(client, testClusterServiceBrokerName)
-	if err != nil {
-		t.Fatalf("error waiting for Broker to not exist: %v", err)
 	}
 }
 
 // TestBindingFailure tests that a binding gets a failure condition when the
 // broker returns a failure response for a bind operation.
 func TestBindingFailure(t *testing.T) {
-	_, fakeCatalogClient, _, osbClient, _, _, shutdownServer, shutdownController := newTestController(t)
-	defer shutdownController()
-	defer shutdownServer()
-
-	osbClient.BindReaction = &fakeosb.BindReaction{
-		Error: osb.HTTPStatusCodeError{
-			StatusCode:   http.StatusConflict,
-			ErrorMessage: strPtr("ServiceBindingExists"),
-			Description:  strPtr("Service binding with the same id, for the same service instance already exists."),
+	ct := &controllerTest{
+		t:                           t,
+		broker:                      getTestBroker(),
+		instance:                    getTestInstance(),
+		binding:                     getTestBinding(),
+		skipVerifyingBindingSuccess: true,
+		setup: func(ct *controllerTest) {
+			ct.osbClient.BindReaction = &fakeosb.BindReaction{
+				Error: osb.HTTPStatusCodeError{
+					StatusCode:   http.StatusConflict,
+					ErrorMessage: strPtr("ServiceBindingExists"),
+					Description:  strPtr("Service binding with the same id, for the same service instance already exists."),
+				},
+			}
 		},
 	}
-
-	client := fakeCatalogClient.ServicecatalogV1beta1()
-
-	broker := &v1beta1.ClusterServiceBroker{
-		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
-		Spec: v1beta1.ClusterServiceBrokerSpec{
-			URL: testBrokerURL,
-		},
-	}
-
-	_, err := client.ClusterServiceBrokers().Create(broker)
-	if nil != err {
-		t.Fatalf("error creating the broker %q (%q)", broker.Name, err)
-	}
-
-	err = util.WaitForBrokerCondition(client,
-		testClusterServiceBrokerName,
-		v1beta1.ServiceBrokerCondition{
-			Type:   v1beta1.ServiceBrokerConditionReady,
+	ct.run(func(ct *controllerTest) {
+		if err := util.WaitForBindingCondition(ct.client, testNamespace, testBindingName, v1beta1.ServiceBindingCondition{
+			Type:   v1beta1.ServiceBindingConditionFailed,
 			Status: v1beta1.ConditionTrue,
-		})
-	if err != nil {
-		t.Fatalf("error waiting for broker to become ready: %v", err)
-	}
-
-	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
-	if nil != err {
-		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
-	}
-
-	// TODO: find some way to compose scenarios; extract method here for real
-	// logic for this test.
-
-	//-----------------
-
-	instance := &v1beta1.ServiceInstance{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
-		Spec: v1beta1.ServiceInstanceSpec{
-			PlanReference: v1beta1.PlanReference{
-				ClusterServiceClassExternalName: testClusterServiceClassName,
-				ClusterServicePlanExternalName:  testClusterServicePlanName,
-			},
-			ExternalID: testExternalID,
-		},
-	}
-
-	if _, err := client.ServiceInstances(testNamespace).Create(instance); err != nil {
-		t.Fatalf("error creating Instance: %v", err)
-	}
-
-	if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
-		Type:   v1beta1.ServiceInstanceConditionReady,
-		Status: v1beta1.ConditionTrue,
-	}); err != nil {
-		t.Fatalf("error waiting for instance to become ready: %v", err)
-	}
-
-	retInst, err := client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-	}
-	if retInst.Spec.ExternalID != instance.Spec.ExternalID {
-		t.Fatalf(
-			"returned OSB GUID '%s' doesn't match original '%s'",
-			retInst.Spec.ExternalID,
-			instance.Spec.ExternalID,
-		)
-	}
-
-	// Binding test begins here
-	//-----------------
-
-	binding := &v1beta1.ServiceBinding{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testBindingName},
-		Spec: v1beta1.ServiceBindingSpec{
-			ServiceInstanceRef: v1beta1.LocalObjectReference{
-				Name: testInstanceName,
-			},
-		},
-	}
-
-	_, err = client.ServiceBindings(testNamespace).Create(binding)
-	if err != nil {
-		t.Fatalf("error creating Binding: %v", binding)
-	}
-
-	err = util.WaitForBindingCondition(client, testNamespace, testBindingName, v1beta1.ServiceBindingCondition{
-		Type:   v1beta1.ServiceBindingConditionFailed,
-		Status: v1beta1.ConditionTrue,
+		}); err != nil {
+			t.Fatalf("error waiting for binding to become failed: %v", err)
+		}
 	})
-	if err != nil {
-		t.Fatalf("error waiting for binding to become failed: %v", err)
+}
+
+// verifyUsernameInLastBrokerAction verifies that the originating identity sent in the request to the broker
+// included the specified username.
+func verifyUsernameInLastBrokerAction(t *testing.T, osbClient *fakeosb.FakeClient, actionType fakeosb.ActionType, username string) {
+	brokerAction := getLastBrokerAction(t, osbClient, actionType)
+	var oi *osb.OriginatingIdentity
+	switch request := brokerAction.Request.(type) {
+	case *osb.ProvisionRequest:
+		oi = request.OriginatingIdentity
+	case *osb.UpdateInstanceRequest:
+		oi = request.OriginatingIdentity
+	case *osb.DeprovisionRequest:
+		oi = request.OriginatingIdentity
+	case *osb.BindRequest:
+		oi = request.OriginatingIdentity
+	case *osb.UnbindRequest:
+		oi = request.OriginatingIdentity
+	default:
+		t.Fatalf("unexpected request type: %T", request)
 	}
-
-	err = client.ServiceBindings(testNamespace).Delete(testBindingName, &metav1.DeleteOptions{})
-	if err != nil {
-		t.Fatalf("binding delete should have been accepted: %v", err)
+	if oi == nil {
+		t.Fatalf("originating identity not sent in request")
 	}
-
-	err = util.WaitForBindingToNotExist(client, testNamespace, testBindingName)
-	if err != nil {
-		t.Fatalf("error waiting for binding to not exist: %v", err)
+	if e, a := "kubernetes", oi.Platform; e != a {
+		t.Fatalf("unexpected originating identity platform: expected %q, got %q", e, a)
 	}
-
-	//-----------------
-	// End binding test
-
-	err = client.ServiceInstances(testNamespace).Delete(testInstanceName, &metav1.DeleteOptions{})
-	if nil != err {
-		t.Fatalf("instance delete should have been accepted: %v", err)
+	oiValues := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(oi.Value), &oiValues); err != nil {
+		t.Fatalf("could not unmarshal originating identity value as json: %v", err)
 	}
-
-	err = util.WaitForInstanceToNotExist(client, testNamespace, testInstanceName)
-	if err != nil {
-		t.Fatalf("error waiting for instance to be deleted: %v", err)
-	}
-
-	//-----------------
-	// End provision test
-
-	// Delete the broker
-	err = client.ClusterServiceBrokers().Delete(testClusterServiceBrokerName, &metav1.DeleteOptions{})
-	if nil != err {
-		t.Fatalf("broker should be deleted (%s)", err)
-	}
-
-	err = util.WaitForClusterServiceClassToNotExist(client, testClusterServiceClassName)
-	if err != nil {
-		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
-	}
-
-	err = util.WaitForBrokerToNotExist(client, testClusterServiceBrokerName)
-	if err != nil {
-		t.Fatalf("error waiting for Broker to not exist: %v", err)
+	if e, a := username, oiValues["username"]; e != a {
+		t.Fatalf("unexpected username in originating identity: expected %q, got %q", e, a)
 	}
 }
 
-// TestBasicFlowsWithOriginatingIdentity test the same flow as TestBasicFlowsSync, with OriginatingIdentity
-// feature enabled.
+// TestBasicFlowsWithOriginatingIdentity tests that the correct username is sent
+// as part of originating identity included in broker requests.
 func TestBasicFlowsWithOriginatingIdentity(t *testing.T) {
 	// Enable the OriginatingIdentity feature
 	utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.OriginatingIdentity))
 	defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.OriginatingIdentity))
 
-	_, catalogClient, catalogClientConfig, _, _, _, shutdownServer, shutdownController := newTestController(t)
-	defer shutdownController()
-	defer shutdownServer()
-
-	client := catalogClient.ServicecatalogV1beta1()
-
-	broker := &v1beta1.ClusterServiceBroker{
-		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
-		Spec: v1beta1.ClusterServiceBrokerSpec{
-			URL: testBrokerURL,
-		},
+	createChangeUsernameFunc := func(username string) func(*controllerTest) {
+		return func(ct *controllerTest) {
+			catalogClient, err := changeUsernameForCatalogClient(ct.catalogClient, ct.catalogClientConfig, username)
+			if err != nil {
+				t.Fatalf("could not change the username for the catalog client: %v", err)
+			}
+			ct.catalogClient = catalogClient
+			ct.client = catalogClient.ServicecatalogV1beta1()
+		}
 	}
 
-	_, err := client.ClusterServiceBrokers().Create(broker)
-	if nil != err {
-		t.Fatalf("error creating the broker %v (%q)", broker, err)
+	createVerifyUsernameFunc := func(actionType fakeosb.ActionType, username string) func(*controllerTest) {
+		return func(ct *controllerTest) {
+			verifyUsernameInLastBrokerAction(ct.t, ct.osbClient, actionType, username)
+		}
 	}
 
-	err = util.WaitForBrokerCondition(client,
-		testClusterServiceBrokerName,
-		v1beta1.ServiceBrokerCondition{
-			Type:   v1beta1.ServiceBrokerConditionReady,
-			Status: v1beta1.ConditionTrue,
-		})
-	if err != nil {
-		t.Fatalf("error waiting for broker to become ready: %v", err)
+	ct := &controllerTest{
+		t:                  t,
+		broker:             getTestBroker(),
+		instance:           getTestInstance(),
+		binding:            getTestBinding(),
+		preCreateInstance:  createChangeUsernameFunc("instance-creator"),
+		postCreateInstance: createVerifyUsernameFunc(fakeosb.ProvisionInstance, "instance-creator"),
+		preDeleteInstance:  createChangeUsernameFunc("instance-deleter"),
+		postDeleteInstance: createVerifyUsernameFunc(fakeosb.DeprovisionInstance, "instance-deleter"),
+		preCreateBinding:   createChangeUsernameFunc("binding-creator"),
+		postCreateBinding:  createVerifyUsernameFunc(fakeosb.Bind, "binding-creator"),
+		preDeleteBinding:   createChangeUsernameFunc("binding-deleter"),
+		postDeleteBinding:  createVerifyUsernameFunc(fakeosb.Unbind, "binding-deleter"),
 	}
+	ct.run(func(ct *controllerTest) {
+		// Update Instance
+		createChangeUsernameFunc("instance-updater")(ct)
 
-	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
-	if nil != err {
-		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
-	}
+		ct.instance.Spec.UpdateRequests = ct.instance.Spec.UpdateRequests + 1
+		if _, err := ct.client.ServiceInstances(testNamespace).Update(ct.instance); err != nil {
+			t.Fatalf("error updating Instance: %v", err)
+		}
 
-	// TODO: find some way to compose scenarios; extract method here for real
-	// logic for this test.
+		if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Status.ReconciledGeneration+1); err != nil {
+			t.Fatalf("error waiting for instance to reconcile: %v", err)
+		}
 
-	//-----------------
-
-	catalogClient, err = changeUsernameForCatalogClient(catalogClient, catalogClientConfig, testCreatorUsername)
-	if err != nil {
-		t.Fatalf("could not change the username for the catalog client: %v", err)
-	}
-
-	client = catalogClient.ServicecatalogV1beta1()
-
-	instance := &v1beta1.ServiceInstance{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
-		Spec: v1beta1.ServiceInstanceSpec{
-			PlanReference: v1beta1.PlanReference{
-				ClusterServiceClassExternalName: testClusterServiceClassName,
-				ClusterServicePlanExternalName:  testClusterServicePlanName,
-			},
-			ExternalID: testExternalID,
-		},
-	}
-
-	// Create Instance
-	if _, err := client.ServiceInstances(testNamespace).Create(instance); err != nil {
-		t.Fatalf("error creating Instance: %v", err)
-	}
-
-	if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
-		Type:   v1beta1.ServiceInstanceConditionReady,
-		Status: v1beta1.ConditionTrue,
-	}); err != nil {
-		t.Fatalf("error waiting for instance to become ready: %v", err)
-	}
-
-	retInst, err := client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-	}
-	if retInst.Spec.UserInfo == nil {
-		t.Fatalf("instance spec does not include creating user info")
-	}
-	if e, a := testCreatorUsername, retInst.Spec.UserInfo.Username; e != a {
-		t.Fatalf("unexpected creating user name in instance spec: expected %v, got %v", e, a)
-	}
-
-	// Update Instance
-	catalogClient, err = changeUsernameForCatalogClient(catalogClient, catalogClientConfig, testUpdaterUsername)
-	if err != nil {
-		t.Fatalf("could not change the username for the catalog client: %v", err)
-	}
-
-	client = catalogClient.ServicecatalogV1beta1()
-
-	retInst.Spec.UpdateRequests = retInst.Spec.UpdateRequests + 1
-	if _, err := client.ServiceInstances(testNamespace).Update(retInst); err != nil {
-		t.Fatalf("error updating Instance: %v", err)
-	}
-
-	if err := util.WaitForInstanceReconciledGeneration(client, testNamespace, testInstanceName, retInst.Status.ReconciledGeneration+1); err != nil {
-		t.Fatalf("error waiting for instance to reconcile: %v", err)
-	}
-
-	retInst, err = client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-	}
-	if retInst.Spec.UserInfo == nil {
-		t.Fatalf("instance spec does not include creating user info")
-	}
-	if e, a := testUpdaterUsername, retInst.Spec.UserInfo.Username; e != a {
-		t.Fatalf("unexpected updating user name in instance spec: expected %v, got %v", e, a)
-	}
-
-	// Binding test begins here
-	//-----------------
-
-	// Create ServiceBinding
-	catalogClient, err = changeUsernameForCatalogClient(catalogClient, catalogClientConfig, testCreatorUsername)
-	if err != nil {
-		t.Fatalf("could not change the username for the catalog client: %v", err)
-	}
-
-	client = catalogClient.ServicecatalogV1beta1()
-
-	binding := &v1beta1.ServiceBinding{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testBindingName},
-		Spec: v1beta1.ServiceBindingSpec{
-			ServiceInstanceRef: v1beta1.LocalObjectReference{
-				Name: testInstanceName,
-			},
-		},
-	}
-
-	_, err = client.ServiceBindings(testNamespace).Create(binding)
-	if err != nil {
-		t.Fatalf("error creating Binding: %v", binding)
-	}
-
-	err = util.WaitForBindingCondition(client, testNamespace, testBindingName, v1beta1.ServiceBindingCondition{
-		Type:   v1beta1.ServiceBindingConditionReady,
-		Status: v1beta1.ConditionTrue,
+		verifyUsernameInLastBrokerAction(t, ct.osbClient, fakeosb.UpdateInstance, "instance-updater")
 	})
-	if err != nil {
-		t.Fatalf("error waiting for binding to become ready: %v", err)
-	}
-
-	retBinding, err := client.ServiceBindings(testNamespace).Get(testBindingName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting binding %s/%s back", testNamespace, testBindingName)
-	}
-	if retBinding.Spec.UserInfo == nil {
-		t.Fatalf("binding spec does not include creating user info")
-	}
-	if e, a := testCreatorUsername, retBinding.Spec.UserInfo.Username; e != a {
-		t.Fatalf("unexpected creating user name in binding spec: expected %v, got %v", e, a)
-	}
-
-	// Delete ServiceBinding
-	catalogClient, err = changeUsernameForCatalogClient(catalogClient, catalogClientConfig, testDeleterUsername)
-	if err != nil {
-		t.Fatalf("could not change the username for the catalog client: %v", err)
-	}
-
-	client = catalogClient.ServicecatalogV1beta1()
-
-	deleteGracePeriod := int64(60)
-	deleteOptions := &metav1.DeleteOptions{GracePeriodSeconds: &deleteGracePeriod}
-	if err := client.ServiceInstances(testNamespace).Delete(instance.Name, deleteOptions); err != nil {
-		t.Fatalf("error updating Instance: %v", err)
-	}
-
-	retInst, err = client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-	}
-	if retInst.Spec.UserInfo == nil {
-		t.Fatalf("instance spec does not include creating user info")
-	}
-	if e, a := testDeleterUsername, retInst.Spec.UserInfo.Username; e != a {
-		t.Fatalf("unexpected deleting user name in instance spec: expected %v, got %v", e, a)
-	}
-
-	//-----------------
-	// End binding test
-
-	// Delete Instance
-	catalogClient, err = changeUsernameForCatalogClient(catalogClient, catalogClientConfig, testDeleterUsername)
-	if err != nil {
-		t.Fatalf("could not change the username for the catalog client: %v", err)
-	}
-
-	client = catalogClient.ServicecatalogV1beta1()
-
-	if err := client.ServiceInstances(testNamespace).Delete(instance.Name, deleteOptions); err != nil {
-		t.Fatalf("error updating Instance: %v", err)
-	}
-
-	retInst, err = client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-	}
-	if retInst.Spec.UserInfo == nil {
-		t.Fatalf("instance spec does not include creating user info")
-	}
-	if e, a := testDeleterUsername, retInst.Spec.UserInfo.Username; e != a {
-		t.Fatalf("unexpected deleting user name in instance spec: expected %v, got %v", e, a)
-	}
-}
-
-// TestServiceInstanceOrphanMitigation tests whether an instance is
-// successfully deprovisioned after a provision request returns a status code
-// that should trigger orphan mitigation.
-func TestServiceInstanceOrphanMitigation(t *testing.T) {
-	_, catalogClient, _, osbClient, _, _, shutdownServer, shutdownController := newTestController(t)
-	defer shutdownController()
-	defer shutdownServer()
-
-	osbClient.ProvisionReaction = &fakeosb.ProvisionReaction{
-		Error: osb.HTTPStatusCodeError{
-			StatusCode: http.StatusInternalServerError,
-		},
-	}
-
-	client := catalogClient.ServicecatalogV1beta1()
-
-	broker := &v1beta1.ClusterServiceBroker{
-		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
-		Spec: v1beta1.ClusterServiceBrokerSpec{
-			URL: testBrokerURL,
-		},
-	}
-
-	_, err := client.ClusterServiceBrokers().Create(broker)
-	if nil != err {
-		t.Fatalf("error creating the broker %q (%q)", broker.Name, err)
-	}
-
-	err = util.WaitForBrokerCondition(client,
-		testClusterServiceBrokerName,
-		v1beta1.ServiceBrokerCondition{
-			Type:   v1beta1.ServiceBrokerConditionReady,
-			Status: v1beta1.ConditionTrue,
-		})
-	if err != nil {
-		t.Fatalf("error waiting for broker to become ready: %v", err)
-	}
-
-	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
-	if nil != err {
-		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
-	}
-
-	// TODO: find some way to compose scenarios; extract method here for real
-	// logic for this test.
-
-	//-----------------
-
-	instance := &v1beta1.ServiceInstance{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
-		Spec: v1beta1.ServiceInstanceSpec{
-			PlanReference: v1beta1.PlanReference{
-				ClusterServiceClassExternalName: testClusterServiceClassName,
-				ClusterServicePlanExternalName:  testClusterServicePlanName,
-			},
-			ExternalID: testExternalID,
-		},
-	}
-
-	if _, err := client.ServiceInstances(testNamespace).Create(instance); err != nil {
-		t.Fatalf("error creating Instance: %v", err)
-	}
-
-	if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
-		Type:   v1beta1.ServiceInstanceConditionFailed,
-		Status: v1beta1.ConditionTrue,
-	}); err != nil {
-		t.Fatalf("error waiting for instance to become failed: %v", err)
-	}
-
-	if err := util.WaitForInstanceReconciledGeneration(client, testNamespace, testInstanceName, instance.Status.ReconciledGeneration+1); err != nil {
-		t.Fatalf("error waiting for instance to reconcile: %v", err)
-	}
-
-	retInst, err := client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-	}
-
-	util.AssertServiceInstanceCondition(
-		t,
-		retInst,
-		v1beta1.ServiceInstanceConditionReady,
-		v1beta1.ConditionFalse,
-		"OrphanMitigationSuccessful",
-	)
-
-	err = client.ServiceInstances(testNamespace).Delete(testInstanceName, &metav1.DeleteOptions{})
-	if nil != err {
-		t.Fatalf("instance delete should have been accepted: %v", err)
-	}
-
-	err = util.WaitForInstanceToNotExist(client, testNamespace, testInstanceName)
-	if err != nil {
-		t.Fatalf("error waiting for instance to be deleted: %v", err)
-	}
-
-	//-----------------
-	// End orphan mitigation test
-
-	// Delete the broker
-	err = client.ClusterServiceBrokers().Delete(testClusterServiceBrokerName, &metav1.DeleteOptions{})
-	if nil != err {
-		t.Fatalf("broker should be deleted (%s)", err)
-	}
-
-	err = util.WaitForClusterServiceClassToNotExist(client, testClusterServiceClassName)
-	if err != nil {
-		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
-	}
-
-	err = util.WaitForBrokerToNotExist(client, testClusterServiceBrokerName)
-	if err != nil {
-		t.Fatalf("error waiting for Broker to not exist: %v", err)
-	}
 }
 
 // TestServiceBindingOrphanMitigation tests whether a binding is
 // successfully deleted after a bind request returns a status code
 // that should trigger orphan mitigation.
 func TestServiceBindingOrphanMitigation(t *testing.T) {
-	_, fakeCatalogClient, _, osbClient, _, _, shutdownServer, shutdownController := newTestController(t)
-	defer shutdownController()
-	defer shutdownServer()
-
-	osbClient.BindReaction = &fakeosb.BindReaction{
-		Error: osb.HTTPStatusCodeError{
-			StatusCode: http.StatusInternalServerError,
+	ct := &controllerTest{
+		t:                           t,
+		broker:                      getTestBroker(),
+		instance:                    getTestInstance(),
+		binding:                     getTestBinding(),
+		skipVerifyingBindingSuccess: true,
+		setup: func(ct *controllerTest) {
+			ct.osbClient.BindReaction = &fakeosb.BindReaction{
+				Error: osb.HTTPStatusCodeError{
+					StatusCode: http.StatusInternalServerError,
+				},
+			}
 		},
 	}
-
-	client := fakeCatalogClient.ServicecatalogV1beta1()
-
-	broker := &v1beta1.ClusterServiceBroker{
-		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
-		Spec: v1beta1.ClusterServiceBrokerSpec{
-			URL: testBrokerURL,
-		},
-	}
-
-	_, err := client.ClusterServiceBrokers().Create(broker)
-	if nil != err {
-		t.Fatalf("error creating the broker %q (%q)", broker.Name, err)
-	}
-
-	err = util.WaitForBrokerCondition(client,
-		testClusterServiceBrokerName,
-		v1beta1.ServiceBrokerCondition{
-			Type:   v1beta1.ServiceBrokerConditionReady,
+	ct.run(func(ct *controllerTest) {
+		if err := util.WaitForBindingCondition(ct.client, testNamespace, testBindingName, v1beta1.ServiceBindingCondition{
+			Type:   v1beta1.ServiceBindingConditionFailed,
 			Status: v1beta1.ConditionTrue,
-		})
-	if err != nil {
-		t.Fatalf("error waiting for broker to become ready: %v", err)
-	}
+		}); err != nil {
+			t.Fatalf("error waiting for binding to become failed: %v", err)
+		}
 
-	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
-	if nil != err {
-		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
-	}
+		if err := util.WaitForBindingReconciledGeneration(ct.client, testNamespace, testBindingName, 1); err != nil {
+			t.Fatalf("error waiting for binding to reconcile: %v", err)
+		}
 
-	// TODO: find some way to compose scenarios; extract method here for real
-	// logic for this test.
+		retBinding, err := ct.client.ServiceBindings(testNamespace).Get(testBindingName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("error getting binding %s/%s back", testNamespace, testBindingName)
+		}
 
-	//-----------------
-
-	instance := &v1beta1.ServiceInstance{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
-		Spec: v1beta1.ServiceInstanceSpec{
-			PlanReference: v1beta1.PlanReference{
-				ClusterServiceClassExternalName: testClusterServiceClassName,
-				ClusterServicePlanExternalName:  testClusterServicePlanName,
-			},
-			ExternalID: testExternalID,
-		},
-	}
-
-	if _, err := client.ServiceInstances(testNamespace).Create(instance); err != nil {
-		t.Fatalf("error creating Instance: %v", err)
-	}
-
-	if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
-		Type:   v1beta1.ServiceInstanceConditionReady,
-		Status: v1beta1.ConditionTrue,
-	}); err != nil {
-		t.Fatalf("error waiting for instance to become ready: %v", err)
-	}
-
-	retInst, err := client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-	}
-	if retInst.Spec.ExternalID != instance.Spec.ExternalID {
-		t.Fatalf(
-			"returned OSB GUID '%s' doesn't match original '%s'",
-			retInst.Spec.ExternalID,
-			instance.Spec.ExternalID,
+		util.AssertServiceBindingCondition(
+			t,
+			retBinding,
+			v1beta1.ServiceBindingConditionReady,
+			v1beta1.ConditionFalse,
+			"OrphanMitigationSuccessful",
 		)
-	}
-
-	// Binding test begins here
-	//-----------------
-	binding := &v1beta1.ServiceBinding{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testBindingName},
-		Spec: v1beta1.ServiceBindingSpec{
-			ServiceInstanceRef: v1beta1.LocalObjectReference{
-				Name: testInstanceName,
-			},
-		},
-	}
-
-	_, err = client.ServiceBindings(testNamespace).Create(binding)
-	if err != nil {
-		t.Fatalf("error creating Binding: %v", binding)
-	}
-
-	if err := util.WaitForBindingReconciledGeneration(client, testNamespace, testBindingName, binding.Status.ReconciledGeneration+1); err != nil {
-		t.Fatalf("error waiting for binding to reconcile: %v", err)
-	}
-
-	retBinding, err := client.ServiceBindings(binding.Namespace).Get(binding.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting binding %s/%s back", binding.Namespace, binding.Name)
-	}
-
-	util.AssertServiceBindingCondition(
-		t,
-		retBinding,
-		v1beta1.ServiceBindingConditionReady,
-		v1beta1.ConditionFalse,
-		"OrphanMitigationSuccessful",
-	)
-
-	err = client.ServiceBindings(testNamespace).Delete(testBindingName, &metav1.DeleteOptions{})
-	if err != nil {
-		t.Fatalf("binding delete should have been accepted: %v", err)
-	}
-
-	err = util.WaitForBindingToNotExist(client, testNamespace, testBindingName)
-	if err != nil {
-		t.Fatalf("error waiting for binding to not exist: %v", err)
-	}
-
-	//-----------------
-	// End binding test
-
-	err = client.ServiceInstances(testNamespace).Delete(testInstanceName, &metav1.DeleteOptions{})
-	if nil != err {
-		t.Fatalf("instance delete should have been accepted: %v", err)
-	}
-
-	err = util.WaitForInstanceToNotExist(client, testNamespace, testInstanceName)
-	if err != nil {
-		t.Fatalf("error waiting for instance to be deleted: %v", err)
-	}
-
-	//-----------------
-	// End provision test
-
-	// Delete the broker
-	err = client.ClusterServiceBrokers().Delete(testClusterServiceBrokerName, &metav1.DeleteOptions{})
-	if nil != err {
-		t.Fatalf("broker should be deleted (%s)", err)
-	}
-
-	err = util.WaitForClusterServiceClassToNotExist(client, testClusterServiceClassName)
-	if err != nil {
-		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
-	}
-
-	err = util.WaitForBrokerToNotExist(client, testClusterServiceBrokerName)
-	if err != nil {
-		t.Fatalf("error waiting for Broker to not exist: %v", err)
-	}
+	})
 }
 
 // TestAsyncProvisionWithMultiplePolls tests an async instance provisioning
 // where the first few last-operation polls respond still in-progress.
 func TestAsyncProvisionWithMultiplePolls(t *testing.T) {
-	_, catalogClient, _, osbClient, _, _, shutdownServer, shutdownController := newTestController(t)
-	defer shutdownController()
-	defer shutdownServer()
-
-	osbClient.ProvisionReaction.(*fakeosb.ProvisionReaction).Response.Async = true
-
 	const NumberOfInProgressResponses = 2
 	numberOfPolls := 0
-	osbClient.PollLastOperationReaction = fakeosb.DynamicPollLastOperationReaction(
-		func(_ *osb.LastOperationRequest) (*osb.LastOperationResponse, error) {
-			numberOfPolls++
-			state := osb.StateInProgress
-			if numberOfPolls > NumberOfInProgressResponses {
-				state = osb.StateSucceeded
-			}
-			return &osb.LastOperationResponse{State: state}, nil
-		})
 
-	client := catalogClient.ServicecatalogV1beta1()
-
-	broker := &v1beta1.ClusterServiceBroker{
-		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
-		Spec: v1beta1.ClusterServiceBrokerSpec{
-			URL: testBrokerURL,
+	ct := &controllerTest{
+		t:                            t,
+		broker:                       getTestBroker(),
+		instance:                     getTestInstance(),
+		skipVerifyingInstanceSuccess: true,
+		setup: func(ct *controllerTest) {
+			ct.osbClient.ProvisionReaction.(*fakeosb.ProvisionReaction).Response.Async = true
+			ct.osbClient.PollLastOperationReaction = fakeosb.DynamicPollLastOperationReaction(
+				func(_ *osb.LastOperationRequest) (*osb.LastOperationResponse, error) {
+					numberOfPolls++
+					state := osb.StateInProgress
+					if numberOfPolls > NumberOfInProgressResponses {
+						state = osb.StateSucceeded
+					}
+					return &osb.LastOperationResponse{State: state}, nil
+				})
 		},
 	}
+	ct.run(func(ct *controllerTest) {
+		// Polling is going to take at least 3 seconds, with a 1-second break between the first poll and the second
+		// and a 2-second break between the second poll and the third. Let's sleep here so that we don't risk
+		// timing out while waiting for the instance condition to be ready in the following wait.
+		//time.Sleep(3 * time.Second)
 
-	_, err := client.ClusterServiceBrokers().Create(broker)
-	if nil != err {
-		t.Fatalf("error creating the broker %q (%q)", broker.Name, err)
-	}
-
-	err = util.WaitForBrokerCondition(client,
-		testClusterServiceBrokerName,
-		v1beta1.ServiceBrokerCondition{
-			Type:   v1beta1.ServiceBrokerConditionReady,
-			Status: v1beta1.ConditionTrue,
-		})
-	if err != nil {
-		t.Fatalf("error waiting for broker to become ready: %v", err)
-	}
-
-	err = util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID)
-	if nil != err {
-		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
-	}
-
-	// TODO: find some way to compose scenarios; extract method here for real
-	// logic for this test.
-
-	//-----------------
-
-	instance := &v1beta1.ServiceInstance{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
-		Spec: v1beta1.ServiceInstanceSpec{
-			PlanReference: v1beta1.PlanReference{
-				ClusterServiceClassExternalName: testClusterServiceClassName,
-				ClusterServicePlanExternalName:  testClusterServicePlanName,
-			},
-			ExternalID: testExternalID,
-		},
-	}
-
-	if _, err := client.ServiceInstances(testNamespace).Create(instance); err != nil {
-		t.Fatalf("error creating Instance: %v", err)
-	}
-
-	// Polling is going to take at least 3 seconds, with a 1-second break between the first poll and the second
-	// and a 2-second break between the second poll and the third. Let's sleep here so that we don't risk
-	// timing out while waiting for the instance condition to be ready in the following wait.
-	time.Sleep(3 * time.Second)
-
-	if err := util.WaitForInstanceCondition(client, testNamespace, testInstanceName, v1beta1.ServiceInstanceCondition{
-		Type:   v1beta1.ServiceInstanceConditionReady,
-		Status: v1beta1.ConditionTrue,
-	}); err != nil {
-		t.Fatalf("error waiting for instance to become ready: %v", err)
-	}
-
-	retInst, err := client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
-	}
-	if retInst.Spec.ExternalID != instance.Spec.ExternalID {
-		t.Fatalf(
-			"returned OSB GUID '%s' doesn't match original '%s'",
-			retInst.Spec.ExternalID,
-			instance.Spec.ExternalID,
-		)
-	}
-
-	err = client.ServiceInstances(testNamespace).Delete(testInstanceName, &metav1.DeleteOptions{})
-	if nil != err {
-		t.Fatalf("instance delete should have been accepted: %v", err)
-	}
-
-	err = util.WaitForInstanceToNotExist(client, testNamespace, testInstanceName)
-	if err != nil {
-		t.Fatalf("error waiting for instance to be deleted: %v", err)
-	}
-
-	//-----------------
-	// End provision test
-
-	// Delete the broker
-	err = client.ClusterServiceBrokers().Delete(testClusterServiceBrokerName, &metav1.DeleteOptions{})
-	if nil != err {
-		t.Fatalf("broker should be deleted (%s)", err)
-	}
-
-	err = util.WaitForClusterServiceClassToNotExist(client, testClusterServiceClassName)
-	if err != nil {
-		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
-	}
-
-	err = util.WaitForBrokerToNotExist(client, testClusterServiceBrokerName)
-	if err != nil {
-		t.Fatalf("error waiting for Broker to not exist: %v", err)
-	}
+		verifyInstanceCreated(t, ct.client, ct.instance)
+	})
 }
 
 // newTestController creates a new test controller injected with fake clients
@@ -1164,6 +355,8 @@ func TestAsyncProvisionWithMultiplePolls(t *testing.T) {
 // - a fake osb client, with configuration for happy path testing
 // - a test controller
 // - the shared informers for the service catalog v1beta1 api
+// - a function for shutting down the API server
+// - a function for shutting down the controller.
 //
 // If there is an error, newTestController calls 'Fatal' on the injected
 // testing.T.
@@ -1179,7 +372,7 @@ func newTestController(t *testing.T) (
 
 	// create a fake kube client
 	fakeKubeClient := &fake.Clientset{}
-	addGetSecretNotFoundReaction(fakeKubeClient)
+	prependGetSecretNotFoundReaction(fakeKubeClient)
 
 	// create an sc client and running server
 	catalogClient, catalogClientConfig, shutdownServer := getFreshApiserverAndClient(t, server.StorageTypeEtcd.String(), func() runtime.Object {
@@ -1234,6 +427,7 @@ func newTestController(t *testing.T) (
 	return fakeKubeClient, catalogClient, catalogClientConfig, fakeOSBClient, testController, serviceCatalogSharedInformers, shutdownServer, shutdownController
 }
 
+// changeUsernameForCatalogClient changes the name of the user that is using the catalog client
 func changeUsernameForCatalogClient(catalogClient clientset.Interface, catalogClientConfig *restclient.Config, username string) (clientset.Interface, error) {
 	catalogClientConfig.Username = username
 	var err error
@@ -1244,12 +438,38 @@ func changeUsernameForCatalogClient(catalogClient clientset.Interface, catalogCl
 	return catalogClient, nil
 }
 
-func addGetSecretNotFoundReaction(fakeKubeClient *fake.Clientset) {
-	fakeKubeClient.AddReactor("get", "secrets", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+// prependGetSecretNotFoundReaction prepends a reaction to getting secrets from the fake kube client
+// that returns a not found error.
+func prependGetSecretNotFoundReaction(fakeKubeClient *fake.Clientset) {
+	fakeKubeClient.PrependReactor("get", "secrets", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		return true, nil, apierrors.NewNotFound(action.GetResource().GroupResource(), action.(clientgotesting.GetAction).GetName())
 	})
 }
 
+// prependGetSecretReaction prepends a reaction to getting secrets from the fake kube client
+// that returns a secret with the specified secret data when a request is made for the secret
+// with the specified secret name.
+func prependGetSecretReaction(fakeKubeClient *fake.Clientset, secretName string, secretData map[string][]byte) {
+	fakeKubeClient.PrependReactor("get", "secrets", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		getAction, ok := action.(clientgotesting.GetAction)
+		if !ok {
+			return true, nil, apierrors.NewInternalError(fmt.Errorf("could not convert get secrets action to a GetAction: %T", action))
+		}
+		if getAction.GetName() != secretName {
+			return false, nil, nil
+		}
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      secretName,
+			},
+			Data: secretData,
+		}
+		return true, secret, nil
+	})
+}
+
+// getTestCatalogResponse returns a sample response to a get catalog request.
 func getTestCatalogResponse() *osb.CatalogResponse {
 	return &osb.CatalogResponse{
 		Services: []osb.Service{
@@ -1271,6 +491,8 @@ func getTestCatalogResponse() *osb.CatalogResponse {
 	}
 }
 
+// getTestBindCredentials returns binding credentials to include in the response
+// to a bind request.
 func getTestBindCredentials() map[string]interface{} {
 	return map[string]interface{}{
 		"foo": "bar",
@@ -1318,4 +540,364 @@ func getTestHappyPathBrokerClientConfig() fakeosb.FakeClientConfiguration {
 			},
 		},
 	}
+}
+
+// getTestBroker returns a ClusterServiceBroker to use for testing.
+func getTestBroker() *v1beta1.ClusterServiceBroker {
+	return &v1beta1.ClusterServiceBroker{
+		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceBrokerName},
+		Spec: v1beta1.ClusterServiceBrokerSpec{
+			URL: testBrokerURL,
+		},
+	}
+}
+
+// verifyBrokerCreated verifies that the specified broker has been created
+// and reconciled successfully.
+func verifyBrokerCreated(t *testing.T, client clientsetsc.ServicecatalogV1beta1Interface, broker *v1beta1.ClusterServiceBroker) *v1beta1.ClusterServiceBroker {
+	if err := util.WaitForBrokerCondition(client,
+		broker.Name,
+		v1beta1.ServiceBrokerCondition{
+			Type:   v1beta1.ServiceBrokerConditionReady,
+			Status: v1beta1.ConditionTrue,
+		}); err != nil {
+		t.Fatalf("error waiting for broker to become ready: %v", err)
+	}
+
+	if err := util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID); err != nil {
+		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
+	}
+
+	retBroker, err := client.ClusterServiceBrokers().Get(broker.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting the broker from storage: %v", err)
+	}
+
+	return retBroker
+}
+
+// deleteBroker deletes the specified broker.
+func deleteBroker(t *testing.T, client clientsetsc.ServicecatalogV1beta1Interface, broker *v1beta1.ClusterServiceBroker) {
+	if err := client.ClusterServiceBrokers().Delete(broker.Name, &metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("broker should be deleted (%s)", err)
+	}
+
+	if err := util.WaitForClusterServiceClassToNotExist(client, testClusterServiceClassName); err != nil {
+		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
+	}
+
+	if err := util.WaitForBrokerToNotExist(client, broker.Name); err != nil {
+		t.Fatalf("error waiting for Broker to not exist: %v", err)
+	}
+}
+
+// getTestInstance returns a ServiceInstance to use for testing.
+func getTestInstance() *v1beta1.ServiceInstance {
+	return &v1beta1.ServiceInstance{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testInstanceName},
+		Spec: v1beta1.ServiceInstanceSpec{
+			PlanReference: v1beta1.PlanReference{
+				ClusterServiceClassExternalName: testClusterServiceClassName,
+				ClusterServicePlanExternalName:  testClusterServicePlanName,
+			},
+			ExternalID: testExternalID,
+		},
+	}
+}
+
+// verifyInstanceCreated verifies that the specified instance has been created
+// and reconciled successfully.
+func verifyInstanceCreated(t *testing.T, client clientsetsc.ServicecatalogV1beta1Interface, instance *v1beta1.ServiceInstance) *v1beta1.ServiceInstance {
+	if err := util.WaitForInstanceCondition(client, instance.Namespace, instance.Name, v1beta1.ServiceInstanceCondition{
+		Type:   v1beta1.ServiceInstanceConditionReady,
+		Status: v1beta1.ConditionTrue,
+	}); err != nil {
+		t.Fatalf("error waiting for instance to become ready: %v", err)
+	}
+
+	retInst, err := client.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting instance %s/%s back", instance.Namespace, instance.Name)
+	}
+	if e, a := instance.Spec.ExternalID, retInst.Spec.ExternalID; e != a {
+		t.Fatalf("returned OSB GUID '%s' doesn't match original '%s'", e, a)
+	}
+
+	return retInst
+}
+
+// deleteInstance deletes the specified instance
+func deleteInstance(t *testing.T, client clientsetsc.ServicecatalogV1beta1Interface, instance *v1beta1.ServiceInstance) {
+	if err := client.ServiceInstances(instance.Namespace).Delete(instance.Name, &metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("instance delete should have been accepted: %v", err)
+	}
+
+	if err := util.WaitForInstanceToNotExist(client, instance.Namespace, instance.Name); err != nil {
+		t.Fatalf("error waiting for instance to be deleted: %v", err)
+	}
+}
+
+// getTestBinding gets a ServiceBinding to use for testing.
+func getTestBinding() *v1beta1.ServiceBinding {
+	return &v1beta1.ServiceBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testBindingName},
+		Spec: v1beta1.ServiceBindingSpec{
+			ServiceInstanceRef: v1beta1.LocalObjectReference{
+				Name: testInstanceName,
+			},
+		},
+	}
+}
+
+// verifyBindingCreated verifies that the specified binding has been created
+// and reconciled successfully.
+func verifyBindingCreated(t *testing.T, client clientsetsc.ServicecatalogV1beta1Interface, binding *v1beta1.ServiceBinding) *v1beta1.ServiceBinding {
+	if err := util.WaitForBindingCondition(client, binding.Namespace, binding.Name, v1beta1.ServiceBindingCondition{
+		Type:   v1beta1.ServiceBindingConditionReady,
+		Status: v1beta1.ConditionTrue,
+	}); err != nil {
+		t.Fatalf("error waiting for binding to become ready: %v", err)
+	}
+
+	retBinding, err := client.ServiceBindings(binding.Namespace).Get(binding.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting binding %s/%s back", binding.Namespace, binding.Name)
+	}
+
+	return retBinding
+}
+
+// deleteBinding deletes the specified binding.
+func deleteBinding(t *testing.T, client clientsetsc.ServicecatalogV1beta1Interface, binding *v1beta1.ServiceBinding) {
+	if err := client.ServiceBindings(binding.Namespace).Delete(binding.Name, &metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("binding delete should have been accepted: %v", err)
+	}
+
+	if err := util.WaitForBindingToNotExist(client, binding.Namespace, binding.Name); err != nil {
+		t.Fatalf("error waiting for binding to not exist: %v", err)
+	}
+}
+
+// controllerTest is used to set-up, run, and tear-down an integration test
+// that tests the functionality of the controller.
+type controllerTest struct {
+	// testing.T for the integration test being run
+	t *testing.T
+
+	// fake kube client
+	kubeClient *fake.Clientset
+	// fake catalog client
+	catalogClient clientset.Interface
+	// fake catalog client configuration
+	catalogClientConfig *restclient.Config
+	// fake service catalog client
+	client clientsetsc.ServicecatalogV1beta1Interface
+	// fake osb broker client
+	osbClient *fakeosb.FakeClient
+	// fake controller
+	controller controller.Controller
+	// fake informers
+	informers informers.Interface
+
+	// the broker to create.
+	// After the broker is created and verified, this is the broker from storage.
+	// This is not updated after creation, so will not reflect any updates.
+	broker *v1beta1.ClusterServiceBroker
+	// the instance to create.
+	// After the instance is created and verified, this is the instance from storage
+	// This is not updated after creation, so will not reflect any updates.
+	instance *v1beta1.ServiceInstance
+	// the binding to create
+	// After the binding is created and verified, this is the binding from storage
+	// This is not updated after creation, so will not reflect any updates.
+	binding *v1beta1.ServiceBinding
+
+	// true if the verification that the broker was created and reconciled
+	// successfully should be skipped. This is useful for tests where the
+	// reconciliation is expected to fail.
+	skipVerifyingBrokerSuccess bool
+	// true if the verification that the broker was created and reconciled
+	// successfully should be skipped. This is useful for tests where the
+	// reconciliation is expected to fail.
+	skipVerifyingInstanceSuccess bool
+	// true if the verification that the broker was created and reconciled
+	// successfully should be skipped. This is useful for tests where the
+	// reconciliation is expected to fail.
+	skipVerifyingBindingSuccess bool
+
+	// function to run before creating any resources. This is useful for setting
+	// up reactions for the fake components.
+	setup func(t *controllerTest)
+	// function to run just prior to creating the broker. This will only be run
+	// if there is actually a broker to create.
+	preCreateBroker func(t *controllerTest)
+	// function to run just after creating, and optionally verifying, the broker.
+	// This will only be run if there is actually a broker to create.
+	postCreateBroker func(t *controllerTest)
+	// function to run just prior to deleting the broker. This will only be run
+	// if there was a broker created.
+	preDeleteBroker func(t *controllerTest)
+	// function to run just after deleting the broker. This will only be run
+	// if there was a broker created.
+	postDeleteBroker func(t *controllerTest)
+	// function to run before creating the instance. This will only be run
+	// if there is actually an instance to create.
+	preCreateInstance func(t *controllerTest)
+	// function to run just after creating, and optionally verifying, the instance.
+	// This will only be run if there is actually an instance to create.
+	postCreateInstance func(t *controllerTest)
+	// function to run just prior to deleting the instance. This will only be run
+	// if there was an instance created.
+	preDeleteInstance func(t *controllerTest)
+	// function to run just after deleting the instance. This will only be run
+	// if there was an instance created.
+	postDeleteInstance func(t *controllerTest)
+	// function to run before creating the binding. This will only be run
+	// if there is actually a binding to create.
+	preCreateBinding func(t *controllerTest)
+	// function to run just after creating, and optionally verifying, the binding.
+	// This will only be run if there is actually a binding to create.
+	postCreateBinding func(t *controllerTest)
+	// function to run just prior to deleting the binding. This will only be run
+	// if there was a binding created.
+	preDeleteBinding func(t *controllerTest)
+	// function to run just after deleting the binding. This will only be run
+	// if there was a binding created.
+	postDeleteBinding func(t *controllerTest)
+}
+
+// run executes the test.
+//
+// Steps performed:
+// - create controller and API server with fakes
+// - call setup function
+// - create broker
+// - create instance
+// - create binding
+// - call supplied test function
+// - delete binding
+// - delete instance
+// - delete broker
+// - clean up controller and API server
+func (ct *controllerTest) run(test func(*controllerTest)) {
+	kubeClient, catalogClient, catalogClientConfig, osbClient, controller, informers, shutdownServer, shutdownController := newTestController(ct.t)
+	defer shutdownController()
+	defer shutdownServer()
+
+	ct.kubeClient = kubeClient
+	ct.catalogClient = catalogClient
+	ct.catalogClientConfig = catalogClientConfig
+	ct.osbClient = osbClient
+	ct.controller = controller
+	ct.informers = informers
+
+	ct.client = catalogClient.ServicecatalogV1beta1()
+
+	if ct.setup != nil {
+		ct.setup(ct)
+	}
+
+	if ct.broker != nil {
+		if ct.preCreateBroker != nil {
+			ct.preCreateBroker(ct)
+		}
+		_, err := ct.client.ClusterServiceBrokers().Create(ct.broker)
+		if nil != err {
+			ct.t.Fatalf("error creating the broker %q (%q)", ct.broker.Name, err)
+		}
+		if !ct.skipVerifyingBrokerSuccess {
+			ct.broker = verifyBrokerCreated(ct.t, ct.client, ct.broker)
+		}
+		if ct.postCreateBroker != nil {
+			ct.postCreateBroker(ct)
+		}
+	}
+
+	if ct.instance != nil {
+		if ct.preCreateInstance != nil {
+			ct.preCreateInstance(ct)
+		}
+		if _, err := ct.client.ServiceInstances(ct.instance.Namespace).Create(ct.instance); err != nil {
+			ct.t.Fatalf("error creating Instance: %v", err)
+		}
+		if !ct.skipVerifyingInstanceSuccess {
+			ct.instance = verifyInstanceCreated(ct.t, ct.client, ct.instance)
+		}
+		if ct.postCreateInstance != nil {
+			ct.postCreateInstance(ct)
+		}
+	}
+
+	if ct.binding != nil {
+		if ct.preCreateBinding != nil {
+			ct.preCreateBinding(ct)
+		}
+		_, err := ct.client.ServiceBindings(ct.binding.Namespace).Create(ct.binding)
+		if err != nil {
+			ct.t.Fatalf("error creating Binding: %v", err)
+		}
+		if !ct.skipVerifyingBindingSuccess {
+			ct.binding = verifyBindingCreated(ct.t, ct.client, ct.binding)
+		}
+		if ct.postCreateBinding != nil {
+			ct.postCreateBinding(ct)
+		}
+	}
+
+	test(ct)
+
+	if ct.binding != nil {
+		if ct.preDeleteBinding != nil {
+			ct.preDeleteBinding(ct)
+		}
+		deleteBinding(ct.t, ct.client, ct.binding)
+		if ct.postDeleteBinding != nil {
+			ct.postDeleteBinding(ct)
+		}
+	}
+
+	if ct.instance != nil {
+		if ct.preDeleteInstance != nil {
+			ct.preDeleteInstance(ct)
+		}
+		deleteInstance(ct.t, ct.client, ct.instance)
+		if ct.postDeleteInstance != nil {
+			ct.postDeleteInstance(ct)
+		}
+	}
+
+	if ct.broker != nil {
+		if ct.preDeleteBroker != nil {
+			ct.preDeleteBroker(ct)
+		}
+		deleteBroker(ct.t, ct.client, ct.broker)
+		if ct.postDeleteBroker != nil {
+			ct.postDeleteBroker(ct)
+		}
+	}
+}
+
+// getLastBrokerActions gets the last action made to the fake broker client.
+// It also verifies that the last action had the specified action type.
+func getLastBrokerAction(t *testing.T, osbClient *fakeosb.FakeClient, actionType fakeosb.ActionType) fakeosb.Action {
+	brokerActions := osbClient.Actions()
+	if len(brokerActions) == 0 {
+		t.Fatalf("no broker actions")
+	}
+	brokerAction := brokerActions[len(brokerActions)-1]
+	if e, a := actionType, brokerAction.Type; e != a {
+		t.Fatalf("unexpected action type: expected %s, got %s", e, a)
+	}
+	return brokerAction
+}
+
+// convertParametersIntoRawExtension converts the specified map of parameters
+// into a RawExtension object that can be used in the Parameters field of
+// ServiceInstanceSpec or ServiceBindingSpec.
+func convertParametersIntoRawExtension(t *testing.T, parameters map[string]interface{}) *runtime.RawExtension {
+	marshalledParams, err := json.Marshal(parameters)
+	if err != nil {
+		t.Fatalf("Failed to marshal parameters %v : %v", parameters, err)
+	}
+	return &runtime.RawExtension{Raw: marshalledParams}
 }

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -46,9 +46,13 @@ func WaitForBrokerCondition(client v1beta1servicecatalog.ServicecatalogV1beta1In
 				return false, nil
 			}
 
+			glog.V(5).Infof("Conditions = %#v", broker.Status.Conditions)
+
 			for _, cond := range broker.Status.Conditions {
 				if condition.Type == cond.Type && condition.Status == cond.Status {
-					return true, nil
+					if condition.Reason == "" || condition.Reason == cond.Reason {
+						return true, nil
+					}
 				}
 			}
 
@@ -164,9 +168,13 @@ func WaitForInstanceCondition(client v1beta1servicecatalog.ServicecatalogV1beta1
 				return false, nil
 			}
 
+			glog.V(5).Infof("Conditions = %#v", instance.Status.Conditions)
+
 			for _, cond := range instance.Status.Conditions {
 				if condition.Type == cond.Type && condition.Status == cond.Status {
-					return true, nil
+					if condition.Reason == "" || condition.Reason == cond.Reason {
+						return true, nil
+					}
 				}
 			}
 
@@ -232,9 +240,13 @@ func WaitForBindingCondition(client v1beta1servicecatalog.ServicecatalogV1beta1I
 				return false, nil
 			}
 
+			glog.V(5).Infof("Conditions = %#v", binding.Status.Conditions)
+
 			for _, cond := range binding.Status.Conditions {
 				if condition.Type == cond.Type && condition.Status == cond.Status {
-					return true, nil
+					if condition.Reason == "" || condition.Reason == cond.Reason {
+						return true, nil
+					}
 				}
 			}
 


### PR DESCRIPTION
* Add `controllerTest` which extracts a lot of the boilerplate for setting up integration tests that test controller logic.
* Add integration tests that tests scenarios around creating and updating ServiceInstances.

This is a WIP because there are 3 bug fix PR that need to be merged first so that the integration tests pass.