### PR TITLE
run each integration test individually

### DIFF
--- a/test/integration.sh
+++ b/test/integration.sh
@@ -30,7 +30,9 @@ runTests() {
   fi
 
   go test -race $FLAGS github.com/kubernetes-incubator/service-catalog/test/integration/... -c \
-      && ./integration.test -test.v $@
+      && for test in $(./integration.test -test.list .); do
+             ./integration.test -test.v -test.run $test $@ 
+          done        
 }
 
 runTests $@


### PR DESCRIPTION
This is just about the simplest and quickest workaround I can think of for both #1649 and #1660 that require no code changes. We should end up with a fresh etcd and a fresh set of file descriptors for each integration test case. 

We should still fix the underlying issues. 

I think this might mess up the INT_TEST_FLAGS. I think `test.run` takes only the last argument so if you want to run a specific test, it will end up running `./integration.test -test.list . | wc -l` times, which, right now, is 36.