### PR TITLE
Updating the install documentation

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -74,7 +74,7 @@ You should see the following output:
 
 ```console
 NAME           	VERSION	DESCRIPTION
-svc-cat/catalog	0.0.1  	service-catalog API server and controller-manag...
+svc-cat/catalog	x,y.z  	service-catalog API server and controller-manag...
 ```
 
 If you see it, your repository is properly added.

--- a/docs/install.md
+++ b/docs/install.md
@@ -19,13 +19,12 @@ The rest of this document details how to:
 
 ## Kubernetes Version
 
-Service Catalog requires a Kubernetes cluster v1.7.0 or later. You'll also need a 
+Service Catalog requires a Kubernetes cluster v1.7 or later. You'll also need a 
 [Kubernetes configuration file](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) 
 installed on your host. You need this file so you can use `kubectl` and 
-[`helm`](https://helm.sh) to communicate with the cluster.
-
-Many Kubernetes installation tools and/or cloud providers will set up this 
-configuration file for you. Please check with your tool for details.
+[`helm`](https://helm.sh) to communicate with the cluster. Many Kubernetes installation 
+tools and/or cloud providers will set this configuration file up for you. Please
+check with your tool or provider for details.
 
 ### `kubectl` Version
 
@@ -39,7 +38,7 @@ First, check your version of `kubectl`:
 kubectl version
 ```
 
-Ensure that the server version and client versions are both `1.7.0` or above.
+Ensure that the server version and client versions are both `1.7` or above.
 
 If you need to upgrade your client, follow the 
 [installation instructions](https://kubernetes.io/docs/tasks/kubectl/install/) 

--- a/docs/install.md
+++ b/docs/install.md
@@ -17,22 +17,55 @@ The rest of this document details how to:
 
 # Step 1 - Prerequisites
 
-## Starting Kubernetes with DNS
+## Kubernetes Version
 
-You *must* have a Kubernetes cluster with cluster DNS enabled. We can't list
-instructions here for enabling cluster DNS for all Kubernetes distributions, but
-here are a few notes:
+Service Catalog requires a Kubernetes cluster v1.7.0 or later. You'll also need a 
+[Kubernetes configuration file](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) 
+installed on your host. You need this file so you can use `kubectl` and 
+[`helm`](https://helm.sh) to communicate with the cluster.
 
-* If you are using a cloud-based Kubernetes cluster or minikube, you likely have
-cluster DNS enabled already.
-* If you are using `hack/local-up-cluster.sh`, ensure the
-`KUBE_ENABLE_CLUSTER_DNS` environment variable is set, then run the install
-script.
+Many Kubernetes installation tools and/or cloud providers will set up this 
+configuration file for you. Please check with your tool for details.
+
+### `kubectl` Version
+
+Most interaction with the service catalog system is achieved through the 
+`kubectl` command line interface. As with the cluster version, Service Catalog
+requires `kubectl` version 1.7 or newer.
+
+First, check your version of `kubectl`:
+
+```console
+kubectl version
+```
+
+Ensure that the server version and client versions are both `1.7.0` or above.
+
+If you need to upgrade your client, follow the 
+[installation instructions](https://kubernetes.io/docs/tasks/kubectl/install/) 
+to get a new `kubectl` binary.
+
+For example, run the following command to get an up-to-date binary on Mac OS:
+
+```console
+curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl
+chmod +x ./kubectl
+```
+
+## In-Cluster DNS
+
+You'll need a Kubernetes installation with in-cluster DNS enabled. Most popular
+installation methods will automatically configure in-cluster DNS for you:
+
+- [Minikube](https://github.com/kubernetes/minikube)
+- [`hack/local-up-cluster.sh`](https://github.com/kubernetes/kubernetes/blob/master/hack/local-up-cluster.sh)
+(in the Kubernetes repository)
+- Most cloud providers
 
 ## Helm
 
-You *must* use [Helm](http://helm.sh/) v2.7.0 or newer in the installation
-steps below.
+You'll install Service Catalog with [Helm](http://helm.sh/), and you'll need
+v2.7.0 or newer for that. See the steps below to install.
 
 ### If You Don't Have Helm Installed
 
@@ -53,12 +86,29 @@ and run `helm init --upgrade`.
 For more details on installation, see the
 [Helm installation instructions](https://github.com/kubernetes/helm/blob/master/docs/install.md).
 
-### Helm Charts
+### Tiller Permissions
+
+Tiller is the in-cluster server component of Helm. By default, 
+`helm init` installs the Tiller pod into the `kube-system` namespace,
+and configures Tiller to use the `default` service account.
+
+Tiller will need to be configured with `cluster-admin` access to properly install
+Service Catalog:
+
+```console
+kubectl create clusterrolebinding tiller-cluster-admin \
+    --clusterrole=cluster-admin \
+    --serviceaccount=kube-system:default
+```
+
+## Helm Repository Setup
 
 Service Catalog is easily installed via a 
 [Helm chart](https://github.com/kubernetes/helm/blob/master/docs/charts.md).
 
-Before installation, add the service-catalog Helm repository to your local machine:
+This chart is located in a
+[chart repository](https://github.com/kubernetes/helm/blob/master/docs/chart_repository.md)
+just for Service Catalog. Add this repository to your local machine:
 
 ```console
 helm repo add svc-cat https://svc-catalog-charts.storage.googleapis.com
@@ -77,66 +127,36 @@ NAME           	VERSION	DESCRIPTION
 svc-cat/catalog	x,y.z  	service-catalog API server and controller-manag...
 ```
 
-If you see it, your repository is properly added.
-
 ## RBAC
 
 Your Kubernetes cluster must have 
 [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/) enabled to use
 Service Catalog.
 
-If you are using Minikube, make sure to run your `minikube start` command with
-this flag:
+Like in-cluster DNS, many installation methods should enable RBAC for you.
+
+### Minikube
+
+If you are using Minikube, start your cluster with this command:
 
 ```console
 minikube start --extra-config=apiserver.Authorization.Mode=RBAC
 ```
 
-If you are using `hack/local-up-cluster.sh`, ensure the
-`AUTHORIZATION_MODE` environment variable is set as follows:
+### `hack/local-cluster-up.sh`
+
+If you are using the 
+[`hack/local-up-cluster.sh`](https://github.com/kubernetes/kubernetes/blob/master/hack/local-up-cluster.sh)
+script in the Kubernetes core repository, start your cluster with this command:
 
 ```console
 AUTHORIZATION_MODE=Node,RBAC hack/local-up-cluster.sh -O
 ```
 
-### Tiller Permissions
+### Cloud Providers
 
-Tiller is the in-cluster server component of Helm. By default, 
-`helm init` installs the Tiller pod into the `kube-system` namespace,
-and configures Tiller to use the `default` service account.
-
-Tiller will need to be configured with `cluster-admin` access to properly install
-Service Catalog:
-
-```console
-kubectl create clusterrolebinding tiller-cluster-admin \
-    --clusterrole=cluster-admin \
-    --serviceaccount=kube-system:default
-```
-
-## A Recent kubectl
-
-As with Kubernetes itself, interaction with the service catalog system is
-achieved through the `kubectl` command line interface. Service Catalog 
-requires `kubectl` version 1.7 or newer.
-
-To check your version of `kubectl`, run:
-
-```console
-kubectl version
-```
-
-Recall that the server version must be `1.7` or above. If the client version
-is below 1.7, follow the 
-[installation instructions](https://kubernetes.io/docs/tasks/kubectl/install/) 
-to get a new `kubectl` binary.
-
-For example, run the following command to get an up-to-date binary on Mac OS:
-
-```console
-curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl
-chmod +x ./kubectl
-```
+Many cloud providers set up new clusters with RBAC enabled for you. Please
+check with your provider's documentation for details.
 
 # Step 2 - Install Service Catalog
 


### PR DESCRIPTION
These documentation were verbose and fairly confusing. A subjective measurement, I know, but I believe this patch should make the installation instructions a little bit clearer. We may need a follow-up to restructure them to more closely match an actual installation workflow.