### PR TITLE
use pvc for etcd volume

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -48,6 +48,10 @@ chart and their default values.
 | `apiserver.storage.type` | The storage backend to use; the only valid value is `etcd`, left for other storages support in future, e.g. `crd` | `etcd` |
 | `apiserver.storage.etcd.useEmbedded` | If storage type is `etcd`: Whether to embed an etcd container in the apiserver pod; THIS IS INADEQUATE FOR PRODUCTION USE! | `true` |
 | `apiserver.storage.etcd.servers` | If storage type is `etcd`: etcd URL(s); override this if NOT using embedded etcd | `http://localhost:2379` |
+| `apiserver.storage.etcd.persistence.enabled` | Enable persistence using PVC | `false` |
+| `apiserver.storage.etcd.persistence.storageClass` | PVC Storage Class | `nil` (uses alpha storage class annotation) |
+| `apiserver.storage.etcd.persistence.accessMode` | PVC Access Mode | `ReadWriteOnce` |
+| `apiserver.storage.etcd.persistence.size` | PVC Storage Request | `4Gi` |
 | `apiserver.verbosity` | Log level; valid values are in the range 0 - 10 | `10` |
 | `apiserver.auth.enabled` | Enable authentication and authorization | `true` |
 | `controllerManager.verbosity` | Log level; valid values are in the range 0 - 10 | `10` |

--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -147,7 +147,12 @@ spec:
           - key: requestheader-ca.crt
             path: requestheader-ca.crt
           {{- end }}
-      {{- if eq .Values.apiserver.storage.type "etcd" }}
+      {{- if and (eq .Values.apiserver.storage.type "etcd") .Values.apiserver.storage.etcd.useEmbedded }}
       - name: etcd-data-dir
+      {{- if .Values.apiserver.storage.etcd.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.apiserver.storage.etcd.persistence.existingClaim | default (printf "%s-%s" (include "fullname" .) "etcd") }}
+      {{- else }}
         emptyDir: {}
+      {{- end }}
       {{- end }}

--- a/charts/catalog/templates/etcd-pvc.yaml
+++ b/charts/catalog/templates/etcd-pvc.yaml
@@ -1,0 +1,24 @@
+{{- if and (eq .Values.apiserver.storage.type "etcd") .Values.apiserver.storage.etcd.useEmbedded .Values.apiserver.storage.etcd.persistence.enabled (not .Values.apiserver.storage.etcd.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-etcd
+  labels:
+    app: {{ template "fullname" . }}-etcd
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+    - {{ .Values.apiserver.storage.etcd.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.apiserver.storage.etcd.persistence.size | quote }}
+{{- if .Values.apiserver.storage.etcd.persistence.storageClass }}
+{{- if (eq "-" .Values.apiserver.storage.etcd.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.apiserver.storage.etcd.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -54,6 +54,18 @@ apiserver:
       useEmbedded: true
       # etcd URL(s); override this if NOT using embedded etcd
       servers: http://localhost:2379
+      # etcd persistence options IF using embedded etcd
+      persistence:
+        enabled: true
+        ## If defined, storageClassName: <storageClass>
+        ## If set to "-", storageClassName: "", which disables dynamic provisioning
+        ## If undefined (the default) or set to null, no storageClassName spec is
+        ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+        ##   GKE, AWS & OpenStack)
+        ##
+        # storageClass: "-"
+        accessMode: ReadWriteOnce
+        size: 4Gi
   # Log level; valid values are in the range 0 - 10
   verbosity: 10
   auth:

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -56,7 +56,7 @@ apiserver:
       servers: http://localhost:2379
       # etcd persistence options IF using embedded etcd
       persistence:
-        enabled: true
+        enabled: false
         ## If defined, storageClassName: <storageClass>
         ## If set to "-", storageClassName: "", which disables dynamic provisioning
         ## If undefined (the default) or set to null, no storageClassName spec is


### PR DESCRIPTION
I noticed we were unconditionally using an `emptyDir` volume for the "embedded" etcd. Since these are coupled to the lifecycle of a pod, this means all data vanishes anytime the deployment replaces the pod (e.g. upon upgrade).

This PR switches it to use a PVC, by default. There are a few things you can tweak here. The pattern observed is the one that has been used broadly across all the stable charts in kubernetes/charts. (i.e. The approach is canonical.)