### PR TITLE
refactor binding reconciliation functions

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -622,3 +622,14 @@ func (c *controller) reconciliationRetryDurationExceeded(operationStartTime *met
 	}
 	return true
 }
+
+// ReconciliationAction reprents a type of action the reconciler should take
+// for a resource.
+type ReconciliationAction string
+
+const (
+	reconcileAdd    ReconciliationAction = "Add"
+	reconcileUpdate ReconciliationAction = "Update"
+	reconcileDelete ReconciliationAction = "Delete"
+	reconcilePoll   ReconciliationAction = "Poll"
+)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
@@ -621,6 +622,17 @@ func (c *controller) reconciliationRetryDurationExceeded(operationStartTime *met
 		return false
 	}
 	return true
+}
+
+// shouldStartOrphanMitigation returns whether an error with the given status
+// code indicates that orphan migitation should start.
+func shouldStartOrphanMitigation(statusCode int) bool {
+	is2XX := (statusCode >= 200 && statusCode < 300)
+	is5XX := (statusCode >= 500 && statusCode < 600)
+
+	return (is2XX && statusCode != http.StatusOK) ||
+		statusCode == http.StatusRequestTimeout ||
+		is5XX
 }
 
 // ReconciliationAction reprents a type of action the reconciler should take

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"fmt"
 	"net"
-	"net/http"
 	"time"
 
 	"github.com/golang/glog"
@@ -42,12 +41,12 @@ const (
 	errorBindCallReason                       string = "BindCallFailed"
 	errorInjectingBindResultReason            string = "ErrorInjectingBindResult"
 	errorEjectingBindReason                   string = "ErrorEjectingServiceBinding"
-	errorEjectingBindMessage                  string = "Error ejecting binding."
 	errorUnbindCallReason                     string = "UnbindCallFailed"
 	errorNonbindableClusterServiceClassReason string = "ErrorNonbindableServiceClass"
 	errorServiceInstanceNotReadyReason        string = "ErrorInstanceNotReady"
 	errorServiceBindingOrphanMitigation       string = "ServiceBindingNeedsOrphanMitigation"
 	errorFetchingBindingFailedReason          string = "FetchingBindingFailed"
+	errorAsyncOpTimeoutReason                 string = "AsyncOperationTimeout"
 
 	successInjectedBindResultReason  string = "InjectedBindResult"
 	successInjectedBindResultMessage string = "Injected bind result"
@@ -138,107 +137,63 @@ func isServiceBindingFailed(binding *v1beta1.ServiceBinding) bool {
 	return false
 }
 
-// setAndUpdateServiceBindingStartOrphanMitigation is for setting the
-// OrphanMitigationInProgress status to true, setting the proper condition
-// statuses, and persisting the changes via updateServiceBindingStatus.
-func (c *controller) setAndUpdateServiceBindingStartOrphanMitigation(toUpdate *v1beta1.ServiceBinding) error {
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, toUpdate.Name, toUpdate.Namespace)
-	s := pcb.Message("Starting orphan mitigation")
-
-	toUpdate.Status.OrphanMitigationInProgress = true
-	toUpdate.Status.OperationStartTime = nil
-	glog.V(5).Info(s)
-
-	setServiceBindingCondition(
-		toUpdate,
-		v1beta1.ServiceBindingConditionReady,
-		v1beta1.ConditionFalse,
-		errorServiceBindingOrphanMitigation,
-		s,
-	)
-
-	c.recorder.Event(toUpdate, corev1.EventTypeWarning, errorServiceBindingOrphanMitigation, s)
-	if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-		return err
+// getReconciliationActionForServiceBinding gets the action the reconciler
+// should be taking on the given binding.
+func getReconciliationActionForServiceBinding(binding *v1beta1.ServiceBinding) ReconciliationAction {
+	switch {
+	case binding.Status.AsyncOpInProgress:
+		return reconcilePoll
+	case binding.ObjectMeta.DeletionTimestamp != nil || binding.Status.OrphanMitigationInProgress:
+		return reconcileDelete
+	default:
+		return reconcileAdd
 	}
-	return nil
 }
 
-// an error is returned to indicate that the binding has not been
-// fully processed and should be resubmitted at a later time.
+// reconcileServiceBinding is the control-loop for reconciling ServiceBindings.
+// An error is returned to indicate that the binding has not been fully
+// processed and should be resubmitted at a later time.
 func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) error {
 	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
 	glog.V(6).Info(pcb.Messagef(`beginning to process resourceVersion: %v`, binding.ResourceVersion))
 
-	if binding.Status.AsyncOpInProgress {
+	reconciliationAction := getReconciliationActionForServiceBinding(binding)
+	switch reconciliationAction {
+	case reconcileAdd:
+		return c.reconcileServiceBindingAdd(binding)
+	case reconcileDelete:
+		return c.reconcileServiceBindingDelete(binding)
+	case reconcilePoll:
 		return c.pollServiceBinding(binding)
+	default:
+		return fmt.Errorf(pcb.Messagef("Unknown reconciliation action %v", reconciliationAction))
 	}
+}
 
-	if isServiceBindingFailed(binding) && binding.ObjectMeta.DeletionTimestamp == nil && !binding.Status.OrphanMitigationInProgress {
+// reconcileServiceBindingAdd is responsible for handling the creation of new
+// service bindings.
+func (c *controller) reconcileServiceBindingAdd(binding *v1beta1.ServiceBinding) error {
+	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
+
+	if isServiceBindingFailed(binding) {
 		glog.V(4).Info(pcb.Message("not processing event; status showed that it has failed"))
 		return nil
 	}
 
-	// Determine whether there is a new generation of the object. If the binding's
-	// generation does not match the reconciled generation, then there is a new
-	// generation, indicating that changes have been made to the binding's spec.
-	//
-	// We only do this if the deletion timestamp is nil, because the deletion
-	// timestamp changes the object's state in a way that we must reconcile,
-	// but does not affect the generation.
-	if binding.DeletionTimestamp == nil {
-		if binding.Status.ReconciledGeneration == binding.Generation {
-			glog.V(4).Info(pcb.Message("Not processing event; reconciled generation showed there is no work to do"))
-			return nil
-		}
-	}
-	if binding.DeletionTimestamp != nil || binding.Status.OrphanMitigationInProgress {
-		return c.reconcileServiceBindingDelete(binding)
+	if binding.Status.ReconciledGeneration == binding.Generation {
+		glog.V(4).Info(pcb.Message("Not processing event; reconciled generation showed there is no work to do"))
+		return nil
 	}
 
 	glog.V(4).Info(pcb.Message("Processing"))
 
-	toUpdate := binding.DeepCopy()
+	binding = binding.DeepCopy()
 
 	instance, err := c.instanceLister.ServiceInstances(binding.Namespace).Get(binding.Spec.ServiceInstanceRef.Name)
 	if err != nil {
-		s := fmt.Sprintf(
-			`References a non-existent %s "%s/%s"`,
-			pretty.ServiceInstance, binding.Namespace, binding.Spec.ServiceInstanceRef.Name,
-		)
-		glog.Warningf(pcb.Messagef("%s (%s)", s, err))
-		c.recorder.Event(binding, corev1.EventTypeWarning, errorNonexistentServiceInstanceReason, s)
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionFalse,
-			errorNonexistentServiceInstanceReason,
-			"The binding references an ServiceInstance that does not exist. "+s,
-		)
-		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-			return err
-		}
-		return err
-	}
-
-	if instance.Status.AsyncOpInProgress {
-		s := fmt.Sprintf(
-			`trying to bind to %s "%s/%s" that has ongoing asynchronous operation`,
-			pretty.ServiceInstance, binding.Namespace, binding.Spec.ServiceInstanceRef.Name,
-		)
-		glog.Info(pcb.Message(s))
-		c.recorder.Event(binding, corev1.EventTypeWarning, errorWithOngoingAsyncOperation, s)
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionFalse,
-			errorWithOngoingAsyncOperation,
-			errorWithOngoingAsyncOperationMessage,
-		)
-		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-			return err
-		}
-		return fmt.Errorf("Ongoing Asynchronous operation")
+		msg := fmt.Sprintf(`References a non-existent %s "%s/%s"`, pretty.ServiceInstance, binding.Namespace, binding.Spec.ServiceInstanceRef.Name)
+		readyCond := newServiceBindingReadyCondition(v1beta1.ConditionFalse, errorNonexistentServiceInstanceReason, msg)
+		return c.processServiceBindingOperationError(binding, readyCond)
 	}
 
 	if instance.Spec.ClusterServiceClassRef == nil || instance.Spec.ClusterServicePlanRef == nil {
@@ -252,358 +207,103 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 	}
 
 	if !isPlanBindable(serviceClass, servicePlan) {
-		s := fmt.Sprintf(
-			`References a non-bindable %s and Plan (%q) combination`,
-			pretty.ClusterServiceClassName(serviceClass), instance.Spec.ClusterServicePlanExternalName,
-		)
-		glog.Warning(pcb.Message(s))
-		c.recorder.Event(binding, corev1.EventTypeWarning, errorNonbindableClusterServiceClassReason, s)
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionFalse,
-			errorNonbindableClusterServiceClassReason,
-			s,
-		)
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionFailed,
-			v1beta1.ConditionTrue,
-			errorNonbindableClusterServiceClassReason,
-			s,
-		)
-		clearServiceBindingCurrentOperation(toUpdate)
-		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-			return err
-		}
-		return nil
+		msg := fmt.Sprintf(`References a non-bindable %s and Plan (%q) combination`, pretty.ClusterServiceClassName(serviceClass), instance.Spec.ClusterServicePlanExternalName)
+		readyCond := newServiceBindingReadyCondition(v1beta1.ConditionFalse, errorNonbindableClusterServiceClassReason, msg)
+		failedCond := newServiceBindingFailedCondition(v1beta1.ConditionTrue, errorNonbindableClusterServiceClassReason, msg)
+		return c.processBindFailure(binding, readyCond, failedCond, false)
 	}
 
-	if binding.DeletionTimestamp == nil && !binding.Status.OrphanMitigationInProgress { // Add or update
-		glog.V(4).Info(pcb.Message("Adding/Updating"))
+	if !isServiceInstanceReady(instance) {
+		msg := fmt.Sprintf(`Binding cannot begin because referenced %s is not ready`, pretty.ServiceInstanceName(instance))
+		readyCond := newServiceBindingReadyCondition(v1beta1.ConditionFalse, errorServiceInstanceNotReadyReason, msg)
+		return c.processServiceBindingOperationError(binding, readyCond)
+	}
 
-		ns, err := c.kubeClient.CoreV1().Namespaces().Get(instance.Namespace, metav1.GetOptions{})
+	glog.V(4).Info(pcb.Message("Adding/Updating"))
+
+	request, inProgressProperties, err := c.prepareBindRequest(binding, instance, serviceClass, servicePlan)
+	if err != nil {
+		return c.handleServiceBindingReconciliationError(binding, err)
+	}
+
+	if binding.Status.CurrentOperation == "" {
+		binding, err = c.recordStartOfServiceBindingOperation(binding, v1beta1.ServiceBindingOperationBind, inProgressProperties)
 		if err != nil {
-			s := fmt.Sprintf(`Failed to get namespace %q during binding: %s`, instance.Namespace, err)
-			glog.Info(pcb.Message(s))
-			c.recorder.Eventf(binding, corev1.EventTypeWarning, errorFindingNamespaceServiceInstanceReason, s)
-			setServiceBindingCondition(
-				toUpdate,
-				v1beta1.ServiceBindingConditionReady,
-				v1beta1.ConditionFalse,
-				errorFindingNamespaceServiceInstanceReason,
-				"Error finding namespace for instance. "+s,
-			)
-			if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-				return err
-			}
+			// There has been an update to the binding. Start reconciliation
+			// over with a fresh view of the binding.
 			return err
 		}
+	}
 
-		if !isServiceInstanceReady(instance) {
-			s := fmt.Sprintf(
-				`ServiceBinding cannot begin because referenced %s is not ready`,
-				pretty.ServiceInstanceName(instance),
-			)
-			glog.Info(pcb.Message(s))
-			c.recorder.Eventf(binding, corev1.EventTypeWarning, errorServiceInstanceNotReadyReason, s)
-			setServiceBindingCondition(
-				toUpdate,
-				v1beta1.ServiceBindingConditionReady,
-				v1beta1.ConditionFalse,
-				errorServiceInstanceNotReadyReason,
-				s,
-			)
-			if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-				return err
-			}
-			return nil
+	response, err := brokerClient.Bind(request)
+	if err != nil {
+		if httpErr, ok := osb.IsHTTPError(err); ok {
+			msg := fmt.Sprintf("ServiceBroker returned failure; bind operation will not be retried: %v", err.Error())
+			readyCond := newServiceBindingReadyCondition(v1beta1.ConditionFalse, errorBindCallReason, msg)
+			failedCond := newServiceBindingFailedCondition(v1beta1.ConditionTrue, "ServiceBindingReturnedFailure", msg)
+			return c.processBindFailure(binding, readyCond, failedCond, shouldStartOrphanMitigation(httpErr.StatusCode))
 		}
 
-		parameters, parametersChecksum, rawParametersWithRedaction, err := prepareInProgressPropertyParameters(
-			c.kubeClient,
-			binding.Namespace,
-			binding.Spec.Parameters,
-			binding.Spec.ParametersFrom,
-		)
-		if err != nil {
-			glog.Warning(pcb.Message(err.Error()))
-			c.recorder.Event(toUpdate, corev1.EventTypeWarning, errorWithParameters, err.Error())
-			setServiceBindingCondition(
-				toUpdate,
-				v1beta1.ServiceBindingConditionReady,
-				v1beta1.ConditionFalse,
-				errorWithParameters,
-				err.Error(),
-			)
-			if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-				return err
-			}
-		}
-
-		toUpdate.Status.InProgressProperties = &v1beta1.ServiceBindingPropertiesState{
-			Parameters:         rawParametersWithRedaction,
-			ParametersChecksum: parametersChecksum,
-			UserInfo:           toUpdate.Spec.UserInfo,
-		}
-
-		appGUID := string(ns.UID)
-		request := &osb.BindRequest{
-			BindingID:    binding.Spec.ExternalID,
-			InstanceID:   instance.Spec.ExternalID,
-			ServiceID:    serviceClass.Spec.ExternalID,
-			PlanID:       servicePlan.Spec.ExternalID,
-			AppGUID:      &appGUID,
-			Parameters:   parameters,
-			BindResource: &osb.BindResource{AppGUID: &appGUID},
-		}
-
-		// Asynchronous binding operations is currently ALPHA and not
-		// enabled by default. To use this feature, you must enable the
-		// AsyncBindingOperations feature gate. This may be easily set
-		// by setting `asyncBindingOperationsEnabled=true` when
-		// deploying the Service Catalog via the Helm charts.
-		if serviceClass.Spec.BindingRetrievable &&
-			utilfeature.DefaultFeatureGate.Enabled(scfeatures.AsyncBindingOperations) {
-
-			request.AcceptsIncomplete = true
-		}
-
-		if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {
-			originatingIdentity, err := buildOriginatingIdentity(binding.Spec.UserInfo)
-			if err != nil {
-				s := fmt.Sprintf(`Error building originating identity headers for binding: %v`, err)
-				glog.Warning(pcb.Message(s))
-				c.recorder.Event(binding, corev1.EventTypeWarning, errorWithOriginatingIdentity, s)
-				setServiceBindingCondition(
-					toUpdate,
-					v1beta1.ServiceBindingConditionReady,
-					v1beta1.ConditionFalse,
-					errorWithOriginatingIdentity,
-					s,
-				)
-				if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-					return err
-				}
-				return err
-			}
-			request.OriginatingIdentity = originatingIdentity
-		}
-
-		toUpdate.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusRequired
-
-		if toUpdate.Status.CurrentOperation == "" {
-			toUpdate, err = c.recordStartOfServiceBindingOperation(toUpdate, v1beta1.ServiceBindingOperationBind)
-			if err != nil {
-				// There has been an update to the binding. Start reconciliation
-				// over with a fresh view of the binding.
-				return err
-			}
-		}
-
-		response, err := brokerClient.Bind(request)
-		// orphan mitigation: looking for timeout
 		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-			setServiceBindingCondition(
-				toUpdate,
-				v1beta1.ServiceBindingConditionFailed,
-				v1beta1.ConditionTrue,
-				errorBindCallReason,
-				"Communication with the ServiceBroker timed out; Bind operation will not be retried: "+err.Error(),
-			)
-			return c.setAndUpdateServiceBindingStartOrphanMitigation(toUpdate)
-		} else if err != nil {
-			if httpErr, ok := osb.IsHTTPError(err); ok {
-				// orphan mitigation: looking for 2xx (excluding 200), 408, 5xx
-				if httpErr.StatusCode > 200 && httpErr.StatusCode < 300 ||
-					httpErr.StatusCode == http.StatusRequestTimeout ||
-					httpErr.StatusCode >= 500 && httpErr.StatusCode < 600 {
-					setServiceBindingCondition(
-						toUpdate,
-						v1beta1.ServiceBindingConditionFailed,
-						v1beta1.ConditionTrue,
-						errorBindCallReason,
-						"ServiceBroker returned a failure; Bind operation will not be retried: "+err.Error(),
-					)
-					return c.setAndUpdateServiceBindingStartOrphanMitigation(toUpdate)
-				}
-				s := fmt.Sprintf(
-					`Error creating ServiceBinding for %s: %v`,
-					pretty.FromServiceInstanceOfClusterServiceClassAtBrokerName(instance, serviceClass, brokerName), httpErr.Error(),
-				)
-				glog.Warning(pcb.Message(s))
-				c.recorder.Event(binding, corev1.EventTypeWarning, errorBindCallReason, s)
-
-				setServiceBindingCondition(
-					toUpdate,
-					v1beta1.ServiceBindingConditionFailed,
-					v1beta1.ConditionTrue,
-					"ServiceBindingReturnedFailure",
-					s,
-				)
-				setServiceBindingCondition(
-					toUpdate,
-					v1beta1.ServiceBindingConditionReady,
-					v1beta1.ConditionFalse,
-					errorBindCallReason,
-					"Bind call failed. "+s)
-				clearServiceBindingCurrentOperation(toUpdate)
-				if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-					return err
-				}
-				return nil
-			}
-
-			s := fmt.Sprintf(
-				`Error creating ServiceBinding for %s: %s`,
-				pretty.FromServiceInstanceOfClusterServiceClassAtBrokerName(instance, serviceClass, brokerName), err,
-			)
-			glog.Warning(pcb.Message(s))
-			c.recorder.Event(binding, corev1.EventTypeWarning, errorBindCallReason, s)
-			setServiceBindingCondition(
-				toUpdate,
-				v1beta1.ServiceBindingConditionReady,
-				v1beta1.ConditionFalse,
-				errorBindCallReason,
-				"Bind call failed. "+s)
-
-			if !time.Now().Before(toUpdate.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
-				s := "Stopping reconciliation retries, too much time has elapsed"
-				glog.Info(pcb.Message(s))
-				c.recorder.Event(binding, corev1.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
-				setServiceBindingCondition(toUpdate,
-					v1beta1.ServiceBindingConditionFailed,
-					v1beta1.ConditionTrue,
-					errorReconciliationRetryTimeoutReason,
-					s)
-				clearServiceBindingCurrentOperation(toUpdate)
-				if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-					return err
-				}
-				return nil
-			}
-
-			if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-				return err
-			}
-			return err
+			msg := "Communication with the ServiceBroker timed out; Bind operation will not be retried: " + err.Error()
+			failedCond := newServiceBindingFailedCondition(v1beta1.ConditionTrue, errorBindCallReason, msg)
+			return c.processBindFailure(binding, nil, failedCond, true)
 		}
 
-		if response.Async {
-			glog.Info(pcb.Message("Received asynchronous bind response"))
-
-			if response.OperationKey != nil && *response.OperationKey != "" {
-				key := string(*response.OperationKey)
-				toUpdate.Status.LastOperation = &key
-			}
-
-			toUpdate.Status.AsyncOpInProgress = true
-
-			setServiceBindingCondition(
-				toUpdate,
-				v1beta1.ServiceBindingConditionReady,
-				v1beta1.ConditionFalse,
-				asyncBindingReason,
-				asyncBindingMessage,
-			)
-
-			if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-				return err
-			}
-
-			if err := c.beginPollingServiceBinding(binding); err != nil {
-				return err
-			}
-
-			c.recorder.Eventf(binding, corev1.EventTypeNormal, asyncBindingReason, asyncBindingMessage)
-
-			return nil
-		}
-
-		// The Bind request has returned successfully from the Broker. Continue
-		// with the success case of creating the ServiceBinding.
-
-		// Save off the external properties here even if the subsequent
-		// credentials injection fails. The Broker has already processed the
-		// request, so this is what the Broker knows about the state of the
-		// binding.
-		toUpdate.Status.ExternalProperties = toUpdate.Status.InProgressProperties
-
-		err = c.injectServiceBinding(binding, response.Credentials)
-		if err != nil {
-			s := fmt.Sprintf(`Error injecting binding results: %s`, err)
-			glog.Warning(pcb.Message(s))
-			c.recorder.Event(binding, corev1.EventTypeWarning, errorInjectingBindResultReason, s)
-			setServiceBindingCondition(
-				toUpdate,
-				v1beta1.ServiceBindingConditionReady,
-				v1beta1.ConditionFalse,
-				errorInjectingBindResultReason,
-				"Error injecting bind result "+s,
-			)
-
-			if !time.Now().Before(toUpdate.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
-				s := fmt.Sprint(pcb.Message("Stopping reconciliation retries, too much time has elapsed"))
-				glog.Info(pcb.Message(s))
-				c.recorder.Event(binding, corev1.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
-				setServiceBindingCondition(toUpdate,
-					v1beta1.ServiceBindingConditionFailed,
-					v1beta1.ConditionTrue,
-					errorReconciliationRetryTimeoutReason,
-					s)
-				return c.setAndUpdateServiceBindingStartOrphanMitigation(toUpdate)
-			}
-
-			if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-				return err
-			}
-			// TODO: solve scenario where bind request successful, credential injection fails, later reconciliations have non-failing errors
-			// with Bind request. After retry duration, reconciler gives up but will not do orphan mitigation.
-			return err
-		}
-
-		clearServiceBindingCurrentOperation(toUpdate)
-
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionTrue,
-			successInjectedBindResultReason,
-			successInjectedBindResultMessage,
+		msg := fmt.Sprintf(
+			`Error creating ServiceBinding for %s: %s`,
+			pretty.FromServiceInstanceOfClusterServiceClassAtBrokerName(instance, serviceClass, brokerName), err,
 		)
+		readyCond := newServiceBindingReadyCondition(v1beta1.ConditionFalse, errorBindCallReason, msg)
 
-		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-			return err
+		if c.reconciliationRetryDurationExceeded(binding.Status.OperationStartTime) {
+			msg := "Stopping reconciliation retries, too much time has elapsed"
+			failedCond := newServiceBindingFailedCondition(v1beta1.ConditionTrue, errorReconciliationRetryTimeoutReason, msg)
+			return c.processBindFailure(binding, readyCond, failedCond, false)
 		}
 
-		c.recorder.Event(binding, corev1.EventTypeNormal, successInjectedBindResultReason, successInjectedBindResultMessage)
-		glog.V(5).Info(pcb.Messagef(
-			`Successfully bound to %s`,
-			pretty.FromServiceInstanceOfClusterServiceClassAtBrokerName(instance, serviceClass, brokerName),
-		))
-
-		return nil
+		return c.processServiceBindingOperationError(binding, readyCond)
 	}
 
-	return nil
+	if response.Async {
+		return c.processBindAsyncResponse(binding, response)
+	}
+
+	// Save off the external properties here even if the subsequent
+	// credentials injection fails. The Broker has already processed the
+	// request, so this is what the Broker knows about the state of the
+	// binding.
+	binding.Status.ExternalProperties = binding.Status.InProgressProperties
+
+	err = c.injectServiceBinding(binding, response.Credentials)
+	if err != nil {
+		msg := fmt.Sprintf(`Error injecting bind result: %s`, err)
+		readyCond := newServiceBindingReadyCondition(v1beta1.ConditionFalse, errorInjectingBindResultReason, msg)
+
+		if c.reconciliationRetryDurationExceeded(binding.Status.OperationStartTime) {
+			msg := "Stopping reconciliation retries, too much time has elapsed"
+			failedCond := newServiceBindingFailedCondition(v1beta1.ConditionTrue, errorReconciliationRetryTimeoutReason, msg)
+			return c.processBindFailure(binding, readyCond, failedCond, true)
+		}
+
+		// TODO: solve scenario where bind request successful, credential injection fails, later reconciliations have non-failing errors
+		// with Bind request. After retry duration, reconciler gives up but will not do orphan mitigation.
+		return c.processServiceBindingOperationError(binding, readyCond)
+	}
+
+	return c.processBindSuccess(binding)
 }
 
 func (c *controller) reconcileServiceBindingDelete(binding *v1beta1.ServiceBinding) error {
-	// All updates having a DeletingTimestamp will have been handled here.
-	// We're dealing with an update that's actually a soft delete-- i.e. we
-	// have some finalization to do.
+	var err error
+	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
 
 	if binding.DeletionTimestamp == nil && !binding.Status.OrphanMitigationInProgress {
 		// nothing to do...
 		return nil
 	}
 
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
-	glog.V(4).Info(pcb.Message("Processing Delete"))
-
-	finalizerToken := v1beta1.FinalizerServiceCatalog
-	finalizers := sets.NewString(binding.Finalizers...)
-	if !finalizers.Has(finalizerToken) {
+	if finalizers := sets.NewString(binding.Finalizers...); !finalizers.Has(v1beta1.FinalizerServiceCatalog) {
 		return nil
 	}
 
@@ -613,56 +313,31 @@ func (c *controller) reconcileServiceBindingDelete(binding *v1beta1.ServiceBindi
 		return nil
 	}
 
-	toUpdate := binding.DeepCopy()
+	glog.V(4).Info(pcb.Message("Processing Delete"))
+
+	binding = binding.DeepCopy()
 
 	// If unbinding succeeded or is not needed, then clear out the finalizers
 	if binding.Status.UnbindStatus == v1beta1.ServiceBindingUnbindStatusNotRequired ||
 		binding.Status.UnbindStatus == v1beta1.ServiceBindingUnbindStatusSucceeded {
 
-		glog.V(5).Info(pcb.Message("Clearing catalog finalizer"))
-
-		// Clear the finalizer
-		finalizers.Delete(v1beta1.FinalizerServiceCatalog)
-		toUpdate.Finalizers = finalizers.List()
-
-		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-			return err
-		}
-		return nil
+		return c.processServiceBindingGracefulDeletionSuccess(binding)
 	}
 
-	err := c.ejectServiceBinding(binding)
-	if err != nil {
-		s := fmt.Sprintf(`Error deleting secret: %s`, err)
-		glog.Warning(pcb.Message(s))
-		c.recorder.Eventf(binding, corev1.EventTypeWarning, errorEjectingBindReason, "%v %v", errorEjectingBindMessage, s)
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionUnknown,
-			errorEjectingBindReason,
-			errorEjectingBindMessage+s,
-		)
-		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-			return err
-		}
-		return err
+	if err := c.ejectServiceBinding(binding); err != nil {
+		msg := fmt.Sprintf(`Error ejecting binding. Error deleting secret: %s`, err)
+		readyCond := newServiceBindingReadyCondition(v1beta1.ConditionFalse, errorEjectingBindReason, msg)
+		return c.processServiceBindingOperationError(binding, readyCond)
 	}
 
-	if toUpdate.DeletionTimestamp == nil {
-		if toUpdate.Status.OperationStartTime == nil {
+	if binding.DeletionTimestamp == nil {
+		if binding.Status.OperationStartTime == nil {
 			now := metav1.Now()
-			toUpdate.Status.OperationStartTime = &now
+			binding.Status.OperationStartTime = &now
 		}
 	} else {
-		if toUpdate.Status.CurrentOperation != v1beta1.ServiceBindingOperationUnbind {
-			// Cancel any in-progress operation or pending orphan mitigation since the resource is being deleted.
-			// Do not update the reconciled generation since the operation was aborted and not finished.
-			currentReconciledGeneration := toUpdate.Status.ReconciledGeneration
-			clearServiceBindingCurrentOperation(toUpdate)
-			toUpdate.Status.ReconciledGeneration = currentReconciledGeneration
-
-			toUpdate, err = c.recordStartOfServiceBindingOperation(toUpdate, v1beta1.ServiceBindingOperationUnbind)
+		if binding.Status.CurrentOperation != v1beta1.ServiceBindingOperationUnbind {
+			binding, err = c.recordStartOfServiceBindingOperation(binding, v1beta1.ServiceBindingOperationUnbind, nil)
 			if err != nil {
 				// There has been an update to the binding. Start reconciliation
 				// over with a fresh view of the binding.
@@ -671,218 +346,64 @@ func (c *controller) reconcileServiceBindingDelete(binding *v1beta1.ServiceBindi
 		}
 	}
 
-	if binding.Status.UnbindStatus == v1beta1.ServiceBindingUnbindStatusRequired {
-		if ok, err := c.serviceBindingRequestUnbinding(binding, toUpdate, pcb); !ok || err != nil {
-			return err
-		}
-	}
-
-	if toUpdate.Status.OrphanMitigationInProgress {
-		s := "Orphan mitigation successful"
-		setServiceBindingCondition(toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionFalse,
-			successOrphanMitigationReason,
-			s)
-	} else {
-		s := "The binding was deleted successfully"
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionFalse,
-			successUnboundReason,
-			s,
-		)
-		// Clear the finalizer
-		finalizers.Delete(v1beta1.FinalizerServiceCatalog)
-		toUpdate.Finalizers = finalizers.List()
-	}
-
-	toUpdate.Status.ExternalProperties = nil
-	clearServiceBindingCurrentOperation(toUpdate)
-	if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-		return err
-	}
-
-	c.recorder.Event(binding, corev1.EventTypeNormal, successUnboundReason, "This binding was deleted successfully")
-	glog.V(5).Info(pcb.Message("Successfully deleted ServiceBinding"))
-
-	return nil
-}
-
-// serviceBindingRequestUnbinding validates and makes the binding request to the broker.
-// Returns if reconciliation should continue and any error produced.
-func (c *controller) serviceBindingRequestUnbinding(binding *v1beta1.ServiceBinding, toUpdate *v1beta1.ServiceBinding, pcb *pretty.ContextBuilder) (bool, error) {
-	glog.V(4).Info(pcb.Message("Going to make request to unbind"))
 	instance, err := c.instanceLister.ServiceInstances(binding.Namespace).Get(binding.Spec.ServiceInstanceRef.Name)
 	if err != nil {
-		s := fmt.Sprintf(
+		msg := fmt.Sprintf(
 			`References a non-existent %s "%s/%s"`,
 			pretty.ServiceInstance, binding.Namespace, binding.Spec.ServiceInstanceRef.Name,
 		)
-		glog.Warningf(pcb.Messagef("%s (%s)", s, err))
-		c.recorder.Event(binding, corev1.EventTypeWarning, errorNonexistentServiceInstanceReason, s)
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionFalse,
-			errorNonexistentServiceInstanceReason,
-			"The binding references an ServiceInstance that does not exist. "+s,
-		)
-		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-			return false, err
-
-		}
-		return false, err
+		readyCond := newServiceBindingReadyCondition(v1beta1.ConditionFalse, errorNonexistentServiceInstanceReason, msg)
+		return c.processServiceBindingOperationError(binding, readyCond)
 	}
 
 	if instance.Status.AsyncOpInProgress {
-		s := fmt.Sprintf(
+		msg := fmt.Sprintf(
 			`trying to unbind to %s "%s/%s" that has ongoing asynchronous operation`,
 			pretty.ServiceInstance, binding.Namespace, binding.Spec.ServiceInstanceRef.Name,
 		)
-		glog.Info(pcb.Message(s))
-		c.recorder.Event(binding, corev1.EventTypeWarning, errorWithOngoingAsyncOperation, s)
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionFalse,
-			errorWithOngoingAsyncOperation,
-			errorWithOngoingAsyncOperationMessage,
-		)
-		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-			return false, err
-		}
-		return false, fmt.Errorf("Ongoing Asynchronous operation")
+		readyCond := newServiceBindingReadyCondition(v1beta1.ConditionFalse, errorWithOngoingAsyncOperation, msg)
+		return c.processServiceBindingOperationError(binding, readyCond)
 	}
 
 	if instance.Spec.ClusterServiceClassRef == nil || instance.Spec.ClusterServicePlanRef == nil {
 		// TODO(#1562): ultimately here we need to use logic similar to what is done to determine the plan ID for
 		// deprovisioning. We need to allow a ServiceBinding to be deleted, with an unbind request sent to the broker,
 		// even if the ServiceInstance has been changed to a non-existent plan.
-		return false, fmt.Errorf("ClusterServiceClass or ClusterServicePlan references for Instance have not been resolved yet")
+		return fmt.Errorf("ClusterServiceClass or ClusterServicePlan references for Instance have not been resolved yet")
 	}
 
 	serviceClass, servicePlan, brokerName, brokerClient, err := c.getClusterServiceClassPlanAndClusterServiceBrokerForServiceBinding(instance, binding)
 	if err != nil {
-		return false, err // retry later
+		return c.handleServiceBindingReconciliationError(binding, err)
 	}
 
-	unbindRequest := &osb.UnbindRequest{
-		BindingID:  binding.Spec.ExternalID,
-		InstanceID: instance.Spec.ExternalID,
-		ServiceID:  serviceClass.Spec.ExternalID,
-		PlanID:     servicePlan.Spec.ExternalID,
-	}
-
-	// Asynchronous binding operations is currently ALPHA and not
-	// enabled by default. To use this feature, you must enable the
-	// AsyncBindingOperations feature gate. This may be easily set
-	// by setting `asyncBindingOperationsEnabled=true` when
-	// deploying the Service Catalog via the Helm charts.
-	if serviceClass.Spec.BindingRetrievable &&
-		utilfeature.DefaultFeatureGate.Enabled(scfeatures.AsyncBindingOperations) {
-
-		unbindRequest.AcceptsIncomplete = true
-	}
-
-	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {
-		originatingIdentity, err := buildOriginatingIdentity(binding.Spec.UserInfo)
-		if err != nil {
-			s := fmt.Sprintf(`Error building originating identity headers while unbinding: %v`, err)
-			glog.Warning(pcb.Message(s))
-			c.recorder.Event(binding, corev1.EventTypeWarning, errorWithOriginatingIdentity, s)
-			setServiceBindingCondition(
-				toUpdate,
-				v1beta1.ServiceBindingConditionReady,
-				v1beta1.ConditionFalse,
-				errorWithOriginatingIdentity,
-				s,
-			)
-			if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-				return false, err
-			}
-			return false, err
-		}
-		unbindRequest.OriginatingIdentity = originatingIdentity
-	}
-
-	response, err := brokerClient.Unbind(unbindRequest)
+	request, err := c.prepareUnbindRequest(binding, instance, serviceClass, servicePlan)
 	if err != nil {
-		s := fmt.Sprintf(
+		return c.handleServiceBindingReconciliationError(binding, err)
+	}
+
+	response, err := brokerClient.Unbind(request)
+	if err != nil {
+		msg := fmt.Sprintf(
 			`Error unbinding from %s: %s`,
 			pretty.FromServiceInstanceOfClusterServiceClassAtBrokerName(instance, serviceClass, brokerName), err,
 		)
-		glog.Warning(pcb.Message(s))
-		c.recorder.Event(binding, corev1.EventTypeWarning, errorUnbindCallReason, s)
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionUnknown,
-			errorUnbindCallReason,
-			"Unbind call failed. "+s)
+		readyCond := newServiceBindingReadyCondition(v1beta1.ConditionUnknown, errorUnbindCallReason, msg)
 
-		if !time.Now().Before(toUpdate.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
-			if toUpdate.Status.OrphanMitigationInProgress {
-				s := "Stopping reconciliation retries, too much time has elapsed during orphan mitigation"
-				glog.Info(pcb.Message(s))
-				c.recorder.Event(binding, corev1.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
-			} else {
-				s := "Stopping reconciliation retries, too much time has elapsed"
-				glog.Info(pcb.Message(s))
-				c.recorder.Event(binding, corev1.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
-				setServiceBindingCondition(toUpdate,
-					v1beta1.ServiceBindingConditionFailed,
-					v1beta1.ConditionTrue,
-					errorReconciliationRetryTimeoutReason,
-					s)
-			}
-			clearServiceBindingCurrentOperation(toUpdate)
-			toUpdate.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusFailed
-			if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-				return false, err
-			}
-			return false, nil
+		if c.reconciliationRetryDurationExceeded(binding.Status.OperationStartTime) {
+			msg := "Stopping reconciliation retries, too much time has elapsed"
+			failedCond := newServiceBindingReadyCondition(v1beta1.ConditionTrue, errorReconciliationRetryTimeoutReason, msg)
+			return c.processUnbindFailure(binding, readyCond, failedCond)
 		}
 
-		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-			return false, err
-		}
-		return false, err
+		return c.processServiceBindingOperationError(binding, readyCond)
 	}
 
 	if response.Async {
-		glog.Info(pcb.Message("Received asynchronous unbind response"))
-
-		if response.OperationKey != nil && *response.OperationKey != "" {
-			key := string(*response.OperationKey)
-			toUpdate.Status.LastOperation = &key
-		}
-
-		toUpdate.Status.AsyncOpInProgress = true
-
-		setServiceBindingCondition(
-			toUpdate,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionFalse,
-			asyncUnbindingReason,
-			asyncUnbindingMessage,
-		)
-
-		if _, err := c.updateServiceBindingStatus(toUpdate); err != nil {
-			return false, err
-		}
-
-		if err := c.beginPollingServiceBinding(binding); err != nil {
-			return false, err
-		}
-
-		c.recorder.Eventf(binding, corev1.EventTypeNormal, asyncUnbindingReason, asyncUnbindingMessage)
-
-		return false, nil
+		return c.processUnbindAsyncResponse(binding, response)
 	}
-	toUpdate.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusSucceeded
-	return true, nil
+
+	return c.processUnbindSuccess(binding)
 }
 
 // isPlanBindable returns whether the given ClusterServiceClass and ClusterServicePlan
@@ -1006,6 +527,7 @@ func setServiceBindingConditionInternal(toUpdate *v1beta1.ServiceBinding,
 	reason, message string,
 	t metav1.Time) {
 	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, toUpdate.Namespace, toUpdate.Name)
+	glog.Info(pcb.Message(message))
 	glog.V(5).Info(pcb.Messagef(
 		"Setting condition %q to %v",
 		conditionType, status,
@@ -1101,19 +623,29 @@ func (c *controller) updateServiceBindingCondition(
 // params:
 // toUpdate - a modifiable copy of the binding in the registry to update
 // operation - operation that is being performed on the binding
+// inProgressProperties - the new properties, if any, to apply to the binding
 // returns:
 // 1 - a modifiable copy of toUpdate; or toUpdate if there was an error
 // 2 - any error that occurred
-func (c *controller) recordStartOfServiceBindingOperation(toUpdate *v1beta1.ServiceBinding, operation v1beta1.ServiceBindingOperation) (*v1beta1.ServiceBinding, error) {
+func (c *controller) recordStartOfServiceBindingOperation(
+	toUpdate *v1beta1.ServiceBinding, operation v1beta1.ServiceBindingOperation, inProgressProperties *v1beta1.ServiceBindingPropertiesState) (
+	*v1beta1.ServiceBinding, error) {
+
+	currentReconciledGeneration := toUpdate.Status.ReconciledGeneration
+	clearServiceBindingCurrentOperation(toUpdate)
+
+	toUpdate.Status.ReconciledGeneration = currentReconciledGeneration
 	toUpdate.Status.CurrentOperation = operation
 	now := metav1.Now()
 	toUpdate.Status.OperationStartTime = &now
+	toUpdate.Status.InProgressProperties = inProgressProperties
 	reason := ""
 	message := ""
 	switch operation {
 	case v1beta1.ServiceBindingOperationBind:
 		reason = bindingInFlightReason
 		message = bindingInFlightMessage
+		toUpdate.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusRequired
 	case v1beta1.ServiceBindingOperationUnbind:
 		reason = unbindingInFlightReason
 		message = unbindingInFlightMessage
@@ -1183,14 +715,15 @@ func (c *controller) finishPollingServiceBinding(binding *v1beta1.ServiceBinding
 
 func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
 	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Name, binding.Namespace)
-
 	glog.V(4).Infof(pcb.Message("Processing"))
 
 	binding = binding.DeepCopy()
 
 	instance, err := c.instanceLister.ServiceInstances(binding.Namespace).Get(binding.Spec.ServiceInstanceRef.Name)
 	if err != nil {
-		return fmt.Errorf("could not get instance for ServiceBinding %v/%v", binding.Namespace, binding.Name)
+		msg := fmt.Sprintf(`References a non-existent %s "%s/%s"`, pretty.ServiceInstance, binding.Namespace, binding.Spec.ServiceInstanceRef.Name)
+		readyCond := newServiceBindingReadyCondition(v1beta1.ConditionFalse, errorNonexistentServiceInstanceReason, msg)
+		return c.processServiceBindingOperationError(binding, readyCond)
 	}
 
 	serviceClass, servicePlan, _, brokerClient, err := c.getClusterServiceClassPlanAndClusterServiceBrokerForServiceBinding(instance, binding)
@@ -1202,80 +735,11 @@ func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
 	// deleting or mitigating an orphan; this is more readable than
 	// checking the timestamps in various places.
 	mitigatingOrphan := binding.Status.OrphanMitigationInProgress
-	deleting := false
-	if binding.Status.CurrentOperation == v1beta1.ServiceBindingOperationUnbind || mitigatingOrphan {
-		deleting = true
-	}
+	deleting := binding.Status.CurrentOperation == v1beta1.ServiceBindingOperationUnbind || mitigatingOrphan
 
-	if binding.Status.OperationStartTime == nil {
-		s := "Stopping reconciliation retries because the operation start time is not set"
-		glog.Info(pcb.Message(s))
-		c.recorder.Event(binding, corev1.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
-
-		if mitigatingOrphan {
-			setServiceBindingCondition(
-				binding,
-				v1beta1.ServiceBindingConditionReady,
-				v1beta1.ConditionUnknown,
-				errorOrphanMitigationFailedReason,
-				"Orphan mitigation failed: "+s,
-			)
-		} else {
-			setServiceBindingCondition(
-				binding,
-				v1beta1.ServiceBindingConditionFailed,
-				v1beta1.ConditionTrue,
-				errorReconciliationRetryTimeoutReason,
-				s,
-			)
-		}
-
-		if deleting {
-			clearServiceBindingCurrentOperation(binding)
-			binding.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusFailed
-
-			if _, err := c.updateServiceBindingStatus(binding); err != nil {
-				return err
-			}
-		} else {
-			if err := c.setAndUpdateServiceBindingStartOrphanMitigation(binding); err != nil {
-				return err
-			}
-		}
-
-		return c.finishPollingServiceBinding(binding)
-	}
-
-	request := &osb.BindingLastOperationRequest{
-		InstanceID: instance.Spec.ExternalID,
-		BindingID:  binding.Spec.ExternalID,
-		ServiceID:  &serviceClass.Spec.ExternalID,
-		PlanID:     &servicePlan.Spec.ExternalID,
-	}
-	if binding.Status.LastOperation != nil && *binding.Status.LastOperation != "" {
-		key := osb.OperationKey(*binding.Status.LastOperation)
-		request.OperationKey = &key
-	}
-
-	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {
-		originatingIdentity, err := buildOriginatingIdentity(binding.Spec.UserInfo)
-		if err != nil {
-			s := fmt.Sprintf("Error building originating identity headers for polling last operation: %v", err)
-			glog.Warningf(pcb.Message(s))
-			c.recorder.Event(binding, corev1.EventTypeWarning, errorWithOriginatingIdentity, s)
-			setServiceBindingCondition(
-				binding,
-				v1beta1.ServiceBindingConditionReady,
-				v1beta1.ConditionFalse,
-				errorWithOriginatingIdentity,
-				s,
-			)
-			if _, err := c.updateServiceBindingStatus(binding); err != nil {
-				return err
-			}
-			return err
-		}
-		request.OriginatingIdentity = originatingIdentity
+	request, err := c.prepareServiceBindingLastOperationRequest(binding, instance, serviceClass, servicePlan)
+	if err != nil {
+		return c.handleServiceBindingReconciliationError(binding, err)
 	}
 
 	glog.V(5).Info(pcb.Message("Polling last operation"))
@@ -1283,72 +747,25 @@ func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
 	response, err := brokerClient.PollBindingLastOperation(request)
 	if err != nil {
 		// If the operation was for delete and we receive a http.StatusGone,
-		// this is considered a success as per the spec, so mark as deleted
-		// and remove any finalizers.
+		// this is considered a success as per the spec.
 		if osb.IsGoneError(err) && deleting {
-			var (
-				reason  string
-				message string
-			)
-			switch {
-			case mitigatingOrphan:
-				reason = successOrphanMitigationReason
-				message = successOrphanMitigationMessage
-			default:
-				reason = successUnboundReason
-				message = "The binding was deleted successfully"
+			if err := c.processUnbindSuccess(binding); err != nil {
+				return c.handleServiceBindingPollingError(binding, err)
 			}
-
-			clearServiceBindingCurrentOperation(binding)
-			binding.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusSucceeded
-			binding.Status.ExternalProperties = nil
-
-			setServiceBindingCondition(
-				binding,
-				v1beta1.ServiceBindingConditionReady,
-				v1beta1.ConditionFalse,
-				reason,
-				message,
-			)
-
-			if !mitigatingOrphan {
-				// Clear the finalizer
-				if finalizers := sets.NewString(binding.Finalizers...); finalizers.Has(v1beta1.FinalizerServiceCatalog) {
-					finalizers.Delete(v1beta1.FinalizerServiceCatalog)
-					binding.Finalizers = finalizers.List()
-				}
-			}
-
-			if _, err := c.updateServiceBindingStatus(binding); err != nil {
-				return err
-			}
-
-			c.recorder.Event(binding, corev1.EventTypeNormal, reason, message)
-			glog.V(4).Info(pcb.Message(message))
-
 			return c.finishPollingServiceBinding(binding)
 		}
 
-		// We got some kind of error from the broker.  While polling last
-		// operation, this represents an invalid response and we should
-		// continue polling last operation.
+		// We got some kind of error and should continue polling as per
+		// the spec.
 		//
-		// The ready condition on the binding should already have
-		// condition false; it should be sufficient to create an event for
-		// the instance.
-		errText := ""
-		if httpErr, ok := osb.IsHTTPError(err); ok {
-			errText = httpErr.Error()
-		} else {
-			errText = err.Error()
-		}
-
-		s := fmt.Sprintf("Error polling last operation: %v", errText)
+		// The binding's Ready condition should already be False, so we
+		// just need to record an event.
+		s := fmt.Sprintf("Error polling last operation: %v", err)
 		glog.V(4).Info(pcb.Message(s))
 		c.recorder.Event(binding, corev1.EventTypeWarning, errorPollingLastOperationReason, s)
 
-		if c.isServiceBindingReconciliationRetryDurationExceeded(binding) {
-			return c.reconciliationRetryDurationExceededFinishPollingServiceBinding(binding)
+		if c.reconciliationRetryDurationExceeded(binding.Status.OperationStartTime) {
+			return c.processServiceBindingPollingFailureRetryTimeout(binding, nil)
 		}
 
 		return c.continuePollingServiceBinding(binding)
@@ -1358,84 +775,35 @@ func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
 
 	switch response.State {
 	case osb.StateInProgress:
+		if c.reconciliationRetryDurationExceeded(binding.Status.OperationStartTime) {
+			return c.processServiceBindingPollingFailureRetryTimeout(binding, nil)
+		}
+
 		// if the description is non-nil, then update the instance condition with it
 		if response.Description != nil {
-			var (
-				message string
-				reason  string
-			)
+			reason := asyncBindingReason
+			message := asyncBindingMessage
 			if deleting {
 				reason = asyncUnbindingReason
 				message = asyncUnbindingMessage
-			} else {
-				reason = asyncBindingReason
-				message = asyncBindingMessage
 			}
 
 			message = fmt.Sprintf("%s (%s)", message, *response.Description)
-
-			setServiceBindingCondition(
-				binding,
-				v1beta1.ServiceBindingConditionReady,
-				v1beta1.ConditionFalse,
-				reason,
-				message,
-			)
-		}
-
-		if c.isServiceBindingReconciliationRetryDurationExceeded(binding) {
-			return c.reconciliationRetryDurationExceededFinishPollingServiceBinding(binding)
-		}
-
-		if _, err := c.updateServiceBindingStatus(binding); err != nil {
-			return err
-		}
-
-		glog.V(4).Info(pcb.Message("Last operation not completed (still in progress)"))
-
-		return c.continuePollingServiceBinding(binding)
-	case osb.StateSucceeded:
-		if deleting {
-			var (
-				reason  string
-				message string
-			)
-			switch {
-			case mitigatingOrphan:
-				reason = successOrphanMitigationReason
-				message = successOrphanMitigationMessage
-			default:
-				reason = successUnboundReason
-				message = "The binding was deleted successfully"
-			}
-
-			clearServiceBindingCurrentOperation(binding)
-			binding.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusSucceeded
-			binding.Status.ExternalProperties = nil
-
-			setServiceBindingCondition(
-				binding,
-				v1beta1.ServiceBindingConditionReady,
-				v1beta1.ConditionFalse,
-				reason,
-				message,
-			)
-
-			if !mitigatingOrphan {
-				// Clear the finalizer
-				if finalizers := sets.NewString(binding.Finalizers...); finalizers.Has(v1beta1.FinalizerServiceCatalog) {
-					finalizers.Delete(v1beta1.FinalizerServiceCatalog)
-					binding.Finalizers = finalizers.List()
-				}
-			}
+			setServiceBindingCondition(binding, v1beta1.ServiceBindingConditionReady, v1beta1.ConditionFalse, reason, message)
+			c.recorder.Event(binding, corev1.EventTypeNormal, reason, message)
 
 			if _, err := c.updateServiceBindingStatus(binding); err != nil {
 				return err
 			}
+		}
 
-			c.recorder.Event(binding, corev1.EventTypeNormal, reason, message)
-			glog.V(4).Info(pcb.Message(message))
-
+		glog.V(4).Info(pcb.Message("Last operation not completed (still in progress)"))
+		return c.continuePollingServiceBinding(binding)
+	case osb.StateSucceeded:
+		if deleting {
+			if err := c.processUnbindSuccess(binding); err != nil {
+				return err
+			}
 			return c.finishPollingServiceBinding(binding)
 		}
 
@@ -1448,21 +816,15 @@ func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
 			BindingID:  binding.Spec.ExternalID,
 		}
 
+		// TODO(mkibbe): Break this logic out so that GET and inject are retried separately on error
 		getBindingResponse, err := brokerClient.GetBinding(getBindingRequest)
 		if err != nil {
-			s := fmt.Sprintf("Could not do a GET on binding resource: %v", err)
-			glog.Warning(pcb.Message(s))
-			c.recorder.Event(binding, corev1.EventTypeWarning, errorFetchingBindingFailedReason, s)
+			reason := errorFetchingBindingFailedReason
+			msg := fmt.Sprintf("Could not do a GET on binding resource: %v", err)
+			readyCond := newServiceBindingReadyCondition(v1beta1.ConditionFalse, reason, msg)
+			failedCond := newServiceBindingFailedCondition(v1beta1.ConditionTrue, reason, msg)
 
-			setServiceBindingCondition(
-				binding,
-				v1beta1.ServiceBindingConditionFailed,
-				v1beta1.ConditionTrue,
-				errorFetchingBindingFailedReason,
-				s,
-			)
-
-			if err := c.setAndUpdateServiceBindingStartOrphanMitigation(binding); err != nil {
+			if err := c.processBindFailure(binding, readyCond, failedCond, true); err != nil {
 				return err
 			}
 
@@ -1470,38 +832,20 @@ func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
 		}
 
 		if err := c.injectServiceBinding(binding, getBindingResponse.Credentials); err != nil {
-			s := fmt.Sprintf("Error injecting bind results: %v", err)
-			glog.Warning(pcb.Message(s))
-			c.recorder.Event(binding, corev1.EventTypeWarning, errorInjectingBindResultReason, s)
+			reason := errorInjectingBindResultReason
+			msg := fmt.Sprintf("Error injecting bind results: %v", err)
 
-			setServiceBindingCondition(
-				binding,
-				v1beta1.ServiceBindingConditionFailed,
-				v1beta1.ConditionTrue,
-				errorInjectingBindResultReason,
-				s,
-			)
+			readyCond := newServiceBindingReadyCondition(v1beta1.ConditionFalse, reason, msg)
+			failedCond := newServiceBindingFailedCondition(v1beta1.ConditionTrue, reason, msg)
 
-			if err := c.setAndUpdateServiceBindingStartOrphanMitigation(binding); err != nil {
+			if err := c.processBindFailure(binding, readyCond, failedCond, true); err != nil {
 				return err
 			}
 
 			return c.finishPollingServiceBinding(binding)
 		}
 
-		glog.V(4).Info(pcb.Message(successInjectedBindResultMessage))
-		c.recorder.Event(binding, corev1.EventTypeNormal, successInjectedBindResultReason, successInjectedBindResultMessage)
-
-		setServiceBindingCondition(
-			binding,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionTrue,
-			successInjectedBindResultReason,
-			successInjectedBindResultMessage,
-		)
-		clearServiceBindingCurrentOperation(binding)
-
-		if _, err := c.updateServiceBindingStatus(binding); err != nil {
+		if err := c.processBindSuccess(binding); err != nil {
 			return err
 		}
 
@@ -1512,56 +856,26 @@ func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
 			description = *response.Description
 		}
 
-		var (
-			readyCond v1beta1.ConditionStatus
-			reason    string
-			message   string
-		)
-		switch {
-		case mitigatingOrphan:
-			readyCond = v1beta1.ConditionUnknown
-			reason = errorOrphanMitigationFailedReason
-			message = "Orphan mitigation failed: " + description
-		case deleting:
-			readyCond = v1beta1.ConditionUnknown
-			reason = errorUnbindCallReason
-			message = "Unbind call failed: " + description
-		default:
-			readyCond = v1beta1.ConditionFalse
-			reason = errorBindCallReason
-			message = "Bind call failed: " + description
-		}
-
-		glog.Warning(pcb.Message(message))
-		c.recorder.Event(binding, corev1.EventTypeWarning, reason, message)
-
-		setServiceBindingCondition(
-			binding,
-			v1beta1.ServiceBindingConditionReady,
-			readyCond,
-			reason,
-			message,
-		)
-
 		if !deleting {
-			setServiceBindingCondition(
-				binding,
-				v1beta1.ServiceBindingConditionFailed,
-				v1beta1.ConditionTrue,
-				reason,
-				message,
-			)
-			clearServiceBindingCurrentOperation(binding)
-
-			if _, err := c.updateServiceBindingStatus(binding); err != nil {
-				return err
+			reason := errorBindCallReason
+			message := "Bind call failed: " + description
+			readyCond := newServiceBindingReadyCondition(v1beta1.ConditionFalse, reason, message)
+			failedCond := newServiceBindingFailedCondition(v1beta1.ConditionTrue, reason, message)
+			if err := c.processBindFailure(binding, readyCond, failedCond, false); err != nil {
+				return c.handleServiceBindingPollingError(binding, err)
 			}
-
 			return c.finishPollingServiceBinding(binding)
 		}
-		if !time.Now().Before(binding.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
-			return c.reconciliationRetryDurationExceededFinishPollingServiceBinding(binding)
+
+		msg := "Unbind call failed: " + description
+		readyCond := newServiceBindingReadyCondition(v1beta1.ConditionUnknown, errorUnbindCallReason, msg)
+
+		if c.reconciliationRetryDurationExceeded(binding.Status.OperationStartTime) {
+			return c.processServiceBindingPollingFailureRetryTimeout(binding, readyCond)
 		}
+
+		setServiceBindingCondition(binding, v1beta1.ServiceBindingConditionReady, readyCond.Status, readyCond.Reason, readyCond.Message)
+		c.recorder.Event(binding, corev1.EventTypeWarning, errorUnbindCallReason, msg)
 
 		// we must trigger a new unbind attempt entirely (as opposed to
 		// retrying querying the failed operation endpoint). Finish
@@ -1575,12 +889,12 @@ func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
 		}
 
 		c.finishPollingServiceBinding(binding)
-		return fmt.Errorf(message)
+		return fmt.Errorf(readyCond.Message)
 	default:
 		glog.Warning(pcb.Messagef("Got invalid state in LastOperationResponse: %q", response.State))
 
-		if c.isServiceBindingReconciliationRetryDurationExceeded(binding) {
-			return c.reconciliationRetryDurationExceededFinishPollingServiceBinding(binding)
+		if c.reconciliationRetryDurationExceeded(binding.Status.OperationStartTime) {
+			return c.processServiceBindingPollingFailureRetryTimeout(binding, nil)
 		}
 
 		return c.continuePollingServiceBinding(binding)
@@ -1596,55 +910,413 @@ func (c *controller) isServiceBindingReconciliationRetryDurationExceeded(binding
 	return false
 }
 
-// reconciliationRetryDurationExceededFinishPollingServiceBinding marks the
-// binding as failed due to the reconciliation retry duration having been
-// exceeded.
-//
-// The binding resource passed will be directly modified, so make sure it is
-// not directly from the cache.
-func (c *controller) reconciliationRetryDurationExceededFinishPollingServiceBinding(binding *v1beta1.ServiceBinding) error {
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
-
+// processServiceBindingPollingFailureRetryTimeout marks the binding as having
+// failed polling due to its reconciliation retry duration expiring
+func (c *controller) processServiceBindingPollingFailureRetryTimeout(binding *v1beta1.ServiceBinding, readyCond *v1beta1.ServiceBindingCondition) error {
 	mitigatingOrphan := binding.Status.OrphanMitigationInProgress
-	deleting := false
-	if binding.Status.CurrentOperation == v1beta1.ServiceBindingOperationUnbind || mitigatingOrphan {
-		deleting = true
+	deleting := binding.Status.CurrentOperation == v1beta1.ServiceBindingOperationUnbind || mitigatingOrphan
+
+	// if no specific failure provided, just say the operation timed out.
+	if readyCond == nil {
+		operation := "Bind"
+		status := v1beta1.ConditionFalse
+		if deleting {
+			operation = "Unbind"
+			status = v1beta1.ConditionUnknown
+		}
+
+		msg := fmt.Sprintf("The asynchronous %v operation timed out and will not be retried", operation)
+		readyCond = newServiceBindingReadyCondition(status, errorAsyncOpTimeoutReason, msg)
 	}
 
-	s := "Stopping reconciliation retries because too much time has elapsed"
-	glog.Infof(pcb.Message(s))
-	c.recorder.Event(binding, corev1.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
+	msg := "Stopping reconciliation retries because too much time has elapsed"
+	failedCond := newServiceBindingFailedCondition(v1beta1.ConditionTrue, errorReconciliationRetryTimeoutReason, msg)
+
+	var err error
+	if deleting {
+		err = c.processUnbindFailure(binding, readyCond, failedCond)
+	} else {
+		// always finish polling binding, as triggering OM will return an error
+		c.finishPollingServiceBinding(binding)
+		return c.processBindFailure(binding, readyCond, failedCond, true)
+	}
+
+	if err != nil {
+		return c.handleServiceBindingPollingError(binding, err)
+	}
+
+	return c.finishPollingServiceBinding(binding)
+}
+
+// newServiceBindingReadyCondition is a helper function that returns a Ready
+// condition with the given status, reason, and message, with its transition
+// time set to now.
+func newServiceBindingReadyCondition(status v1beta1.ConditionStatus, reason, message string) *v1beta1.ServiceBindingCondition {
+	return &v1beta1.ServiceBindingCondition{
+		Type:               v1beta1.ServiceBindingConditionReady,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+	}
+}
+
+// newServiceBindingFailedCondition is a helper function that returns a Failed
+// condition with the given status, reason, and message, with its transition
+// time set to now.
+func newServiceBindingFailedCondition(status v1beta1.ConditionStatus, reason, message string) *v1beta1.ServiceBindingCondition {
+	return &v1beta1.ServiceBindingCondition{
+		Type:               v1beta1.ServiceBindingConditionFailed,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+	}
+}
+
+// setServiceBindingLastOperation sets the last operation key on the given
+// binding.
+func setServiceBindingLastOperation(binding *v1beta1.ServiceBinding, operationKey *osb.OperationKey) {
+	if operationKey != nil && *operationKey != "" {
+		key := string(*operationKey)
+		binding.Status.LastOperation = &key
+	}
+}
+
+// prepareBindRequest creates a bind request object to be passed to the broker
+// client to create the given binding.
+func (c *controller) prepareBindRequest(
+	binding *v1beta1.ServiceBinding, instance *v1beta1.ServiceInstance, serviceClass *v1beta1.ClusterServiceClass, servicePlan *v1beta1.ClusterServicePlan) (
+	*osb.BindRequest, *v1beta1.ServiceBindingPropertiesState, error) {
+
+	ns, err := c.kubeClient.CoreV1().Namespaces().Get(instance.Namespace, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, &operationError{
+			reason:  errorFindingNamespaceServiceInstanceReason,
+			message: fmt.Sprintf(`Failed to get namespace %q during binding: %s`, instance.Namespace, err),
+		}
+	}
+
+	parameters, parametersChecksum, rawParametersWithRedaction, err := prepareInProgressPropertyParameters(
+		c.kubeClient,
+		binding.Namespace,
+		binding.Spec.Parameters,
+		binding.Spec.ParametersFrom,
+	)
+	if err != nil {
+		return nil, nil, &operationError{
+			reason:  errorWithParameters,
+			message: err.Error(),
+		}
+	}
+
+	inProgressProperties := &v1beta1.ServiceBindingPropertiesState{
+		Parameters:         rawParametersWithRedaction,
+		ParametersChecksum: parametersChecksum,
+		UserInfo:           binding.Spec.UserInfo,
+	}
+
+	appGUID := string(ns.UID)
+	request := &osb.BindRequest{
+		BindingID:    binding.Spec.ExternalID,
+		InstanceID:   instance.Spec.ExternalID,
+		ServiceID:    serviceClass.Spec.ExternalID,
+		PlanID:       servicePlan.Spec.ExternalID,
+		AppGUID:      &appGUID,
+		Parameters:   parameters,
+		BindResource: &osb.BindResource{AppGUID: &appGUID},
+	}
+
+	// Asynchronous binding operations are currently ALPHA and not
+	// enabled by default. To use this feature, you must enable the
+	// AsyncBindingOperations feature gate. This may be easily set
+	// by setting `asyncBindingOperationsEnabled=true` when
+	// deploying the Service Catalog via the Helm charts.
+	if serviceClass.Spec.BindingRetrievable &&
+		utilfeature.DefaultFeatureGate.Enabled(scfeatures.AsyncBindingOperations) {
+
+		request.AcceptsIncomplete = true
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {
+		originatingIdentity, err := buildOriginatingIdentity(binding.Spec.UserInfo)
+		if err != nil {
+			return nil, nil, &operationError{
+				reason:  errorWithOriginatingIdentity,
+				message: fmt.Sprintf(`Error building originating identity headers for binding: %v`, err),
+			}
+		}
+		request.OriginatingIdentity = originatingIdentity
+	}
+
+	return request, inProgressProperties, nil
+}
+
+// prepareUnbindRequest creates an unbind request object to be passed to the
+// broker client to delete the given binding.
+func (c *controller) prepareUnbindRequest(
+	binding *v1beta1.ServiceBinding, instance *v1beta1.ServiceInstance, serviceClass *v1beta1.ClusterServiceClass, servicePlan *v1beta1.ClusterServicePlan) (
+	*osb.UnbindRequest, error) {
+
+	request := &osb.UnbindRequest{
+		BindingID:  binding.Spec.ExternalID,
+		InstanceID: instance.Spec.ExternalID,
+		ServiceID:  serviceClass.Spec.ExternalID,
+		PlanID:     servicePlan.Spec.ExternalID,
+	}
+
+	// Asynchronous binding operations is currently ALPHA and not
+	// enabled by default. To use this feature, you must enable the
+	// AsyncBindingOperations feature gate. This may be easily set
+	// by setting `asyncBindingOperationsEnabled=true` when
+	// deploying the Service Catalog via the Helm charts.
+	if serviceClass.Spec.BindingRetrievable &&
+		utilfeature.DefaultFeatureGate.Enabled(scfeatures.AsyncBindingOperations) {
+
+		request.AcceptsIncomplete = true
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {
+		originatingIdentity, err := buildOriginatingIdentity(binding.Spec.UserInfo)
+		if err != nil {
+			return nil, &operationError{
+				reason:  errorWithOriginatingIdentity,
+				message: fmt.Sprintf(`Error building originating identity headers for binding: %v`, err),
+			}
+		}
+		request.OriginatingIdentity = originatingIdentity
+	}
+
+	return request, nil
+}
+
+// prepareServiceBindingLastOperationRequest creates a request object to be
+// passed to the broker client to query the given binding's last operation
+// endpoint.
+func (c *controller) prepareServiceBindingLastOperationRequest(
+	binding *v1beta1.ServiceBinding, instance *v1beta1.ServiceInstance, serviceClass *v1beta1.ClusterServiceClass, servicePlan *v1beta1.ClusterServicePlan) (
+	*osb.BindingLastOperationRequest, error) {
+
+	request := &osb.BindingLastOperationRequest{
+		InstanceID: instance.Spec.ExternalID,
+		BindingID:  binding.Spec.ExternalID,
+		ServiceID:  &serviceClass.Spec.ExternalID,
+		PlanID:     &servicePlan.Spec.ExternalID,
+	}
+	if binding.Status.LastOperation != nil && *binding.Status.LastOperation != "" {
+		key := osb.OperationKey(*binding.Status.LastOperation)
+		request.OperationKey = &key
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {
+		originatingIdentity, err := buildOriginatingIdentity(binding.Spec.UserInfo)
+		if err != nil {
+			return nil, &operationError{
+				reason:  errorWithOriginatingIdentity,
+				message: fmt.Sprintf(`Error building originating identity headers for polling binding last operation: %v`, err),
+			}
+		}
+		request.OriginatingIdentity = originatingIdentity
+	}
+
+	return request, nil
+}
+
+// processServiceBindingOperationError handles the logging and updating of a
+// ServiceBinding that hit a retryable error during reconciliation.
+func (c *controller) processServiceBindingOperationError(binding *v1beta1.ServiceBinding, readyCond *v1beta1.ServiceBindingCondition) error {
+	c.recorder.Event(binding, corev1.EventTypeWarning, readyCond.Reason, readyCond.Message)
+	setServiceBindingCondition(binding, readyCond.Type, readyCond.Status, readyCond.Reason, readyCond.Message)
+	if _, err := c.updateServiceBindingStatus(binding); err != nil {
+		return err
+	}
+
+	return fmt.Errorf(readyCond.Message)
+}
+
+// processBindSuccess handles the logging and updating of a ServiceBinding that
+// has successfully been created at the broker and has had its credentials
+// injected in the cluster.
+func (c *controller) processBindSuccess(binding *v1beta1.ServiceBinding) error {
+	setServiceBindingCondition(binding, v1beta1.ServiceBindingConditionReady, v1beta1.ConditionTrue, successInjectedBindResultReason, successInjectedBindResultMessage)
+	clearServiceBindingCurrentOperation(binding)
+
+	if _, err := c.updateServiceBindingStatus(binding); err != nil {
+		return err
+	}
+
+	c.recorder.Event(binding, corev1.EventTypeNormal, successInjectedBindResultReason, successInjectedBindResultMessage)
+	return nil
+}
+
+// processBindFailure handles the logging and updating of a ServiceBinding that
+// hit a terminal failure during bind reconciliation.
+func (c *controller) processBindFailure(binding *v1beta1.ServiceBinding, readyCond, failedCond *v1beta1.ServiceBindingCondition, shouldMitigateOrphan bool) error {
+	if readyCond != nil {
+		c.recorder.Event(binding, corev1.EventTypeWarning, readyCond.Reason, readyCond.Message)
+		setServiceBindingCondition(binding, readyCond.Type, readyCond.Status, readyCond.Reason, readyCond.Message)
+	}
+
+	c.recorder.Event(binding, corev1.EventTypeWarning, failedCond.Reason, failedCond.Message)
+	setServiceBindingCondition(binding, failedCond.Type, failedCond.Status, failedCond.Reason, failedCond.Message)
+
+	if shouldMitigateOrphan {
+		msg := "Starting orphan mitigation"
+		readyCond := newServiceBindingReadyCondition(v1beta1.ConditionFalse, errorServiceBindingOrphanMitigation, msg)
+		setServiceBindingCondition(binding, readyCond.Type, readyCond.Status, readyCond.Reason, readyCond.Message)
+		c.recorder.Event(binding, corev1.EventTypeWarning, readyCond.Reason, readyCond.Message)
+
+		binding.Status.OrphanMitigationInProgress = true
+		binding.Status.AsyncOpInProgress = false
+		binding.Status.OperationStartTime = nil
+	} else {
+		clearServiceBindingCurrentOperation(binding)
+	}
+
+	if _, err := c.updateServiceBindingStatus(binding); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// processBindAsyncResponse handles the logging and updating of a
+// ServiceInstance that received an asynchronous response from the broker when
+// requesting a bind.
+func (c *controller) processBindAsyncResponse(binding *v1beta1.ServiceBinding, response *osb.BindResponse) error {
+	setServiceBindingLastOperation(binding, response.OperationKey)
+	setServiceBindingCondition(binding, v1beta1.ServiceBindingConditionReady, v1beta1.ConditionFalse, asyncBindingReason, asyncBindingMessage)
+	binding.Status.AsyncOpInProgress = true
+
+	if _, err := c.updateServiceBindingStatus(binding); err != nil {
+		return err
+	}
+
+	c.recorder.Event(binding, corev1.EventTypeNormal, asyncBindingReason, asyncBindingMessage)
+	return c.beginPollingServiceBinding(binding)
+}
+
+// handleServiceBindingReconciliationError is a helper function that handles on
+// error whether the error represents an operation error and should update the
+// ServiceBinding resource.
+func (c *controller) handleServiceBindingReconciliationError(binding *v1beta1.ServiceBinding, err error) error {
+	if resourceErr, ok := err.(*operationError); ok {
+		readyCond := newServiceBindingReadyCondition(v1beta1.ConditionFalse, resourceErr.reason, resourceErr.message)
+		return c.processServiceBindingOperationError(binding, readyCond)
+	}
+	return err
+}
+
+// processServiceBindingGracefulDeletionSuccess handles the logging and
+// updating of a ServiceBinding that has successfully finished graceful
+// deletion.
+func (c *controller) processServiceBindingGracefulDeletionSuccess(binding *v1beta1.ServiceBinding) error {
+	finalizers := sets.NewString(binding.Finalizers...)
+	finalizers.Delete(v1beta1.FinalizerServiceCatalog)
+	binding.Finalizers = finalizers.List()
+
+	if _, err := c.updateServiceBindingStatus(binding); err != nil {
+		return err
+	}
+
+	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
+	glog.Info(pcb.Message("Cleared finalizer"))
+
+	return nil
+}
+
+// processUnbindSuccess handles the logging and updating of a ServiceBinding
+// that has successfully been deleted at the broker.
+func (c *controller) processUnbindSuccess(binding *v1beta1.ServiceBinding) error {
+	mitigatingOrphan := binding.Status.OrphanMitigationInProgress
+
+	reason := successUnboundReason
+	msg := "The binding was deleted successfully"
+	if mitigatingOrphan {
+		reason = successOrphanMitigationReason
+		msg = successOrphanMitigationMessage
+	}
+
+	setServiceBindingCondition(binding, v1beta1.ServiceBindingConditionReady, v1beta1.ConditionFalse, reason, msg)
+	clearServiceBindingCurrentOperation(binding)
+	binding.Status.ExternalProperties = nil
+	binding.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusSucceeded
 
 	if mitigatingOrphan {
-		setServiceBindingCondition(
-			binding,
-			v1beta1.ServiceBindingConditionReady,
-			v1beta1.ConditionUnknown,
-			errorOrphanMitigationFailedReason,
-			"Orphan mitigation failed: "+s,
-		)
-	} else {
-		setServiceBindingCondition(
-			binding,
-			v1beta1.ServiceBindingConditionFailed,
-			v1beta1.ConditionTrue,
-			errorReconciliationRetryTimeoutReason,
-			s,
-		)
-	}
-
-	if deleting {
-		clearServiceBindingCurrentOperation(binding)
-		binding.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusFailed
-
 		if _, err := c.updateServiceBindingStatus(binding); err != nil {
 			return err
 		}
 	} else {
-		if err := c.setAndUpdateServiceBindingStartOrphanMitigation(binding); err != nil {
+		// If part of a resource deletion request, follow-through to
+		// the graceful deletion handler in order to clear the finalizer.
+		if err := c.processServiceBindingGracefulDeletionSuccess(binding); err != nil {
 			return err
 		}
 	}
 
-	return c.finishPollingServiceBinding(binding)
+	c.recorder.Event(binding, corev1.EventTypeNormal, reason, msg)
+	return nil
+}
+
+// processUnbindFailure handles the logging and updating of a
+// ServiceBinding that hit a terminal failure during unbind
+// reconciliation.
+func (c *controller) processUnbindFailure(binding *v1beta1.ServiceBinding, readyCond, failedCond *v1beta1.ServiceBindingCondition) error {
+	if failedCond == nil {
+		return fmt.Errorf("failedCond must not be nil")
+	}
+
+	if readyCond != nil {
+		setServiceBindingCondition(binding, v1beta1.ServiceBindingConditionReady, v1beta1.ConditionUnknown, readyCond.Reason, readyCond.Message)
+		c.recorder.Event(binding, corev1.EventTypeWarning, readyCond.Reason, readyCond.Message)
+	}
+
+	if binding.Status.OrphanMitigationInProgress {
+		// replace Ready condition with orphan mitigation-related one.
+		msg := "Orphan mitigation failed: " + failedCond.Message
+		readyCond := newServiceBindingReadyCondition(v1beta1.ConditionUnknown, errorOrphanMitigationFailedReason, msg)
+		setServiceBindingCondition(binding, v1beta1.ServiceBindingConditionReady, readyCond.Status, readyCond.Reason, readyCond.Message)
+		c.recorder.Event(binding, corev1.EventTypeWarning, readyCond.Reason, readyCond.Message)
+	} else {
+		setServiceBindingCondition(binding, v1beta1.ServiceBindingConditionFailed, failedCond.Status, failedCond.Reason, failedCond.Message)
+		c.recorder.Event(binding, corev1.EventTypeWarning, failedCond.Reason, failedCond.Message)
+	}
+
+	clearServiceBindingCurrentOperation(binding)
+	binding.Status.UnbindStatus = v1beta1.ServiceBindingUnbindStatusFailed
+
+	if _, err := c.updateServiceBindingStatus(binding); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// processUnbindAsyncResponse handles the logging and updating of a
+// ServiceBinding that received an asynchronous response from the broker when
+// requesting an unbind.
+func (c *controller) processUnbindAsyncResponse(binding *v1beta1.ServiceBinding, response *osb.UnbindResponse) error {
+	setServiceBindingLastOperation(binding, response.OperationKey)
+	setServiceBindingCondition(binding, v1beta1.ServiceBindingConditionReady, v1beta1.ConditionFalse, asyncUnbindingReason, asyncUnbindingMessage)
+	binding.Status.AsyncOpInProgress = true
+
+	if _, err := c.updateServiceBindingStatus(binding); err != nil {
+		return err
+	}
+
+	c.recorder.Event(binding, corev1.EventTypeNormal, asyncUnbindingReason, asyncUnbindingMessage)
+	return c.beginPollingServiceBinding(binding)
+}
+
+// handleServiceBindingPollingError is a helper function that handles logic for
+// an error returned during reconciliation while polling a service binding.
+func (c *controller) handleServiceBindingPollingError(binding *v1beta1.ServiceBinding, err error) error {
+	// During polling, an error means we should:
+	//	1) log the error
+	//	2) attempt to requeue in the polling queue
+	//		- if successful, we can return nil to avoid regular queue
+	//		- if failure, return err to fall back to regular queue
+	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
+	glog.V(4).Info(pcb.Messagef("Error during polling: %v", err))
+	return c.continuePollingServiceBinding(binding)
 }

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -189,17 +189,6 @@ func (c *controller) finishPollingServiceInstance(instance *v1beta1.ServiceInsta
 	return nil
 }
 
-// ReconciliationAction reprents a type of action the reconciler should take
-// for a resource.
-type ReconciliationAction string
-
-const (
-	reconcileAdd    ReconciliationAction = "Add"
-	reconcileUpdate ReconciliationAction = "Update"
-	reconcileDelete ReconciliationAction = "Delete"
-	reconcilePoll   ReconciliationAction = "Poll"
-)
-
 // getReconciliationActionForServiceInstance gets the action the reconciler
 // should be taking on the given instance.
 func getReconciliationActionForServiceInstance(instance *v1beta1.ServiceInstance) ReconciliationAction {

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"fmt"
-	"net/http"
 	"net/url"
 
 	"github.com/golang/glog"
@@ -1168,17 +1167,6 @@ func clearServiceInstanceCurrentOperation(toUpdate *v1beta1.ServiceInstance) {
 	toUpdate.Status.LastOperation = nil
 	toUpdate.Status.InProgressProperties = nil
 	toUpdate.Status.ReconciledGeneration = toUpdate.Generation
-}
-
-// shouldStartOrphanMitigation returns whether an error with the given status
-// code indicates that orphan migitation should start.
-func shouldStartOrphanMitigation(statusCode int) bool {
-	is2XX := (statusCode >= 200 && statusCode < 300)
-	is5XX := (statusCode >= 500 && statusCode < 600)
-
-	return (is2XX && statusCode != http.StatusOK) ||
-		statusCode == http.StatusRequestTimeout ||
-		is5XX
 }
 
 // serviceInstanceHasExistingBindings returns true if there are any existing

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2583,7 +2583,7 @@ func assertServiceBindingAsyncBindErrorAfterStateSucceeded(t *testing.T, obj run
 }
 
 func assertServiceBindingAsyncUnbindRetryDurationExceeded(t *testing.T, obj runtime.Object, operation v1beta1.ServiceBindingOperation, readyReason string, failureReason string, originalBinding *v1beta1.ServiceBinding) {
-	assertServiceBindingReadyCondition(t, obj, v1beta1.ConditionFalse, readyReason)
+	assertServiceBindingReadyCondition(t, obj, v1beta1.ConditionUnknown, readyReason)
 	assertServiceBindingCondition(t, obj, v1beta1.ServiceBindingConditionFailed, v1beta1.ConditionTrue, failureReason)
 	assertServiceBindingCurrentOperationClear(t, obj)
 	assertServiceBindingOperationStartTimeSet(t, obj, false)
@@ -2658,8 +2658,8 @@ func assertServiceBindingRequestRetriableErrorWithParameters(t *testing.T, obj r
 	assertServiceBindingUnbindStatus(t, obj, v1beta1.ServiceBindingUnbindStatusRequired)
 }
 
-func assertServiceBindingRequestRetriableOrphanMitigation(t *testing.T, obj runtime.Object, originalBinding *v1beta1.ServiceBinding) {
-	assertServiceBindingReadyCondition(t, obj, v1beta1.ConditionUnknown, errorOrphanMitigationFailedReason)
+func assertServiceBindingRequestRetriableOrphanMitigation(t *testing.T, obj runtime.Object, reason string, originalBinding *v1beta1.ServiceBinding) {
+	assertServiceBindingReadyCondition(t, obj, v1beta1.ConditionUnknown, reason)
 	assertServiceBindingCurrentOperation(t, obj, v1beta1.ServiceBindingOperationBind)
 	assertServiceBindingOperationStartTimeSet(t, obj, true)
 	assertServiceBindingReconciledGeneration(t, obj, originalBinding.Status.ReconciledGeneration)


### PR DESCRIPTION
Refactors `controller_binding.go` reconciliation logic to be in line with that of instances.

A few changes to note:
- Removes binding check on whether the instance has an async operation in progress. We already block binding if the instance is not ready, which is always true if there's an async op.
- Modifies some event messages/number of events
- Adds async operation timeout reason & message