### PR TITLE
thread through stopCh to DestroyFunc

### DIFF
--- a/cmd/apiserver/app/server/run_server.go
+++ b/cmd/apiserver/app/server/run_server.go
@@ -101,7 +101,7 @@ func runEtcdServer(opts *ServiceCatalogServerOptions, stopCh <-chan struct{}) er
 
 	// make the server
 	glog.V(4).Infoln("Completing API server configuration")
-	server, err := completed.NewServer()
+	server, err := completed.NewServer(stopCh)
 	if err != nil {
 		return fmt.Errorf("error completing API server configuration: %v", err)
 	}

--- a/pkg/apiserver/config.go
+++ b/pkg/apiserver/config.go
@@ -25,5 +25,5 @@ type Config interface {
 // CompletedConfig is the result of a Config being Complete()-ed. Calling code should call Start()
 // to start a server from its completed config
 type CompletedConfig interface {
-	NewServer() (*ServiceCatalogAPIServer, error)
+	NewServer(stopCh <-chan struct{}) (*ServiceCatalogAPIServer, error)
 }

--- a/pkg/apiserver/etcd_config.go
+++ b/pkg/apiserver/etcd_config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
 	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/generic/registry"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/storage"
 )
@@ -79,7 +80,7 @@ type completedEtcdConfig struct {
 
 // NewServer creates a new server that can be run. Returns a non-nil error if the server couldn't
 // be created
-func (c completedEtcdConfig) NewServer() (*ServiceCatalogAPIServer, error) {
+func (c completedEtcdConfig) NewServer(stopCh <-chan struct{}) (*ServiceCatalogAPIServer, error) {
 	s, err := createSkeletonServer(c.genericConfig)
 	if err != nil {
 		return nil, err
@@ -110,6 +111,19 @@ func (c completedEtcdConfig) NewServer() (*ServiceCatalogAPIServer, error) {
 		glog.V(4).Infof("Installing API group %v", provider.GroupName())
 		if err := s.GenericAPIServer.InstallAPIGroup(groupInfo); err != nil {
 			glog.Fatalf("Error installing API group %v: %v", provider.GroupName(), err)
+		} else {
+			// we've sucessfully installed, so hook the stopCh to the destroy func of all the sucessfully installed apigroups
+			for _, mappings := range groupInfo.VersionedResourcesStorageMap { // gv to resource mappings
+				for _, storage := range mappings { // resource name (brokers, brokers/status) to backing storage
+					go func() {
+						s, ok := storage.(*registry.Store)
+						if ok {
+							<-stopCh
+							s.DestroyFunc()
+						}
+					}()
+				}
+			}
 		}
 	}
 

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -101,7 +101,6 @@ func TestCreateServiceInstanceNonExistentClusterServiceClassOrPlan(t *testing.T)
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			ct := &controllerTest{
 				t:      t,
 				broker: getTestBroker(),


### PR DESCRIPTION
partial mitigation for #1649
still many outstanding goroutines by test end

experimental data in https://gist.github.com/MHBauer/8c7c94c43f4a53b20ee447a926641166

without this mitigation there are approx 5547 goroutines waiting
with it there are fewer but still 2700 goroutines waiting

﻿
![chart](https://user-images.githubusercontent.com/13337345/35128800-3a70ce10-fc6d-11e7-814b-07a66dcb5821.png)


@sttts this is my attempted implementation wrt https://github.com/kubernetes/apiserver/issues/30 what do you think? 