### PR TITLE
also build with golang tip and allow tip to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: generic
+env:
+  - GO_VERSION=1.9
+  - GO_VERSION=rc
+matrix:
+  allow_failures:
+    - env: GO_VERSION=rc
+  fast_finish: true
 sudo: required
 services:
 - docker
@@ -19,18 +26,19 @@ before_install:
           [[ -z "$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -vE $DOCS_REGEX)" ]]
           DOCS_ONLY=$?
       fi
+# Test
+script:
+  - |
+    if (( $DOCS_ONLY == 0 )); then
+      echo "Running verify-docs"
+      make verify-docs
+    else
+      echo "Running full build"
+      make verify build build-integration build-e2e test images svcat
+    fi
 jobs:
   include:
-    # Test
-    - script:
-      - |
-          if (( $DOCS_ONLY == 0 )); then
-              echo "Running verify-docs"
-              make verify-docs
-          else
-              echo "Running full build"
-              make verify build build-integration build-e2e test images svcat
-          fi
+    # Test is implicit from the build matrix
     # Deploy
     - stage: deploy
       deploy:


### PR DESCRIPTION
Now I told you that story so I could tell you this one.

#1731 exposes the go version to the environment. I think this works the same as before with one additional job in the test stage. deploy is same as before.

Of course, I wouldn't want to blow another release, so maybe wait to merge until after we succeed once.