### PR TITLE
Build the integration test binary before running any tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
   - .glide
 script:
-- make verify build build-e2e test images
+- make verify build build-integration build-e2e test images
 deploy:
   skip_cleanup: true
   provider: script

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,10 @@ test-unit: .init build
 	$(DOCKER_CMD) go test -race $(UNIT_TEST_FLAGS) \
 	  $(addprefix $(SC_PKG)/,$(TEST_DIRS)) $(UNIT_TEST_LOG_FLAGS)
 
-test-integration: .init $(scBuildImageTarget) build
+build-integration: .generate_files
+	$(DOCKER_CMD) go test -race github.com/kubernetes-incubator/service-catalog/test/integration/... -c
+
+test-integration: .init $(scBuildImageTarget) build build-integration
 	# test kubectl
 	contrib/hack/setup-kubectl.sh
 	contrib/hack/test-apiserver.sh


### PR DESCRIPTION
There have been a lot of PRs that I can personally remember where CI eventually failed because the int test binary didn't build.  This PR makes travis build the int test binary before running any tests for faster feedback (travis now builds all binaries in the project before running any tests).