### PR TITLE
Add additional service to ups-broker to fix e2e

### DIFF
--- a/contrib/pkg/broker/user_provided/controller/controller.go
+++ b/contrib/pkg/broker/user_provided/controller/controller.go
@@ -76,6 +76,21 @@ func (c *userProvidedController) Catalog() (*brokerapi.Catalog, error) {
 				Bindable:       true,
 				PlanUpdateable: true,
 			},
+			{
+				Name:        "user-provided-service-single-plan",
+				ID:          "5f6e6cf6-ffdd-425f-a2c7-3c9258ad2468",
+				Description: "A user provided service",
+				Plans: []brokerapi.ServicePlan{
+					{
+						Name:        "default",
+						ID:          "96064792-7ea2-467b-af93-ac9694d96d52",
+						Description: "Sample plan description",
+						Free:        true,
+					},
+				},
+				Bindable:       true,
+				PlanUpdateable: true,
+			},
 		},
 	}, nil
 }

--- a/plugin/pkg/admission/serviceplan/defaultserviceplan/admission.go
+++ b/plugin/pkg/admission/serviceplan/defaultserviceplan/admission.go
@@ -113,7 +113,7 @@ func (d *defaultServicePlan) Admit(a admission.Attributes) error {
 
 	// check if more than one service plan was specified and error
 	if len(plans) > 1 {
-		msg := fmt.Sprintf("ServiceClass %q has more than one plan, PlanName must be specified", instance.Spec.ClusterServiceClassExternalName)
+		msg := fmt.Sprintf("ClusterServiceClass (K8S: %v ExternalName: %v) has more than one plan, PlanName must be specified", instance.Spec.ClusterServiceClassName, instance.Spec.ClusterServiceClassExternalName)
 		glog.V(4).Infof(`ServiceInstance "%s/%s": %s`, instance.Namespace, instance.Name, msg)
 		return admission.NewForbidden(a, errors.New(msg))
 	}

--- a/test/e2e/walkthrough.go
+++ b/test/e2e/walkthrough.go
@@ -63,16 +63,18 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 
 	It("Run walkthrough-example ", func() {
 		var (
-			brokerName              = upsbrokername
-			serviceclassName        = "user-provided-service"
-			serviceclassID          = "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
-			serviceplanID           = "86064792-7ea2-467b-af93-ac9694d96d52"
-			testns                  = "test-ns"
-			instanceName            = "ups-instance"
-			bindingName             = "ups-binding"
-			instanceNameDef         = "ups-instance-def"
-			instanceNameK8sNames    = "ups-instance-k8s-names"
-			instanceNameK8sNamesDef = "ups-instance-k8s-names-def"
+			brokerName                     = upsbrokername
+			serviceclassName               = "user-provided-service"
+			serviceclassID                 = "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
+			serviceplanID                  = "86064792-7ea2-467b-af93-ac9694d96d52"
+			serviceclassNameWithSinglePlan = "user-provided-service-single-plan"
+			serviceclassIDWithSinglePlan   = "5f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
+			testns                         = "test-ns"
+			instanceName                   = "ups-instance"
+			bindingName                    = "ups-binding"
+			instanceNameDef                = "ups-instance-def"
+			instanceNameK8sNames           = "ups-instance-k8s-names"
+			instanceNameK8sNamesDef        = "ups-instance-k8s-names-def"
 		)
 
 		// Broker and ClusterServiceClass should become ready
@@ -218,7 +220,7 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 			},
 			Spec: v1beta1.ServiceInstanceSpec{
 				PlanReference: v1beta1.PlanReference{
-					ClusterServiceClassExternalName: serviceclassName,
+					ClusterServiceClassExternalName: serviceclassNameWithSinglePlan,
 				},
 			},
 		}
@@ -291,7 +293,7 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 			},
 			Spec: v1beta1.ServiceInstanceSpec{
 				PlanReference: v1beta1.PlanReference{
-					ClusterServiceClassName: serviceclassID,
+					ClusterServiceClassName: serviceclassIDWithSinglePlan,
 				},
 			},
 		}


### PR DESCRIPTION
The e2e walkthrough tests were written in a way to test default service plan
assignment, which is only possible if only one service plan exists. This
adds an additional "user provided service" to contain a single plan such
that testing with either a single plan or more than one is now possible.

Also, fixed some logging in the serviceplan admission controller.

Closes #1582