### PR TITLE
silence go-restful logging output

### DIFF
--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -20,11 +20,13 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"math/rand"
 	"net/http"
 	"testing"
 	"time"
 
+	restfullog "github.com/emicklei/go-restful/log"
 	"github.com/golang/glog"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -42,6 +44,8 @@ import (
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
+	// silence the go-restful webservices swagger logger
+	restfullog.SetLogger(log.New(ioutil.Discard, "[restful]", log.LstdFlags|log.Lshortfile))
 }
 
 type TestServerConfig struct {


### PR DESCRIPTION
This removes from the integration tests the repeated output:
```
[restful] 2017/12/16 00:49:53 log.go:33: [restful/swagger] listing is available at https:///swaggerapi
[restful] 2017/12/16 00:49:53 log.go:33: [restful/swagger] https:///swaggerui/ is mapped to folder /swagger-ui/
```
Which I don't think has any useful information for us.