### PR TITLE
Publish svcat binaries during build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
       make verify-docs
     else
       echo "Running full build"
-      make verify build build-integration build-e2e test images svcat
+              make verify build build-integration build-e2e test images svcat-all
     fi
 jobs:
   include:

--- a/Makefile
+++ b/Makefile
@@ -394,6 +394,13 @@ svcat-xbuild: $(BINDIR)/svcat/$(SVCAT_VERSION)/$(PLATFORM)/$(ARCH)/svcat$(FILE_E
 $(BINDIR)/svcat/$(SVCAT_VERSION)/$(PLATFORM)/$(ARCH)/svcat$(FILE_EXT): .init .generate_files
 	$(DOCKER_CMD) $(GO_BUILD) -o $@ $(SC_PKG)/cmd/svcat
 
+svcat-publish: clean-bin svcat-all
+	# Download the latest client with https://download.svcat.sh/cli/latest/darwin/amd64/svcat
+	# Download an older client with  https://download.svcat.sh/cli/VERSION/darwin/amd64/svcat
+	cp -R $(BINDIR)/svcat/$(SVCAT_VERSION) $(BINDIR)/svcat/$(MUTABLE_TAG)
+	# AZURE_STORAGE_CONNECTION_STRING will be used for auth in the following command
+	$(DOCKER_CMD) az storage blob upload-batch -d cli -s $(BINDIR)/svcat
+
 # Dependency management via dep (https://golang.github.io/dep)
 .PHONY: verify-vendor test-dep
 verify-vendor: .init

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ SRC_DIRS       = $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*.go \
                    -exec dirname {} \\; | sort | uniq")
 TEST_DIRS     ?= $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go \
                    -exec dirname {} \\; | sort | uniq")
-VERSION       ?= $(shell git describe --always --abbrev=7 --dirty)
+VERSION       ?= $(shell git describe --tags --abbrev=7 --dirty --match=v*)
+SVCAT_VERSION ?= $(shell git describe --tags --abbrev=7 --dirty --match=svcat* &> /dev/null | echo v0)
 BUILD_LDFLAGS  = $(shell build/version.sh $(ROOT) $(SC_PKG))
 GIT_BRANCH    ?= $(shell git rev-parse --abbrev-ref HEAD)
 

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ ifdef NO_DOCKER
 else
 	# Mount .pkg as pkg so that we save our cached "go build" output files
 	DOCKER_CMD = docker run --security-opt label:disable --rm -v $(PWD):/go/src/$(SC_PKG) \
-	  -v $(PWD)/.pkg:/go/pkg scbuildimage
+	  -v $(PWD)/.pkg:/go/pkg --env AZURE_STORAGE_CONNECTION_STRING scbuildimage
 	scBuildImageTarget = .scBuildImage
 endif
 

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -34,7 +34,7 @@ ENV PATH=$PATH:/vlinker/bin
 ENV AZCLI_VERSION=2.0.25
 RUN apt-get update && apt-get install -y python-pip && \
     rm -rf /var/lib/apt/lists/*
-RUN pip install --disable-pip-version-check --no-cache-dir azure-cli==${AZCLI_VERSION}
+RUN pip install --disable-pip-version-check --no-cache-dir --upgrade cryptography azure-cli==${AZCLI_VERSION}
 
 # Create the full dir tree that we'll mount our src into when we run the image
 RUN mkdir -p /go/src/github.com/kubernetes-incubator/service-catalog

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -30,6 +30,12 @@ RUN go get -u github.com/golang/lint/golint
 RUN git clone https://github.com/duglin/vlinker.git /vlinker
 ENV PATH=$PATH:/vlinker/bin
 
+# Install the azure client, used to publish svcat binaries
+ENV AZCLI_VERSION=2.0.25
+RUN apt-get update && apt-get install -y python-pip && \
+    rm -rf /var/lib/apt/lists/*
+RUN pip install --disable-pip-version-check --no-cache-dir azure-cli==${AZCLI_VERSION}
+
 # Create the full dir tree that we'll mount our src into when we run the image
 RUN mkdir -p /go/src/github.com/kubernetes-incubator/service-catalog
 

--- a/cmd/svcat/README.md
+++ b/cmd/svcat/README.md
@@ -24,18 +24,26 @@ In order to use svcat, you will need:
 Follow the appropriate instructions for your shell to download svcat. The binary
 can be used by itself, or as kubectl plugin.
 
-## Bash
+## MacOS
 ```
-curl -sLO https://servicecatalogcli.blob.core.windows.net/cli/latest/$(uname -s)/$(uname -m)/svcat
+curl -sLO https://download.svcat.sh/cli/latest/darwin/amd64/svcat
 chmod +x ./svcat
 mv ./svcat /usr/local/bin/
 svcat --version
 ```
 
-## PowerShell
+## Linux
+```
+curl -sLO https://download.svcat.sh/cli/latest/linux/amd64/svcat
+chmod +x ./svcat
+mv ./svcat /usr/local/bin/
+svcat --version
+```
+
+## Windows
 
 ```
-iwr 'https://servicecatalogcli.blob.core.windows.net/cli/latest/Windows/x86_64/svcat.exe' -UseBasicParsing -OutFile svcat.exe
+iwr 'https://download.svcat.sh/cli/latest/windows/amd64/svcat.exe' -UseBasicParsing -OutFile svcat.exe
 mkdir -f ~\bin
 $env:PATH += ";${pwd}\bin"
 svcat --version
@@ -46,9 +54,9 @@ You will need to find a permanent location for it and add it to your PATH.
 
 ## Manual
 1. Download the appropriate binary for your operating system:
-    * macOS: https://servicecatalogcli.blob.core.windows.net/cli/latest/Darwin/x86_64/svcat
-    * Windows: https://servicecatalogcli.blob.core.windows.net/cli/latest/Windows/x86_64/svcat.exe
-    * Linux: https://servicecatalogcli.blob.core.windows.net/cli/latest/Linux/x86_64/svcat
+    * macOS: https://download.svcat.sh/cli/latest/darwin/amd64/svcat
+    * Windows: https://download.svcat.sh/cli/latest/windows/amd64/svcat.exe
+    * Linux: https://download.svcat.sh/cli/latest/linux/amd64/svcat
 1. Make the binary executable.
 1. Move the binary to a directory on your PATH.
 

--- a/cmd/svcat/main.go
+++ b/cmd/svcat/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/binding"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/broker"
@@ -110,8 +109,7 @@ func buildRootCommand() *cobra.Command {
 }
 
 func printVersion(cxt *command.Context) {
-	v := strings.Replace(pkg.VERSION, "svcat-", "", 1)
-	fmt.Fprintf(cxt.Output, "svcat %s\n", v)
+	fmt.Fprintf(cxt.Output, "svcat %s\n", pkg.VERSION)
 }
 
 func newSyncCmd(cxt *command.Context) *cobra.Command {

--- a/cmd/svcat/main.go
+++ b/cmd/svcat/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/binding"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/broker"
@@ -27,6 +28,7 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/instance"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/plan"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/plugin"
+	"github.com/kubernetes-incubator/service-catalog/pkg"
 	"github.com/kubernetes-incubator/service-catalog/pkg/svcat"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -108,11 +110,8 @@ func buildRootCommand() *cobra.Command {
 }
 
 func printVersion(cxt *command.Context) {
-	if commit == "" { // commit is empty for Homebrew builds
-		fmt.Fprintf(cxt.Output, "svcat %s\n", version)
-	} else {
-		fmt.Fprintf(cxt.Output, "svcat %s (%s)\n", version, commit)
-	}
+	v := strings.Replace(pkg.VERSION, "svcat-", "", 1)
+	fmt.Fprintf(cxt.Output, "svcat %s\n", v)
 }
 
 func newSyncCmd(cxt *command.Context) *cobra.Command {

--- a/contrib/travis/deploy.sh
+++ b/contrib/travis/deploy.sh
@@ -25,6 +25,9 @@ docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
 if [[ "${TRAVIS_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[a-z]*(-(r|R)(c|C)[0-9]+)*$ ]]; then
     echo "Pushing images with tags '${TRAVIS_TAG}' and 'latest'."
     VERSION="${TRAVIS_TAG}" MUTABLE_TAG="latest" make release-push
+if [[ "${TRAVIS_TAG}" =~ ^svcat-v[0-9]+\.[0-9]+\.[0-9]+[a-z]*(-(r|R)(c|C)[0-9]+)*$ ]]; then
+    echo "Publishing svcat binaries for '${TRAVIS_TAG}' and tagging with 'latest'."
+    SVCAT_VERSION="${TRAVIS_TAG}" MUTABLE_TAG="latest" make svcat-publish
 elif [[ "${TRAVIS_BRANCH}" == "master" ]]; then
     echo "Pushing images with default tags (git sha and 'canary')."
     make push

--- a/contrib/travis/deploy.sh
+++ b/contrib/travis/deploy.sh
@@ -24,10 +24,7 @@ docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
 
 if [[ "${TRAVIS_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[a-z]*(-(r|R)(c|C)[0-9]+)*$ ]]; then
     echo "Pushing images with tags '${TRAVIS_TAG}' and 'latest'."
-    VERSION="${TRAVIS_TAG}" MUTABLE_TAG="latest" make release-push
-if [[ "${TRAVIS_TAG}" =~ ^svcat-v[0-9]+\.[0-9]+\.[0-9]+[a-z]*(-(r|R)(c|C)[0-9]+)*$ ]]; then
-    echo "Publishing svcat binaries for '${TRAVIS_TAG}' and tagging with 'latest'."
-    SVCAT_VERSION="${TRAVIS_TAG}" MUTABLE_TAG="latest" make svcat-publish
+    VERSION="${TRAVIS_TAG}" MUTABLE_TAG="latest" make release-push svcat-publish
 elif [[ "${TRAVIS_BRANCH}" == "master" ]]; then
     echo "Pushing images with default tags (git sha and 'canary')."
     make push

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -147,7 +147,7 @@ git remote -v
 ## Building
 
 First `cd` to the root of the cloned repository tree.
-To build the service-catalog:
+To build the service-catalog server components:
 
     $ make build
 
@@ -155,6 +155,10 @@ The above will build all executables and place them in the `bin` directory. This
 is done within a Docker container-- meaning you do not need to have all of the
 necessary tooling installed on your host (such as a golang compiler or dep).
 Building outside the container is possible, but not officially supported.
+
+To build the service-catalog client, `svcat`:
+
+    $ make svcat
 
 Note, this will do the basic build of the service catalog. There are more
 more [advanced build steps](#advanced-build-steps) below as well.
@@ -262,6 +266,29 @@ they can be accessed by your Kubernetes cluster.
 The images are tagged with the current Git commit SHA:
 
     $ docker images
+
+### svcat targets
+These are targets for the service-catalog client, `svcat`:
+
+* `make svcat-all` builds all supported client platforms (darwin, linux, windows).
+* `make svcat-for-X` builds a specific platform.
+* `make svcat` builds for the current dev's platform.
+* `make svcat-publish` compiles everything and uploads the binaries.
+
+The same tags are used for both client and server. The cli uses the format that 
+always includes a tag, so that it's clear which release you are "closest" to, 
+e.g. v1.2.3 for official releases and v1.2.3-2-gabc123 for untagged commits.
+
+### Deploying Releases
+
+* Merge to master - A docker image for the server is pushed to [quay.io/kubernetes-service-catalog/service-catalog](http://quay.io/kubernetes-service-catalog/service-catalog),
+  tagged with the abbreviated commit hash. Nothing is deployed for the client, `svcat`.
+* Tag a commit on master with vX.Y.Z - A docker image for the server is pushed,
+  tagged with the version, e.g. vX.Y.Z. The client binaries are published to 
+  https://download.svcat.sh/cli/latest/OS/ARCH/svcat and https://download.svcat.sh/cli/VERSION/OS/ARCH/svcat.
+
+The idea behind "latest" link is that we can provide a permanent link to the most recent stable release of `svcat`. 
+If someone wants to install a unreleased version, they must build it locally.
 
 ----
 


### PR DESCRIPTION
* `make svcat-all` builds all supported client platforms (darwin, linux, windows).
* `make svcat-for-X` builds a specific platform.
* `make svcat` builds for the current dev's platform.
* `make svcat-publish` compiles everything and uploads the binaries.
* ~Versions for svcat are tracked using svcat-vX.Y.Z tags.~ UPDATE: The same tags are used for both client and server. The cli uses the format that always includes a tag, so that it's clear which release you are "closest" to, e.g. v1.2.3 for official releases and v1.2.3-2-gabc123 for untagged commits.
* Versions for service catalog continue to use vX.Y.Z.
* ~I've fixed the VERSION variable to contain the tag value to account for not using annotated tags.~ UPDATE: Reverted to maintain current docker image tags.
* Download from https://download.svcat.sh/cli/latest/GOOS/amd64/svcat (hosted by my team). If you want a specific version it's at https://download.svcat.sh/cli/vX.Y.Z/GOOS/amd64/svcat.

Since there are no existing versions for svcat yet I have a small hack to print v0 so that the first PR can build. We can remove that once we have svcat tags in the repo.

TODO:
- [x] I'm waiting on an SSL cert for that domain but should have that fixed by tomorrow. 😊
- [ ] A secret environment variable needs to be set. Not sure if y'all prefer putting that encrypted value in the travis file or if you set it in the website.