### PR TITLE
Load all client auth plugins in the cli

### DIFF
--- a/pkg/svcat/kube/kube.go
+++ b/pkg/svcat/kube/kube.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kube
 
 import (
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // Load all client auth plugins for gcp, azure, etc
 	"k8s.io/client-go/tools/clientcmd"
 )
 


### PR DESCRIPTION
The go-client auth plugins rely on registration that occurs during init. The auth package handles importing all the client packages for side effects, so we can just import the auth package and that will take care of every plugin.

@kibbles-n-bytes I don't have a gcp cluster to test against, would you be willing to try this out? 

Closes #1676.