### PR TITLE
 Add a constraint on go-autorest 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1176,6 +1176,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "82091c32c985d8f8a15946af85f91e501fcc78424418667de9626396fd7ddc30"
+  inputs-digest = "89604b0b55e1164e1bde03eaeb10b7f2763c95718fe5e8d20973f629291aa8d0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,7 +11,7 @@
 
 
 # Force dep to vendor the code generators, which aren't imported just used at dev time.
-# Picking a subpackage with Go code won't be necessary once https://github.com/golang/dep/issues/1306 is implemented.
+# Picking a subpackage with Go code won't be necessary once https://github.com/golang/dep/pull/1545 is merged.
 required = [
   "github.com/jteeuwen/go-bindata/go-bindata",
   "k8s.io/code-generator/cmd/defaulter-gen",
@@ -40,6 +40,10 @@ required = [
 [[override]]
   name = "github.com/golang/glog"
   revision = "44145f04b68cf362d9c4df2182967c2275eaefed"
+
+[[constraint]]
+  name = "github.com/Azure/go-autorest"
+  version = "^9.1.0"
 
 [[constraint]]
   name = "github.com/spf13/viper"

--- a/pkg/svcat/dep.go
+++ b/pkg/svcat/dep.go
@@ -1,0 +1,8 @@
+package svcat
+
+import (
+	// This workaround a gap in dep where we have no control over the version of
+	// our transitive dependencies.
+	// Once https://github.com/golang/dep/pull/1489 is merged, we can remove this file.
+	_ "github.com/Azure/go-autorest/autorest"
+)

--- a/test/test-dep.sh
+++ b/test/test-dep.sh
@@ -32,7 +32,7 @@ function cleanup() {
 pushd contrib/examples/consumer
 trap "cleanup" EXIT
 
-dep ensure
+dep ensure -v
 go build .
 
 echo "Verified that our Gopkg.toml is sufficient for a downstream consumer of our client library."

--- a/test/test-dep.sh
+++ b/test/test-dep.sh
@@ -21,7 +21,7 @@ result=0
 
 function cleanup() {
     popd
-    rm -r contrib/examples/consumer/vendor
+    git clean ./contrib/examples/consumer/ -xdf
 
     if [[ "${result:-}" != "0" ]]; then
         echo "A downstream consumer of our client library cannot use dep to vendor Service Catalog. You may need to add a constraint to Gopkg.toml to address."
@@ -32,7 +32,9 @@ function cleanup() {
 pushd contrib/examples/consumer
 trap "cleanup" EXIT
 
+echo "Running dep ensure..."
 dep ensure -v
+echo "Compiling the downstream consumer using the resolved dependencies..."
 go build .
 
 echo "Verified that our Gopkg.toml is sufficient for a downstream consumer of our client library."


### PR DESCRIPTION
Breaking changes were introduced in v10 of github.com/Azure/go-autorest which affect downstream consumers of our client library. This is why all of our pull requests started failing yesterday night. We had difficulty reproducing because the Gopkg.lock generated during `make test-dep` wasn't being cleaned up, so if you had run it previously a good version of autorest was in the lock.