### PR TITLE
Make ups-instance.yaml in walkthrough to demonstrate good practices

### DIFF
--- a/contrib/examples/walkthrough/ups-instance-default-sp.yaml
+++ b/contrib/examples/walkthrough/ups-instance-default-sp.yaml
@@ -6,6 +6,5 @@ metadata:
 spec:
   clusterServiceClassExternalName: user-provided-service
   parameters:
-    credentials:
-      name: root
-      password: letmein
+    param-1: value-1
+    param-2: value-2

--- a/contrib/examples/walkthrough/ups-instance.yaml
+++ b/contrib/examples/walkthrough/ups-instance.yaml
@@ -7,6 +7,5 @@ spec:
   clusterServiceClassExternalName: user-provided-service
   clusterServicePlanExternalName: default
   parameters:
-    credentials:
-      param-1: value-1
-      param-2: value-2
+    param-1: value-1
+    param-2: value-2

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -252,9 +252,8 @@ spec:
     name: 86064792-7ea2-467b-af93-ac9694d96d52
   externalID: 10ca3610-8200-4b5d-b788-897365f191fa
   parameters:
-    credentials:
-      param-1: value-1
-      param-2: value-2
+    param-1: value-1
+    param-2: value-2
   updateRequests: 0
 status:
   asyncOpInProgress: false
@@ -269,9 +268,8 @@ status:
     clusterServicePlanExternalName: default
     parameterChecksum: e65c764db8429f9afef45f1e8f71bcbf9fdbe9a13306b86fd5dcc3c5d11e5dd3
     parameters:
-      credentials:
-        param-1: value-1
-        param-2: value-2
+      param-1: value-1
+      param-2: value-2
   orphanMitigationInProgress: false
   reconciledGeneration: 1
 ```


### PR DESCRIPTION
We should not show something that appears to inject sensitive values directly in the instance resource in the walkthrough.