### PR TITLE
print schemas when describing plan in svcat

### DIFF
--- a/cmd/svcat/output/plan.go
+++ b/cmd/svcat/output/plan.go
@@ -120,3 +120,25 @@ func WritePlanDetails(w io.Writer, plan *v1beta1.ClusterServicePlan, class *v1be
 
 	t.Render()
 }
+
+// WritePlanSchemas prints the schemas for a single plan.
+func WritePlanSchemas(w io.Writer, plan *v1beta1.ClusterServicePlan) {
+	instanceCreateSchema := plan.Spec.ServiceInstanceCreateParameterSchema
+	instanceUpdateSchema := plan.Spec.ServiceInstanceUpdateParameterSchema
+	bindingCreateSchema := plan.Spec.ServiceBindingCreateParameterSchema
+
+	if instanceCreateSchema != nil {
+		fmt.Fprintln(w, "\nInstance Create Parameter Schema:")
+		writeYAML(w, instanceCreateSchema, 2)
+	}
+
+	if instanceUpdateSchema != nil {
+		fmt.Fprintln(w, "\nInstance Update Parameter Schema:")
+		writeYAML(w, instanceUpdateSchema, 2)
+	}
+
+	if bindingCreateSchema != nil {
+		fmt.Fprintln(w, "\nBinding Create Parameter Schema:")
+		writeYAML(w, bindingCreateSchema, 2)
+	}
+}

--- a/cmd/svcat/output/yaml.go
+++ b/cmd/svcat/output/yaml.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/ghodss/yaml"
+)
+
+// writeYAML writes the given obj to the given Writer in YAML format, indented
+// n spaces
+func writeYAML(w io.Writer, obj interface{}, n int) {
+	yBytes, err := yaml.Marshal(obj)
+	if err != nil {
+		fmt.Fprintf(w, "err marshaling yaml: %v\n", err)
+		return
+	}
+	y := string(yBytes)
+	if n > 0 {
+		indent := strings.Repeat(" ", n)
+		y = indent + strings.Replace(y, "\n", "\n"+indent, -1)
+		y = strings.TrimRight(y, " ")
+	}
+
+	fmt.Fprint(w, y)
+}

--- a/cmd/svcat/plan/describe_cmd.go
+++ b/cmd/svcat/plan/describe_cmd.go
@@ -29,6 +29,7 @@ type describeCmd struct {
 	*command.Context
 	traverse     bool
 	lookupByUUID bool
+	showSchemas  bool
 	uuid         string
 	name         string
 }
@@ -60,6 +61,13 @@ func NewDescribeCmd(cxt *command.Context) *cobra.Command {
 		"u",
 		false,
 		"Whether or not to get the class by UUID (the default is by name)",
+	)
+	cmd.Flags().BoolVarP(
+		&describeCmd.showSchemas,
+		"show-schemas",
+		"",
+		true,
+		"Whether or not to show instance and binding parameter schemas",
 	)
 	return cmd
 }
@@ -117,7 +125,9 @@ func (c *describeCmd) describe() error {
 		output.WriteParentBroker(c.Output, broker)
 	}
 
-	output.WritePlanSchemas(c.Output, plan)
+	if c.showSchemas {
+		output.WritePlanSchemas(c.Output, plan)
+	}
 
 	return nil
 }

--- a/cmd/svcat/plan/describe_cmd.go
+++ b/cmd/svcat/plan/describe_cmd.go
@@ -117,5 +117,7 @@ func (c *describeCmd) describe() error {
 		output.WriteParentBroker(c.Output, broker)
 	}
 
+	output.WritePlanSchemas(c.Output, plan)
+
 	return nil
 }

--- a/cmd/svcat/svcat_test.go
+++ b/cmd/svcat/svcat_test.go
@@ -87,6 +87,7 @@ func TestCommandOutput(t *testing.T) {
 		{name: "describe plan by name", cmd: "describe plan default", golden: "output/describe-plan.txt"},
 		{name: "describe plan by uuid", cmd: "describe plan --uuid 86064792-7ea2-467b-af93-ac9694d96d52", golden: "output/describe-plan.txt"},
 		{name: "describe plan with schemas", cmd: "describe plan premium", golden: "output/describe-plan-with-schemas.txt"},
+		{name: "describe plan without schemas", cmd: "describe plan premium --show-schemas=false", golden: "output/describe-plan-without-schemas.txt"},
 
 		{name: "list all instances", cmd: "get instances -n test-ns", golden: "output/get-instances.txt"},
 		{name: "get instance", cmd: "get instance ups-instance -n test-ns", golden: "output/get-instance.txt"},

--- a/cmd/svcat/svcat_test.go
+++ b/cmd/svcat/svcat_test.go
@@ -86,6 +86,7 @@ func TestCommandOutput(t *testing.T) {
 		{name: "get plan by uuid", cmd: "get plan --uuid 86064792-7ea2-467b-af93-ac9694d96d52", golden: "output/get-plan.txt"},
 		{name: "describe plan by name", cmd: "describe plan default", golden: "output/describe-plan.txt"},
 		{name: "describe plan by uuid", cmd: "describe plan --uuid 86064792-7ea2-467b-af93-ac9694d96d52", golden: "output/describe-plan.txt"},
+		{name: "describe plan with schemas", cmd: "describe plan premium", golden: "output/describe-plan-with-schemas.txt"},
 
 		{name: "list all instances", cmd: "get instances -n test-ns", golden: "output/get-instances.txt"},
 		{name: "get instance", cmd: "get instance ups-instance -n test-ns", golden: "output/get-instance.txt"},

--- a/cmd/svcat/testdata/output/describe-plan-with-schemas.txt
+++ b/cmd/svcat/testdata/output/describe-plan-with-schemas.txt
@@ -8,7 +8,7 @@
 Instances:
 No instances defined
 
-Instance Create Schema:
+Instance Create Parameter Schema:
   properties:
     testInstanceProperty:
       description: A test instance property.
@@ -17,7 +17,7 @@ Instance Create Schema:
   - testInstanceProperty
   type: object
 
-Binding Create Schema:
+Binding Create Parameter Schema:
   properties:
     testBindingProperty:
       description: A test binding property.

--- a/cmd/svcat/testdata/output/describe-plan-with-schemas.txt
+++ b/cmd/svcat/testdata/output/describe-plan-with-schemas.txt
@@ -1,0 +1,27 @@
+  Name:          premium                               
+  Description:   Premium plan                          
+  UUID:          cc0d7529-18e8-416d-8946-6f7456acd589  
+  Status:        Active                                
+  Free:          false                                 
+  Class:         user-provided-service                 
+
+Instances:
+No instances defined
+
+Instance Create Schema:
+  properties:
+    testInstanceProperty:
+      description: A test instance property.
+      type: string
+  required:
+  - testInstanceProperty
+  type: object
+
+Binding Create Schema:
+  properties:
+    testBindingProperty:
+      description: A test binding property.
+      type: string
+  required:
+  - testBindingProperty
+  type: object

--- a/cmd/svcat/testdata/output/describe-plan-without-schemas.txt
+++ b/cmd/svcat/testdata/output/describe-plan-without-schemas.txt
@@ -1,0 +1,9 @@
+  Name:          premium                               
+  Description:   Premium plan                          
+  UUID:          cc0d7529-18e8-416d-8946-6f7456acd589  
+  Status:        Active                                
+  Free:          false                                 
+  Class:         user-provided-service                 
+
+Instances:
+No instances defined

--- a/cmd/svcat/testdata/plugin.yaml
+++ b/cmd/svcat/testdata/plugin.yaml
@@ -58,6 +58,8 @@ tree:
     shortDesc: Show details of a specific plan
     command: ./svcat describe plan
     flags:
+    - name: show-schemas
+      desc: Whether or not to show instance and binding parameter schemas
     - name: traverse
       shorthand: t
       desc: Whether or not to traverse from plan -> class -> broker

--- a/cmd/svcat/testdata/responses/clusterserviceplans.json
+++ b/cmd/svcat/testdata/responses/clusterserviceplans.json
@@ -44,7 +44,31 @@
         "free": false,
         "clusterServiceClassRef": {
           "name": "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
-        }
+        },
+	"instanceCreateParameterSchema": {
+	  "properties": {
+	    "testInstanceProperty": {
+	      "description": "A test instance property.",
+	      "type": "string"
+	    }
+	  },
+	  "required": [
+	    "testInstanceProperty"
+	  ],
+	  "type": "object"
+	},
+	"serviceBindingCreateParameterSchema": {
+	  "properties": {
+	    "testBindingProperty": {
+	      "description": "A test binding property.",
+	      "type": "string"
+	    }
+	  },
+	  "required": [
+	    "testBindingProperty"
+	  ],
+	  "type": "object"
+	}
       },
       "status": {
         "removedFromBrokerCatalog": false

--- a/cmd/svcat/testdata/responses/clusterserviceplans?fieldSelector=spec.clusterServiceClassRef.name=4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468.json
+++ b/cmd/svcat/testdata/responses/clusterserviceplans?fieldSelector=spec.clusterServiceClassRef.name=4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468.json
@@ -44,7 +44,31 @@
         "free": false,
         "clusterServiceClassRef": {
           "name": "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
-        }
+        },
+	"instanceCreateParameterSchema": {
+	  "properties": {
+	    "testInstanceProperty": {
+	      "description": "A test instance property.",
+	      "type": "string"
+	    }
+	  },
+	  "required": [
+	    "testInstanceProperty"
+	  ],
+	  "type": "object"
+	},
+	"serviceBindingCreateParameterSchema": {
+	  "properties": {
+	    "testBindingProperty": {
+	      "description": "A test binding property.",
+	      "type": "string"
+	    }
+	  },
+	  "required": [
+	    "testBindingProperty"
+	  ],
+	  "type": "object"
+	}
       },
       "status": {
         "removedFromBrokerCatalog": false

--- a/cmd/svcat/testdata/responses/clusterserviceplans?fieldSelector=spec.externalName=premium.json
+++ b/cmd/svcat/testdata/responses/clusterserviceplans?fieldSelector=spec.externalName=premium.json
@@ -22,7 +22,31 @@
         "free": false,
         "clusterServiceClassRef": {
           "name": "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
-        }
+        },
+	"instanceCreateParameterSchema": {
+	  "properties": {
+	    "testInstanceProperty": {
+	      "description": "A test instance property.",
+	      "type": "string"
+	    }
+	  },
+	  "required": [
+	    "testInstanceProperty"
+	  ],
+	  "type": "object"
+	},
+	"serviceBindingCreateParameterSchema": {
+	  "properties": {
+	    "testBindingProperty": {
+	      "description": "A test binding property.",
+	      "type": "string"
+	    }
+	  },
+	  "required": [
+	    "testBindingProperty"
+	  ],
+	  "type": "object"
+	}
       },
       "status": {
         "removedFromBrokerCatalog": false

--- a/cmd/svcat/testdata/responses/serviceinstances?fieldSelector=spec.clusterServicePlanRef.name=cc0d7529-18e8-416d-8946-6f7456acd589.json
+++ b/cmd/svcat/testdata/responses/serviceinstances?fieldSelector=spec.clusterServicePlanRef.name=cc0d7529-18e8-416d-8946-6f7456acd589.json
@@ -1,0 +1,9 @@
+{
+  "kind": "ServiceInstanceList",
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "metadata": {
+    "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/serviceinstances",
+    "resourceVersion": "109"
+  },
+  "items": []
+}


### PR DESCRIPTION
Prints the schemas for the plan when you run `svcat describe plan ${PLANNAME}` in YAML format. This way you don't need to muck around with kubectl and our human-unfriendly resource names to find the schemas.

closes: #1720  