### PR TITLE
run some integration subtests in parallel

### DIFF
--- a/test/integration/controller_binding_test.go
+++ b/test/integration/controller_binding_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -28,7 +29,6 @@ import (
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-incubator/service-catalog/test/util"
-	"net/http"
 )
 
 // TestCreateServiceBindingSuccess successful paths binding
@@ -416,7 +416,9 @@ func TestCreateServiceBindingWithParameters(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ct := &controllerTest{
 				t:        t,
 				broker:   getTestBroker(),

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -99,7 +99,9 @@ func TestCreateServiceInstanceNonExistentClusterServiceClassOrPlan(t *testing.T)
 		},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ct := &controllerTest{
 				t:      t,
 				broker: getTestBroker(),
@@ -421,7 +423,9 @@ func TestCreateServiceInstanceWithParameters(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ct := &controllerTest{
 				t:      t,
 				broker: getTestBroker(),
@@ -520,7 +524,9 @@ func TestUpdateServiceInstanceChangePlans(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ct := &controllerTest{
 				t:      t,
 				broker: getTestBroker(),
@@ -763,7 +769,9 @@ func TestUpdateServiceInstanceUpdateParameters(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ct := &controllerTest{
 				t:      t,
 				broker: getTestBroker(),
@@ -983,7 +991,9 @@ func TestCreateServiceInstanceWithProvisionFailure(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ct := &controllerTest{
 				t:                            t,
 				broker:                       getTestBroker(),
@@ -1301,7 +1311,9 @@ func TestDeleteServiceInstance(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ct := &controllerTest{
 				t:                            t,
 				broker:                       getTestBroker(),
@@ -1502,7 +1514,9 @@ func TestPollServiceInstanceLastOperation(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ct := &controllerTest{
 				t:                            t,
 				broker:                       getTestBroker(),

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -106,7 +106,9 @@ func TestBasicFlows(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			if tc.asyncForBindings {
 				// Enable the AsyncBindingOperations feature
 				utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.AsyncBindingOperations))


### PR DESCRIPTION
I looked for all the long running tests. Saw that many had
subtests. Let's try and run the subtests in parallel and see what
happens.

Travis sees less of a speedup than I do locally. Not sure why. This shouldn't be a CPU bound task since all of the servers are just goroutines doing waiting. All of the individual subtests (which should be running at the same time) take very similar lengths of time compared to original runs.
