### PR TITLE
Add constraint for go-open-service-broker-client

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -539,7 +539,8 @@
     "v2",
     "v2/fake"
   ]
-  revision = "31d8027f493f8f23f850415d171c7c52a972a6f2"
+  revision = "4c53612134f3e9dc633016a9dfe556fe915119d7"
+  version = "0.0.1"
 
 [[projects]]
   name = "github.com/prometheus/client_golang"
@@ -1176,6 +1177,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "89604b0b55e1164e1bde03eaeb10b7f2763c95718fe5e8d20973f629291aa8d0"
+  inputs-digest = "39ba6909fde80c5c33b4e6ba5fac95a20d6bf2b1351e931af01edbaf0a6f17f7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -69,6 +69,10 @@ required = [
   name = "k8s.io/code-generator"
   version = "kubernetes-1.9.1"
 
+[[constraint]]
+  name = "github.com/pmorie/go-open-service-broker-client"
+  version = "~0.0.1"
+
 [prune]
   non-go = true
   go-tests = true

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -8,6 +8,7 @@ Table of Contents
 - [Building](#building)
 - [Testing](#testing)
 - [Advanced Build Steps](#advanced-build-steps)
+- [Dependency Management](#dependency-management)
 - [Deploying to Kubernetes](#deploying-to-kubernetes)
 - [Demo walkthrough](#demo-walkthrough)
 
@@ -296,6 +297,36 @@ the data in the etcd server container.
 If you choose third party resources storage, the helm chart will not launch an
 etcd server, but will instead instruct the API server to store all resources in
 the Kubernetes cluster as third party resources.
+
+## Dependency Management
+We use [dep](https://golang.github.io/dep) manage our dependencies. We commit the resulting
+vendor directory to ensure repeatable builds and isolation from upstream source disruptions.
+Because vendor is committed, you do not need to interact with dep unless you are
+changing dependencies.
+
+* Gopkg.toml - the dep manifest, this is intended to be hand-edited and contains a set of
+constraints and other rules for dep to apply when selecting appropriate versions of dependencies.
+* Gopkg.lock - the dep lockfile (generated). For the most part, don't edit this file because dep
+completely overwrites that file during `dep ensure`. If you run into trouble with this file, ask.
+* vendor/ - the source of all of our dependencies. Commit changes to this directory in a 
+separate commit from any other changes (including to the Gopkg files) so that it's easier to 
+review your pull request.
+
+If you use VS Code, we recommend installing the [dep extension](https://marketplace.visualstudio.com/items?itemName=carolynvs.dep).
+It provides snippets and improved highlighting that makes it easier to work with dep.
+
+### Add a new dependency
+1. Run `dep ensure -add github.com/example/project/pkg/foo`. This adds a constraint to Gopkg.toml,
+and downloads the dependency to vendor/.
+1. Import the package in the code and use it.
+1. Run `dep ensure -v` to sync Gopkg.lock and vendor/ with your changes.
+
+### Change the version of a dependency
+1. Edit Gopkg.toml and update the version for the project. If the project is not in
+Gopkg.toml already, add a constraint for it and set the version.
+1. Run `dep ensure -v` to sync Gopkg.lock and vendor/ with the updated version.
+
+[Watch a screencast](https://youtu.be/yvL66s_hQ94)
 
 ## Demo walkthrough
 

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -299,21 +299,26 @@ etcd server, but will instead instruct the API server to store all resources in
 the Kubernetes cluster as third party resources.
 
 ## Dependency Management
-We use [dep](https://golang.github.io/dep) manage our dependencies. We commit the resulting
+We use [dep](https://golang.github.io/dep) to manage our dependencies. We commit the resulting
 vendor directory to ensure repeatable builds and isolation from upstream source disruptions.
 Because vendor is committed, you do not need to interact with dep unless you are
 changing dependencies.
 
 * Gopkg.toml - the dep manifest, this is intended to be hand-edited and contains a set of
 constraints and other rules for dep to apply when selecting appropriate versions of dependencies.
-* Gopkg.lock - the dep lockfile (generated). For the most part, don't edit this file because dep
-completely overwrites that file during `dep ensure`. If you run into trouble with this file, ask.
+* Gopkg.lock - the dep lockfile, do not edit because it is a generated file.
 * vendor/ - the source of all of our dependencies. Commit changes to this directory in a 
 separate commit from any other changes (including to the Gopkg files) so that it's easier to 
 review your pull request.
 
 If you use VS Code, we recommend installing the [dep extension](https://marketplace.visualstudio.com/items?itemName=carolynvs.dep).
 It provides snippets and improved highlighting that makes it easier to work with dep.
+
+### Selecting the version for a dependency
+* Use released versions of a dependency, for example v1.2.3.
+* Use the master branch when a dependency does not tag releases, or we require an unreleased change.
+* Include an explanatory comment with a link to any relevant issues anytime a dependency is
+  pinned to a specific revision in Gopkg.toml.
 
 ### Add a new dependency
 1. Run `dep ensure -add github.com/example/project/pkg/foo`. This adds a constraint to Gopkg.toml,

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/types.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/types.go
@@ -217,6 +217,8 @@ type UpdateInstanceRequest struct {
 	// unset, indicates that the client does not wish to update the parameters
 	// for an instance.
 	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	// Previous values contains information about the service instance prior to the update.
+	PreviousValues *PreviousValues `json:"previous_values,omitempty"`
 	// Context requires a client API version >= 2.12.
 	//
 	// Context is platform-specific contextual information under which the
@@ -224,17 +226,23 @@ type UpdateInstanceRequest struct {
 	Context map[string]interface{} `json:"context,omitempty"`
 	// OriginatingIdentity is the identity on the platform of the user making this request.
 	OriginatingIdentity *OriginatingIdentity `json:"originatingIdentity,omitempty"`
+}
 
-	// The OSB API also has a field called `previous_values` that contains:
-	// OrgID
-	// SpaceID
-	// ServiceID
-	// PlanID
-	//
-	// ...but those fields seem to be a relic of some API design mistakes in
-	// the past.  As such, this client library does not currently support
-	// them.  I will happily change this if someone can present a specific
-	// example of a broker that requires these fields to be sent.
+// PreviousValues represents information about the service instance prior to the update.
+type PreviousValues struct {
+	// ID of the plan prior to the update. If present, MUST be a non-empty string.
+	PlanID string `json:"plan_id,omitempty"`
+	// Deprecated; determined to be unnecessary as the value is immutable. ID of the service
+	// for the service instance. If present, MUST be a non-empty string.
+	ServiceID string `json:"service_id,omitempty"`
+	// Deprecated; Organization for the service instance MUST be provided by platforms in the
+	// top-level field context. ID of the organization specified for the service instance.
+	// If present, MUST be a non-empty string.
+	OrgID string `json:"organization_id,omitempty"`
+	// Deprecated; Space for the service instance MUST be provided by platforms in the top-level
+	// field context. ID of the space specified for the service instance. If present, MUST be
+	// a non-empty string.
+	SpaceID string `json:"space_id,omitempty"`
 }
 
 // UpdateInstanceResponse represents a broker's response to an update instance

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/update_instance.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/update_instance.go
@@ -8,13 +8,11 @@ import (
 // internal message body types
 
 type updateInstanceRequestBody struct {
-	ServiceID  string                 `json:"service_id"`
-	PlanID     *string                `json:"plan_id,omitempty"`
-	Parameters map[string]interface{} `json:"parameters,omitempty"`
-	Context    map[string]interface{} `json:"context,omitempty"`
-
-	// Note: this client does not currently support the 'previous_values'
-	// field of this request body.
+	ServiceID      string                 `json:"service_id"`
+	PlanID         *string                `json:"plan_id,omitempty"`
+	Parameters     map[string]interface{} `json:"parameters,omitempty"`
+	Context        map[string]interface{} `json:"context,omitempty"`
+	PreviousValues *PreviousValues        `json:"previous_values,omitempty"`
 }
 
 func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceResponse, error) {
@@ -29,9 +27,10 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 	}
 
 	requestBody := &updateInstanceRequestBody{
-		ServiceID:  r.ServiceID,
-		PlanID:     r.PlanID,
-		Parameters: r.Parameters,
+		ServiceID:      r.ServiceID,
+		PlanID:         r.PlanID,
+		Parameters:     r.Parameters,
+		PreviousValues: r.PreviousValues,
 	}
 
 	if c.APIVersion.AtLeast(Version2_12()) {
@@ -42,7 +41,6 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 	if err != nil {
 		return nil, err
 	}
-
 	switch response.StatusCode {
 	case http.StatusOK:
 		if err := c.unmarshalResponse(response, &struct{}{}); err != nil {


### PR DESCRIPTION
* Add a dep constraint for the osb-client in preparation for upcoming breaking changes. The constraint is for 0.0.1 <= X < 0.1.0 (patches only).
* Document how to update a dependency with dep in the devguide, including a screencast of me doing this PR.

Closes #1737 

