### PR TITLE
Check if file permissions allow go install

### DIFF
--- a/test/integration.sh
+++ b/test/integration.sh
@@ -21,11 +21,20 @@ set -o pipefail
 # this script resides in the `test/` folder at the root of the project
 KUBE_ROOT=$(realpath $(dirname "${BASH_SOURCE}")/../pkg/kubernetes)
 source "${KUBE_ROOT}/hack/lib/init.sh"
+GOROOT=$(go env GOROOT)
 
 runTests() {
   kube::etcd::start
 
-  go test -race -i github.com/kubernetes-incubator/service-catalog/test/integration/... -c \
+  if [[ -w ${GOROOT}/pkg ]]; then
+    FLAGS="-i"
+  elif [[ -n ${PKGDIR:-} ]]; then
+    FLAGS="-pkgdir $PKGDIR"
+  else
+    FLAGS=""
+  fi
+
+  go test -race $FLAGS github.com/kubernetes-incubator/service-catalog/test/integration/... -c \
       && ./integration.test -test.v $@
 }
 


### PR DESCRIPTION
This works around a permissions issue when using go via a distribution package. See commit for more details.