### PR TITLE
Ensure only href-checker runs on docs only commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,28 @@ stages:
   - test
   - name: deploy
     if: type != pull_request
+before_install:
+  - |
+      if [[ -z "$TRAVIS_COMMIT_RANGE" ]]; then
+          # Builds triggered by initial commit of a new branch.
+          DOCS_ONLY=0
+      else
+          DOCS_REGEX='(OWNERS|LICENSE)|(\.md$)|(^docs/)'
+          [[ -z "$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -vE $DOCS_REGEX)" ]]
+          DOCS_ONLY=$?
+      fi
 jobs:
   include:
     # Test
-    - script: make verify build build-integration build-e2e test images svcat
+    - script:
+      - |
+          if (( $DOCS_ONLY == 0 )); then
+              echo "Running verify-docs"
+              make verify-docs
+          else
+              echo "Running full build"
+              make verify build build-integration build-e2e test images svcat
+          fi
     # Deploy
     - stage: deploy
       deploy:

--- a/Makefile
+++ b/Makefile
@@ -183,8 +183,8 @@ $(BINDIR)/e2e.test: .init $(NEWEST_E2ETEST_SOURCE) $(NEWEST_GO_FILE)
 
 # Util targets
 ##############
-.PHONY: verify verify-generated verify-client-gen
-verify: .init .generate_files verify-generated verify-client-gen verify-vendor
+.PHONY: verify verify-generated verify-client-gen verify-docs
+verify: .init .generate_files verify-generated verify-client-gen verify-docs verify-vendor
 	@echo Running gofmt:
 	@$(DOCKER_CMD) gofmt -l -s $(TOP_TEST_DIRS) $(TOP_SRC_DIRS)>.out 2>&1||true
 	@[ ! -s .out ] || \
@@ -211,12 +211,14 @@ verify: .init .generate_files verify-generated verify-client-gen verify-vendor
 	@[ ! -s .out ] || (cat .out && rm .out && false)
 	@rm .out
 	@#
-	@echo Running href checker$(SKIP_COMMENT):
-	@$(DOCKER_CMD) verify-links.sh -s .pkg -t $(SKIP_HTTP) .
 	@echo Running errexit checker:
 	@$(DOCKER_CMD) build/verify-errexit.sh
 	@echo Running tag verification:
 	@$(DOCKER_CMD) build/verify-tags.sh
+
+verify-docs: .init
+	@echo Running href checker$(SKIP_COMMENT):
+	@$(DOCKER_CMD) verify-links.sh -s .pkg -t $(SKIP_HTTP) .
 
 verify-generated: .init .generate_files
 	$(DOCKER_CMD) $(BUILD_DIR)/update-apiserver-gen.sh --verify-only


### PR DESCRIPTION
* Seperates href-checker into `make verify-docs` command.

* Updates Travis script to only run full build on changes to
  non-markdown or docs/ files.

The href-checker still runs via `make verify-docs` for all Travis
builds.

Closes #1673 