### PR TITLE
Rename the imported package to avoid name conflict

### DIFF
--- a/cmd/apiserver/app/server/run_server.go
+++ b/cmd/apiserver/app/server/run_server.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apiserver"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apiserver/options"
-	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	registryserver "github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
 )
 
 // RunServer runs an API server with configuration according to opts
@@ -47,7 +47,7 @@ func RunServer(opts *ServiceCatalogServerOptions, stopCh <-chan struct{}) error 
 		return err
 	}
 
-	if storageType == server.StorageTypeEtcd {
+	if storageType == registryserver.StorageTypeEtcd {
 		return runEtcdServer(opts, stopCh)
 	}
 	// This should never happen, catch for potential bugs


### PR DESCRIPTION
As declared in [#1601](https://github.com/kubernetes-incubator/service-catalog/issues/1601), there are some confusions when reading the code. So I rename the package from ```server``` to ```registeryserver``` to make it more clear to readers.