### PR TITLE
Provide OSB Client proxy to instrument with metrics

### DIFF
--- a/cmd/controller-manager/app/controller_manager.go
+++ b/cmd/controller-manager/app/controller_manager.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/kubernetes/pkg/util/configz"
 	"github.com/kubernetes-incubator/service-catalog/pkg/metrics"
+	"github.com/kubernetes-incubator/service-catalog/pkg/metrics/osbclientproxy"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -57,7 +58,6 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/pkg/controller"
 
 	"github.com/golang/glog"
-	osb "github.com/pmorie/go-open-service-broker-client/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -330,7 +330,7 @@ func StartControllers(s *options.ControllerManagerServer,
 			serviceCatalogSharedInformers.ServiceInstances(),
 			serviceCatalogSharedInformers.ServiceBindings(),
 			serviceCatalogSharedInformers.ClusterServicePlans(),
-			osb.NewClient,
+			osbclientproxy.NewClient,
 			s.ServiceBrokerRelistInterval,
 			s.OSBAPIPreferredVersion,
 			recorder,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -63,14 +63,14 @@ var (
 
 	// OSBRequestCount exposes the number of HTTP requests made to Open Service
 	// Brokers.  The metric is broken out by broker name and response status
-	// (100/200/300/400/500 or 'client-error')
+	// group (1xx/2xx/3xx/4xx/5xx or 'client-error')
 	OSBRequestCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: catalogNamespace,
 			Name:      "osb_request_count",
-			Help:      "Cumulative number of HTTP requests from the OSB Client to the specified Service Broker grouped by name and response status.",
+			Help:      "Cumulative number of HTTP requests from the OSB Client to the specified Service Broker grouped by broker name, broker method, and response status.",
 		},
-		[]string{"broker", "status"},
+		[]string{"broker", "method", "status"},
 	)
 )
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -60,12 +60,25 @@ var (
 		},
 		[]string{"broker"},
 	)
+
+	// OSBRequestCount exposes the number of HTTP requests made to Open Service
+	// Brokers.  The metric is broken out by broker name and response status
+	// (100/200/300/400/500 or 'client-error')
+	OSBRequestCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: catalogNamespace,
+			Name:      "osb_request_count",
+			Help:      "Cumulative number of HTTP requests from the OSB Client to the specified Service Broker grouped by name and response status.",
+		},
+		[]string{"broker", "status"},
+	)
 )
 
 func register() {
 	registerMetrics.Do(func() {
 		prometheus.MustRegister(BrokerServiceClassCount)
 		prometheus.MustRegister(BrokerServicePlanCount)
+		prometheus.MustRegister(OSBRequestCount)
 	})
 }
 

--- a/pkg/metrics/osbclientproxy/osbproxy.go
+++ b/pkg/metrics/osbclientproxy/osbproxy.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package osbclientproxy proxies the OSB Client Library enabling
+// metrics instrumentation
+package osbclientproxy
+
+import (
+	"strconv"
+
+	"github.com/golang/glog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/metrics"
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+)
+
+// proxyclient provides a functional implementation of the OSB V2 Client
+// interface
+type proxyclient struct {
+	brokerName    string
+	realOSBClient osb.Client
+}
+
+// NewClient is a CreateFunc for creating a new functional Client and
+// implements the CreateFunc interface.
+func NewClient(config *osb.ClientConfiguration) (osb.Client, error) {
+	osbClient, err := osb.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+	proxy := proxyclient{realOSBClient: osbClient}
+	proxy.brokerName = config.Name
+	return proxy, nil
+}
+
+var _ osb.CreateFunc = NewClient
+
+// GetCatalog implements go-open-service-broker-client/v2/Client.GetCatalog by
+// proxying the method to the underlying implementation and capturing request
+// metrics.
+func (pc proxyclient) GetCatalog() (*osb.CatalogResponse, error) {
+	glog.V(9).Info("OSBClientProxy getCatalog()")
+	response, err := pc.realOSBClient.GetCatalog()
+	pc.updateMetrics(err)
+	return response, err
+}
+
+// ProvisionInstance implements
+// go-open-service-broker-client/v2/Client.ProvisionInstance by proxying the
+// method to the underlying implementation and capturing request metrics.
+func (pc proxyclient) ProvisionInstance(r *osb.ProvisionRequest) (*osb.ProvisionResponse, error) {
+	glog.V(9).Info("OSBClientProxy ProvisionInstance()")
+	response, err := pc.realOSBClient.ProvisionInstance(r)
+	pc.updateMetrics(err)
+	return response, err
+
+}
+
+// UpdateInstance implements
+// go-open-service-broker-client/v2/Client.UpdateInstance by proxying the method
+// to the underlying implementation and capturing request metrics.
+func (pc proxyclient) UpdateInstance(r *osb.UpdateInstanceRequest) (*osb.UpdateInstanceResponse, error) {
+	glog.V(9).Info("OSBClientProxy UpdateInstance()")
+	response, err := pc.realOSBClient.UpdateInstance(r)
+	pc.updateMetrics(err)
+	return response, err
+}
+
+// DeprovisionInstance implements
+// go-open-service-broker-client/v2/Client.DeprovisionInstance by proxying the
+// method to the underlying implementation and capturing request metrics.
+func (pc proxyclient) DeprovisionInstance(r *osb.DeprovisionRequest) (*osb.DeprovisionResponse, error) {
+	glog.V(9).Info("OSBClientProxy DeprovisionInstance()")
+	response, err := pc.realOSBClient.DeprovisionInstance(r)
+	pc.updateMetrics(err)
+	return response, err
+}
+
+// PollLastOperation implements
+// go-open-service-broker-client/v2/Client.PollLastOperation by proxying the
+// method to the underlying implementation and capturing request metrics.
+func (pc proxyclient) PollLastOperation(r *osb.LastOperationRequest) (*osb.LastOperationResponse, error) {
+	glog.V(9).Info("OSBClientProxy PollLastOperation()")
+	response, err := pc.realOSBClient.PollLastOperation(r)
+	pc.updateMetrics(err)
+	return response, err
+}
+
+// PollBindingLastOperation implements
+// go-open-service-broker-client/v2/Client.PollBindingLastOperation by proxying
+// the method to the underlying implementation and capturing request metrics.
+func (pc proxyclient) PollBindingLastOperation(r *osb.BindingLastOperationRequest) (*osb.LastOperationResponse, error) {
+	glog.V(9).Info("OSBClientProxy PollBindingLastOperation()")
+	response, err := pc.realOSBClient.PollBindingLastOperation(r)
+	pc.updateMetrics(err)
+	return response, err
+}
+
+// Bind implements go-open-service-broker-client/v2/Client.Bind by proxying the
+// method to the underlying implementation and capturing request metrics.
+func (pc proxyclient) Bind(r *osb.BindRequest) (*osb.BindResponse, error) {
+	glog.V(9).Info("OSBClientProxy Bind().")
+	response, err := pc.realOSBClient.Bind(r)
+	pc.updateMetrics(err)
+	return response, err
+}
+
+// Unbind implements go-open-service-broker-client/v2/Client.Unbind by proxying
+// the method to the underlying implementation and capturing request metrics.
+func (pc proxyclient) Unbind(r *osb.UnbindRequest) (*osb.UnbindResponse, error) {
+	glog.V(9).Info("OSBClientProxy Unbind()")
+	response, err := pc.realOSBClient.Unbind(r)
+	pc.updateMetrics(err)
+	return response, err
+}
+
+// GetBinding implements go-open-service-broker-client/v2/Client.GetBinding by
+// proxying the method to the underlying implementation and capturing request
+// metrics.
+func (pc proxyclient) GetBinding(r *osb.GetBindingRequest) (*osb.GetBindingResponse, error) {
+	glog.V(9).Info("OSBClientProxy GetBinding()")
+	response, err := pc.realOSBClient.GetBinding(r)
+	pc.updateMetrics(err)
+	return response, err
+}
+
+// updateMetrics bumps the request count metric for the specific broker and
+// status
+func (pc proxyclient) updateMetrics(err error) {
+	if err == nil {
+		metrics.OSBRequestCount.WithLabelValues(pc.brokerName, "200").Inc()
+	} else {
+		status, ok := osb.IsHTTPError(err)
+		if ok {
+			metrics.OSBRequestCount.WithLabelValues(pc.brokerName, strconv.Itoa(status.StatusCode/100*100)).Inc()
+		} else {
+			metrics.OSBRequestCount.WithLabelValues(pc.brokerName, "client-error").Inc()
+		}
+	}
+}


### PR DESCRIPTION
We want to collect metrics from the OSB Client library such as the number of requests made to each broker and the error rate.  This PR provides a client proxy in Service Catalog to keep the details out of the OSB client library implementation.