### PR TITLE
Add ObservedGeneration and Provisioned into ServiceInstanceStatus

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -545,12 +545,6 @@ type ServiceInstanceStatus struct {
 	// whenever the status is updated regardless of operation result
 	ObservedGeneration int64
 
-	// Provisioned is the flag that marks whether the instance has been
-	// successfully provisioned (i.e. it exists on the broker's side and can be
-	// updated or deprovisioned). The flag should be reset after successful
-	// deprovisioning.
-	Provisioned bool
-
 	// OperationStartTime is the time at which the current operation began.
 	OperationStartTime *metav1.Time
 
@@ -562,6 +556,9 @@ type ServiceInstanceStatus struct {
 	// ExternalProperties is the properties state of the ServiceInstance which the
 	// broker knows about.
 	ExternalProperties *ServiceInstancePropertiesState
+
+	// ProvisionStatus describes whether the instance is in the provisioned state.
+	ProvisionStatus ServiceInstanceProvisionStatus
 
 	// DeprovisionStatus describes what has been done to deprovision the
 	// ServiceInstance.
@@ -663,6 +660,19 @@ const (
 	// requests have been sent for the ServiceInstance but they failed. The
 	// controller has given up on sending more deprovision requests.
 	ServiceInstanceDeprovisionStatusFailed ServiceInstanceDeprovisionStatus = "Failed"
+)
+
+// ServiceInstanceProvisionStatus is the status of provisioning a
+// ServiceInstance
+type ServiceInstanceProvisionStatus string
+
+const (
+	// ServiceInstanceProvisionStatusProvisioned indicates that the instance
+	// was provisioned.
+	ServiceInstanceProvisionStatusProvisioned ServiceInstanceProvisionStatus = "Provisioned"
+	// ServiceInstanceProvisionStatusNotProvisioned indicates that the instance
+	// was not ever provisioned or was deprovisioned.
+	ServiceInstanceProvisionStatusNotProvisioned ServiceInstanceProvisionStatus = "NotProvisioned"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -537,7 +537,19 @@ type ServiceInstanceStatus struct {
 	// ReconciledGeneration is the 'Generation' of the serviceInstanceSpec that
 	// was last processed by the controller. The reconciled generation is updated
 	// even if the controller failed to process the spec.
+	// Deprecated: use ObservedGeneration instead
 	ReconciledGeneration int64
+
+	// ObservedGeneration is the 'Generation' of the serviceInstanceSpec that
+	// was last processed by the controller. The observed generation is updated
+	// whenever the status is updated regardless of operation result
+	ObservedGeneration int64
+
+	// Provisioned is the flag that marks whether the instance has been
+	// successfully provisioned (i.e. it exists on the broker's side and can be
+	// updated or deprovisioned). The flag should be reset after successful
+	// deprovisioning.
+	Provisioned bool
 
 	// OperationStartTime is the time at which the current operation began.
 	OperationStartTime *metav1.Time

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -537,12 +537,13 @@ type ServiceInstanceStatus struct {
 	// ReconciledGeneration is the 'Generation' of the serviceInstanceSpec that
 	// was last processed by the controller. The reconciled generation is updated
 	// even if the controller failed to process the spec.
-	// Deprecated: use ObservedGeneration instead
+	// Deprecated: use ObservedGeneration with conditions set to true to find
+	// whether generation was reconciled.
 	ReconciledGeneration int64
 
 	// ObservedGeneration is the 'Generation' of the serviceInstanceSpec that
 	// was last processed by the controller. The observed generation is updated
-	// whenever the status is updated regardless of operation result
+	// whenever the status is updated regardless of operation result.
 	ObservedGeneration int64
 
 	// OperationStartTime is the time at which the current operation began.

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -609,12 +609,6 @@ type ServiceInstanceStatus struct {
 	// whenever the status is updated regardless of operation result
 	ObservedGeneration int64 `json:"observedGeneration"`
 
-	// Provisioned is the flag that marks whether the instance has been
-	// successfully provisioned (i.e. it exists on the broker's side and can be
-	// updated or deprovisioned). The flag should be reset after successful
-	// deprovisioning.
-	Provisioned bool `json:"provisioned"`
-
 	// OperationStartTime is the time at which the current operation began.
 	OperationStartTime *metav1.Time `json:"operationStartTime,omitempty"`
 
@@ -626,6 +620,9 @@ type ServiceInstanceStatus struct {
 	// ExternalProperties is the properties state of the ServiceInstance which the
 	// broker knows about.
 	ExternalProperties *ServiceInstancePropertiesState `json:"externalProperties,omitempty"`
+
+	// ProvisionStatus describes whether the instance is in the provisioned state.
+	ProvisionStatus ServiceInstanceProvisionStatus `json:"provisioned"`
 
 	// DeprovisionStatus describes what has been done to deprovision the
 	// ServiceInstance.
@@ -727,6 +724,19 @@ const (
 	// requests have been sent for the ServiceInstance but they failed. The
 	// controller has given up on sending more deprovision requests.
 	ServiceInstanceDeprovisionStatusFailed ServiceInstanceDeprovisionStatus = "Failed"
+)
+
+// ServiceInstanceProvisionStatus is the status of provisioning a
+// ServiceInstance
+type ServiceInstanceProvisionStatus string
+
+const (
+	// ServiceInstanceProvisionStatusProvisioned indicates that the instance
+	// was provisioned.
+	ServiceInstanceProvisionStatusProvisioned ServiceInstanceProvisionStatus = "Provisioned"
+	// ServiceInstanceProvisionStatusNotProvisioned indicates that the instance
+	// was not ever provisioned or was deprovisioned.
+	ServiceInstanceProvisionStatusNotProvisioned ServiceInstanceProvisionStatus = "NotProvisioned"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -601,12 +601,13 @@ type ServiceInstanceStatus struct {
 	// ReconciledGeneration is the 'Generation' of the serviceInstanceSpec that
 	// was last processed by the controller. The reconciled generation is updated
 	// even if the controller failed to process the spec.
-	// Deprecated: use ObservedGeneration instead
+	// Deprecated: use ObservedGeneration with conditions set to true to find
+	// whether generation was reconciled.
 	ReconciledGeneration int64 `json:"reconciledGeneration"`
 
 	// ObservedGeneration is the 'Generation' of the serviceInstanceSpec that
 	// was last processed by the controller. The observed generation is updated
-	// whenever the status is updated regardless of operation result
+	// whenever the status is updated regardless of operation result.
 	ObservedGeneration int64 `json:"observedGeneration"`
 
 	// OperationStartTime is the time at which the current operation began.

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -622,7 +622,7 @@ type ServiceInstanceStatus struct {
 	ExternalProperties *ServiceInstancePropertiesState `json:"externalProperties,omitempty"`
 
 	// ProvisionStatus describes whether the instance is in the provisioned state.
-	ProvisionStatus ServiceInstanceProvisionStatus `json:"provisioned"`
+	ProvisionStatus ServiceInstanceProvisionStatus `json:"provisionStatus"`
 
 	// DeprovisionStatus describes what has been done to deprovision the
 	// ServiceInstance.

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -601,7 +601,19 @@ type ServiceInstanceStatus struct {
 	// ReconciledGeneration is the 'Generation' of the serviceInstanceSpec that
 	// was last processed by the controller. The reconciled generation is updated
 	// even if the controller failed to process the spec.
+	// Deprecated: use ObservedGeneration instead
 	ReconciledGeneration int64 `json:"reconciledGeneration"`
+
+	// ObservedGeneration is the 'Generation' of the serviceInstanceSpec that
+	// was last processed by the controller. The observed generation is updated
+	// whenever the status is updated regardless of operation result
+	ObservedGeneration int64 `json:"observedGeneration"`
+
+	// Provisioned is the flag that marks whether the instance has been
+	// successfully provisioned (i.e. it exists on the broker's side and can be
+	// updated or deprovisioned). The flag should be reset after successful
+	// deprovisioning.
+	Provisioned bool `json:"provisioned"`
 
 	// OperationStartTime is the time at which the current operation began.
 	OperationStartTime *metav1.Time `json:"operationStartTime,omitempty"`

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
@@ -1006,10 +1006,10 @@ func autoConvert_v1beta1_ServiceInstanceStatus_To_servicecatalog_ServiceInstance
 	out.CurrentOperation = servicecatalog.ServiceInstanceOperation(in.CurrentOperation)
 	out.ReconciledGeneration = in.ReconciledGeneration
 	out.ObservedGeneration = in.ObservedGeneration
-	out.Provisioned = in.Provisioned
 	out.OperationStartTime = (*v1.Time)(unsafe.Pointer(in.OperationStartTime))
 	out.InProgressProperties = (*servicecatalog.ServiceInstancePropertiesState)(unsafe.Pointer(in.InProgressProperties))
 	out.ExternalProperties = (*servicecatalog.ServiceInstancePropertiesState)(unsafe.Pointer(in.ExternalProperties))
+	out.ProvisionStatus = servicecatalog.ServiceInstanceProvisionStatus(in.ProvisionStatus)
 	out.DeprovisionStatus = servicecatalog.ServiceInstanceDeprovisionStatus(in.DeprovisionStatus)
 	return nil
 }
@@ -1028,10 +1028,10 @@ func autoConvert_servicecatalog_ServiceInstanceStatus_To_v1beta1_ServiceInstance
 	out.CurrentOperation = ServiceInstanceOperation(in.CurrentOperation)
 	out.ReconciledGeneration = in.ReconciledGeneration
 	out.ObservedGeneration = in.ObservedGeneration
-	out.Provisioned = in.Provisioned
 	out.OperationStartTime = (*v1.Time)(unsafe.Pointer(in.OperationStartTime))
 	out.InProgressProperties = (*ServiceInstancePropertiesState)(unsafe.Pointer(in.InProgressProperties))
 	out.ExternalProperties = (*ServiceInstancePropertiesState)(unsafe.Pointer(in.ExternalProperties))
+	out.ProvisionStatus = ServiceInstanceProvisionStatus(in.ProvisionStatus)
 	out.DeprovisionStatus = ServiceInstanceDeprovisionStatus(in.DeprovisionStatus)
 	return nil
 }

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
@@ -1005,6 +1005,8 @@ func autoConvert_v1beta1_ServiceInstanceStatus_To_servicecatalog_ServiceInstance
 	out.DashboardURL = (*string)(unsafe.Pointer(in.DashboardURL))
 	out.CurrentOperation = servicecatalog.ServiceInstanceOperation(in.CurrentOperation)
 	out.ReconciledGeneration = in.ReconciledGeneration
+	out.ObservedGeneration = in.ObservedGeneration
+	out.Provisioned = in.Provisioned
 	out.OperationStartTime = (*v1.Time)(unsafe.Pointer(in.OperationStartTime))
 	out.InProgressProperties = (*servicecatalog.ServiceInstancePropertiesState)(unsafe.Pointer(in.InProgressProperties))
 	out.ExternalProperties = (*servicecatalog.ServiceInstancePropertiesState)(unsafe.Pointer(in.ExternalProperties))
@@ -1025,6 +1027,8 @@ func autoConvert_servicecatalog_ServiceInstanceStatus_To_v1beta1_ServiceInstance
 	out.DashboardURL = (*string)(unsafe.Pointer(in.DashboardURL))
 	out.CurrentOperation = ServiceInstanceOperation(in.CurrentOperation)
 	out.ReconciledGeneration = in.ReconciledGeneration
+	out.ObservedGeneration = in.ObservedGeneration
+	out.Provisioned = in.Provisioned
 	out.OperationStartTime = (*v1.Time)(unsafe.Pointer(in.OperationStartTime))
 	out.InProgressProperties = (*ServiceInstancePropertiesState)(unsafe.Pointer(in.InProgressProperties))
 	out.ExternalProperties = (*ServiceInstancePropertiesState)(unsafe.Pointer(in.ExternalProperties))

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -590,16 +590,28 @@ func convertClusterServicePlans(plans []osb.Plan, serviceClassID string) ([]*v1b
 	return servicePlans, nil
 }
 
-// isServiceInstanceReady returns whether the given instance has a ready condition
+// isServiceInstanceConditionTrue returns whether the given instance has a given condition
 // with status true.
-func isServiceInstanceReady(instance *v1beta1.ServiceInstance) bool {
+func isServiceInstanceConditionTrue(instance *v1beta1.ServiceInstance, conditionType v1beta1.ServiceInstanceConditionType) bool {
 	for _, cond := range instance.Status.Conditions {
-		if cond.Type == v1beta1.ServiceInstanceConditionReady {
+		if cond.Type == conditionType {
 			return cond.Status == v1beta1.ConditionTrue
 		}
 	}
 
 	return false
+}
+
+// isServiceInstanceReady returns whether the given instance has a ready condition
+// with status true.
+func isServiceInstanceReady(instance *v1beta1.ServiceInstance) bool {
+	return isServiceInstanceConditionTrue(instance, v1beta1.ServiceInstanceConditionReady)
+}
+
+// isServiceInstanceFailed returns whether the instance has a failed condition with
+// status true.
+func isServiceInstanceFailed(instance *v1beta1.ServiceInstance) bool {
+	return isServiceInstanceConditionTrue(instance, v1beta1.ServiceInstanceConditionFailed)
 }
 
 // NewClientConfigurationForBroker creates a new ClientConfiguration for connecting

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -257,7 +257,7 @@ func (c *controller) reconcileServiceInstance(instance *v1beta1.ServiceInstance)
 // initObservedGeneration implements ObservedGeneration initialization based on
 // ReconciledGeneration for status API migration
 func (c *controller) initObservedGeneration(instance *v1beta1.ServiceInstance) (bool, error) {
-	if instance.Status.ObservedGeneration == 0 && instance.Status.ReconciledGeneration == 0 {
+	if instance.Status.ObservedGeneration == 0 && instance.Status.ReconciledGeneration != 0 {
 		instance.Status.ObservedGeneration = instance.Status.ReconciledGeneration
 		// Before we implement https://github.com/kubernetes-incubator/service-catalog/issues/1715
 		// and switch to non-terminal errors, the "Failed":"True" is a sign that the provisioning failed

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -763,6 +763,8 @@ func (c *controller) pollServiceInstance(instance *v1beta1.ServiceInstance) erro
 // isServiceInstanceProcessedAlready returns true if there is no further processing
 // needed for the instance based on ObservedGeneration
 func isServiceInstanceProcessedAlready(instance *v1beta1.ServiceInstance) bool {
+	// The observed generation is considered to be reconciled if either of the
+	// conditions is set to true and there is no orphan mitigation in progress
 	return instance.Status.ObservedGeneration >= instance.Generation &&
 		(isServiceInstanceReady(instance) || isServiceInstanceFailed(instance)) && !instance.Status.OrphanMitigationInProgress
 }

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -255,7 +255,9 @@ func (c *controller) reconcileServiceInstance(instance *v1beta1.ServiceInstance)
 }
 
 // initObservedGeneration implements ObservedGeneration initialization based on
-// ReconciledGeneration for status API migration
+// ReconciledGeneration for status API migration.
+// Returns true if the status was updated (i.e. the iteration has finished and no
+// more processing needed).
 func (c *controller) initObservedGeneration(instance *v1beta1.ServiceInstance) (bool, error) {
 	if instance.Status.ObservedGeneration == 0 && instance.Status.ReconciledGeneration != 0 {
 		instance.Status.ObservedGeneration = instance.Status.ReconciledGeneration

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -234,7 +234,7 @@ func (c *controller) reconcileServiceInstance(instance *v1beta1.ServiceInstance)
 	}
 	if handled {
 		// Update the status and finish the iteration
-		// The updates instance will be automatically added to the instance queue
+		// The updated instance will be automatically added back to the queue
 		// and be processed again
 		return nil
 	}

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -1986,9 +1986,12 @@ func TestReconcileServiceInstanceDeleteFailedUpdate(t *testing.T) {
 	assertNumberOfActions(t, kubeActions, 0)
 
 	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+	assertNumberOfActions(t, actions, 2)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
+	assertServiceInstanceOperationInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationDeprovision, testClusterServicePlanName, testClusterServicePlanGUID, instance)
+
+	updatedServiceInstance = assertUpdateStatus(t, actions[1], instance)
 	assertServiceInstanceOperationSuccess(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationDeprovision, testClusterServicePlanName, testClusterServicePlanGUID, instance)
 
 	events := getRecordedEvents(testController)

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -1345,7 +1345,7 @@ func TestReconcileServiceInstanceAsynchronous(t *testing.T) {
 	assertServiceInstanceOperationInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationProvision, testClusterServicePlanName, testClusterServicePlanGUID, instance)
 
 	updatedServiceInstance = assertUpdateStatus(t, actions[1], instance)
-	assertServiceInstanceAsyncInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationProvision, testOperation, testClusterServicePlanName, testClusterServicePlanGUID, instance)
+	assertServiceInstanceAsyncStartInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationProvision, testOperation, testClusterServicePlanName, testClusterServicePlanGUID, instance)
 	assertServiceInstanceDashboardURL(t, updatedServiceInstance, testDashboardURL)
 
 	// verify no kube resources created.
@@ -1412,7 +1412,7 @@ func TestReconcileServiceInstanceAsynchronousNoOperation(t *testing.T) {
 	assertServiceInstanceOperationInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationProvision, testClusterServicePlanName, testClusterServicePlanGUID, instance)
 
 	updatedServiceInstance = assertUpdateStatus(t, actions[1], instance)
-	assertServiceInstanceAsyncInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationProvision, "", testClusterServicePlanName, testClusterServicePlanGUID, instance)
+	assertServiceInstanceAsyncStartInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationProvision, "", testClusterServicePlanName, testClusterServicePlanGUID, instance)
 	assertServiceInstanceDashboardURL(t, updatedServiceInstance, testDashboardURL)
 
 	// verify no kube resources created.
@@ -1721,7 +1721,7 @@ func TestReconcileServiceInstanceDeleteAsynchronous(t *testing.T) {
 	assertServiceInstanceOperationInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationDeprovision, testClusterServicePlanName, testClusterServicePlanGUID, instance)
 
 	updatedServiceInstance = assertUpdateStatus(t, actions[1], instance)
-	assertServiceInstanceAsyncInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationDeprovision, testOperation, testClusterServicePlanName, testClusterServicePlanGUID, instance)
+	assertServiceInstanceAsyncStartInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationDeprovision, testOperation, testClusterServicePlanName, testClusterServicePlanGUID, instance)
 
 	events := getRecordedEvents(testController)
 
@@ -2134,7 +2134,7 @@ func TestPollServiceInstanceInProgressProvisioningWithOperation(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceAsyncInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationProvision, testOperation, testClusterServicePlanName, testClusterServicePlanGUID, instance)
+	assertServiceInstanceAsyncStartInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationProvision, testOperation, testClusterServicePlanName, testClusterServicePlanGUID, instance)
 	assertServiceInstanceConditionHasLastOperationDescription(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationProvision, lastOperationDescription)
 
 	// verify no kube resources created.
@@ -2308,7 +2308,7 @@ func TestPollServiceInstanceInProgressDeprovisioningWithOperationNoFinalizer(t *
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceAsyncInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationDeprovision, testOperation, testClusterServicePlanName, testClusterServicePlanGUID, instance)
+	assertServiceInstanceAsyncStillInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationDeprovision, testOperation, testClusterServicePlanName, testClusterServicePlanGUID, instance)
 	assertServiceInstanceConditionHasLastOperationDescription(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationDeprovision, lastOperationDescription)
 
 	// verify no kube resources created.
@@ -4829,7 +4829,7 @@ func TestReconcileServiceInstanceUpdateAsynchronous(t *testing.T) {
 	assertServiceInstanceOperationInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, testClusterServicePlanName, testClusterServicePlanGUID, instance)
 
 	updatedServiceInstance = assertUpdateStatus(t, actions[1], instance)
-	assertServiceInstanceAsyncInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, testOperation, testClusterServicePlanName, testClusterServicePlanGUID, instance)
+	assertServiceInstanceAsyncStartInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, testOperation, testClusterServicePlanName, testClusterServicePlanGUID, instance)
 
 	// verify no kube resources created.
 	// One single action comes from getting namespace uid
@@ -4891,7 +4891,7 @@ func TestPollServiceInstanceAsyncInProgressUpdating(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceAsyncInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, testOperation, testClusterServicePlanName, testClusterServicePlanGUID, instance)
+	assertServiceInstanceAsyncStillInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, testOperation, testClusterServicePlanName, testClusterServicePlanGUID, instance)
 	assertServiceInstanceConditionHasLastOperationDescription(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, lastOperationDescription)
 
 	// verify no kube resources created.

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -1494,6 +1494,8 @@ func TestReconcileServiceInstanceDelete(t *testing.T) {
 	// as that implies a previous success.
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
+	instance.Status.ObservedGeneration = 1
+	instance.Status.Provisioned = true
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{
 		ClusterServicePlanExternalName: testClusterServicePlanName,
 		ClusterServicePlanExternalID:   testClusterServicePlanGUID,
@@ -1563,6 +1565,8 @@ func TestReconcileServiceInstanceDeleteBlockedByCredentials(t *testing.T) {
 	// as that implies a previous success.
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
+	instance.Status.ObservedGeneration = 1
+	instance.Status.Provisioned = true
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{
 		ClusterServicePlanExternalName: testClusterServicePlanName,
 		ClusterServicePlanExternalID:   testClusterServicePlanGUID,
@@ -1668,6 +1672,8 @@ func TestReconcileServiceInstanceDeleteAsynchronous(t *testing.T) {
 	// as that implies a previous success.
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
+	instance.Status.ObservedGeneration = 1
+	instance.Status.Provisioned = true
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{
 		ClusterServicePlanExternalName: testClusterServicePlanName,
 		ClusterServicePlanExternalID:   testClusterServicePlanGUID,
@@ -1747,6 +1753,8 @@ func TestReconcileServiceInstanceDeleteFailedProvisionWithRequest(t *testing.T) 
 
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
+	instance.Status.ObservedGeneration = 1
+	instance.Status.Provisioned = false
 
 	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		return true, instance, nil
@@ -1791,44 +1799,44 @@ func TestReconcileServiceInstanceDeleteFailedProvisionWithRequest(t *testing.T) 
 // an instance will be finalized under various conditions defined by test parameters
 func TestReconsileServiceInstanceDeleteWithParameters(t *testing.T) {
 	cases := []struct {
-		name                  string
-		externalProperties    *v1beta1.ServiceInstancePropertiesState
-		deprovisionStatus     v1beta1.ServiceInstanceDeprovisionStatus
-		serviceBinding        *v1beta1.ServiceBinding
-		generation            int64
-		reconceiledGeneration int64
+		name                 string
+		externalProperties   *v1beta1.ServiceInstancePropertiesState
+		deprovisionStatus    v1beta1.ServiceInstanceDeprovisionStatus
+		serviceBinding       *v1beta1.ServiceBinding
+		generation           int64
+		reconciledGeneration int64
 	}{
 		{
-			name:                  "With a failed to provision instance and without making a provision request",
-			externalProperties:    &v1beta1.ServiceInstancePropertiesState{},
-			deprovisionStatus:     v1beta1.ServiceInstanceDeprovisionStatusNotRequired,
-			serviceBinding:        nil,
-			generation:            1,
-			reconceiledGeneration: 0,
+			name:                 "With a failed to provision instance and without making a provision request",
+			externalProperties:   &v1beta1.ServiceInstancePropertiesState{},
+			deprovisionStatus:    v1beta1.ServiceInstanceDeprovisionStatusNotRequired,
+			serviceBinding:       nil,
+			generation:           1,
+			reconciledGeneration: 0,
 		},
 		{
-			name:                  "With a failed to provision instance, with inactive binding, and without making a provision request",
-			externalProperties:    &v1beta1.ServiceInstancePropertiesState{},
-			deprovisionStatus:     v1beta1.ServiceInstanceDeprovisionStatusNotRequired,
-			serviceBinding:        getTestServiceInactiveBinding(),
-			generation:            1,
-			reconceiledGeneration: 0,
+			name:                 "With a failed to provision instance, with inactive binding, and without making a provision request",
+			externalProperties:   &v1beta1.ServiceInstancePropertiesState{},
+			deprovisionStatus:    v1beta1.ServiceInstanceDeprovisionStatusNotRequired,
+			serviceBinding:       getTestServiceInactiveBinding(),
+			generation:           1,
+			reconciledGeneration: 0,
 		},
 		{
-			name:                  "With a deprovisioned instance and without making a deprovision request",
-			externalProperties:    nil,
-			deprovisionStatus:     v1beta1.ServiceInstanceDeprovisionStatusSucceeded,
-			serviceBinding:        nil,
-			generation:            2,
-			reconceiledGeneration: 1,
+			name:                 "With a deprovisioned instance and without making a deprovision request",
+			externalProperties:   nil,
+			deprovisionStatus:    v1beta1.ServiceInstanceDeprovisionStatusSucceeded,
+			serviceBinding:       nil,
+			generation:           2,
+			reconciledGeneration: 1,
 		},
 		{
-			name:                  "With a deprovisioned instance, with inactive binding, and without making a deprovision request",
-			externalProperties:    nil,
-			deprovisionStatus:     v1beta1.ServiceInstanceDeprovisionStatusSucceeded,
-			serviceBinding:        getTestServiceInactiveBinding(),
-			generation:            2,
-			reconceiledGeneration: 1,
+			name:                 "With a deprovisioned instance, with inactive binding, and without making a deprovision request",
+			externalProperties:   nil,
+			deprovisionStatus:    v1beta1.ServiceInstanceDeprovisionStatusSucceeded,
+			serviceBinding:       getTestServiceInactiveBinding(),
+			generation:           2,
+			reconciledGeneration: 1,
 		},
 	}
 
@@ -1850,7 +1858,9 @@ func TestReconsileServiceInstanceDeleteWithParameters(t *testing.T) {
 			instance.Status.DeprovisionStatus = tc.deprovisionStatus
 
 			instance.Generation = tc.generation
-			instance.Status.ReconciledGeneration = tc.reconceiledGeneration
+			instance.Status.ReconciledGeneration = tc.reconciledGeneration
+			instance.Status.ObservedGeneration = 1
+			instance.Status.Provisioned = true
 
 			fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 				return true, instance, nil
@@ -1899,6 +1909,8 @@ func TestReconcileServiceInstanceDeleteWhenAlreadyDeprovisionedUnsuccessfully(t 
 
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
+	instance.Status.ObservedGeneration = 1
+	instance.Status.Provisioned = true
 
 	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		return true, instance, nil
@@ -1947,6 +1959,8 @@ func TestReconcileServiceInstanceDeleteFailedUpdate(t *testing.T) {
 	}
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 2
+	instance.Status.ObservedGeneration = 2
+	instance.Status.Provisioned = true
 	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 
 	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
@@ -2006,6 +2020,8 @@ func TestReconcileServiceInstanceDeleteDoesNotInvokeClusterServiceBroker(t *test
 	instance.ObjectMeta.Finalizers = []string{v1beta1.FinalizerServiceCatalog}
 	instance.Generation = 1
 	instance.Status.ReconciledGeneration = 0
+	instance.Status.ObservedGeneration = 0
+	instance.Status.Provisioned = false
 	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusNotRequired
 
 	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
@@ -3366,6 +3382,8 @@ func TestReconcileInstanceDeleteUsingOriginatingIdentity(t *testing.T) {
 			// ReconciledGeneration set as that implies a previous success.
 			instance.Generation = 2
 			instance.Status.ReconciledGeneration = 1
+			instance.Status.ObservedGeneration = 1
+			instance.Status.Provisioned = true
 			instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 			if tc.includeUserInfo {
 				instance.Spec.UserInfo = testUserInfo
@@ -4028,6 +4046,8 @@ func TestReconcileServiceInstanceUpdateParameters(t *testing.T) {
 	instance := getTestServiceInstanceWithRefs()
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
+	instance.Status.ObservedGeneration = 1
+	instance.Status.Provisioned = true
 	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 
 	oldParameters := map[string]interface{}{
@@ -4155,6 +4175,8 @@ func TestReconcileServiceInstanceDeleteParameters(t *testing.T) {
 	instance := getTestServiceInstanceWithRefs()
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
+	instance.Status.ObservedGeneration = 1
+	instance.Status.Provisioned = true
 	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 
 	oldParameters := map[string]interface{}{
@@ -4328,6 +4350,8 @@ func TestReconcileServiceInstanceUpdatePlan(t *testing.T) {
 	instance := getTestServiceInstanceWithRefs()
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
+	instance.Status.ObservedGeneration = 1
+	instance.Status.Provisioned = true
 	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 
 	oldParameters := map[string]interface{}{
@@ -4766,6 +4790,8 @@ func TestReconcileServiceInstanceUpdateAsynchronous(t *testing.T) {
 	instance := getTestServiceInstanceWithRefs()
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
+	instance.Status.ObservedGeneration = 1
+	instance.Status.Provisioned = true
 	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{
@@ -5233,6 +5259,8 @@ func TestReconcileServiceInstanceDeleteWithNonExistentPlan(t *testing.T) {
 	// as that implies a previous success.
 	instance.Generation = 2
 	instance.Status.ReconciledGeneration = 1
+	instance.Status.ObservedGeneration = 1
+	instance.Status.Provisioned = true
 	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{
 		ClusterServicePlanExternalName: "old-plan-name",
 		ClusterServicePlanExternalID:   "old-plan-id",

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -4559,7 +4559,7 @@ func TestReconcileServiceInstanceWithUpdateFailure(t *testing.T) {
 	assertServiceInstanceOperationInProgress(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, testClusterServicePlanName, testClusterServicePlanGUID, instance)
 
 	updatedServiceInstance = assertUpdateStatus(t, actions[1], instance)
-	assertServiceInstanceRequestFailingErrorNoOrphanMitigation(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, errorUpdateInstanceCallFailedReason, "ClusterServiceBrokerReturnedFailure", instance)
+	assertServiceInstanceRequestFailingErrorNoOrphanMitigation(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, errorUpdateInstanceCallFailedReason, errorUpdateInstanceCallFailedReason, instance)
 
 	events := getRecordedEvents(testController)
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -687,6 +687,8 @@ func getTestServiceInstanceUpdatingPlan() *v1beta1.ServiceInstance {
 		},
 		// It's been provisioned successfully.
 		ReconciledGeneration: 1,
+		ObservedGeneration:   1,
+		Provisioned:          true,
 		DeprovisionStatus:    v1beta1.ServiceInstanceDeprovisionStatusRequired,
 	}
 
@@ -707,6 +709,8 @@ func getTestServiceInstanceUpdatingParameters() *v1beta1.ServiceInstance {
 		},
 		// It's been provisioned successfully.
 		ReconciledGeneration: 1,
+		ObservedGeneration:   1,
+		Provisioned:          true,
 		DeprovisionStatus:    v1beta1.ServiceInstanceDeprovisionStatusRequired,
 	}
 
@@ -727,6 +731,8 @@ func getTestServiceInstanceUpdatingParametersOfDeletedPlan() *v1beta1.ServiceIns
 		},
 		// It's been provisioned successfully.
 		ReconciledGeneration: 1,
+		ObservedGeneration:   1,
+		Provisioned:          true,
 		DeprovisionStatus:    v1beta1.ServiceInstanceDeprovisionStatusRequired,
 	}
 
@@ -770,6 +776,8 @@ func getTestServiceInstanceAsyncUpdating(operation string) *v1beta1.ServiceInsta
 	operationStartTime := metav1.NewTime(time.Now().Add(-1 * time.Hour))
 	instance.Status = v1beta1.ServiceInstanceStatus{
 		ReconciledGeneration: 1,
+		ObservedGeneration:   1,
+		Provisioned:          true,
 		Conditions: []v1beta1.ServiceInstanceCondition{{
 			Type:               v1beta1.ServiceInstanceConditionReady,
 			Status:             v1beta1.ConditionFalse,
@@ -812,6 +820,8 @@ func getTestServiceInstanceAsyncDeprovisioning(operation string) *v1beta1.Servic
 		OperationStartTime:   &operationStartTime,
 		CurrentOperation:     v1beta1.ServiceInstanceOperationDeprovision,
 		ReconciledGeneration: 1,
+		ObservedGeneration:   1,
+		Provisioned:          true,
 		ExternalProperties: &v1beta1.ServiceInstancePropertiesState{
 			ClusterServicePlanExternalName: testClusterServicePlanName,
 			ClusterServicePlanExternalID:   testClusterServicePlanGUID,

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2176,29 +2176,12 @@ func assertServiceInstanceOperationSuccessWithParameters(t *testing.T, obj runti
 }
 
 func assertServiceInstanceRequestFailingError(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, readyReason string, failureReason string, originalInstance *v1beta1.ServiceInstance) {
-	var (
-		readyStatus       v1beta1.ConditionStatus
-		deprovisionStatus v1beta1.ServiceInstanceDeprovisionStatus
-	)
-	switch operation {
-	case v1beta1.ServiceInstanceOperationProvision, v1beta1.ServiceInstanceOperationUpdate:
-		readyStatus = v1beta1.ConditionFalse
-		deprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
-	case v1beta1.ServiceInstanceOperationDeprovision:
-		readyStatus = v1beta1.ConditionUnknown
-		deprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusFailed
-	}
-	assertServiceInstanceReadyCondition(t, obj, readyStatus, readyReason)
-	switch operation {
-	case v1beta1.ServiceInstanceOperationProvision, v1beta1.ServiceInstanceOperationDeprovision:
-		assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionFailed, v1beta1.ConditionTrue, failureReason)
-	case v1beta1.ServiceInstanceOperationUpdate:
-		assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionFailed, v1beta1.ConditionTrue, failureReason)
-	}
+	assertServiceInstanceReadyCondition(t, obj, v1beta1.ConditionFalse, readyReason)
+	assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionFailed, v1beta1.ConditionTrue, failureReason)
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertAsyncOpInProgressFalse(t, obj)
 	assertServiceInstanceExternalPropertiesUnchanged(t, obj, originalInstance)
-	assertServiceInstanceDeprovisionStatus(t, obj, deprovisionStatus)
+	assertServiceInstanceDeprovisionStatus(t, obj, v1beta1.ServiceInstanceDeprovisionStatusRequired)
 }
 
 func assertServiceInstanceRequestFailingErrorNoOrphanMitigation(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, readyReason string, failureReason string, originalInstance *v1beta1.ServiceInstance) {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2072,7 +2072,7 @@ func assertServiceInstanceErrorBeforeRequest(t *testing.T, obj runtime.Object, r
 	assertServiceInstanceCurrentOperationClear(t, obj)
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
-	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Status.ObservedGeneration)
+	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
 	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.ProvisionStatus)
 	assertAsyncOpInProgressFalse(t, obj)
 	assertServiceInstanceOrphanMitigationInProgressFalse(t, obj)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2192,12 +2192,25 @@ func assertServiceInstanceOperationSuccessWithParameters(t *testing.T, obj runti
 }
 
 func assertServiceInstanceRequestFailingError(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, readyReason string, failureReason string, originalInstance *v1beta1.ServiceInstance) {
-	assertServiceInstanceReadyCondition(t, obj, v1beta1.ConditionFalse, readyReason)
+	var (
+		readyStatus       v1beta1.ConditionStatus
+		deprovisionStatus v1beta1.ServiceInstanceDeprovisionStatus
+	)
+	switch operation {
+	case v1beta1.ServiceInstanceOperationProvision, v1beta1.ServiceInstanceOperationUpdate:
+		readyStatus = v1beta1.ConditionFalse
+		deprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
+	case v1beta1.ServiceInstanceOperationDeprovision:
+		readyStatus = v1beta1.ConditionUnknown
+		deprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusFailed
+	}
+
+	assertServiceInstanceReadyCondition(t, obj, readyStatus, readyReason)
 	assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionFailed, v1beta1.ConditionTrue, failureReason)
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertAsyncOpInProgressFalse(t, obj)
 	assertServiceInstanceExternalPropertiesUnchanged(t, obj, originalInstance)
-	assertServiceInstanceDeprovisionStatus(t, obj, v1beta1.ServiceInstanceDeprovisionStatusRequired)
+	assertServiceInstanceDeprovisionStatus(t, obj, deprovisionStatus)
 }
 
 func assertServiceInstanceRequestFailingErrorNoOrphanMitigation(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, readyReason string, failureReason string, originalInstance *v1beta1.ServiceInstance) {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2193,7 +2193,7 @@ func assertServiceInstanceRequestFailingError(t *testing.T, obj runtime.Object, 
 	case v1beta1.ServiceInstanceOperationProvision, v1beta1.ServiceInstanceOperationDeprovision:
 		assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionFailed, v1beta1.ConditionTrue, failureReason)
 	case v1beta1.ServiceInstanceOperationUpdate:
-		assertServiceInstanceConditionsCount(t, obj, 1)
+		assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionFailed, v1beta1.ConditionTrue, failureReason)
 	}
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertAsyncOpInProgressFalse(t, obj)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2072,8 +2072,8 @@ func assertServiceInstanceErrorBeforeRequest(t *testing.T, obj runtime.Object, r
 	assertServiceInstanceCurrentOperationClear(t, obj)
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
-	// TODO: should be originalInstance.Generation?
-	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
+	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Status.ObservedGeneration)
+	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.Provisioned)
 	assertAsyncOpInProgressFalse(t, obj)
 	assertServiceInstanceOrphanMitigationInProgressFalse(t, obj)
 	assertServiceInstanceInProgressPropertiesNil(t, obj)
@@ -2100,6 +2100,7 @@ func assertServiceInstanceOperationInProgressWithParameters(t *testing.T, obj ru
 	assertServiceInstanceOperationStartTimeSet(t, obj, true)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
+	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.Provisioned)
 	assertAsyncOpInProgressFalse(t, obj)
 	assertServiceInstanceOrphanMitigationInProgressFalse(t, obj)
 	switch operation {
@@ -2119,6 +2120,7 @@ func assertServiceInstanceStartingOrphanMitigation(t *testing.T, obj runtime.Obj
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
+	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.Provisioned)
 	assertServiceInstanceOrphanMitigationInProgressTrue(t, obj)
 	assertServiceInstanceDeprovisionStatus(t, obj, v1beta1.ServiceInstanceDeprovisionStatusRequired)
 }
@@ -2133,16 +2135,20 @@ func assertServiceInstanceOperationSuccessWithParameters(t *testing.T, obj runti
 		readyStatus       v1beta1.ConditionStatus
 		deprovisionStatus v1beta1.ServiceInstanceDeprovisionStatus
 	)
+	var provisioned bool
 	switch operation {
 	case v1beta1.ServiceInstanceOperationProvision:
+		provisioned = true
 		reason = successProvisionReason
 		readyStatus = v1beta1.ConditionTrue
 		deprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 	case v1beta1.ServiceInstanceOperationUpdate:
+		provisioned = true
 		reason = successUpdateInstanceReason
 		readyStatus = v1beta1.ConditionTrue
 		deprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 	case v1beta1.ServiceInstanceOperationDeprovision:
+		provisioned = false
 		reason = successDeprovisionReason
 		readyStatus = v1beta1.ConditionFalse
 		deprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusSucceeded
@@ -2152,6 +2158,7 @@ func assertServiceInstanceOperationSuccessWithParameters(t *testing.T, obj runti
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Generation)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
+	assertServiceInstanceProvisioned(t, obj, provisioned)
 	assertAsyncOpInProgressFalse(t, obj)
 	assertServiceInstanceOrphanMitigationInProgressFalse(t, obj)
 	if operation == v1beta1.ServiceInstanceOperationDeprovision {
@@ -2199,6 +2206,7 @@ func assertServiceInstanceRequestFailingErrorNoOrphanMitigation(t *testing.T, ob
 	assertServiceInstanceCurrentOperationClear(t, obj)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Generation)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
+	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.Provisioned)
 	assertServiceInstanceOrphanMitigationInProgressFalse(t, obj)
 	assertServiceInstanceInProgressPropertiesNil(t, obj)
 }
@@ -2208,6 +2216,7 @@ func assertServiceInstanceRequestFailingErrorStartOrphanMitigation(t *testing.T,
 	assertServiceInstanceCurrentOperation(t, obj, v1beta1.ServiceInstanceOperationProvision)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
+	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.Provisioned)
 	assertServiceInstanceOrphanMitigationInProgressTrue(t, obj)
 }
 
@@ -2228,6 +2237,7 @@ func assertServiceInstanceRequestRetriableErrorWithParameters(t *testing.T, obj 
 	assertServiceInstanceOperationStartTimeSet(t, obj, true)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
+	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.Provisioned)
 	switch operation {
 	case v1beta1.ServiceInstanceOperationProvision, v1beta1.ServiceInstanceOperationUpdate:
 		assertServiceInstanceInProgressPropertiesPlan(t, obj, planName, planID)
@@ -2255,6 +2265,7 @@ func assertServiceInstanceAsyncStartInProgress(t *testing.T, obj runtime.Object,
 	assertServiceInstanceOperationStartTimeSet(t, obj, true)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
+	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.Provisioned)
 	switch operation {
 	case v1beta1.ServiceInstanceOperationProvision, v1beta1.ServiceInstanceOperationUpdate:
 		assertServiceInstanceInProgressPropertiesPlan(t, obj, planName, planID)
@@ -2282,6 +2293,7 @@ func assertServiceInstanceAsyncStillInProgress(t *testing.T, obj runtime.Object,
 	assertServiceInstanceOperationStartTimeSet(t, obj, true)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Status.ObservedGeneration)
+	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.Provisioned)
 	switch operation {
 	case v1beta1.ServiceInstanceOperationProvision, v1beta1.ServiceInstanceOperationUpdate:
 		assertServiceInstanceInProgressPropertiesPlan(t, obj, planName, planID)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1507,13 +1507,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "int64",
 							},
 						},
-						"provisioned": {
-							SchemaProps: spec.SchemaProps{
-								Description: "Provisioned is the flag that marks whether the instance has been successfully provisioned (i.e. it exists on the broker's side and can be updated or deprovisioned). The flag should be reset after successful deprovisioning.",
-								Type:        []string{"boolean"},
-								Format:      "",
-							},
-						},
 						"operationStartTime": {
 							SchemaProps: spec.SchemaProps{
 								Description: "OperationStartTime is the time at which the current operation began.",
@@ -1530,6 +1523,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							SchemaProps: spec.SchemaProps{
 								Description: "ExternalProperties is the properties state of the ServiceInstance which the broker knows about.",
 								Ref:         ref("github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.ServiceInstancePropertiesState"),
+							},
+						},
+						"provisioned": {
+							SchemaProps: spec.SchemaProps{
+								Description: "ProvisionStatus describes whether the instance is in the provisioned state.",
+								Type:        []string{"string"},
+								Format:      "",
 							},
 						},
 						"deprovisionStatus": {

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1495,9 +1495,23 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"reconciledGeneration": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ReconciledGeneration is the 'Generation' of the serviceInstanceSpec that was last processed by the controller. The reconciled generation is updated even if the controller failed to process the spec.",
+								Description: "ReconciledGeneration is the 'Generation' of the serviceInstanceSpec that was last processed by the controller. The reconciled generation is updated even if the controller failed to process the spec. Deprecated: use ObservedGeneration instead",
 								Type:        []string{"integer"},
 								Format:      "int64",
+							},
+						},
+						"observedGeneration": {
+							SchemaProps: spec.SchemaProps{
+								Description: "ObservedGeneration is the 'Generation' of the serviceInstanceSpec that was last processed by the controller. The observed generation is updated whenever the status is updated regardless of operation result",
+								Type:        []string{"integer"},
+								Format:      "int64",
+							},
+						},
+						"provisioned": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Provisioned is the flag that marks whether the instance has been successfully provisioned (i.e. it exists on the broker's side and can be updated or deprovisioned). The flag should be reset after successful deprovisioning.",
+								Type:        []string{"boolean"},
+								Format:      "",
 							},
 						},
 						"operationStartTime": {
@@ -1526,7 +1540,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"conditions", "asyncOpInProgress", "orphanMitigationInProgress", "reconciledGeneration", "deprovisionStatus"},
+					Required: []string{"conditions", "asyncOpInProgress", "orphanMitigationInProgress", "reconciledGeneration", "observedGeneration", "provisioned", "deprovisionStatus"},
 				},
 			},
 			Dependencies: []string{

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1525,7 +1525,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref:         ref("github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.ServiceInstancePropertiesState"),
 							},
 						},
-						"provisioned": {
+						"provisionStatus": {
 							SchemaProps: spec.SchemaProps{
 								Description: "ProvisionStatus describes whether the instance is in the provisioned state.",
 								Type:        []string{"string"},
@@ -1540,7 +1540,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"conditions", "asyncOpInProgress", "orphanMitigationInProgress", "reconciledGeneration", "observedGeneration", "provisioned", "deprovisionStatus"},
+					Required: []string{"conditions", "asyncOpInProgress", "orphanMitigationInProgress", "reconciledGeneration", "observedGeneration", "provisionStatus", "deprovisionStatus"},
 				},
 			},
 			Dependencies: []string{

--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -924,7 +924,7 @@ func testInstanceClient(sType server.StorageType, client servicecatalogclient.In
 	instanceServer.Status = v1beta1.ServiceInstanceStatus{
 		ReconciledGeneration: instanceServer.Generation,
 		ObservedGeneration:   instanceServer.Generation,
-		Provisioned:          true,
+		ProvisionStatus:      v1beta1.ServiceInstanceProvisionStatusProvisioned,
 		Conditions:           []v1beta1.ServiceInstanceCondition{readyConditionTrue},
 		DeprovisionStatus:    v1beta1.ServiceInstanceDeprovisionStatusNotRequired,
 	}

--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -923,6 +923,8 @@ func testInstanceClient(sType server.StorageType, client servicecatalogclient.In
 	}
 	instanceServer.Status = v1beta1.ServiceInstanceStatus{
 		ReconciledGeneration: instanceServer.Generation,
+		ObservedGeneration:   instanceServer.Generation,
+		Provisioned:          true,
 		Conditions:           []v1beta1.ServiceInstanceCondition{readyConditionTrue},
 		DeprovisionStatus:    v1beta1.ServiceInstanceDeprovisionStatusNotRequired,
 	}

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -568,7 +568,7 @@ func TestUpdateServiceInstanceChangePlans(t *testing.T) {
 				}
 				ct.instance = updatedInstance
 
-				if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Generation); err != nil {
+				if err := util.WaitForInstanceProcessedGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Generation); err != nil {
 					t.Fatalf("error waiting for instance to reconcile: %v", err)
 				}
 
@@ -841,7 +841,7 @@ func TestUpdateServiceInstanceUpdateParameters(t *testing.T) {
 				}
 				ct.instance = updatedInstance
 
-				if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Generation); err != nil {
+				if err := util.WaitForInstanceProcessedGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Generation); err != nil {
 					t.Fatalf("error waiting for instance to reconcile: %v", err)
 				}
 
@@ -1036,7 +1036,7 @@ func TestCreateServiceInstanceWithProvisionFailure(t *testing.T) {
 				}
 
 				if tc.expectFailCondition {
-					if err := util.WaitForInstanceReconciledGeneration(ct.client, ct.instance.Namespace, ct.instance.Name, 1); err != nil {
+					if err := util.WaitForInstanceProcessedGeneration(ct.client, ct.instance.Namespace, ct.instance.Name, 1); err != nil {
 						t.Fatalf("error waiting for instance reconciliation to complete: %v", err)
 					}
 				}

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -34,7 +34,6 @@ import (
 	// avoid error `servicecatalog/v1beta1 is not enabled`
 	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
 
-	"encoding/json"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-incubator/service-catalog/test/util"
 )
@@ -570,15 +569,6 @@ func TestUpdateServiceInstanceChangePlans(t *testing.T) {
 				ct.instance = updatedInstance
 
 				if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Generation); err != nil {
-					latestInstance, err := ct.client.ServiceInstances(testNamespace).Get(testInstanceName, metav1.GetOptions{})
-					if err != nil {
-						t.Fatalf("unable to retrieve instance: %v", err)
-					}
-					instanceJson, err := json.Marshal(latestInstance)
-					if err != nil {
-						t.Fatalf("unable to marshal instance: %v", err)
-					}
-					t.Logf("instance: %s", string(instanceJson))
 					t.Fatalf("error waiting for instance to reconcile: %v", err)
 				}
 

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -562,9 +562,11 @@ func TestUpdateServiceInstanceChangePlans(t *testing.T) {
 					ct.instance.Spec.ClusterServicePlanName = otherPlanID
 				}
 
-				if _, err := ct.client.ServiceInstances(testNamespace).Update(ct.instance); err != nil {
+				updatedInstance, err := ct.client.ServiceInstances(testNamespace).Update(ct.instance)
+				if err != nil {
 					t.Fatalf("error updating Instance: %v", err)
 				}
+				ct.instance = updatedInstance
 
 				if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Generation); err != nil {
 					t.Fatalf("error waiting for instance to reconcile: %v", err)
@@ -833,9 +835,11 @@ func TestUpdateServiceInstanceUpdateParameters(t *testing.T) {
 					ct.instance.Spec.UpdateRequests++
 				}
 
-				if _, err := ct.client.ServiceInstances(testNamespace).Update(ct.instance); err != nil {
+				updatedInstance, err := ct.client.ServiceInstances(testNamespace).Update(ct.instance)
+				if err != nil {
 					t.Fatalf("error updating Instance: %v", err)
 				}
+				ct.instance = updatedInstance
 
 				if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Generation); err != nil {
 					t.Fatalf("error waiting for instance to reconcile: %v", err)

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -34,6 +34,7 @@ import (
 	// avoid error `servicecatalog/v1beta1 is not enabled`
 	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
 
+	"encoding/json"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-incubator/service-catalog/test/util"
 )
@@ -569,6 +570,15 @@ func TestUpdateServiceInstanceChangePlans(t *testing.T) {
 				ct.instance = updatedInstance
 
 				if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Generation); err != nil {
+					latestInstance, err := ct.client.ServiceInstances(testNamespace).Get(testInstanceName, metav1.GetOptions{})
+					if err != nil {
+						t.Fatalf("unable to retrieve instance: %v", err)
+					}
+					instanceJson, err := json.Marshal(latestInstance)
+					if err != nil {
+						t.Fatalf("unable to marshal instance: %v", err)
+					}
+					t.Logf("instance: %s", string(instanceJson))
 					t.Fatalf("error waiting for instance to reconcile: %v", err)
 				}
 

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -566,7 +566,7 @@ func TestUpdateServiceInstanceChangePlans(t *testing.T) {
 					t.Fatalf("error updating Instance: %v", err)
 				}
 
-				if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Status.ReconciledGeneration+1); err != nil {
+				if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Generation); err != nil {
 					t.Fatalf("error waiting for instance to reconcile: %v", err)
 				}
 
@@ -837,7 +837,7 @@ func TestUpdateServiceInstanceUpdateParameters(t *testing.T) {
 					t.Fatalf("error updating Instance: %v", err)
 				}
 
-				if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Status.ReconciledGeneration+1); err != nil {
+				if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Generation); err != nil {
 					t.Fatalf("error waiting for instance to reconcile: %v", err)
 				}
 

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -142,7 +142,7 @@ func TestBasicFlows(t *testing.T) {
 					t.Fatalf("error updating Instance: %v", err)
 				}
 
-				if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Status.ReconciledGeneration+1); err != nil {
+				if err := util.WaitForInstanceProcessedGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Status.ReconciledGeneration+1); err != nil {
 					t.Fatalf("error waiting for instance to reconcile: %v", err)
 				}
 
@@ -271,7 +271,7 @@ func TestBasicFlowsWithOriginatingIdentity(t *testing.T) {
 			t.Fatalf("error updating Instance: %v", err)
 		}
 
-		if err := util.WaitForInstanceReconciledGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Status.ReconciledGeneration+1); err != nil {
+		if err := util.WaitForInstanceProcessedGeneration(ct.client, testNamespace, testInstanceName, ct.instance.Status.ReconciledGeneration+1); err != nil {
 			t.Fatalf("error waiting for instance to reconcile: %v", err)
 		}
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -205,19 +205,20 @@ func WaitForInstanceToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta
 	)
 }
 
-// WaitForInstanceReconciledGeneration waits for the status of the named instance to
+// WaitForInstanceProcessedGeneration waits for the status of the named instance to
 // have the specified reconciled generation.
-func WaitForInstanceReconciledGeneration(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, namespace, name string, reconciledGeneration int64) error {
+func WaitForInstanceProcessedGeneration(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, namespace, name string, processedGeneration int64) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for instance %v/%v to have reconciled generation of %v", namespace, name, reconciledGeneration)
+			glog.V(5).Infof("Waiting for instance %v/%v to have processed generation of %v", namespace, name, processedGeneration)
 			instance, err := client.ServiceInstances(namespace).Get(name, metav1.GetOptions{})
 			if nil != err {
 				return false, fmt.Errorf("error getting Instance %v/%v: %v", namespace, name, err)
 			}
 
-			if instance.Status.ObservedGeneration >= reconciledGeneration &&
-				(isServiceInstanceReady(instance) || isServiceInstanceFailed(instance)) {
+			if instance.Status.ObservedGeneration >= processedGeneration &&
+				(isServiceInstanceReady(instance) || isServiceInstanceFailed(instance)) &&
+				!instance.Status.OrphanMitigationInProgress {
 				return true, nil
 			}
 
@@ -226,11 +227,11 @@ func WaitForInstanceReconciledGeneration(client v1beta1servicecatalog.Servicecat
 	)
 }
 
-// isServiceInstanceReady returns whether the given instance has a ready condition
+// isServiceInstanceConditionTrue returns whether the given instance has a given condition
 // with status true.
-func isServiceInstanceReady(instance *v1beta1.ServiceInstance) bool {
+func isServiceInstanceConditionTrue(instance *v1beta1.ServiceInstance, conditionType v1beta1.ServiceInstanceConditionType) bool {
 	for _, cond := range instance.Status.Conditions {
-		if cond.Type == v1beta1.ServiceInstanceConditionReady {
+		if cond.Type == conditionType {
 			return cond.Status == v1beta1.ConditionTrue
 		}
 	}
@@ -238,16 +239,16 @@ func isServiceInstanceReady(instance *v1beta1.ServiceInstance) bool {
 	return false
 }
 
+// isServiceInstanceReady returns whether the given instance has a ready condition
+// with status true.
+func isServiceInstanceReady(instance *v1beta1.ServiceInstance) bool {
+	return isServiceInstanceConditionTrue(instance, v1beta1.ServiceInstanceConditionReady)
+}
+
 // isServiceInstanceFailed returns whether the instance has a failed condition with
 // status true.
 func isServiceInstanceFailed(instance *v1beta1.ServiceInstance) bool {
-	for _, condition := range instance.Status.Conditions {
-		if condition.Type == v1beta1.ServiceInstanceConditionFailed && condition.Status == v1beta1.ConditionTrue {
-			return true
-		}
-	}
-
-	return false
+	return isServiceInstanceConditionTrue(instance, v1beta1.ServiceInstanceConditionFailed)
 }
 
 // WaitForBindingCondition waits for the status of the named binding to contain


### PR DESCRIPTION
See #1747 
- Add `ObservedGeneration` and `Provisioned` fields to `ServiceInstanceStatus`
- Switch to using `ObservedGeneration` and `Provisioned` on the read path (while keeping write paths for both `ReconciledGeneration` and `ObservedGeneration` for backward compatibility)
- Initialize `ObservedGeneration` and `Provisioned` fields if they are not set while `ReconciledGeneration` is set (for API migration between Service Catalog versions)