### PR TITLE
embedded etcd is the way of the future for our tests

### DIFF
--- a/test/integration.sh
+++ b/test/integration.sh
@@ -18,14 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# this script resides in the `test/` folder at the root of the project
-KUBE_ROOT=$(realpath $(dirname "${BASH_SOURCE}")/../pkg/kubernetes)
-source "${KUBE_ROOT}/hack/lib/init.sh"
 GOROOT=$(go env GOROOT)
 
 runTests() {
-  # kube::etcd::start
-
   if [[ -w ${GOROOT}/pkg ]]; then
     FLAGS="-i"
   elif [[ -n ${PKGDIR:-} ]]; then
@@ -37,9 +32,6 @@ runTests() {
   go test -race $FLAGS github.com/kubernetes-incubator/service-catalog/test/integration/... -c \
       && ./integration.test -test.v $@
 }
-
-# Run cleanup to stop etcd on interrupt or other kill signal.
-# trap kube::etcd::cleanup EXIT
 
 runTests $@
 


### PR DESCRIPTION
my first thought was that there was an upstream kube script to emulate realpath, but we'd need realpath working to load it. Turns out we don't even need it, so this should fix [this particular comment](https://github.com/kubernetes-incubator/service-catalog/issues/1649#issuecomment-355424640) at least.