### PR TITLE
less etcd logs during integration test

### DIFF
--- a/test/integration/etcd_test.go
+++ b/test/integration/etcd_test.go
@@ -18,12 +18,14 @@ package integration
 
 import (
 	"fmt"
-	"github.com/coreos/etcd/embed"
-	"github.com/golang/glog"
 	"io/ioutil"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/coreos/etcd/embed"
+	"github.com/coreos/pkg/capnslog"
+	"github.com/golang/glog"
 )
 
 type EtcdContext struct {
@@ -40,6 +42,8 @@ func startEtcd() error {
 		return fmt.Errorf("could not create TempDir: %v", err)
 	}
 	cfg := embed.NewConfig()
+	// default of INFO prints useless information
+	capnslog.SetGlobalLogLevel(capnslog.WARNING)
 	cfg.Dir = etcdContext.dir
 
 	if etcdContext.etcd, err = embed.StartEtcd(cfg); err != nil {


### PR DESCRIPTION
We don't use coreos capnslog anywhere else, so I think this is a safe
change for our tests.

The log message:
2017-11-15 00:34:28.375906 I | etcdserver/api/v3rpc: grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp: missing address"; Reconnecting to { <nil>}
is an info log and normal during startup of etcd.

