### PR TITLE
Increase timeout for broker condition polling in e2e

### DIFF
--- a/test/e2e/broker.go
+++ b/test/e2e/broker.go
@@ -69,7 +69,7 @@ var _ = framework.ServiceCatalogDescribe("ClusterServiceBroker", func() {
 	It("should become ready", func() {
 		By("Creating a Broker")
 
-		url := "http://test-broker." + f.Namespace.Name + ".svc.cluster.local"
+		url := "http://" + brokerName + "." + f.Namespace.Name + ".svc.cluster.local"
 		broker, err := f.ServiceCatalogClientSet.ServicecatalogV1beta1().ClusterServiceBrokers().Create(newTestBroker(brokerName, url))
 		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for Broker to be ready")

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -38,6 +38,7 @@ func NewUPSBrokerPod(name string) *corev1.Pod {
 					Args: []string{
 						"--port",
 						"8080",
+						"-alsologtostderr",
 					},
 					Ports: []corev1.ContainerPort{
 						{

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -34,7 +34,8 @@ import (
 // WaitForBrokerCondition waits for the status of the named broker to contain
 // a condition whose type and status matches the supplied one.
 func WaitForBrokerCondition(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string, condition v1beta1.ServiceBrokerCondition) error {
-	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
+	// GetCatalog default timeout time is 60 seconds, so the wait here must be at least that (previously set to 30 seconds)
+	return wait.PollImmediate(500*time.Millisecond, 3*time.Minute,
 		func() (bool, error) {
 			glog.V(5).Infof("Waiting for broker %v condition %#v", name, condition)
 			broker, err := client.ClusterServiceBrokers().Get(name, metav1.GetOptions{})


### PR DESCRIPTION
This fixes a problem I've seen in internal CI and reproduced on my own system:

W0216 15:54:33.763903       1 controller_broker.go:216] ClusterServiceBroker "ups-broker": Error getting broker catalog: Get http://ups-broker.e2e-tests-walkthrough-example-n45l2.svc.cluster.local/v2/catalog: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)

Essentially anytime the initial catalog fetch timed out (for reasons I couldn't figure out) the walkthrough or broker e2e failed.