### PR TITLE
allow getting and describing plans with class/plan name combo in svcat

### DIFF
--- a/cmd/svcat/plan/describe_cmd.go
+++ b/cmd/svcat/plan/describe_cmd.go
@@ -18,6 +18,7 @@ package plan
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/output"
@@ -95,6 +96,12 @@ func (c *describeCmd) describe() error {
 	var err error
 	if c.lookupByUUID {
 		plan, err = c.App.RetrievePlanByID(c.uuid)
+	} else if strings.Contains(c.name, "/") {
+		names := strings.Split(c.name, "/")
+		if len(names) != 2 {
+			return fmt.Errorf("failed to parse class/plan name combination '%s'", c.name)
+		}
+		plan, err = c.App.RetrievePlanByClassAndPlanNames(names[0], names[1])
 	} else {
 		plan, err = c.App.RetrievePlanByName(c.name)
 	}

--- a/cmd/svcat/plan/get_cmd.go
+++ b/cmd/svcat/plan/get_cmd.go
@@ -18,6 +18,7 @@ package plan
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/output"
@@ -98,6 +99,12 @@ func (c *getCmd) get() error {
 	var err error
 	if c.lookupByUUID {
 		plan, err = c.App.RetrievePlanByID(c.uuid)
+	} else if strings.Contains(c.name, "/") {
+		names := strings.Split(c.name, "/")
+		if len(names) != 2 {
+			return fmt.Errorf("failed to parse class/plan name combination '%s'", c.name)
+		}
+		plan, err = c.App.RetrievePlanByClassAndPlanNames(names[0], names[1])
 	} else {
 		plan, err = c.App.RetrievePlanByName(c.name)
 	}

--- a/cmd/svcat/svcat_test.go
+++ b/cmd/svcat/svcat_test.go
@@ -84,8 +84,10 @@ func TestCommandOutput(t *testing.T) {
 		{name: "list all plans", cmd: "get plans", golden: "output/get-plans.txt"},
 		{name: "get plan by name", cmd: "get plan default", golden: "output/get-plan.txt"},
 		{name: "get plan by uuid", cmd: "get plan --uuid 86064792-7ea2-467b-af93-ac9694d96d52", golden: "output/get-plan.txt"},
+		{name: "get plan by class/plan name combo", cmd: "get plan user-provided-service/default", golden: "output/get-plan.txt"},
 		{name: "describe plan by name", cmd: "describe plan default", golden: "output/describe-plan.txt"},
 		{name: "describe plan by uuid", cmd: "describe plan --uuid 86064792-7ea2-467b-af93-ac9694d96d52", golden: "output/describe-plan.txt"},
+		{name: "describe plan by class/plan name combo", cmd: "describe plan user-provided-service/default", golden: "output/describe-plan.txt"},
 		{name: "describe plan with schemas", cmd: "describe plan premium", golden: "output/describe-plan-with-schemas.txt"},
 		{name: "describe plan without schemas", cmd: "describe plan premium --show-schemas=false", golden: "output/describe-plan-without-schemas.txt"},
 

--- a/cmd/svcat/testdata/responses/clusterserviceplans?fieldSelector=spec.clusterServiceClassRef.name=4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468,spec.externalName=default.json
+++ b/cmd/svcat/testdata/responses/clusterserviceplans?fieldSelector=spec.clusterServiceClassRef.name=4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468,spec.externalName=default.json
@@ -1,0 +1,32 @@
+{
+  "kind": "ClusterServicePlanList",
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "metadata": {
+    "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/clusterserviceplans",
+    "resourceVersion": "114"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "86064792-7ea2-467b-af93-ac9694d96d52",
+        "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/clusterserviceplans/86064792-7ea2-467b-af93-ac9694d96d52",
+        "uid": "7b3d0190-f711-11e7-aa44-0242ac110005",
+        "resourceVersion": "4",
+        "creationTimestamp": "2018-01-11T20:53:31Z"
+      },
+      "spec": {
+        "clusterServiceBrokerName": "ups-broker",
+        "externalName": "default",
+        "externalID": "86064792-7ea2-467b-af93-ac9694d96d52",
+        "description": "Sample plan description",
+        "free": true,
+        "clusterServiceClassRef": {
+          "name": "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
+        }
+      },
+      "status": {
+        "removedFromBrokerCatalog": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Allows users of svcat to do a `svcat get plan` or `svcat describe plan` with the combination of class and plan name. Plan names are not globally unique, but are unique within the context of a single class. This way, users don't have to search by the plan UUID if the plan has a common name (like "default", "standard", "premium", etc.)

Example usage:
`svcat describe plan pubsub/default`