### PR TITLE
Allow upper case letters in Plan names

### DIFF
--- a/pkg/apis/servicecatalog/validation/serviceclass.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass.go
@@ -26,8 +26,10 @@ import (
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 )
 
-// validateServiceClassName is the validation function for ServiceClass names.
-var validateServiceClassName = apivalidation.NameIsDNSSubdomain
+const serviceClassNameFmt string = `[-a-zA-Z0-9]+`
+const serviceClassNameMaxLength int = 63
+
+var serviceClassNameRegexp = regexp.MustCompile("^" + serviceClassNameFmt + "$")
 
 const guidFmt string = "[a-zA-Z0-9]([-a-zA-Z0-9.]*[a-zA-Z0-9])?"
 const guidMaxLength int = 63
@@ -35,6 +37,19 @@ const guidMaxLength int = 63
 // guidRegexp is a loosened validation for
 // DNS1123 labels that allows uppercase characters.
 var guidRegexp = regexp.MustCompile("^" + guidFmt + "$")
+
+// validateServiceClassName is the validation function for Service names.
+func validateServiceClassName(value string, prefix bool) []string {
+	var errs []string
+	if len(value) > serviceClassNameMaxLength {
+		errs = append(errs, utilvalidation.MaxLenError(serviceClassNameMaxLength))
+	}
+	if !serviceClassNameRegexp.MatchString(value) {
+		errs = append(errs, utilvalidation.RegexError(serviceClassNameFmt, "service-name-40d-0983-1b89"))
+	}
+
+	return errs
+}
 
 // validateExternalID is the validation function for External IDs that
 // have been passed in. External IDs used to be OpenServiceBrokerAPI

--- a/pkg/apis/servicecatalog/validation/serviceclass_test.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass_test.go
@@ -114,6 +114,15 @@ func TestValidateClusterServiceClass(t *testing.T) {
 			valid: false,
 		},
 		{
+			name: "invalid serviceClass - period in externalName",
+			serviceClass: func() *servicecatalog.ClusterServiceClass {
+				s := validClusterServiceClass()
+				s.Spec.ExternalName = "abc.com"
+				return s
+			}(),
+			valid: false,
+		},
+		{
 			name: "invalid serviceClass - missing externalName",
 			serviceClass: func() *servicecatalog.ClusterServiceClass {
 				s := validClusterServiceClass()
@@ -121,6 +130,24 @@ func TestValidateClusterServiceClass(t *testing.T) {
 				return s
 			}(),
 			valid: false,
+		},
+		{
+			name: "invalid serviceClass - valid but weird externalName1",
+			serviceClass: func() *servicecatalog.ClusterServiceClass {
+				s := validClusterServiceClass()
+				s.Spec.ExternalName = "-"
+				return s
+			}(),
+			valid: true,
+		},
+		{
+			name: "invalid serviceClass - valid but weird externalName2",
+			serviceClass: func() *servicecatalog.ClusterServiceClass {
+				s := validClusterServiceClass()
+				s.Spec.ExternalName = "0"
+				return s
+			}(),
+			valid: true,
 		},
 	}
 

--- a/pkg/apis/servicecatalog/validation/serviceplan.go
+++ b/pkg/apis/servicecatalog/validation/serviceplan.go
@@ -26,7 +26,7 @@ import (
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 )
 
-const servicePlanNameFmt string = `[-a-z0-9]+`
+const servicePlanNameFmt string = `[-a-zA-Z0-9]+`
 const servicePlanNameMaxLength int = 63
 
 var servicePlanNameRegexp = regexp.MustCompile("^" + servicePlanNameFmt + "$")

--- a/pkg/apis/servicecatalog/validation/serviceplan_test.go
+++ b/pkg/apis/servicecatalog/validation/serviceplan_test.go
@@ -65,7 +65,7 @@ func TestValidateClusterServicePlan(t *testing.T) {
 			name: "bad name",
 			servicePlan: func() *servicecatalog.ClusterServicePlan {
 				s := validClusterServicePlan()
-				s.Name = "X"
+				s.Name = "#"
 				return s
 			}(),
 			valid: false,
@@ -74,10 +74,28 @@ func TestValidateClusterServicePlan(t *testing.T) {
 			name: "bad externalName",
 			servicePlan: func() *servicecatalog.ClusterServicePlan {
 				s := validClusterServicePlan()
-				s.Spec.ExternalName = "X"
+				s.Spec.ExternalName = "#"
 				return s
 			}(),
 			valid: false,
+		},
+		{
+			name: "mixed case Name",
+			servicePlan: func() *servicecatalog.ClusterServicePlan {
+				s := validClusterServicePlan()
+				s.Name = "abcXYZ"
+				return s
+			}(),
+			valid: true,
+		},
+		{
+			name: "mixed case externalName",
+			servicePlan: func() *servicecatalog.ClusterServicePlan {
+				s := validClusterServicePlan()
+				s.Spec.ExternalName = "abcXYZ"
+				return s
+			}(),
+			valid: true,
 		},
 		{
 			name: "missing clusterServiceBrokerName",
@@ -107,6 +125,9 @@ func TestValidateClusterServicePlan(t *testing.T) {
 			valid: false,
 		},
 		{
+			// Note this is NOT due to the spec, this is due to
+			// a Kubernetes limitation. So, technically this restriction
+			// could cause a valid Broker to not work against Kube.
 			name: "external id too long",
 			servicePlan: func() *servicecatalog.ClusterServicePlan {
 				s := validClusterServicePlan()


### PR DESCRIPTION
We unnecessarily restrict plan names to `[-a-z0-9]`. There are cases
where people use uppercase letters (e.g. "Lite").

Signed-off-by: Doug Davis <dug@us.ibm.com>