### PR TITLE
fix compilation error from updated util.WaitForBindingCondition()-#1629

### DIFF
--- a/test/e2e/walkthrough.go
+++ b/test/e2e/walkthrough.go
@@ -176,7 +176,7 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 		Expect(binding).NotTo(BeNil())
 
 		By("Waiting for ServiceBinding to be ready")
-		err = util.WaitForBindingCondition(f.ServiceCatalogClientSet.ServicecatalogV1beta1(),
+		_, err = util.WaitForBindingCondition(f.ServiceCatalogClientSet.ServicecatalogV1beta1(),
 			testnamespace.Name,
 			bindingName,
 			v1beta1.ServiceBindingCondition{


### PR DESCRIPTION
WaitForBindingCondition() was updated with multiple return values, this fixes a compilation error in the walkthrough.  Fixes #1629.

Also created issue #1630 to build e2e as part of CI (the run of e2e is currently disabled)