### PR TITLE
Cluster-id configmap

### DIFF
--- a/cmd/controller-manager/app/controller_manager.go
+++ b/cmd/controller-manager/app/controller_manager.go
@@ -363,6 +363,8 @@ func StartControllers(s *options.ControllerManagerServer,
 		recorder,
 		s.ReconciliationRetryDuration,
 		s.OperationPollingMaximumBackoffDuration,
+		s.ClusterIDConfigMapName,
+		s.ClusterIDConfigMapNamespace,
 	)
 	if err != nil {
 		return err

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -27,6 +27,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/componentconfig"
+	"github.com/kubernetes-incubator/service-catalog/pkg/controller"
 	k8scomponentconfig "github.com/kubernetes-incubator/service-catalog/pkg/kubernetes/pkg/apis/componentconfig"
 	"github.com/kubernetes-incubator/service-catalog/pkg/kubernetes/pkg/client/leaderelectionconfig"
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
@@ -119,4 +120,6 @@ func (s *ControllerManagerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.OperationPollingMaximumBackoffDuration, "operation-polling-maximum-backoff-duration", s.OperationPollingMaximumBackoffDuration, "The maximum amount of time to back-off while polling an OSB API operation")
 	s.SecureServingOptions.AddFlags(fs)
 	utilfeature.DefaultFeatureGate.AddFlag(fs)
+	fs.StringVar(&s.ClusterIDConfigMapName, "cluster-id-configmap-name", controller.DefaultClusterIDConfigMapName, "k8s name for clusterid configmap")
+	fs.StringVar(&s.ClusterIDConfigMapNamespace, "cluster-id-configmap-namespace", controller.DefaultClusterIDConfigMapNamespace, "k8s namespace for clusterid configmap")
 }

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -104,4 +104,9 @@ type ControllerManagerConfiguration struct {
 	OperationPollingMaximumBackoffDuration time.Duration
 
 	SecureServingOptions *genericoptions.SecureServingOptions
+
+	// ClusterIDConfigMapName is the k8s name that the clusterid configmap will have
+	ClusterIDConfigMapName string
+	// ClusterIDConfigMapNamespace is the k8s namespace that the clusterid configmap will be stored in.
+	ClusterIDConfigMapNamespace string
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -192,8 +192,6 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 		}
 	}
 
-	c.setClusterID(string(uuid.NewUUID()))
-
 	func() {
 		waitGroup.Add(1)
 		go func() {
@@ -759,6 +757,14 @@ func (c *controller) getClusterID() (id string) {
 	c.clusterIDLock.RLock()
 	id = c.clusterID
 	c.clusterIDLock.RUnlock()
+
+	// fast exit if it exists
+	if id != "" {
+		return
+	}
+	// lazily create on first access if does not exist
+	id = string(uuid.NewUUID())
+	c.setClusterID(id)
 	return
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -226,7 +226,7 @@ func createWorker(queue workqueue.RateLimitingInterface, resourceType string, ma
 func (c *controller) createConfigMapMonitorWorker(stopCh <-chan struct{}, waitGroup *sync.WaitGroup) {
 	waitGroup.Add(1)
 	go func() {
-		wait.Until(c.monitorConfigMap, time.Second, stopCh)
+		wait.Until(c.monitorConfigMap, 15*time.Second, stopCh)
 		waitGroup.Done()
 	}()
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -262,7 +262,7 @@ func (c *controller) monitorConfigMap() {
 			c.kubeClient.CoreV1().ConfigMaps("default").Update(cm)
 		}
 	} else { // some err we can't handle
-		glog.V(4).Info("error getting the cluster info configmap")
+		glog.V(4).Infof("error getting the cluster info configmap: %q", err)
 	}
 	glog.V(9).Info("cluster ID monitor loop exit")
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -252,7 +252,7 @@ func (c *controller) monitorConfigMap() {
 		if _, err := c.kubeClient.CoreV1().ConfigMaps("default").Create(cm); err != nil {
 			glog.Warningf("due to error %q, could not set clusterid configmap to %#v ", err, cm)
 		}
-	} else if err != nil {
+	} else if nil == err {
 		// cluster id exists and is set
 		// get id out of cm
 		if id := cm.Data["id"]; "" != id {
@@ -267,7 +267,6 @@ func (c *controller) monitorConfigMap() {
 		glog.V(4).Info("error getting the cluster info configmap")
 	}
 	glog.V(9).Info("cluster ID monitor loop exit")
-
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -770,14 +770,12 @@ func (c *controller) getClusterID() (id string) {
 	}
 	// lazily create on first access if does not exist
 	c.clusterIDLock.Lock()
-	// make sure nobody set ID while we were locking
-	id = c.clusterID
-	if id != "" {
-		c.clusterIDLock.Unlock()
-		return
+	// check the id again to make sure nobody set ID while we were
+	// locking
+	if id = c.clusterID; id == "" {
+		id = string(uuid.NewUUID())
+		c.clusterID = id
 	}
-	id = string(uuid.NewUUID())
-	c.clusterID = id
 	c.clusterIDLock.Unlock()
 	return
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -763,8 +763,16 @@ func (c *controller) getClusterID() (id string) {
 		return
 	}
 	// lazily create on first access if does not exist
+	c.clusterIDLock.Lock()
+	// make sure nobody set ID while we were locking
+	id = c.clusterID
+	if id != "" {
+		c.clusterIDLock.Unlock()
+		return
+	}
 	id = string(uuid.NewUUID())
-	c.setClusterID(id)
+	c.clusterID = id
+	c.clusterIDLock.Unlock()
 	return
 }
 

--- a/pkg/controller/controller_clusterid_test.go
+++ b/pkg/controller/controller_clusterid_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+// TestGetClusterIDDefaulting ensures the ID defaulting works to
+// create an ID on access if one is not set.
+func TestGetClusterIDDefaulting(t *testing.T) {
+	_, _, _, tc, _ := newTestController(t, noFakeActions())
+	tc.setClusterID("")
+	if tc.getClusterID() == "" {
+		t.Fatalf("cluster id should have been generated and filled in upon request")
+	}
+	t.Log(tc.getClusterID())
+}
+
+// TestGetClusterIDRoundTrip soley tests the controllers ID accessor
+// functions to ensure we get back out what we put in.
+func TestGetClusterIDRoundTrip(t *testing.T) {
+	_, _, _, tc, _ := newTestController(t, noFakeActions())
+	tc.setClusterID("")
+	tc.setClusterID(testClusterID)
+	if tc.getClusterID() != testClusterID {
+		t.Fatalf("should have got the same string out that we put in")
+	}
+}
+
+// TestMonitorConfigMapNoConfigmap ensures that if we don't have a
+// configmap ID, but the ID in the controller is set, that the ID in
+// the controller does not change. The configmap is also created with
+// the existing value filled in.
+func TestMonitorConfigMapNoConfigmap(t *testing.T) {
+	kc, _, _, tc, _ := newTestController(t, noFakeActions())
+	kc.AddReactor("get", "configmaps", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		m := make(map[string]string)
+		m["id"] = testClusterID
+		return true, nil, errors.NewNotFound(schema.GroupResource{"core", "configmap"}, "cluster-info")
+	})
+	tc.setClusterID(testClusterID)
+	tc.monitorConfigMap()
+	if tc.getClusterID() != testClusterID {
+		t.Fatalf("should have got the same string out that we put in")
+	}
+	if kc.Actions()[1].Matches("create", "configmaps") {
+		createdCM := kc.Actions()[1].(clientgotesting.CreateAction).GetObject().(*corev1.ConfigMap)
+		if id, ok := createdCM.Data["id"]; !(ok && id == testClusterID) {
+			t.Fatalf("new configmap should have id as existing testClusterID. Had id %q", id)
+		}
+	} else {
+		t.Fatalf("should have created a new configmap")
+	}
+}
+
+// TestMonitorConfigMapNoConfigmapNoExistingClusterID checks that if a
+// configmap does not exist, it is created and filled in with a
+// generated ID
+func TestMonitorConfigMapNoConfigmapNoExistingClusterID(t *testing.T) {
+	kc, _, _, tc, _ := newTestController(t, noFakeActions())
+	kc.AddReactor("get", "configmaps", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		m := make(map[string]string)
+		m["id"] = testClusterID
+		return true, nil, errors.NewNotFound(schema.GroupResource{"core", "configmap"}, "cluster-info")
+	})
+	tc.setClusterID("")
+	tc.monitorConfigMap()
+	if tc.getClusterID() == "" {
+		t.Fatalf("cluster id should have been generated and filled in upon request")
+	}
+	if kc.Actions()[1].Matches("create", "configmaps") {
+		createdCM := kc.Actions()[1].(clientgotesting.CreateAction).GetObject().(*corev1.ConfigMap)
+		if id, ok := createdCM.Data["id"]; !(ok && id != "") {
+			t.Fatalf("new configmap should have a non-blank id")
+		}
+	} else {
+		t.Fatalf("should have created a new configmap")
+	}
+
+}
+
+// TestMonitorConfigMapConfigmapOverride checks that the ID is set to
+// the value contained in the ConfigMap, even if an existing ID is
+// present in the controller.
+func TestMonitorConfigMapConfigmapOverride(t *testing.T) {
+	kc, _, _, tc, _ := newTestController(t, noFakeActions())
+	kc.AddReactor("get", "configmaps", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		m := make(map[string]string)
+		m["id"] = testClusterID // override existing ID with standard test ID
+		return true, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster-info",
+			},
+			Data: m,
+		}, nil
+	})
+	tc.setClusterID("non-cluster-id") // existing id to be overridden
+	tc.monitorConfigMap()
+	if tc.getClusterID() != testClusterID {
+		t.Fatalf("should have got the override id from the configmap")
+	}
+}
+
+// TestMonitorConfigMapConfigmapWithNoData checks that if a configmap
+// with no data to have an ID is returned, that we update the
+// configmap to have an ID field with the currently existing ID from
+// the controller
+func TestMonitorConfigMapConfigmapWithNoData(t *testing.T) {
+	kc, _, _, tc, _ := newTestController(t, noFakeActions())
+	blankcm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster-info",
+		},
+	}
+	kc.AddReactor("get", "configmaps", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, blankcm, nil
+	})
+	tc.setClusterID(testClusterID)
+	tc.monitorConfigMap()
+	if tc.getClusterID() != testClusterID {
+		t.Fatalf("should have got the set cluster id")
+	}
+	if expectedCMget := kc.Actions()[0]; expectedCMget.GetVerb() != "get" {
+		t.Fatalf("get configmap is first")
+	}
+	if expectedCMupdate := kc.Actions()[1]; expectedCMupdate.GetVerb() == "update" {
+		updatedCM := expectedCMupdate.(clientgotesting.UpdateAction).GetObject().(*corev1.ConfigMap)
+		if id := updatedCM.Data["id"]; id != testClusterID {
+			t.Fatalf("configmap should have been updated with the existing clusterid")
+		}
+	} else {
+		t.Fatalf("configmap should have been updated with the existing clusterid")
+	}
+}

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -85,6 +85,8 @@ const (
 	deprovisioningInFlightMessage           string = "Deprovision request for ServiceInstance in-flight to Broker"
 	startingInstanceOrphanMitigationReason  string = "StartingInstanceOrphanMitigation"
 	startingInstanceOrphanMitigationMessage string = "The instance provision call failed with an ambiguous error; attempting to deprovision the instance in order to mitigate an orphaned resource"
+
+	clusterIdentifierKey string = "clusterid"
 )
 
 // ServiceInstance handlers and control-loop
@@ -1416,9 +1418,9 @@ func (c *controller) prepareRequestHelper(instance *v1beta1.ServiceInstance, ser
 	// on the version of the client.
 	id := c.getClusterID()
 	rh.requestContext = map[string]interface{}{
-		"platform":  ContextProfilePlatformKubernetes,
-		"namespace": instance.Namespace,
-		"clusterID": id,
+		"platform":           ContextProfilePlatformKubernetes,
+		"namespace":          instance.Namespace,
+		clusterIdentifierKey: id,
 	}
 	return rh, nil
 }

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1416,8 +1416,8 @@ func (c *controller) prepareRequestHelper(instance *v1beta1.ServiceInstance, ser
 	// on the version of the client.
 	c.clusterIDLock.RLock()
 	rh.requestContext = map[string]interface{}{
-		"platform": ContextProfilePlatformKubernetes,
-		"namespace": instance.Namespace,
+		"platform":   ContextProfilePlatformKubernetes,
+		"namespace":  instance.Namespace,
 		"cluster-id": c.clusterID,
 	}
 	c.clusterIDLock.RUnlock()

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1416,9 +1416,9 @@ func (c *controller) prepareRequestHelper(instance *v1beta1.ServiceInstance, ser
 	// on the version of the client.
 	id := c.getClusterID()
 	rh.requestContext = map[string]interface{}{
-		"platform":   ContextProfilePlatformKubernetes,
-		"namespace":  instance.Namespace,
-		"cluster-id": id,
+		"platform":  ContextProfilePlatformKubernetes,
+		"namespace": instance.Namespace,
+		"clusterID": id,
 	}
 	return rh, nil
 }

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1414,12 +1414,13 @@ func (c *controller) prepareRequestHelper(instance *v1beta1.ServiceInstance, ser
 
 	// osb client handles whether or not to really send this based
 	// on the version of the client.
+	c.clusterIDLock.RLock()
 	rh.requestContext = map[string]interface{}{
 		"platform": ContextProfilePlatformKubernetes,
 		"namespace": instance.Namespace,
 		"cluster-id": c.clusterID,
 	}
-
+	c.clusterIDLock.RUnlock()
 	return rh, nil
 }
 

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1415,7 +1415,7 @@ func (c *controller) prepareRequestHelper(instance *v1beta1.ServiceInstance, ser
 	// osb client handles whether or not to really send this based
 	// on the version of the client.
 	rh.requestContext = map[string]interface{}{
-		"platform":  ContextProfilePlatformKubernetes,
+		"platform": ContextProfilePlatformKubernetes,
 		"namespace": instance.Namespace,
 		"cluster-id": c.clusterID,
 	}

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1417,6 +1417,7 @@ func (c *controller) prepareRequestHelper(instance *v1beta1.ServiceInstance, ser
 	rh.requestContext = map[string]interface{}{
 		"platform":  ContextProfilePlatformKubernetes,
 		"namespace": instance.Namespace,
+		"cluster-id": c.clusterID,
 	}
 
 	return rh, nil

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1414,13 +1414,12 @@ func (c *controller) prepareRequestHelper(instance *v1beta1.ServiceInstance, ser
 
 	// osb client handles whether or not to really send this based
 	// on the version of the client.
-	c.clusterIDLock.RLock()
+	id := c.getClusterID()
 	rh.requestContext = map[string]interface{}{
 		"platform":   ContextProfilePlatformKubernetes,
 		"namespace":  instance.Namespace,
-		"cluster-id": c.clusterID,
+		"cluster-id": id,
 	}
-	c.clusterIDLock.RUnlock()
 	return rh, nil
 }
 

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -678,7 +678,7 @@ func TestReconcileServiceInstanceWithParameters(t *testing.T) {
 				Context: map[string]interface{}{
 					"platform":  "kubernetes",
 					"namespace": "test-ns",
-					"clusterID": "",
+					"clusterID": testClusterID,
 				},
 				Parameters: tc.expectedParams,
 			})
@@ -889,7 +889,7 @@ func TestReconcileServiceInstanceWithProvisionCallFailure(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
-			"clusterID": "",
+			"clusterID": testClusterID,
 		}})
 
 	// verify no kube resources created
@@ -1078,7 +1078,7 @@ func TestReconcileServiceInstanceWithTerminalProvisionFailure(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
-			"clusterID": "",
+			"clusterID": testClusterID,
 		}})
 
 	// verify one kube action occurred
@@ -1162,7 +1162,7 @@ func TestReconcileServiceInstance(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
-			"clusterID": "",
+			"clusterID": testClusterID,
 		}})
 
 	instanceKey := testNamespace + "/" + testServiceInstanceName
@@ -1361,7 +1361,7 @@ func TestReconcileServiceInstanceSuccessWithK8SNames(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
-			"clusterID": "",
+			"clusterID": testClusterID,
 		}})
 
 	instanceKey := testNamespace + "/" + testServiceInstanceName
@@ -1449,7 +1449,7 @@ func TestReconcileServiceInstanceAsynchronous(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": testNamespace,
-			"clusterID": "",
+			"clusterID": testClusterID,
 		},
 	})
 
@@ -1523,7 +1523,7 @@ func TestReconcileServiceInstanceAsynchronousNoOperation(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
-			"clusterID": "",
+			"clusterID": testClusterID,
 		}})
 
 	actions := fakeCatalogClient.Actions()
@@ -2229,7 +2229,7 @@ func TestReconcileServiceInstanceWithFailedCondition(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
-			"clusterID": "",
+			"clusterID": testClusterID,
 		},
 	})
 
@@ -2923,7 +2923,7 @@ func TestReconcileServiceInstanceSuccessOnFinalRetry(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
-			"clusterID": "",
+			"clusterID": testClusterID,
 		}})
 
 	actions := fakeCatalogClient.Actions()
@@ -2982,7 +2982,7 @@ func TestReconcileServiceInstanceFailureOnFinalRetry(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
-			"clusterID": "",
+			"clusterID": testClusterID,
 		}})
 
 	// verify no kube resources created
@@ -4147,7 +4147,7 @@ func TestReconcileServiceInstanceWithSecretParameters(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
-			"clusterID": "",
+			"clusterID": testClusterID,
 		}, Parameters: map[string]interface{}{
 			"a": "1",
 			"b": "2",
@@ -4353,7 +4353,7 @@ func TestReconcileServiceInstanceUpdateParameters(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
-			"clusterID": "",
+			"clusterID": testClusterID,
 		}, Parameters: map[string]interface{}{
 			"args": map[string]interface{}{
 				"first":  "first-arg",
@@ -4459,7 +4459,7 @@ func TestReconcileServiceInstanceDeleteParameters(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
-			"clusterID": "",
+			"clusterID": testClusterID,
 		}, Parameters: make(map[string]interface{}),
 	})
 
@@ -4647,7 +4647,7 @@ func TestReconcileServiceInstanceUpdatePlan(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
-			"clusterID": "",
+			"clusterID": testClusterID,
 		}, Parameters: nil, // no change to parameters
 	})
 
@@ -4722,7 +4722,7 @@ func TestReconcileServiceInstanceWithUpdateCallFailure(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
-			"clusterID": "",
+			"clusterID": testClusterID,
 		}})
 
 	// verify no kube resources created
@@ -4790,7 +4790,7 @@ func TestReconcileServiceInstanceWithUpdateFailure(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
-			"clusterID": "",
+			"clusterID": testClusterID,
 		}})
 
 	// verify one kube action occurred
@@ -5062,7 +5062,7 @@ func TestReconcileServiceInstanceUpdateAsynchronous(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
-			"clusterID": "",
+			"clusterID": testClusterID,
 		}})
 
 	actions := fakeCatalogClient.Actions()

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -676,8 +676,8 @@ func TestReconcileServiceInstanceWithParameters(t *testing.T) {
 				ServiceID:         testClusterServiceClassGUID,
 				PlanID:            testClusterServicePlanGUID,
 				Context: map[string]interface{}{
-					"platform":  "kubernetes",
-					"namespace": "test-ns",
+					"platform":   "kubernetes",
+					"namespace":  "test-ns",
 					"cluster-id": "",
 				},
 				Parameters: tc.expectedParams,
@@ -2227,8 +2227,8 @@ func TestReconcileServiceInstanceWithFailedCondition(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
+			"platform":   "kubernetes",
+			"namespace":  "test-ns",
 			"cluster-id": "",
 		},
 	})

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -612,7 +612,6 @@ func TestReconcileServiceInstanceWithParameters(t *testing.T) {
 
 			brokerActions := fakeClusterServiceBrokerClient.Actions()
 			assertNumberOfClusterServiceBrokerActions(t, brokerActions, 0)
-
 			expectedKubeActions := []kubeClientAction{
 				{verb: "get", resourceName: "namespaces", checkType: checkGetActionType},
 			}
@@ -679,6 +678,7 @@ func TestReconcileServiceInstanceWithParameters(t *testing.T) {
 				Context: map[string]interface{}{
 					"platform":  "kubernetes",
 					"namespace": "test-ns",
+					"cluster-id": "",
 				},
 				Parameters: tc.expectedParams,
 			})
@@ -887,10 +887,10 @@ func TestReconcileServiceInstanceWithProvisionCallFailure(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-		},
-	})
+			"platform":   "kubernetes",
+			"namespace":  "test-ns",
+			"cluster-id": "",
+		}})
 
 	// verify no kube resources created
 	// One single action comes from getting namespace uid
@@ -1076,10 +1076,10 @@ func TestReconcileServiceInstanceWithTerminalProvisionFailure(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-		},
-	})
+			"platform":   "kubernetes",
+			"namespace":  "test-ns",
+			"cluster-id": "",
+		}})
 
 	// verify one kube action occurred
 	kubeActions := fakeKubeClient.Actions()
@@ -1160,10 +1160,10 @@ func TestReconcileServiceInstance(t *testing.T) {
 		OrganizationGUID:  testNamespaceGUID,
 		SpaceGUID:         testNamespaceGUID,
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-		},
-	})
+			"platform":   "kubernetes",
+			"namespace":  "test-ns",
+			"cluster-id": "",
+		}})
 
 	instanceKey := testNamespace + "/" + testServiceInstanceName
 
@@ -1359,10 +1359,10 @@ func TestReconcileServiceInstanceSuccessWithK8SNames(t *testing.T) {
 		OrganizationGUID:  testNamespaceGUID,
 		SpaceGUID:         testNamespaceGUID,
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-		},
-	})
+			"platform":   "kubernetes",
+			"namespace":  "test-ns",
+			"cluster-id": "",
+		}})
 
 	instanceKey := testNamespace + "/" + testServiceInstanceName
 
@@ -1447,8 +1447,9 @@ func TestReconcileServiceInstanceAsynchronous(t *testing.T) {
 		OrganizationGUID:  testNamespaceGUID,
 		SpaceGUID:         testNamespaceGUID,
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": testNamespace,
+			"platform":   "kubernetes",
+			"namespace":  testNamespace,
+			"cluster-id": "",
 		},
 	})
 
@@ -1520,10 +1521,10 @@ func TestReconcileServiceInstanceAsynchronousNoOperation(t *testing.T) {
 		OrganizationGUID:  testNamespaceGUID,
 		SpaceGUID:         testNamespaceGUID,
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-		},
-	})
+			"platform":   "kubernetes",
+			"namespace":  "test-ns",
+			"cluster-id": "",
+		}})
 
 	actions := fakeCatalogClient.Actions()
 	assertNumberOfActions(t, actions, 1)
@@ -2228,6 +2229,7 @@ func TestReconcileServiceInstanceWithFailedCondition(t *testing.T) {
 		Context: map[string]interface{}{
 			"platform":  "kubernetes",
 			"namespace": "test-ns",
+			"cluster-id": "",
 		},
 	})
 
@@ -2919,10 +2921,10 @@ func TestReconcileServiceInstanceSuccessOnFinalRetry(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-		},
-	})
+			"platform":   "kubernetes",
+			"namespace":  "test-ns",
+			"cluster-id": "",
+		}})
 
 	actions := fakeCatalogClient.Actions()
 	assertNumberOfActions(t, actions, 1)
@@ -2978,10 +2980,10 @@ func TestReconcileServiceInstanceFailureOnFinalRetry(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-		},
-	})
+			"platform":   "kubernetes",
+			"namespace":  "test-ns",
+			"cluster-id": "",
+		}})
 
 	// verify no kube resources created
 	// One single action comes from getting namespace uid
@@ -4143,10 +4145,10 @@ func TestReconcileServiceInstanceWithSecretParameters(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-		},
-		Parameters: map[string]interface{}{
+			"platform":   "kubernetes",
+			"namespace":  "test-ns",
+			"cluster-id": "",
+		}, Parameters: map[string]interface{}{
 			"a": "1",
 			"b": "2",
 		},
@@ -4349,10 +4351,10 @@ func TestReconcileServiceInstanceUpdateParameters(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            nil, // no change to plan
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-		},
-		Parameters: map[string]interface{}{
+			"platform":   "kubernetes",
+			"namespace":  "test-ns",
+			"cluster-id": "",
+		}, Parameters: map[string]interface{}{
 			"args": map[string]interface{}{
 				"first":  "first-arg",
 				"second": "new-second-arg",
@@ -4455,10 +4457,10 @@ func TestReconcileServiceInstanceDeleteParameters(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            nil, // no change to plan
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-		},
-		Parameters: make(map[string]interface{}),
+			"platform":   "kubernetes",
+			"namespace":  "test-ns",
+			"cluster-id": "",
+		}, Parameters: make(map[string]interface{}),
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -4643,10 +4645,10 @@ func TestReconcileServiceInstanceUpdatePlan(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-		},
-		Parameters: nil, // no change to parameters
+			"platform":   "kubernetes",
+			"namespace":  "test-ns",
+			"cluster-id": "",
+		}, Parameters: nil, // no change to parameters
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -4718,10 +4720,10 @@ func TestReconcileServiceInstanceWithUpdateCallFailure(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-		},
-	})
+			"platform":   "kubernetes",
+			"namespace":  "test-ns",
+			"cluster-id": "",
+		}})
 
 	// verify no kube resources created
 	// One single action comes from getting namespace uid
@@ -4786,10 +4788,10 @@ func TestReconcileServiceInstanceWithUpdateFailure(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-		},
-	})
+			"platform":   "kubernetes",
+			"namespace":  "test-ns",
+			"cluster-id": "",
+		}})
 
 	// verify one kube action occurred
 	kubeActions := fakeKubeClient.Actions()
@@ -5058,10 +5060,10 @@ func TestReconcileServiceInstanceUpdateAsynchronous(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
 		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-		},
-	})
+			"platform":   "kubernetes",
+			"namespace":  "test-ns",
+			"cluster-id": "",
+		}})
 
 	actions := fakeCatalogClient.Actions()
 	assertNumberOfActions(t, actions, 1)

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -676,9 +676,9 @@ func TestReconcileServiceInstanceWithParameters(t *testing.T) {
 				ServiceID:         testClusterServiceClassGUID,
 				PlanID:            testClusterServicePlanGUID,
 				Context: map[string]interface{}{
-					"platform":   "kubernetes",
-					"namespace":  "test-ns",
-					"cluster-id": "",
+					"platform":  "kubernetes",
+					"namespace": "test-ns",
+					"clusterID": "",
 				},
 				Parameters: tc.expectedParams,
 			})
@@ -887,9 +887,9 @@ func TestReconcileServiceInstanceWithProvisionCallFailure(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  "test-ns",
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+			"clusterID": "",
 		}})
 
 	// verify no kube resources created
@@ -1076,9 +1076,9 @@ func TestReconcileServiceInstanceWithTerminalProvisionFailure(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  "test-ns",
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+			"clusterID": "",
 		}})
 
 	// verify one kube action occurred
@@ -1160,9 +1160,9 @@ func TestReconcileServiceInstance(t *testing.T) {
 		OrganizationGUID:  testNamespaceGUID,
 		SpaceGUID:         testNamespaceGUID,
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  "test-ns",
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+			"clusterID": "",
 		}})
 
 	instanceKey := testNamespace + "/" + testServiceInstanceName
@@ -1359,9 +1359,9 @@ func TestReconcileServiceInstanceSuccessWithK8SNames(t *testing.T) {
 		OrganizationGUID:  testNamespaceGUID,
 		SpaceGUID:         testNamespaceGUID,
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  "test-ns",
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+			"clusterID": "",
 		}})
 
 	instanceKey := testNamespace + "/" + testServiceInstanceName
@@ -1447,9 +1447,9 @@ func TestReconcileServiceInstanceAsynchronous(t *testing.T) {
 		OrganizationGUID:  testNamespaceGUID,
 		SpaceGUID:         testNamespaceGUID,
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  testNamespace,
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": testNamespace,
+			"clusterID": "",
 		},
 	})
 
@@ -1521,9 +1521,9 @@ func TestReconcileServiceInstanceAsynchronousNoOperation(t *testing.T) {
 		OrganizationGUID:  testNamespaceGUID,
 		SpaceGUID:         testNamespaceGUID,
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  "test-ns",
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+			"clusterID": "",
 		}})
 
 	actions := fakeCatalogClient.Actions()
@@ -2227,9 +2227,9 @@ func TestReconcileServiceInstanceWithFailedCondition(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  "test-ns",
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+			"clusterID": "",
 		},
 	})
 
@@ -2921,9 +2921,9 @@ func TestReconcileServiceInstanceSuccessOnFinalRetry(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  "test-ns",
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+			"clusterID": "",
 		}})
 
 	actions := fakeCatalogClient.Actions()
@@ -2980,9 +2980,9 @@ func TestReconcileServiceInstanceFailureOnFinalRetry(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  "test-ns",
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+			"clusterID": "",
 		}})
 
 	// verify no kube resources created
@@ -4145,9 +4145,9 @@ func TestReconcileServiceInstanceWithSecretParameters(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  "test-ns",
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+			"clusterID": "",
 		}, Parameters: map[string]interface{}{
 			"a": "1",
 			"b": "2",
@@ -4351,9 +4351,9 @@ func TestReconcileServiceInstanceUpdateParameters(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            nil, // no change to plan
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  "test-ns",
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+			"clusterID": "",
 		}, Parameters: map[string]interface{}{
 			"args": map[string]interface{}{
 				"first":  "first-arg",
@@ -4457,9 +4457,9 @@ func TestReconcileServiceInstanceDeleteParameters(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            nil, // no change to plan
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  "test-ns",
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+			"clusterID": "",
 		}, Parameters: make(map[string]interface{}),
 	})
 
@@ -4645,9 +4645,9 @@ func TestReconcileServiceInstanceUpdatePlan(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  "test-ns",
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+			"clusterID": "",
 		}, Parameters: nil, // no change to parameters
 	})
 
@@ -4720,9 +4720,9 @@ func TestReconcileServiceInstanceWithUpdateCallFailure(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  "test-ns",
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+			"clusterID": "",
 		}})
 
 	// verify no kube resources created
@@ -4788,9 +4788,9 @@ func TestReconcileServiceInstanceWithUpdateFailure(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  "test-ns",
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+			"clusterID": "",
 		}})
 
 	// verify one kube action occurred
@@ -5060,9 +5060,9 @@ func TestReconcileServiceInstanceUpdateAsynchronous(t *testing.T) {
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
 		Context: map[string]interface{}{
-			"platform":   "kubernetes",
-			"namespace":  "test-ns",
-			"cluster-id": "",
+			"platform":  "kubernetes",
+			"namespace": "test-ns",
+			"clusterID": "",
 		}})
 
 	actions := fakeCatalogClient.Actions()

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -675,12 +675,8 @@ func TestReconcileServiceInstanceWithParameters(t *testing.T) {
 				InstanceID:        testServiceInstanceGUID,
 				ServiceID:         testClusterServiceClassGUID,
 				PlanID:            testClusterServicePlanGUID,
-				Context: map[string]interface{}{
-					"platform":  "kubernetes",
-					"namespace": "test-ns",
-					"clusterID": testClusterID,
-				},
-				Parameters: tc.expectedParams,
+				Context:           testContext,
+				Parameters:        tc.expectedParams,
 			})
 
 			actions = fakeCatalogClient.Actions()
@@ -886,11 +882,7 @@ func TestReconcileServiceInstanceWithProvisionCallFailure(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-			"clusterID": testClusterID,
-		}})
+		Context:           testContext})
 
 	// verify no kube resources created
 	// One single action comes from getting namespace uid
@@ -989,10 +981,7 @@ func TestReconcileServiceInstanceWithTemporaryProvisionFailure(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-		},
+		Context:           testContext,
 	})
 
 	// verify no kube resources created
@@ -1075,11 +1064,7 @@ func TestReconcileServiceInstanceWithTerminalProvisionFailure(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-			"clusterID": testClusterID,
-		}})
+		Context:           testContext})
 
 	// verify one kube action occurred
 	kubeActions := fakeKubeClient.Actions()
@@ -1159,11 +1144,7 @@ func TestReconcileServiceInstance(t *testing.T) {
 		PlanID:            testClusterServicePlanGUID,
 		OrganizationGUID:  testNamespaceGUID,
 		SpaceGUID:         testNamespaceGUID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-			"clusterID": testClusterID,
-		}})
+		Context:           testContext})
 
 	instanceKey := testNamespace + "/" + testServiceInstanceName
 
@@ -1358,11 +1339,7 @@ func TestReconcileServiceInstanceSuccessWithK8SNames(t *testing.T) {
 		PlanID:            testClusterServicePlanGUID,
 		OrganizationGUID:  testNamespaceGUID,
 		SpaceGUID:         testNamespaceGUID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-			"clusterID": testClusterID,
-		}})
+		Context:           testContext})
 
 	instanceKey := testNamespace + "/" + testServiceInstanceName
 
@@ -1446,11 +1423,7 @@ func TestReconcileServiceInstanceAsynchronous(t *testing.T) {
 		PlanID:            testClusterServicePlanGUID,
 		OrganizationGUID:  testNamespaceGUID,
 		SpaceGUID:         testNamespaceGUID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": testNamespace,
-			"clusterID": testClusterID,
-		},
+		Context:           testContext,
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -1520,11 +1493,7 @@ func TestReconcileServiceInstanceAsynchronousNoOperation(t *testing.T) {
 		PlanID:            testClusterServicePlanGUID,
 		OrganizationGUID:  testNamespaceGUID,
 		SpaceGUID:         testNamespaceGUID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-			"clusterID": testClusterID,
-		}})
+		Context:           testContext})
 
 	actions := fakeCatalogClient.Actions()
 	assertNumberOfActions(t, actions, 1)
@@ -2226,11 +2195,7 @@ func TestReconcileServiceInstanceWithFailedCondition(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-			"clusterID": testClusterID,
-		},
+		Context:           testContext,
 	})
 
 	instanceKey := testNamespace + "/" + testServiceInstanceName
@@ -2920,11 +2885,7 @@ func TestReconcileServiceInstanceSuccessOnFinalRetry(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-			"clusterID": testClusterID,
-		}})
+		Context:           testContext})
 
 	actions := fakeCatalogClient.Actions()
 	assertNumberOfActions(t, actions, 1)
@@ -2979,11 +2940,7 @@ func TestReconcileServiceInstanceFailureOnFinalRetry(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-			"clusterID": testClusterID,
-		}})
+		Context:           testContext})
 
 	// verify no kube resources created
 	// One single action comes from getting namespace uid
@@ -4144,11 +4101,8 @@ func TestReconcileServiceInstanceWithSecretParameters(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            testClusterServicePlanGUID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-			"clusterID": testClusterID,
-		}, Parameters: map[string]interface{}{
+		Context:           testContext,
+		Parameters: map[string]interface{}{
 			"a": "1",
 			"b": "2",
 		},
@@ -4350,11 +4304,8 @@ func TestReconcileServiceInstanceUpdateParameters(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            nil, // no change to plan
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-			"clusterID": testClusterID,
-		}, Parameters: map[string]interface{}{
+		Context:           testContext,
+		Parameters: map[string]interface{}{
 			"args": map[string]interface{}{
 				"first":  "first-arg",
 				"second": "new-second-arg",
@@ -4456,11 +4407,8 @@ func TestReconcileServiceInstanceDeleteParameters(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            nil, // no change to plan
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-			"clusterID": testClusterID,
-		}, Parameters: make(map[string]interface{}),
+		Context:           testContext,
+		Parameters:        make(map[string]interface{}),
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -4644,11 +4592,8 @@ func TestReconcileServiceInstanceUpdatePlan(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-			"clusterID": testClusterID,
-		}, Parameters: nil, // no change to parameters
+		Context:           testContext,
+		Parameters:        nil, // no change to parameters
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -4719,11 +4664,7 @@ func TestReconcileServiceInstanceWithUpdateCallFailure(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-			"clusterID": testClusterID,
-		}})
+		Context:           testContext})
 
 	// verify no kube resources created
 	// One single action comes from getting namespace uid
@@ -4787,11 +4728,7 @@ func TestReconcileServiceInstanceWithUpdateFailure(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-			"clusterID": testClusterID,
-		}})
+		Context:           testContext})
 
 	// verify one kube action occurred
 	kubeActions := fakeKubeClient.Actions()
@@ -5059,11 +4996,7 @@ func TestReconcileServiceInstanceUpdateAsynchronous(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
-		Context: map[string]interface{}{
-			"platform":  "kubernetes",
-			"namespace": "test-ns",
-			"clusterID": testClusterID,
-		}})
+		Context:           testContext})
 
 	actions := fakeCatalogClient.Actions()
 	assertNumberOfActions(t, actions, 1)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -91,9 +91,9 @@ const (
 var (
 	testDashboardURL = "http://dashboard"
 	testContext      = map[string]interface{}{
-		"platform":  "kubernetes",
-		"namespace": testNamespace,
-		"clusterID": testClusterID,
+		"platform":           "kubernetes",
+		"namespace":          testNamespace,
+		clusterIdentifierKey: testClusterID,
 	}
 )
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -88,7 +88,14 @@ const (
 	testClusterID                           = "test-cluster-id"
 )
 
-var testDashboardURL = "http://dashboard"
+var (
+	testDashboardURL = "http://dashboard"
+	testContext      = map[string]interface{}{
+		"platform":  "kubernetes",
+		"namespace": testNamespace,
+		"clusterID": testClusterID,
+	}
+)
 
 const testCatalog = `{
   "services": [{

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -91,7 +91,7 @@ const (
 var (
 	testDashboardURL = "http://dashboard"
 	testContext      = map[string]interface{}{
-		"platform":           "kubernetes",
+		"platform":           ContextProfilePlatformKubernetes,
 		"namespace":          testNamespace,
 		clusterIdentifierKey: testClusterID,
 	}
@@ -1582,6 +1582,8 @@ func newTestController(t *testing.T, config fakeosb.FakeClientConfiguration) (
 		fakeRecorder,
 		7*24*time.Hour,
 		7*24*time.Hour,
+		DefaultClusterIDConfigMapName,
+		DefaultClusterIDConfigMapNamespace,
 	)
 
 	if c, ok := testController.(*controller); ok {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -85,6 +85,7 @@ const (
 	testNamespace                           = "test-ns"
 	testServiceInstanceCredentialSecretName = "test-secret"
 	testOperation                           = "test-operation"
+	testClusterID                           = "test-cluster-id"
 )
 
 var testDashboardURL = "http://dashboard"
@@ -1575,6 +1576,11 @@ func newTestController(t *testing.T, config fakeosb.FakeClientConfiguration) (
 		7*24*time.Hour,
 		7*24*time.Hour,
 	)
+
+	if c, ok := testController.(*controller); ok {
+		c.setClusterID(testClusterID)
+	}
+
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -214,6 +214,10 @@ func TestCreateServiceInstanceWithAuthError(t *testing.T) {
 		instance:                     getTestInstance(),
 		skipVerifyingInstanceSuccess: true,
 		preCreateBroker: func(ct *controllerTest) {
+			ct.kubeClient.Lock()
+			t.Log(ct.kubeClient)
+			ct.kubeClient.Unlock()
+
 			prependGetSecretReaction(ct.kubeClient, "secret-name", map[string][]byte{
 				"username": []byte("user"),
 				"password": []byte("pass"),

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -214,10 +214,6 @@ func TestCreateServiceInstanceWithAuthError(t *testing.T) {
 		instance:                     getTestInstance(),
 		skipVerifyingInstanceSuccess: true,
 		preCreateBroker: func(ct *controllerTest) {
-			ct.kubeClient.Lock()
-			t.Log(ct.kubeClient)
-			ct.kubeClient.Unlock()
-
 			prependGetSecretReaction(ct.kubeClient, "secret-name", map[string][]byte{
 				"username": []byte("user"),
 				"password": []byte("pass"),

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -833,9 +833,11 @@ func TestUpdateServiceInstanceUpdateParameters(t *testing.T) {
 				}
 
 				if tc.updateSecret {
+					ct.kubeClient.Lock()
 					prependGetSecretReaction(ct.kubeClient, "secret-name", map[string][]byte{
 						"secret-key": []byte(`{"new-secret-param-key":"new-secret-param-value"}`),
 					})
+					ct.kubeClient.Unlock()
 					ct.instance.Spec.UpdateRequests++
 				}
 

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -779,8 +779,8 @@ func newControllerTestTestController(ct *controllerTest) (
 		fakeRecorder,
 		7*24*time.Hour,
 		7*24*time.Hour,
-		DefaultClusterIDConfigMapName,
-		DefaultClusterIDConfigMapNamespace,
+		controller.DefaultClusterIDConfigMapName,
+		controller.DefaultClusterIDConfigMapNamespace,
 	)
 	t.Log("controller start")
 	if err != nil {
@@ -930,8 +930,8 @@ func newTestController(t *testing.T) (
 		fakeRecorder,
 		7*24*time.Hour,
 		7*24*time.Hour,
-		DefaultClusterIDConfigMapName,
-		DefaultClusterIDConfigMapNamespace,
+		controller.DefaultClusterIDConfigMapName,
+		controller.DefaultClusterIDConfigMapNamespace,
 	)
 	t.Log("controller start")
 	if err != nil {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -1329,7 +1329,6 @@ func (ct *controllerTest) run(test func(*controllerTest)) {
 	ct.client = catalogClient.ServicecatalogV1beta1()
 
 	if test != nil {
-		t.Log("running test")
 		test(ct)
 	}
 

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -779,6 +779,8 @@ func newControllerTestTestController(ct *controllerTest) (
 		fakeRecorder,
 		7*24*time.Hour,
 		7*24*time.Hour,
+		DefaultClusterIDConfigMapName,
+		DefaultClusterIDConfigMapNamespace,
 	)
 	t.Log("controller start")
 	if err != nil {
@@ -928,6 +930,8 @@ func newTestController(t *testing.T) (
 		fakeRecorder,
 		7*24*time.Hour,
 		7*24*time.Hour,
+		DefaultClusterIDConfigMapName,
+		DefaultClusterIDConfigMapNamespace,
 	)
 	t.Log("controller start")
 	if err != nil {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -747,7 +747,7 @@ func newControllerTestTestController(ct *controllerTest) (
 	fakeKubeClient.Lock()
 	prependGetSecretNotFoundReaction(fakeKubeClient)
 	fakeKubeClient.Unlock()
-	
+
 	// create an sc client and running server
 	catalogClient, catalogClientConfig, shutdownServer := getFreshApiserverAndClient(t, server.StorageTypeEtcd.String(), func() runtime.Object {
 		return &servicecatalog.ClusterServiceBroker{}
@@ -896,7 +896,7 @@ func newTestController(t *testing.T) (
 	fakeKubeClient.Lock()
 	prependGetSecretNotFoundReaction(fakeKubeClient)
 	fakeKubeClient.Unlock()
-	
+
 	// create an sc client and running server
 	catalogClient, catalogClientConfig, shutdownServer := getFreshApiserverAndClient(t, server.StorageTypeEtcd.String(), func() runtime.Object {
 		return &servicecatalog.ClusterServiceBroker{}
@@ -1318,7 +1318,6 @@ func (ct *controllerTest) run(test func(*controllerTest)) {
 	defer shutdownController()
 	defer shutdownServer()
 
-	t := ct.t
 	ct.kubeClient = kubeClient
 	ct.catalogClient = catalogClient
 	ct.catalogClientConfig = catalogClientConfig


### PR DESCRIPTION
alternate to #1624

I've been fighting with getting the tests to work and not blow up or race. 

I thought a poller would be simpler/easier than implementing the entire complexity of a new queue.

Maybe this is better in some other controller, like an admission controller. 