### PR TITLE
Use ConfigMaps for leader election

### DIFF
--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -44,7 +44,8 @@ spec:
         - --port
         - "8080"
         {{ if .Values.controllerManager.leaderElection.activated -}}
-        - "--leader-election-namespace=$(K8S_NAMESPACE)"
+        - "--leader-election-namespace={{ .Release.Namespace }}"
+        - "--leader-elect-resource-lock=configmaps"
         {{- else }}
         - "--leader-elect=false"
         {{- end }}

--- a/charts/catalog/templates/rbac.yaml
+++ b/charts/catalog/templates/rbac.yaml
@@ -112,26 +112,25 @@ items:
     name: "{{ .Values.controllerManager.serviceAccount }}"
     namespace: "{{ .Release.Namespace }}"
 
-# This gives create/update access to an endpoint in kube-system for leader election
-# TODO: use an object other than endpoints, and in the same namespace as the service catalog, not in kube-system
+# This gives create/update access to configmaps in deployment namespace for leader election
 - apiVersion: {{template "rbacApiVersion" . }}
   kind: Role
   metadata:
     name: "servicecatalog.k8s.io:leader-locking-controller-manager"
-    namespace: kube-system
+    namespace: "{{ .Release.Namespace }}"
   rules:
   - apiGroups: [""]
-    resources: ["endpoints"]
+    resources: ["configmaps"]
     verbs:     ["create"]
   - apiGroups:     [""]
-    resources:     ["endpoints"]
+    resources:     ["configmaps"]
     resourceNames: ["service-catalog-controller-manager"]
     verbs:         ["get","update"]
 - apiVersion: {{template "rbacApiVersion" . }}
   kind: RoleBinding
   metadata:
     name: service-catalog-controller-manager
-    namespace: kube-system
+    namespace: "{{ .Release.Namespace }}"
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -84,7 +84,7 @@ controllerManager:
     # Enables lock contention profiling, if profiling is enabled.
     contentionProfiling: false
   leaderElection:
-    # Whether the controller has option to set leader election namespace.
+    # Whether the controller has leader election enabled.
     activated: false
   serviceAccount: service-catalog-controller-manager
   # Controls whether the API server's TLS verification should be skipped.


### PR DESCRIPTION
Giving access to `Endpoints` is scary. Especially in `kube-system` namespace. And also the following:
https://github.com/kubernetes-incubator/service-catalog/blob/99c0644c36b4e5b805bf1864babc98cc6f99e231/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go#L29-L32

I think it's ok to remove support for `Endpoints` as locking resource?