### PR TITLE
comment on commented out test

### DIFF
--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -1261,6 +1261,7 @@ func TestDeleteServiceInstance(t *testing.T) {
 				}
 			},
 		},
+		// #1611 introduced #1625, a data race exists in this test
 		// {
 		// 	name: "deprovision instance after in progress provision",
 		// 	skipVerifyingInstanceSuccess: true,


### PR DESCRIPTION
To save viewers the effort of having to look up why this test case is commented out.