### PR TITLE
Change binding_retrievable to bindingRetrievable

### DIFF
--- a/cmd/svcat/testdata/responses/clusterserviceclasses.json
+++ b/cmd/svcat/testdata/responses/clusterserviceclasses.json
@@ -20,7 +20,7 @@
         "externalID": "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468",
         "description": "A user provided service",
         "bindable": true,
-        "binding_retrievable": false,
+        "bindingRetrievable": false,
         "planUpdatable": true
       },
       "status": {

--- a/cmd/svcat/testdata/responses/clusterserviceclasses/4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468.json
+++ b/cmd/svcat/testdata/responses/clusterserviceclasses/4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468.json
@@ -14,7 +14,7 @@
     "externalID": "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468",
     "description": "A user provided service",
     "bindable": true,
-    "binding_retrievable": false,
+    "bindingRetrievable": false,
     "planUpdatable": true
   },
   "status": {

--- a/cmd/svcat/testdata/responses/clusterserviceclasses?fieldSelector=spec.externalName=user-provided-service.json
+++ b/cmd/svcat/testdata/responses/clusterserviceclasses?fieldSelector=spec.externalName=user-provided-service.json
@@ -20,7 +20,7 @@
         "externalID": "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468",
         "description": "A user provided service",
         "bindable": true,
-        "binding_retrievable": false,
+        "bindingRetrievable": false,
         "planUpdatable": true
       },
       "status": {

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -282,7 +282,7 @@ type ClusterServiceClassSpec struct {
 	//
 	// BindingRetrievable indicates whether fetching a binding via a GET on
 	// its endpoint is supported for all plans.
-	BindingRetrievable bool `json:"binding_retrievable"`
+	BindingRetrievable bool `json:"bindingRetrievable"`
 
 	// PlanUpdatable indicates whether instances provisioned from this
 	// ClusterServiceClass may change ClusterServicePlans after being

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -393,7 +393,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "",
 							},
 						},
-						"binding_retrievable": {
+						"bindingRetrievable": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Currently, this field is ALPHA: it may change or disappear at any time and its data will not be migrated.\n\nBindingRetrievable indicates whether fetching a binding via a GET on its endpoint is supported for all plans.",
 								Type:        []string{"boolean"},
@@ -442,7 +442,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"clusterServiceBrokerName", "externalName", "externalID", "description", "bindable", "binding_retrievable", "planUpdatable"},
+					Required: []string{"clusterServiceBrokerName", "externalName", "externalID", "description", "bindable", "bindingRetrievable", "planUpdatable"},
 				},
 			},
 			Dependencies: []string{


### PR DESCRIPTION
This is to make the serialized name conform to API conventions. Also,
changes example json files to match.