### PR TITLE
Service instance deletion shouldn't be blocked by bindings if the instance was never provisioned

### DIFF
--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -481,11 +481,6 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1beta1.ServiceIns
 
 	instance = instance.DeepCopy()
 
-	// We don't want to delete the instance if there are any bindings associated.
-	if err := c.checkServiceInstanceHasExistingBindings(instance); err != nil {
-		return c.handleServiceInstanceReconciliationError(instance, err)
-	}
-
 	// If the deprovisioning succeeded or is not needed, then no need to
 	// make a request to the broker.
 	if instance.Status.DeprovisionStatus == v1beta1.ServiceInstanceDeprovisionStatusNotRequired ||
@@ -502,6 +497,11 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1beta1.ServiceIns
 		readyCond := newServiceInstanceReadyCondition(v1beta1.ConditionUnknown, errorInvalidDeprovisionStatusReason, msg)
 		failedCond := newServiceInstanceFailedCondition(v1beta1.ConditionTrue, errorInvalidDeprovisionStatusReason, msg)
 		return c.processDeprovisionFailure(instance, readyCond, failedCond)
+	}
+
+	// We don't want to delete the instance if there are any bindings associated.
+	if err := c.checkServiceInstanceHasExistingBindings(instance); err != nil {
+		return c.handleServiceInstanceReconciliationError(instance, err)
 	}
 
 	serviceClass, servicePlan, brokerName, brokerClient, err := c.getClusterServiceClassPlanAndClusterServiceBroker(instance)
@@ -1202,7 +1202,11 @@ func (c *controller) checkServiceInstanceHasExistingBindings(instance *v1beta1.S
 	if err != nil {
 		return err
 	}
+
 	for _, binding := range bindingList {
+		// Note that as we are potentially looking at a stale binding resource
+		// and cannot rely on UnbindStatus == ServiceBindingUnbindStatusNotRequired
+		// to filter out binding requests that have yet to be sent to the broker.
 		if instance.Name == binding.Spec.ServiceInstanceRef.Name {
 			return &operationError{
 				reason:  errorDeprovisionBlockedByCredentialsReason,

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -853,6 +853,26 @@ func getTestServiceBinding() *v1beta1.ServiceBinding {
 	}
 }
 
+// instantiates a yet-to-be-created binding
+func getTestServiceInactiveBinding() *v1beta1.ServiceBinding {
+	return &v1beta1.ServiceBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testServiceBindingName,
+			Namespace:  testNamespace,
+			Finalizers: []string{v1beta1.FinalizerServiceCatalog},
+			Generation: 1,
+		},
+		Spec: v1beta1.ServiceBindingSpec{
+			ServiceInstanceRef: v1beta1.LocalObjectReference{Name: testServiceInstanceName},
+			ExternalID:         testServiceBindingGUID,
+		},
+		Status: v1beta1.ServiceBindingStatus{
+			Conditions:   []v1beta1.ServiceBindingCondition{},
+			UnbindStatus: v1beta1.ServiceBindingUnbindStatusNotRequired,
+		},
+	}
+}
+
 func getTestServiceBindingUnbinding() *v1beta1.ServiceBinding {
 	binding := &v1beta1.ServiceBinding{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Closes #1588