### PR TITLE
remove email from docker login during Travis deploy

### DIFF
--- a/contrib/travis/deploy.sh
+++ b/contrib/travis/deploy.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 export REGISTRY=quay.io/kubernetes-service-catalog/
 
-docker login -e="${QUAY_EMAIL}" -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
+docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
 
 if [[ "${TRAVIS_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[a-z]*(-(r|R)(c|C)[0-9]+)*$ ]]; then
     echo "Pushing images with tags '${TRAVIS_TAG}' and 'latest'."


### PR DESCRIPTION
The email flag has been deprecated for a long time in Docker, and was recently removed entirely. This flag was meant to auto-register a user if the given username doesn't exist. Since our user does exist on Quay, it's a no-op. Removing it should have no effect and unblock deploying.