### PR TITLE
Build the e2e binary in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
   - .glide
 script:
-- make verify build test images
+- make verify build build-e2e test images
 deploy:
   skip_cleanup: true
   provider: script

--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,9 @@ test-integration: .init $(scBuildImageTarget) build
 clean-e2e:
 	rm -f $(BINDIR)/e2e.test
 
-test-e2e: .generate_files $(BINDIR)/e2e.test
+build-e2e: .generate_files $(BINDIR)/e2e.test
+
+test-e2e: build-e2e
 	$(BINDIR)/e2e.test
 
 clean: clean-bin clean-build-image clean-generated clean-coverage


### PR DESCRIPTION
Builds the e2e binary in travis so we can be sure it stays working until #808 is complete.