### PR TITLE
Add validation for broker spec to SAR admission controller

### DIFF
--- a/plugin/pkg/admission/broker/authsarcheck/admission.go
+++ b/plugin/pkg/admission/broker/authsarcheck/admission.go
@@ -90,7 +90,11 @@ func (s *sarcheck) Admit(a admission.Attributes) error {
 	} else if clusterServiceBroker.Spec.AuthInfo.Bearer != nil {
 		secretRef = clusterServiceBroker.Spec.AuthInfo.Bearer.SecretRef
 	}
-	glog.V(5).Infof("ClusterServiceBroker %q: evaluating auth secret ref", clusterServiceBroker)
+
+	if secretRef == nil {
+		return nil
+	}
+	glog.V(5).Infof("ClusterServiceBroker %+v: evaluating auth secret ref, with authInfo %q", clusterServiceBroker, secretRef)
 	userInfo := a.GetUserInfo()
 
 	sar := &authorizationapi.SubjectAccessReview{

--- a/plugin/pkg/admission/broker/authsarcheck/admission_test.go
+++ b/plugin/pkg/admission/broker/authsarcheck/admission_test.go
@@ -89,7 +89,8 @@ func TestAdmissionBroker(t *testing.T) {
 					Name: "test-broker",
 				},
 				Spec: servicecatalog.ClusterServiceBrokerSpec{
-					URL: "http://example.com",
+					URL:            "http://example.com",
+					RelistBehavior: "Manual",
 				},
 			},
 			userInfo: &user.DefaultInfo{
@@ -105,7 +106,8 @@ func TestAdmissionBroker(t *testing.T) {
 					Name: "test-broker",
 				},
 				Spec: servicecatalog.ClusterServiceBrokerSpec{
-					URL: "http://example.com",
+					URL:            "http://example.com",
+					RelistBehavior: "Manual",
 					AuthInfo: &servicecatalog.ServiceBrokerAuthInfo{
 						Basic: &servicecatalog.BasicAuthConfig{
 							SecretRef: &servicecatalog.ObjectReference{
@@ -129,7 +131,8 @@ func TestAdmissionBroker(t *testing.T) {
 					Name: "test-broker",
 				},
 				Spec: servicecatalog.ClusterServiceBrokerSpec{
-					URL: "http://example.com",
+					URL:            "http://example.com",
+					RelistBehavior: "Manual",
 					AuthInfo: &servicecatalog.ServiceBrokerAuthInfo{
 						Bearer: &servicecatalog.BearerTokenAuthConfig{
 							SecretRef: &servicecatalog.ObjectReference{
@@ -153,7 +156,8 @@ func TestAdmissionBroker(t *testing.T) {
 					Name: "test-broker",
 				},
 				Spec: servicecatalog.ClusterServiceBrokerSpec{
-					URL: "http://example.com",
+					URL:            "http://example.com",
+					RelistBehavior: "Manual",
 					AuthInfo: &servicecatalog.ServiceBrokerAuthInfo{
 						Bearer: &servicecatalog.BearerTokenAuthConfig{
 							SecretRef: &servicecatalog.ObjectReference{
@@ -169,6 +173,49 @@ func TestAdmissionBroker(t *testing.T) {
 				Groups: []string{"system:serviceaccount", "system:serviceaccounts:test-ns"},
 			},
 			allowed: false,
+		},
+		{
+			name: "broker with empty authInfo",
+			broker: &servicecatalog.ClusterServiceBroker{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-broker",
+				},
+				Spec: servicecatalog.ClusterServiceBrokerSpec{
+					URL:            "http://example.com",
+					RelistBehavior: "Manual",
+					AuthInfo:       &servicecatalog.ServiceBrokerAuthInfo{},
+				},
+			},
+			userInfo: &user.DefaultInfo{
+				Name:   "system:serviceaccount:test-ns:forbidden",
+				Groups: []string{"system:serviceaccount", "system:serviceaccounts:test-ns"},
+			},
+			allowed: true,
+		},
+		{
+			name: "broker with authInfo, empty strings for Namespace/Name",
+			broker: &servicecatalog.ClusterServiceBroker{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-broker",
+				},
+				Spec: servicecatalog.ClusterServiceBrokerSpec{
+					URL:            "http://example.com",
+					RelistBehavior: "Manual",
+					AuthInfo: &servicecatalog.ServiceBrokerAuthInfo{
+						Bearer: &servicecatalog.BearerTokenAuthConfig{
+							SecretRef: &servicecatalog.ObjectReference{
+								Namespace: "",
+								Name:      "",
+							},
+						},
+					},
+				},
+			},
+			userInfo: &user.DefaultInfo{
+				Name:   "system:serviceaccount:test-ns:catalog",
+				Groups: []string{"system:serviceaccount", "system:serviceaccounts:test-ns"},
+			},
+			allowed: true,
 		},
 	}
 


### PR DESCRIPTION
This changes the admission controller to validate the broker spec based on existing validation code in the case of the authInfo field existing. I thought that the validation code was run before the admission controller evaluated the spec, but this has turned out to be incorrect.

Issue #1600 