### PR TITLE
go install to cache race pkgs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
     - $GOPATH/pkg/dep
 script:
-- make verify build build-integration build-e2e test images svcat
+- make verify build compile-integration build-e2e test images svcat
 deploy:
   skip_cleanup: true
   provider: script

--- a/Makefile
+++ b/Makefile
@@ -251,10 +251,11 @@ test-unit: .init build
 	$(DOCKER_CMD) go test -race $(UNIT_TEST_FLAGS) \
 	  $(addprefix $(SC_PKG)/,$(TEST_DIRS)) $(UNIT_TEST_LOG_FLAGS)
 
-build-integration: .generate_files
-	$(DOCKER_CMD) go test -race github.com/kubernetes-incubator/service-catalog/test/integration/... -c
+.PHONY: compile-integration
+compile-integration: .generate_files
+	$(DOCKER_CMD) go test -race -i github.com/kubernetes-incubator/service-catalog/test/integration/... $(GOFLAGS)
 
-test-integration: .init $(scBuildImageTarget) build build-integration
+test-integration: .init $(scBuildImageTarget) build compile-integration
 	# test kubectl
 	contrib/hack/setup-kubectl.sh
 	contrib/hack/test-apiserver.sh

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -36,4 +36,3 @@ runTests() {
 }
 
 runTests $@
-


### PR DESCRIPTION
a lot of fiddly interactions here

 - the unit tests don't install, so they are always slow, unless run
 after the integration tests, at which point the pkgs will have been
 cached and they can skip compiling
 - building the integration binary takes ~30 seconds with no cache
 - compiling and installing the pkgs takes ~25seconds
 - building and installing the binary takes ~54 seconds
 - just doing the linking to a final binary is ~8 seconds

existing compile recompile is ~92 seconds, rebuild ~23 seconds

this new install then link way is ~40 seconds, rebuild 18 seconds

faster initial builds and rebuilds.