### PR TITLE
Support provisioning by external id

### DIFF
--- a/cmd/svcat/output/instance.go
+++ b/cmd/svcat/output/instance.go
@@ -55,8 +55,8 @@ func WriteInstanceList(w io.Writer, instances ...v1beta1.ServiceInstance) {
 		t.Append([]string{
 			instance.Name,
 			instance.Namespace,
-			instance.Spec.ClusterServiceClassExternalName,
-			instance.Spec.ClusterServicePlanExternalName,
+			instance.Spec.GetSpecifiedClass(),
+			instance.Spec.GetSpecifiedPlan(),
 			getInstanceStatusShort(instance.Status),
 		})
 	}
@@ -107,8 +107,8 @@ func WriteInstanceDetails(w io.Writer, instance *v1beta1.ServiceInstance) {
 		{"Name:", instance.Name},
 		{"Namespace:", instance.Namespace},
 		{"Status:", getInstanceStatusFull(instance.Status)},
-		{"Class:", instance.Spec.ClusterServiceClassExternalName},
-		{"Plan:", instance.Spec.ClusterServicePlanExternalName},
+		{"Class:", instance.Spec.GetSpecifiedClass()},
+		{"Plan:", instance.Spec.GetSpecifiedPlan()},
 	})
 	t.Render()
 

--- a/pkg/apis/servicecatalog/plan_reference.go
+++ b/pkg/apis/servicecatalog/plan_reference.go
@@ -134,7 +134,7 @@ func (pr PlanReference) String() string {
 //     {ClassExternalID:"foo123", PlanExternalID:"bar456"}
 //     {ClassName:"k8s-foo123", PlanName:"k8s-bar456"}
 func (pr PlanReference) Format(s fmt.State, verb rune) {
-	classFields := make([]string, 0, 3)
+	var classFields []string
 	if pr.ClusterServiceClassExternalName != "" {
 		classFields = append(classFields, fmt.Sprintf("ClassExternalName:%q", pr.ClusterServiceClassExternalName))
 	}
@@ -145,7 +145,7 @@ func (pr PlanReference) Format(s fmt.State, verb rune) {
 		classFields = append(classFields, fmt.Sprintf("ClassName:%q", pr.ClusterServiceClassName))
 	}
 
-	planFields := make([]string, 0, 3)
+	var planFields []string
 	if pr.ClusterServicePlanExternalName != "" {
 		planFields = append(planFields, fmt.Sprintf("PlanExternalName:%q", pr.ClusterServicePlanExternalName))
 	}

--- a/pkg/apis/servicecatalog/plan_reference.go
+++ b/pkg/apis/servicecatalog/plan_reference.go
@@ -35,10 +35,11 @@ func (pr PlanReference) PlanSpecified() bool {
 		pr.ClusterServicePlanName != ""
 }
 
-// GetSpecifiedClass returns the user-specified class value from either:
+// GetSpecifiedClass returns the user-specified class value from one of:
 // * ClusterServiceClassExternalName
 // * ClusterServiceClassExternalID
 // * ClusterServiceClassName
+// This method is intended for presentation purposes only.
 func (pr PlanReference) GetSpecifiedClass() string {
 	if pr.ClusterServiceClassExternalName != "" {
 		return pr.ClusterServiceClassExternalName
@@ -55,10 +56,11 @@ func (pr PlanReference) GetSpecifiedClass() string {
 	return ""
 }
 
-// GetSpecifiedPlan returns the user-specified plan value from either:
+// GetSpecifiedPlan returns the user-specified plan value from one of:
 // * ClusterServicePlanExternalName
 // * ClusterServicePlanExternalID
 // * ClusterServicePlanName
+// This method is intended for presentation purposes only.
 func (pr PlanReference) GetSpecifiedPlan() string {
 	if pr.ClusterServicePlanExternalName != "" {
 		return pr.ClusterServicePlanExternalName

--- a/pkg/apis/servicecatalog/plan_reference.go
+++ b/pkg/apis/servicecatalog/plan_reference.go
@@ -1,0 +1,149 @@
+package servicecatalog
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ClassSpecified checks that at least one class field is set.
+func (pr PlanReference) ClassSpecified() bool {
+	return pr.ClusterServiceClassExternalName != "" ||
+		pr.ClusterServiceClassExternalID != "" ||
+		pr.ClusterServiceClassName != ""
+}
+
+// PlanSpecified checks that at least one plan field is set.
+func (pr PlanReference) PlanSpecified() bool {
+	return pr.ClusterServicePlanExternalName != "" ||
+		pr.ClusterServicePlanExternalID != "" ||
+		pr.ClusterServicePlanName != ""
+}
+
+// GetSpecifiedClass returns the user-specified class value from either:
+// * ClusterServiceClassExternalName
+// * ClusterServiceClassExternalID
+// * ClusterServiceClassName
+func (pr PlanReference) GetSpecifiedClass() string {
+	if pr.ClusterServiceClassExternalName != "" {
+		return pr.ClusterServiceClassExternalName
+	}
+
+	if pr.ClusterServiceClassExternalID != "" {
+		return pr.ClusterServiceClassExternalID
+	}
+
+	if pr.ClusterServiceClassName != "" {
+		return pr.ClusterServiceClassName
+	}
+
+	return ""
+}
+
+// GetSpecifiedPlan returns the user-specified plan value from either:
+// * ClusterServicePlanExternalName
+// * ClusterServicePlanExternalID
+// * ClusterServicePlanName
+func (pr PlanReference) GetSpecifiedPlan() string {
+	if pr.ClusterServicePlanExternalName != "" {
+		return pr.ClusterServicePlanExternalName
+	}
+
+	if pr.ClusterServicePlanExternalID != "" {
+		return pr.ClusterServicePlanExternalID
+	}
+
+	if pr.ClusterServicePlanName != "" {
+		return pr.ClusterServicePlanName
+	}
+
+	return ""
+}
+
+// GetClassFilterFieldName returns the appropriate field name for filtering
+// a list of service catalog classes by the PlanReference.
+func (pr PlanReference) GetClassFilterFieldName() string {
+	if pr.ClusterServiceClassExternalName != "" {
+		return "spec.externalName"
+	}
+
+	if pr.ClusterServiceClassExternalID != "" {
+		return "spec.externalID"
+	}
+
+	return ""
+}
+
+// GetPlanFilterFieldName returns the appropriate field name for filtering
+// a list of service catalog plans by the PlanReference.
+func (pr PlanReference) GetPlanFilterFieldName() string {
+	if pr.ClusterServicePlanExternalName != "" {
+		return "spec.externalName"
+	}
+
+	if pr.ClusterServicePlanExternalID != "" {
+		return "spec.externalID"
+	}
+
+	return ""
+}
+
+// String representation of a PlanReference
+// Example: class_name/plan_name, class_id/plan_id
+func (pr PlanReference) String() string {
+	return fmt.Sprintf("%s/%s", pr.GetSpecifiedClass(), pr.GetSpecifiedPlan())
+}
+
+// Format the PlanReference
+// %c - Print specified class fields only
+//    Examples:
+//     {ClassExternalName:"foo"}
+//     {ClassExternalID:"foo123"}
+//     {ClassName:"k8s-foo123"}
+// %b - Print specified plan fields only
+//    NOTE: %p is a reserved verb so we can't use it, and go vet fails for non-standard verbs
+//    Examples:
+//     {PlanExternalName:"bar"}
+//     {PlanExternalID:"bar456"}
+//     {PlanName:"k8s-bar456"}
+// %s - Print a short form of the plan and class
+//    Examples:
+//     foo/bar
+//     foo123/bar456
+//     k8s-foo123/k8s-bar456
+// %v - Print all specified fields
+//    Examples:
+//     {ClassExternalName:"foo", PlanExternalName:"bar"}
+//     {ClassExternalID:"foo123", PlanExternalID:"bar456"}
+//     {ClassName:"k8s-foo123", PlanName:"k8s-bar456"}
+func (pr PlanReference) Format(s fmt.State, verb rune) {
+	classFields := make([]string, 0, 3)
+	if pr.ClusterServiceClassExternalName != "" {
+		classFields = append(classFields, fmt.Sprintf("ClassExternalName:%q", pr.ClusterServiceClassExternalName))
+	}
+	if pr.ClusterServiceClassExternalID != "" {
+		classFields = append(classFields, fmt.Sprintf("ClassExternalID:%q", pr.ClusterServiceClassExternalID))
+	}
+	if pr.ClusterServiceClassName != "" {
+		classFields = append(classFields, fmt.Sprintf("ClassName:%q", pr.ClusterServiceClassName))
+	}
+
+	planFields := make([]string, 0, 3)
+	if pr.ClusterServicePlanExternalName != "" {
+		planFields = append(planFields, fmt.Sprintf("PlanExternalName:%q", pr.ClusterServicePlanExternalName))
+	}
+	if pr.ClusterServicePlanExternalID != "" {
+		planFields = append(planFields, fmt.Sprintf("PlanExternalID:%q", pr.ClusterServicePlanExternalID))
+	}
+	if pr.ClusterServicePlanName != "" {
+		planFields = append(planFields, fmt.Sprintf("PlanName:%q", pr.ClusterServicePlanName))
+	}
+
+	switch verb {
+	case 'c':
+		fmt.Fprintf(s, "{%s}", strings.Join(classFields, ", "))
+	case 'b':
+		fmt.Fprintf(s, "{%s}", strings.Join(planFields, ", "))
+	case 'v':
+		fmt.Fprintf(s, "{%s}", strings.Join(append(classFields, planFields...), ", "))
+	}
+}

--- a/pkg/apis/servicecatalog/plan_reference.go
+++ b/pkg/apis/servicecatalog/plan_reference.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package servicecatalog
 
 import (

--- a/pkg/apis/servicecatalog/plan_reference_test.go
+++ b/pkg/apis/servicecatalog/plan_reference_test.go
@@ -1,0 +1,51 @@
+package servicecatalog
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPlanReference_Format(t *testing.T) {
+	testcases := []struct {
+		name    string
+		format  string
+		want    string
+		planRef PlanReference
+	}{
+		{"all: external-name", "%v", `{ClassExternalName:"foo", PlanExternalName:"bar"}`, PlanReference{
+			ClusterServiceClassExternalName: "foo", ClusterServicePlanExternalName: "bar"}},
+		{"all: external-id", "%v", `{ClassExternalID:"foo-abc123", PlanExternalID:"bar-def456"}`, PlanReference{
+			ClusterServiceClassExternalID: "foo-abc123", ClusterServicePlanExternalID: "bar-def456"}},
+		{"all: cluster-name", "%v", `{ClassName:"k8s-foo1232", PlanName:"k8s-bar456"}`, PlanReference{
+			ClusterServiceClassName: "k8s-foo1232", ClusterServicePlanName: "k8s-bar456"}},
+		{"short: external-name", "%s", `foo/bar`, PlanReference{
+			ClusterServiceClassExternalName: "foo", ClusterServicePlanExternalName: "bar"}},
+		{"short: external-id", "%s", `foo-abc123/bar-def456`, PlanReference{
+			ClusterServiceClassExternalID: "foo-abc123", ClusterServicePlanExternalID: "bar-def456"}},
+		{"short: cluster-name", "%s", `k8s-foo1232/k8s-bar456`, PlanReference{
+			ClusterServiceClassName: "k8s-foo1232", ClusterServicePlanName: "k8s-bar456"}},
+		{"class: external-name", "%c", `{ClassExternalName:"foo"}`, PlanReference{
+			ClusterServiceClassExternalName: "foo", ClusterServicePlanExternalName: "bar"}},
+		{"class: external-id", "%c", `{ClassExternalID:"foo-abc123"}`, PlanReference{
+			ClusterServiceClassExternalID: "foo-abc123", ClusterServicePlanExternalID: "bar-def456"}},
+		{"class: cluster-name", "%c", `{ClassName:"k8s-foo1232"}`, PlanReference{
+			ClusterServiceClassName: "k8s-foo1232", ClusterServicePlanName: "k8s-bar456"}},
+		{"plan: external-name", "%b", `{PlanExternalName:"bar"}`, PlanReference{
+			ClusterServiceClassExternalName: "foo", ClusterServicePlanExternalName: "bar"}},
+		{"plan: external-id", "%b", `{PlanExternalID:"bar-def456"}`, PlanReference{
+			ClusterServiceClassExternalID: "foo-abc123", ClusterServicePlanExternalID: "bar-def456"}},
+		{"plan: cluster-name", "%b", `{PlanName:"k8s-bar456"}`, PlanReference{
+			ClusterServiceClassName: "k8s-foo1232", ClusterServicePlanName: "k8s-bar456"}},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fmt.Sprintf(tc.format, tc.planRef)
+			if tc.want != got {
+				t.Fatalf("\nwant:\t%#v\ngot:\t%#v", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/apis/servicecatalog/plan_reference_test.go
+++ b/pkg/apis/servicecatalog/plan_reference_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package servicecatalog
 
 import (

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -547,6 +547,14 @@ type ServiceInstance struct {
 // ServicePlan and ServiceClass. Because there are multiple ways to
 // specify the desired Class/Plan, this structure specifies the
 // allowed ways to specify the intent.
+//
+// Currently supported ways:
+//  - ClusterServiceClassExternalName and ClusterServicePlanExternalName
+//  - ClusterServiceClassExternalID and ClusterServicePlanExternalID
+//  - ClusterServiceClassName and ClusterServicePlanName
+//
+// For any of these ways, if a ClusterServiceClass only has one plan
+// then leaving the *ServicePlanName is optional.
 type PlanReference struct {
 	// ClusterServiceClassExternalName is the human-readable name of the
 	// service as reported by the broker. Note that if the broker changes
@@ -562,6 +570,14 @@ type PlanReference struct {
 	// the current name of the ClusterServicePlan, you should follow the
 	// ClusterServicePlanRef below.
 	ClusterServicePlanExternalName string
+
+	// ClusterServiceClassExternalID is the broker's external id for the class.
+	//
+	// Immutable.
+	ClusterServiceClassExternalID string
+
+	// ClusterServicePlanExternalID is the broker's external id for the plan.
+	ClusterServicePlanExternalID string
 
 	// ClusterServiceClassName is the kubernetes name of the
 	// ClusterServiceClass.

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -554,7 +554,7 @@ type ServiceInstance struct {
 //  - ClusterServiceClassName and ClusterServicePlanName
 //
 // For any of these ways, if a ClusterServiceClass only has one plan
-// then leaving the *ServicePlanName is optional.
+// then the corresponding service plan field is optional.
 type PlanReference struct {
 	// ClusterServiceClassExternalName is the human-readable name of the
 	// service as reported by the broker. Note that if the broker changes

--- a/pkg/apis/servicecatalog/v1beta1/plan_reference.go
+++ b/pkg/apis/servicecatalog/v1beta1/plan_reference.go
@@ -1,0 +1,149 @@
+package v1beta1
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ClassSpecified checks that at least one class field is set.
+func (pr PlanReference) ClassSpecified() bool {
+	return pr.ClusterServiceClassExternalName != "" ||
+		pr.ClusterServiceClassExternalID != "" ||
+		pr.ClusterServiceClassName != ""
+}
+
+// PlanSpecified checks that at least one plan field is set.
+func (pr PlanReference) PlanSpecified() bool {
+	return pr.ClusterServicePlanExternalName != "" ||
+		pr.ClusterServicePlanExternalID != "" ||
+		pr.ClusterServicePlanName != ""
+}
+
+// GetSpecifiedClass returns the user-specified class value from either:
+// * ClusterServiceClassExternalName
+// * ClusterServiceClassExternalID
+// * ClusterServiceClassName
+func (pr PlanReference) GetSpecifiedClass() string {
+	if pr.ClusterServiceClassExternalName != "" {
+		return pr.ClusterServiceClassExternalName
+	}
+
+	if pr.ClusterServiceClassExternalID != "" {
+		return pr.ClusterServiceClassExternalID
+	}
+
+	if pr.ClusterServiceClassName != "" {
+		return pr.ClusterServiceClassName
+	}
+
+	return ""
+}
+
+// GetSpecifiedPlan returns the user-specified plan value from either:
+// * ClusterServicePlanExternalName
+// * ClusterServicePlanExternalID
+// * ClusterServicePlanName
+func (pr PlanReference) GetSpecifiedPlan() string {
+	if pr.ClusterServicePlanExternalName != "" {
+		return pr.ClusterServicePlanExternalName
+	}
+
+	if pr.ClusterServicePlanExternalID != "" {
+		return pr.ClusterServicePlanExternalID
+	}
+
+	if pr.ClusterServicePlanName != "" {
+		return pr.ClusterServicePlanName
+	}
+
+	return ""
+}
+
+// GetClassFilterFieldName returns the appropriate field name for filtering
+// a list of service catalog classes by the PlanReference.
+func (pr PlanReference) GetClassFilterFieldName() string {
+	if pr.ClusterServiceClassExternalName != "" {
+		return "spec.externalName"
+	}
+
+	if pr.ClusterServiceClassExternalID != "" {
+		return "spec.externalID"
+	}
+
+	return ""
+}
+
+// GetPlanFilterFieldName returns the appropriate field name for filtering
+// a list of service catalog plans by the PlanReference.
+func (pr PlanReference) GetPlanFilterFieldName() string {
+	if pr.ClusterServicePlanExternalName != "" {
+		return "spec.externalName"
+	}
+
+	if pr.ClusterServicePlanExternalID != "" {
+		return "spec.externalID"
+	}
+
+	return ""
+}
+
+// String representation of a PlanReference
+// Example: class_name/plan_name, class_id/plan_id
+func (pr PlanReference) String() string {
+	return fmt.Sprintf("%s/%s", pr.GetSpecifiedClass(), pr.GetSpecifiedPlan())
+}
+
+// Format the PlanReference
+// %c - Print specified class fields only
+//    Examples:
+//     {ClassExternalName:"foo"}
+//     {ClassExternalID:"foo123"}
+//     {ClassName:"k8s-foo123"}
+// %b - Print specified plan fields only
+//    NOTE: %p is a reserved verb so we can't use it, and go vet fails for non-standard verbs
+//    Examples:
+//     {PlanExternalName:"bar"}
+//     {PlanExternalID:"bar456"}
+//     {PlanName:"k8s-bar456"}
+// %s - Print a short form of the plan and class
+//    Examples:
+//     foo/bar
+//     foo123/bar456
+//     k8s-foo123/k8s-bar456
+// %v - Print all specified fields
+//    Examples:
+//     {ClassExternalName:"foo", PlanExternalName:"bar"}
+//     {ClassExternalID:"foo123", PlanExternalID:"bar456"}
+//     {ClassName:"k8s-foo123", PlanName:"k8s-bar456"}
+func (pr PlanReference) Format(s fmt.State, verb rune) {
+	classFields := make([]string, 0, 3)
+	if pr.ClusterServiceClassExternalName != "" {
+		classFields = append(classFields, fmt.Sprintf("ClassExternalName:%q", pr.ClusterServiceClassExternalName))
+	}
+	if pr.ClusterServiceClassExternalID != "" {
+		classFields = append(classFields, fmt.Sprintf("ClassExternalID:%q", pr.ClusterServiceClassExternalID))
+	}
+	if pr.ClusterServiceClassName != "" {
+		classFields = append(classFields, fmt.Sprintf("ClassName:%q", pr.ClusterServiceClassName))
+	}
+
+	planFields := make([]string, 0, 3)
+	if pr.ClusterServicePlanExternalName != "" {
+		planFields = append(planFields, fmt.Sprintf("PlanExternalName:%q", pr.ClusterServicePlanExternalName))
+	}
+	if pr.ClusterServicePlanExternalID != "" {
+		planFields = append(planFields, fmt.Sprintf("PlanExternalID:%q", pr.ClusterServicePlanExternalID))
+	}
+	if pr.ClusterServicePlanName != "" {
+		planFields = append(planFields, fmt.Sprintf("PlanName:%q", pr.ClusterServicePlanName))
+	}
+
+	switch verb {
+	case 'c':
+		fmt.Fprintf(s, "{%s}", strings.Join(classFields, ", "))
+	case 'b':
+		fmt.Fprintf(s, "{%s}", strings.Join(planFields, ", "))
+	case 'v':
+		fmt.Fprintf(s, "{%s}", strings.Join(append(classFields, planFields...), ", "))
+	}
+}

--- a/pkg/apis/servicecatalog/v1beta1/plan_reference.go
+++ b/pkg/apis/servicecatalog/v1beta1/plan_reference.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1beta1
 
 import (

--- a/pkg/apis/servicecatalog/v1beta1/plan_reference.go
+++ b/pkg/apis/servicecatalog/v1beta1/plan_reference.go
@@ -132,7 +132,7 @@ func (pr PlanReference) String() string {
 //     {ClassExternalID:"foo123", PlanExternalID:"bar456"}
 //     {ClassName:"k8s-foo123", PlanName:"k8s-bar456"}
 func (pr PlanReference) Format(s fmt.State, verb rune) {
-	classFields := make([]string, 0, 3)
+	var classFields []string
 	if pr.ClusterServiceClassExternalName != "" {
 		classFields = append(classFields, fmt.Sprintf("ClassExternalName:%q", pr.ClusterServiceClassExternalName))
 	}
@@ -143,7 +143,7 @@ func (pr PlanReference) Format(s fmt.State, verb rune) {
 		classFields = append(classFields, fmt.Sprintf("ClassName:%q", pr.ClusterServiceClassName))
 	}
 
-	planFields := make([]string, 0, 3)
+	var planFields []string
 	if pr.ClusterServicePlanExternalName != "" {
 		planFields = append(planFields, fmt.Sprintf("PlanExternalName:%q", pr.ClusterServicePlanExternalName))
 	}

--- a/pkg/apis/servicecatalog/v1beta1/plan_reference_test.go
+++ b/pkg/apis/servicecatalog/v1beta1/plan_reference_test.go
@@ -1,0 +1,51 @@
+package v1beta1
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPlanReference_Format(t *testing.T) {
+	testcases := []struct {
+		name    string
+		format  string
+		want    string
+		planRef PlanReference
+	}{
+		{"all: external-name", "%v", `{ClassExternalName:"foo", PlanExternalName:"bar"}`, PlanReference{
+			ClusterServiceClassExternalName: "foo", ClusterServicePlanExternalName: "bar"}},
+		{"all: external-id", "%v", `{ClassExternalID:"foo-abc123", PlanExternalID:"bar-def456"}`, PlanReference{
+			ClusterServiceClassExternalID: "foo-abc123", ClusterServicePlanExternalID: "bar-def456"}},
+		{"all: cluster-name", "%v", `{ClassName:"k8s-foo1232", PlanName:"k8s-bar456"}`, PlanReference{
+			ClusterServiceClassName: "k8s-foo1232", ClusterServicePlanName: "k8s-bar456"}},
+		{"short: external-name", "%s", `foo/bar`, PlanReference{
+			ClusterServiceClassExternalName: "foo", ClusterServicePlanExternalName: "bar"}},
+		{"short: external-id", "%s", `foo-abc123/bar-def456`, PlanReference{
+			ClusterServiceClassExternalID: "foo-abc123", ClusterServicePlanExternalID: "bar-def456"}},
+		{"short: cluster-name", "%s", `k8s-foo1232/k8s-bar456`, PlanReference{
+			ClusterServiceClassName: "k8s-foo1232", ClusterServicePlanName: "k8s-bar456"}},
+		{"class: external-name", "%c", `{ClassExternalName:"foo"}`, PlanReference{
+			ClusterServiceClassExternalName: "foo", ClusterServicePlanExternalName: "bar"}},
+		{"class: external-id", "%c", `{ClassExternalID:"foo-abc123"}`, PlanReference{
+			ClusterServiceClassExternalID: "foo-abc123", ClusterServicePlanExternalID: "bar-def456"}},
+		{"class: cluster-name", "%c", `{ClassName:"k8s-foo1232"}`, PlanReference{
+			ClusterServiceClassName: "k8s-foo1232", ClusterServicePlanName: "k8s-bar456"}},
+		{"plan: external-name", "%b", `{PlanExternalName:"bar"}`, PlanReference{
+			ClusterServiceClassExternalName: "foo", ClusterServicePlanExternalName: "bar"}},
+		{"plan: external-id", "%b", `{PlanExternalID:"bar-def456"}`, PlanReference{
+			ClusterServiceClassExternalID: "foo-abc123", ClusterServicePlanExternalID: "bar-def456"}},
+		{"plan: cluster-name", "%b", `{PlanName:"k8s-bar456"}`, PlanReference{
+			ClusterServiceClassName: "k8s-foo1232", ClusterServicePlanName: "k8s-bar456"}},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fmt.Sprintf(tc.format, tc.planRef)
+			if tc.want != got {
+				t.Fatalf("\nwant:\t%#v\ngot:\t%#v", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/apis/servicecatalog/v1beta1/plan_reference_test.go
+++ b/pkg/apis/servicecatalog/v1beta1/plan_reference_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1beta1
 
 import (

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -630,7 +630,7 @@ type ServiceInstance struct {
 //  - ClusterServiceClassName and ClusterServicePlanName
 //
 // For any of these ways, if a ClusterServiceClass only has one plan
-// then leaving the *ServicePlanName is optional.
+// then the corresponding service plan field is optional.
 type PlanReference struct {
 	// ClusterServiceClassExternalName is the human-readable name of the
 	// service as reported by the broker. Note that if the broker changes

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -626,9 +626,10 @@ type ServiceInstance struct {
 //
 // Currently supported ways:
 //  - ClusterServiceClassExternalName and ClusterServicePlanExternalName
+//  - ClusterServiceClassExternalID and ClusterServicePlanExternalID
 //  - ClusterServiceClassName and ClusterServicePlanName
 //
-// For both of these ways, if a ClusterServiceClass only has one plan
+// For any of these ways, if a ClusterServiceClass only has one plan
 // then leaving the *ServicePlanName is optional.
 type PlanReference struct {
 	// ClusterServiceClassExternalName is the human-readable name of the
@@ -645,6 +646,14 @@ type PlanReference struct {
 	// the current name of the ClusterServicePlan, you should follow the
 	// ClusterServicePlanRef below.
 	ClusterServicePlanExternalName string `json:"clusterServicePlanExternalName,omitempty"`
+
+	// ClusterServiceClassExternalID is the broker's external id for the class.
+	//
+	// Immutable.
+	ClusterServiceClassExternalID string `json:"clusterServiceClassExternalID,omitempty"`
+
+	// ClusterServicePlanExternalID is the broker's external id for the plan.
+	ClusterServicePlanExternalID string `json:"clusterServicePlanExternalID,omitempty"`
 
 	// ClusterServiceClassName is the kubernetes name of the
 	// ClusterServiceClass.

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
@@ -750,6 +750,8 @@ func Convert_servicecatalog_ParametersFromSource_To_v1beta1_ParametersFromSource
 func autoConvert_v1beta1_PlanReference_To_servicecatalog_PlanReference(in *PlanReference, out *servicecatalog.PlanReference, s conversion.Scope) error {
 	out.ClusterServiceClassExternalName = in.ClusterServiceClassExternalName
 	out.ClusterServicePlanExternalName = in.ClusterServicePlanExternalName
+	out.ClusterServiceClassExternalID = in.ClusterServiceClassExternalID
+	out.ClusterServicePlanExternalID = in.ClusterServicePlanExternalID
 	out.ClusterServiceClassName = in.ClusterServiceClassName
 	out.ClusterServicePlanName = in.ClusterServicePlanName
 	return nil
@@ -763,6 +765,8 @@ func Convert_v1beta1_PlanReference_To_servicecatalog_PlanReference(in *PlanRefer
 func autoConvert_servicecatalog_PlanReference_To_v1beta1_PlanReference(in *servicecatalog.PlanReference, out *PlanReference, s conversion.Scope) error {
 	out.ClusterServiceClassExternalName = in.ClusterServiceClassExternalName
 	out.ClusterServicePlanExternalName = in.ClusterServicePlanExternalName
+	out.ClusterServiceClassExternalID = in.ClusterServiceClassExternalID
+	out.ClusterServicePlanExternalID = in.ClusterServicePlanExternalID
 	out.ClusterServiceClassName = in.ClusterServiceClassName
 	out.ClusterServicePlanName = in.ClusterServicePlanName
 	return nil

--- a/pkg/apis/servicecatalog/validation/instance.go
+++ b/pkg/apis/servicecatalog/validation/instance.go
@@ -360,7 +360,7 @@ func validatePlanReference(p *sc.PlanReference, fldPath *field.Path) field.Error
 		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServiceClassExternalID"), classSetErrMsg))
 		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServiceClassName"), classSetErrMsg))
 	}
-	// Must specify exactly one source of the class: external id, external name, k8s name.
+	// Must specify exactly one source of the plan: external id, external name, k8s name.
 	if (b2i(externalPlanNameSet) + b2i(externalPlanIDSet) + b2i(k8sPlanSet)) != 1 {
 		planSetErrMsg := "exactly one of clusterServicePlanExternalName, clusterServicePlanExternalID, or clusterServicePlanName required"
 		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServicePlanExternalName"), planSetErrMsg))

--- a/pkg/apis/servicecatalog/validation/instance.go
+++ b/pkg/apis/servicecatalog/validation/instance.go
@@ -261,8 +261,11 @@ func internalValidateServiceInstanceUpdateAllowed(new *sc.ServiceInstance, old *
 	if old.Generation != new.Generation && old.Status.CurrentOperation != "" {
 		errors = append(errors, field.Forbidden(field.NewPath("spec"), "Another update for this service instance is in progress"))
 	}
-	if old.Spec.ClusterServicePlanExternalName != new.Spec.ClusterServicePlanExternalName && new.Spec.ClusterServicePlanRef != nil {
-		errors = append(errors, field.Forbidden(field.NewPath("spec").Child("clusterServicePlanRef"), "clusterServicePlanRef must not be present when clusterServicePlanExternalName is being changed"))
+	planUpdated := old.Spec.ClusterServicePlanExternalName != new.Spec.ClusterServicePlanExternalName
+	planUpdated = planUpdated || old.Spec.ClusterServicePlanExternalID != new.Spec.ClusterServicePlanExternalID
+	planUpdated = planUpdated || old.Spec.ClusterServicePlanName != new.Spec.ClusterServicePlanName
+	if planUpdated && new.Spec.ClusterServicePlanRef != nil {
+		errors = append(errors, field.Forbidden(field.NewPath("spec").Child("clusterServicePlanRef"), "clusterServicePlanRef must not be present when the plan is being changed"))
 	}
 	return errors
 }
@@ -277,7 +280,6 @@ func ValidateServiceInstanceUpdate(new *sc.ServiceInstance, old *sc.ServiceInsta
 	allErrs = append(allErrs, internalValidateServiceInstanceUpdateAllowed(new, old)...)
 	allErrs = append(allErrs, internalValidateServiceInstance(new, false)...)
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Spec.ClusterServiceClassExternalName, old.Spec.ClusterServiceClassExternalName, specFieldPath.Child("clusterServiceClassExternalName"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Spec.ExternalID, old.Spec.ExternalID, specFieldPath.Child("externalID"))...)
 
 	if new.Spec.UpdateRequests < old.Spec.UpdateRequests {
@@ -335,35 +337,63 @@ func ValidateServiceInstanceReferencesUpdate(new *sc.ServiceInstance, old *sc.Se
 func validatePlanReference(p *sc.PlanReference, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	// helper function to test that exactly one set of plan references are set
+	b2i := func(b bool) int8 {
+		if b {
+			return 1
+		}
+		return 0
+	}
+
 	// Just to make reading of the conditionals in the code easier.
-	externalClassSet := p.ClusterServiceClassExternalName != ""
-	externalPlanSet := p.ClusterServicePlanExternalName != ""
+	externalClassNameSet := p.ClusterServiceClassExternalName != ""
+	externalPlanNameSet := p.ClusterServicePlanExternalName != ""
+	externalClassIDSet := p.ClusterServiceClassExternalID != ""
+	externalPlanIDSet := p.ClusterServicePlanExternalID != ""
 	k8sClassSet := p.ClusterServiceClassName != ""
 	k8sPlanSet := p.ClusterServicePlanName != ""
 
-	// Can't specify both External and k8s name but must specify one.
-	if externalClassSet == k8sClassSet {
-		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServiceClassExternalName"), "exactly one of clusterServiceClassExternalName or clusterServiceClassName required"))
-		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServiceClassName"), "exactly one of clusterServiceClassExternalName or clusterServiceClassName required"))
+	// Must specify exactly one source of the class: external id, external name, k8s name.
+	if (b2i(externalClassNameSet) + b2i(externalClassIDSet) + b2i(k8sClassSet)) != 1 {
+		classSetErrMsg := "exactly one of clusterServiceClassExternalName, clusterServiceClassExternalID, or clusterServiceClassName required"
+		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServiceClassExternalName"), classSetErrMsg))
+		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServiceClassExternalID"), classSetErrMsg))
+		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServiceClassName"), classSetErrMsg))
 	}
-	// Can't specify both External and k8s name but must specify one.
-	if externalPlanSet == k8sPlanSet {
-		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServicePlanExternalName"), "exactly one of clusterServicePlanExternalName or clusterServicePlanName required"))
-		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServicePlanName"), "exactly one of clusterServicePlanExternalName or clusterServicePlanName required"))
+	// Must specify exactly one source of the class: external id, external name, k8s name.
+	if (b2i(externalPlanNameSet) + b2i(externalPlanIDSet) + b2i(k8sPlanSet)) != 1 {
+		planSetErrMsg := "exactly one of clusterServicePlanExternalName, clusterServicePlanExternalID, or clusterServicePlanName required"
+		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServicePlanExternalName"), planSetErrMsg))
+		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServicePlanExternalID"), planSetErrMsg))
+		allErrs = append(allErrs, field.Required(fldPath.Child("clusterServicePlanName"), planSetErrMsg))
 	}
 
-	if externalClassSet {
+	if externalClassNameSet {
 		for _, msg := range validateCommonServiceClassName(p.ClusterServiceClassExternalName, false /* prefix */) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("clusterServiceClassExternalName"), p.ClusterServiceClassExternalName, msg))
 		}
 
 		// If ClusterServiceClassExternalName given, must use ClusterServicePlanExternalName
-		if !externalPlanSet {
+		if !externalPlanNameSet {
 			allErrs = append(allErrs, field.Required(fldPath.Child("clusterServicePlanExternalName"), "must specify clusterServicePlanExternalName with clusterServiceClassExternalName"))
 		}
 
 		for _, msg := range validateCommonServicePlanName(p.ClusterServicePlanExternalName, false /* prefix */) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("clusterServicePlanExternalName"), p.ClusterServicePlanName, msg))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("clusterServicePlanExternalName"), p.ClusterServicePlanExternalName, msg))
+		}
+	}
+	if externalClassIDSet {
+		for _, msg := range validateExternalID(p.ClusterServiceClassExternalID) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("clusterServiceClassExternalID"), p.ClusterServiceClassExternalID, msg))
+		}
+
+		// If ClusterServiceClassExternalID given, must use ClusterServicePlanExternalID
+		if !externalPlanIDSet {
+			allErrs = append(allErrs, field.Required(fldPath.Child("clusterServicePlanExternalID"), "must specify clusterServicePlanExternalID with clusterServiceClassExternalID"))
+		}
+
+		for _, msg := range validateExternalID(p.ClusterServicePlanExternalID) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("clusterServicePlanExternalID"), p.ClusterServicePlanExternalID, msg))
 		}
 	}
 	if k8sClassSet {
@@ -387,6 +417,7 @@ func validatePlanReferenceUpdate(pOld *sc.PlanReference, pNew *sc.PlanReference,
 	allErrs = append(allErrs, validatePlanReference(pOld, fldPath)...)
 	allErrs = append(allErrs, validatePlanReference(pNew, fldPath)...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(pNew.ClusterServiceClassExternalName, pOld.ClusterServiceClassExternalName, field.NewPath("spec").Child("clusterServiceClassExternalName"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(pNew.ClusterServiceClassExternalID, pOld.ClusterServiceClassExternalID, field.NewPath("spec").Child("clusterServiceClassExternalID"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(pNew.ClusterServiceClassName, pOld.ClusterServiceClassName, field.NewPath("spec").Child("clusterServiceClassName"))...)
 	return allErrs
 }

--- a/pkg/apis/servicecatalog/validation/instance.go
+++ b/pkg/apis/servicecatalog/validation/instance.go
@@ -381,8 +381,7 @@ func validatePlanReference(p *sc.PlanReference, fldPath *field.Path) field.Error
 		for _, msg := range validateCommonServicePlanName(p.ClusterServicePlanExternalName, false /* prefix */) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("clusterServicePlanExternalName"), p.ClusterServicePlanExternalName, msg))
 		}
-	}
-	if externalClassIDSet {
+	} else if externalClassIDSet {
 		for _, msg := range validateExternalID(p.ClusterServiceClassExternalID) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("clusterServiceClassExternalID"), p.ClusterServiceClassExternalID, msg))
 		}
@@ -395,8 +394,7 @@ func validatePlanReference(p *sc.PlanReference, fldPath *field.Path) field.Error
 		for _, msg := range validateExternalID(p.ClusterServicePlanExternalID) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("clusterServicePlanExternalID"), p.ClusterServicePlanExternalID, msg))
 		}
-	}
-	if k8sClassSet {
+	} else if k8sClassSet {
 		for _, msg := range validateCommonServiceClassName(p.ClusterServiceClassName, false /* prefix */) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("clusterServiceClassName"), p.ClusterServiceClassName, msg))
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -361,8 +361,8 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBroker(instance 
 			return nil, nil, "", nil, &operationError{
 				reason: errorNonexistentClusterServicePlanReason,
 				message: fmt.Sprintf(
-					"The instance references a non-existent ClusterServicePlan (K8S: %q ExternalName: %q) on ClusterServiceClass %v",
-					instance.Spec.ClusterServicePlanName, instance.Spec.ClusterServicePlanExternalName, pretty.ClusterServiceClassName(serviceClass),
+					"The instance references a non-existent ClusterServicePlan %q - %v",
+					instance.Spec.ClusterServicePlanRef.Name, instance.Spec.PlanReference,
 				),
 			}
 		}
@@ -428,8 +428,8 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 	serviceClass, err := c.serviceClassLister.Get(instance.Spec.ClusterServiceClassRef.Name)
 	if err != nil {
 		s := fmt.Sprintf(
-			"References a non-existent ClusterServiceClass (K8S: %q ExternalName: %q)",
-			instance.Spec.ClusterServiceClassRef.Name, instance.Spec.ClusterServiceClassExternalName,
+			"References a non-existent ClusterServiceClass %q - %c",
+			instance.Spec.ClusterServiceClassRef.Name, instance.Spec.PlanReference,
 		)
 		glog.Warning(pcb.Message(s))
 		c.updateServiceBindingCondition(
@@ -446,8 +446,8 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 	servicePlan, err := c.servicePlanLister.Get(instance.Spec.ClusterServicePlanRef.Name)
 	if nil != err {
 		s := fmt.Sprintf(
-			"References a non-existent ClusterServicePlan (K8S: %q ExternalName: %q) on ClusterServiceClass (K8S: %q ExternalName: %q)",
-			instance.Spec.ClusterServicePlanName, instance.Spec.ClusterServicePlanExternalName, serviceClass.Name, serviceClass.Spec.ExternalName,
+			"References a non-existent ClusterServicePlan %q - %v",
+			instance.Spec.ClusterServicePlanRef.Name, instance.Spec.PlanReference,
 		)
 		glog.Warning(pcb.Message(s))
 		c.updateServiceBindingCondition(

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -255,8 +255,8 @@ func TestReconcileServiceBindingNonExistingClusterServiceClass(t *testing.T) {
 	assertNumEvents(t, events, 1)
 
 	expectedEvent := warningEventBuilder(errorNonexistentClusterServiceClassMessage).msgf(
-		"References a non-existent ClusterServiceClass %q - {ClassExternalName:%q}",
-		"nosuchclassid", testNonExistentClusterServiceClassName,
+		"References a non-existent ClusterServiceClass %q - %c",
+		instance.Spec.ClusterServiceClassRef.Name, instance.Spec.PlanReference,
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -255,7 +255,7 @@ func TestReconcileServiceBindingNonExistingClusterServiceClass(t *testing.T) {
 	assertNumEvents(t, events, 1)
 
 	expectedEvent := warningEventBuilder(errorNonexistentClusterServiceClassMessage).msgf(
-		"References a non-existent ClusterServiceClass (K8S: %q ExternalName: %q)",
+		"References a non-existent ClusterServiceClass %q - {ClassExternalName:%q}",
 		"nosuchclassid", testNonExistentClusterServiceClassName,
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -899,7 +899,7 @@ func (c *controller) resolveReferences(instance *v1beta1.ServiceInstance) (bool,
 func (c *controller) resolveClusterServiceClassRef(instance *v1beta1.ServiceInstance) (*v1beta1.ServiceInstance, *v1beta1.ClusterServiceClass, error) {
 	if !instance.Spec.ClassSpecified() {
 		// ServiceInstance is in invalid state, should not ever happen. check
-		return nil, nil, fmt.Errorf("ServiceInstance is in inconsistent state, neither ClusterServiceClassExternalName, ClusterServiceClassExternalID, nor ClusterServiceClassName is set: %+v", instance.Spec)
+		return nil, nil, fmt.Errorf("ServiceInstance %s/%s is in invalid state, neither ClusterServiceClassExternalName, ClusterServiceClassExternalID, nor ClusterServiceClassName is set", instance.Namespace, instance.Name)
 	}
 
 	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
@@ -980,7 +980,7 @@ func (c *controller) resolveClusterServiceClassRef(instance *v1beta1.ServiceInst
 func (c *controller) resolveClusterServicePlanRef(instance *v1beta1.ServiceInstance, brokerName string) (*v1beta1.ServiceInstance, error) {
 	if !instance.Spec.PlanSpecified() {
 		// ServiceInstance is in invalid state, should not ever happen. check
-		return nil, fmt.Errorf("ServiceInstance is in inconsistent state, neither ClusterServicePlanExternalName, ClusterServicePlanExternalID, nor ClusterServicePlanName is set: %+v", instance.Spec)
+		return nil, fmt.Errorf("ServiceInstance %s/%s is in invalid state, neither ClusterServicePlanExternalName, ClusterServicePlanExternalID, nor ClusterServicePlanName is set", instance.Namespace, instance.Name)
 	}
 
 	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -92,8 +92,8 @@ func TestReconcileServiceInstanceNonExistentClusterServiceClass(t *testing.T) {
 	events := getRecordedEvents(testController)
 
 	expectedEvent := warningEventBuilder(errorNonexistentClusterServiceClassReason).msgf(
-		"References a non-existent ClusterServiceClass {ClassExternalName:%q} or there is more than one (found: 0)",
-		"nothere",
+		"References a non-existent ClusterServiceClass %c or there is more than one (found: 0)",
+		instance.Spec.PlanReference,
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)
@@ -135,8 +135,8 @@ func TestReconcileServiceInstanceNonExistentClusterServiceClassWithK8SName(t *te
 	events := getRecordedEvents(testController)
 
 	expectedEvent := warningEventBuilder(errorNonexistentClusterServiceClassReason).msgf(
-		"References a non-existent ClusterServiceClass {ClassName:%q}",
-		"nothereclass",
+		"References a non-existent ClusterServiceClass %c",
+		instance.Spec.PlanReference,
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)
@@ -290,8 +290,8 @@ func TestReconcileServiceInstanceNonExistentClusterServicePlan(t *testing.T) {
 	events := getRecordedEvents(testController)
 
 	expectedEvent := warningEventBuilder(errorNonexistentClusterServicePlanReason).msgf(
-		`References a non-existent ClusterServicePlan {PlanExternalName:%q} on ClusterServiceClass %s {ClassExternalName:%q} or there is more than one (found: %v)`,
-		"nothere", "SCGUID", "test-serviceclass", 0,
+		`References a non-existent ClusterServicePlan %b on ClusterServiceClass %s %c or there is more than one (found: 0)`,
+		instance.Spec.PlanReference, instance.Spec.ClusterServiceClassRef.Name, instance.Spec.PlanReference,
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)
@@ -345,8 +345,8 @@ func TestReconcileServiceInstanceNonExistentClusterServicePlanK8SName(t *testing
 	events := getRecordedEvents(testController)
 
 	expectedEvent := warningEventBuilder(errorNonexistentClusterServicePlanReason).msgf(
-		"References a non-existent ClusterServicePlan {ClassName:%q, PlanName:%q}",
-		testClusterServiceClassGUID, "nothereplan",
+		"References a non-existent ClusterServicePlan %v",
+		instance.Spec.PlanReference,
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)
@@ -4219,7 +4219,9 @@ func TestResolveReferencesNoClusterServiceClass(t *testing.T) {
 
 	events := getRecordedEvents(testController)
 
-	expectedEvent := warningEventBuilder(errorNonexistentClusterServiceClassReason).msg(`References a non-existent ClusterServiceClass {ClassExternalName:"test-serviceclass"} or there is more than one (found: 0)`)
+	expectedEvent := warningEventBuilder(errorNonexistentClusterServiceClassReason).msg(
+		fmt.Sprintf(`References a non-existent ClusterServiceClass %c or there is more than one (found: 0)`,
+			instance.Spec.PlanReference))
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)
 	}
@@ -4511,8 +4513,8 @@ func TestResolveReferencesNoClusterServicePlan(t *testing.T) {
 	events := getRecordedEvents(testController)
 
 	expectedEvent := warningEventBuilder(errorNonexistentClusterServicePlanReason).msgf(
-		`References a non-existent ClusterServicePlan %v or there is more than one (found: 0)`,
-		instance.Spec.PlanReference,
+		`References a non-existent ClusterServicePlan %b on ClusterServiceClass %s %c or there is more than one (found: 0)`,
+		instance.Spec.PlanReference, instance.Spec.ClusterServiceClassRef.Name, instance.Spec.PlanReference,
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -92,8 +92,8 @@ func TestReconcileServiceInstanceNonExistentClusterServiceClass(t *testing.T) {
 	events := getRecordedEvents(testController)
 
 	expectedEvent := warningEventBuilder(errorNonexistentClusterServiceClassReason).msgf(
-		"References a non-existent ClusterServiceClass {ClassExternalName:%q} or there is more than one (found: %d)",
-		"nothere", 0,
+		"References a non-existent ClusterServiceClass {ClassExternalName:%q} or there is more than one (found: 0)",
+		"nothere",
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)
@@ -4511,8 +4511,8 @@ func TestResolveReferencesNoClusterServicePlan(t *testing.T) {
 	events := getRecordedEvents(testController)
 
 	expectedEvent := warningEventBuilder(errorNonexistentClusterServicePlanReason).msgf(
-		`References a non-existent ClusterServicePlan {PlanExternalName:%q} on ClusterServiceClass %s {ClassExternalName:%q} or there is more than one (found: %v)`,
-		"test-plan", "SCGUID", "test-serviceclass", 0,
+		`References a non-existent ClusterServicePlan %v or there is more than one (found: 0)`,
+		instance.Spec.PlanReference,
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -92,7 +92,7 @@ func TestReconcileServiceInstanceNonExistentClusterServiceClass(t *testing.T) {
 	events := getRecordedEvents(testController)
 
 	expectedEvent := warningEventBuilder(errorNonexistentClusterServiceClassReason).msgf(
-		"References a non-existent ClusterServiceClass (ExternalName: %q) or there is more than one (found: %d)",
+		"References a non-existent ClusterServiceClass {ClassExternalName:%q} or there is more than one (found: %d)",
 		"nothere", 0,
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
@@ -135,7 +135,7 @@ func TestReconcileServiceInstanceNonExistentClusterServiceClassWithK8SName(t *te
 	events := getRecordedEvents(testController)
 
 	expectedEvent := warningEventBuilder(errorNonexistentClusterServiceClassReason).msgf(
-		"References a non-existent ClusterServiceClass (K8S: %q)",
+		"References a non-existent ClusterServiceClass {ClassName:%q}",
 		"nothereclass",
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
@@ -290,8 +290,8 @@ func TestReconcileServiceInstanceNonExistentClusterServicePlan(t *testing.T) {
 	events := getRecordedEvents(testController)
 
 	expectedEvent := warningEventBuilder(errorNonexistentClusterServicePlanReason).msgf(
-		`References a non-existent ClusterServicePlan (K8S: %q ExternalName: %q) on ClusterServiceClass (K8S: %q ExternalName: %q) or there is more than one (found: %v)`,
-		"", "nothere", "SCGUID", "test-serviceclass", 0,
+		`References a non-existent ClusterServicePlan {PlanExternalName:%q} on ClusterServiceClass %s {ClassExternalName:%q} or there is more than one (found: %v)`,
+		"nothere", "SCGUID", "test-serviceclass", 0,
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)
@@ -345,8 +345,8 @@ func TestReconcileServiceInstanceNonExistentClusterServicePlanK8SName(t *testing
 	events := getRecordedEvents(testController)
 
 	expectedEvent := warningEventBuilder(errorNonexistentClusterServicePlanReason).msgf(
-		"References a non-existent ClusterServicePlan with K8S name %q on ClusterServiceClass with K8S name %q",
-		"nothereplan", testClusterServiceClassGUID,
+		"References a non-existent ClusterServicePlan {ClassName:%q, PlanName:%q}",
+		testClusterServiceClassGUID, "nothereplan",
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)
@@ -4219,7 +4219,7 @@ func TestResolveReferencesNoClusterServiceClass(t *testing.T) {
 
 	events := getRecordedEvents(testController)
 
-	expectedEvent := warningEventBuilder(errorNonexistentClusterServiceClassReason).msg("References a non-existent ClusterServiceClass (ExternalName: \"test-serviceclass\") or there is more than one (found: 0)")
+	expectedEvent := warningEventBuilder(errorNonexistentClusterServiceClassReason).msg(`References a non-existent ClusterServiceClass {ClassExternalName:"test-serviceclass"} or there is more than one (found: 0)`)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)
 	}
@@ -4511,8 +4511,8 @@ func TestResolveReferencesNoClusterServicePlan(t *testing.T) {
 	events := getRecordedEvents(testController)
 
 	expectedEvent := warningEventBuilder(errorNonexistentClusterServicePlanReason).msgf(
-		`References a non-existent ClusterServicePlan (K8S: %q ExternalName: %q) on ClusterServiceClass (K8S: %q ExternalName: %q) or there is more than one (found: %v)`,
-		"", "test-plan", "SCGUID", "test-serviceclass", 0,
+		`References a non-existent ClusterServicePlan {PlanExternalName:%q} on ClusterServiceClass %s {ClassExternalName:%q} or there is more than one (found: %v)`,
+		"test-plan", "SCGUID", "test-serviceclass", 0,
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1014,7 +1014,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.PlanReference": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "PlanReference defines the user specification for the desired ServicePlan and ServiceClass. Because there are multiple ways to specify the desired Class/Plan, this structure specifies the allowed ways to specify the intent.\n\nCurrently supported ways:\n - ClusterServiceClassExternalName and ClusterServicePlanExternalName\n - ClusterServiceClassExternalID and ClusterServicePlanExternalID\n - ClusterServiceClassName and ClusterServicePlanName\n\nFor any of these ways, if a ClusterServiceClass only has one plan then leaving the *ServicePlanName is optional.",
+					Description: "PlanReference defines the user specification for the desired ServicePlan and ServiceClass. Because there are multiple ways to specify the desired Class/Plan, this structure specifies the allowed ways to specify the intent.\n\nCurrently supported ways:\n - ClusterServiceClassExternalName and ClusterServicePlanExternalName\n - ClusterServiceClassExternalID and ClusterServicePlanExternalID\n - ClusterServiceClassName and ClusterServicePlanName\n\nFor any of these ways, if a ClusterServiceClass only has one plan then the corresponding service plan field is optional.",
 					Properties: map[string]spec.Schema{
 						"clusterServiceClassExternalName": {
 							SchemaProps: spec.SchemaProps{

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1014,7 +1014,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.PlanReference": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "PlanReference defines the user specification for the desired ServicePlan and ServiceClass. Because there are multiple ways to specify the desired Class/Plan, this structure specifies the allowed ways to specify the intent.\n\nCurrently supported ways:\n - ClusterServiceClassExternalName and ClusterServicePlanExternalName\n - ClusterServiceClassName and ClusterServicePlanName\n\nFor both of these ways, if a ClusterServiceClass only has one plan then leaving the *ServicePlanName is optional.",
+					Description: "PlanReference defines the user specification for the desired ServicePlan and ServiceClass. Because there are multiple ways to specify the desired Class/Plan, this structure specifies the allowed ways to specify the intent.\n\nCurrently supported ways:\n - ClusterServiceClassExternalName and ClusterServicePlanExternalName\n - ClusterServiceClassExternalID and ClusterServicePlanExternalID\n - ClusterServiceClassName and ClusterServicePlanName\n\nFor any of these ways, if a ClusterServiceClass only has one plan then leaving the *ServicePlanName is optional.",
 					Properties: map[string]spec.Schema{
 						"clusterServiceClassExternalName": {
 							SchemaProps: spec.SchemaProps{
@@ -1026,6 +1026,20 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						"clusterServicePlanExternalName": {
 							SchemaProps: spec.SchemaProps{
 								Description: "ClusterServicePlanExternalName is the human-readable name of the plan as reported by the broker. Note that if the broker changes the name of the ClusterServicePlan, it will not be reflected here, and to see the current name of the ClusterServicePlan, you should follow the ClusterServicePlanRef below.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
+						"clusterServiceClassExternalID": {
+							SchemaProps: spec.SchemaProps{
+								Description: "ClusterServiceClassExternalID is the broker's external id for the class.\n\nImmutable.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
+						"clusterServicePlanExternalID": {
+							SchemaProps: spec.SchemaProps{
+								Description: "ClusterServicePlanExternalID is the broker's external id for the plan.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
@@ -1876,6 +1890,20 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						"clusterServicePlanExternalName": {
 							SchemaProps: spec.SchemaProps{
 								Description: "ClusterServicePlanExternalName is the human-readable name of the plan as reported by the broker. Note that if the broker changes the name of the ClusterServicePlan, it will not be reflected here, and to see the current name of the ClusterServicePlan, you should follow the ClusterServicePlanRef below.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
+						"clusterServiceClassExternalID": {
+							SchemaProps: spec.SchemaProps{
+								Description: "ClusterServiceClassExternalID is the broker's external id for the class.\n\nImmutable.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
+						"clusterServicePlanExternalID": {
+							SchemaProps: spec.SchemaProps{
+								Description: "ClusterServicePlanExternalID is the broker's external id for the plan.",
 								Type:        []string{"string"},
 								Format:      "",
 							},

--- a/pkg/registry/servicecatalog/instance/strategy.go
+++ b/pkg/registry/servicecatalog/instance/strategy.go
@@ -156,8 +156,10 @@ func (instanceRESTStrategy) PrepareForUpdate(ctx genericapirequest.Context, new,
 	newServiceInstance.Spec.ClusterServicePlanRef = oldServiceInstance.Spec.ClusterServicePlanRef
 
 	// Clear out the ClusterServicePlanRef so that it is resolved during reconciliation
-	if newServiceInstance.Spec.ClusterServicePlanExternalName != oldServiceInstance.Spec.ClusterServicePlanExternalName ||
-		newServiceInstance.Spec.ClusterServicePlanName != oldServiceInstance.Spec.ClusterServicePlanName {
+	planUpdated := newServiceInstance.Spec.ClusterServicePlanExternalName != oldServiceInstance.Spec.ClusterServicePlanExternalName ||
+		newServiceInstance.Spec.ClusterServicePlanExternalID != oldServiceInstance.Spec.ClusterServicePlanExternalID ||
+		newServiceInstance.Spec.ClusterServicePlanName != oldServiceInstance.Spec.ClusterServicePlanName
+	if planUpdated {
 		newServiceInstance.Spec.ClusterServicePlanRef = nil
 	}
 

--- a/pkg/registry/servicecatalog/instance/strategy_test.go
+++ b/pkg/registry/servicecatalog/instance/strategy_test.go
@@ -93,32 +93,53 @@ func TestInstanceUpdate(t *testing.T) {
 			shouldGenerationIncrement: true,
 		},
 		{
-			name:  "plan change",
+			name:  "external plan name change",
 			older: getTestInstance(),
 			newer: func() *servicecatalog.ServiceInstance {
 				i := getTestInstance()
-				i.Spec.ClusterServicePlanExternalName = "new-test-plan"
+				i.Spec.ClusterServicePlanExternalName = "new-plan"
 				return i
 			}(),
 			shouldGenerationIncrement: true,
 			shouldPlanRefClear:        true,
 		},
 		{
-			name: "plan change using k8s name",
+			name: "external plan id change",
 			older: func() *servicecatalog.ServiceInstance {
 				i := getTestInstance()
 				i.Spec.ClusterServiceClassExternalName = ""
 				i.Spec.ClusterServicePlanExternalName = ""
-				i.Spec.ClusterServiceClassName = "class-name"
-				i.Spec.ClusterServicePlanName = "old-plan-name"
+				i.Spec.ClusterServiceClassExternalID = "test-serviceclass"
+				i.Spec.ClusterServicePlanExternalID = "test-plan"
 				return i
 			}(),
 			newer: func() *servicecatalog.ServiceInstance {
 				i := getTestInstance()
 				i.Spec.ClusterServiceClassExternalName = ""
 				i.Spec.ClusterServicePlanExternalName = ""
-				i.Spec.ClusterServiceClassName = "class-name"
-				i.Spec.ClusterServicePlanName = "new-plan-name"
+				i.Spec.ClusterServiceClassExternalID = "test-serviceclass"
+				i.Spec.ClusterServicePlanExternalID = "new plan"
+				return i
+			}(),
+			shouldGenerationIncrement: true,
+			shouldPlanRefClear:        true,
+		},
+		{
+			name: "k8s plan change",
+			older: func() *servicecatalog.ServiceInstance {
+				i := getTestInstance()
+				i.Spec.ClusterServiceClassExternalName = ""
+				i.Spec.ClusterServicePlanExternalName = ""
+				i.Spec.ClusterServiceClassName = "test-serviceclass"
+				i.Spec.ClusterServicePlanName = "test-plan"
+				return i
+			}(),
+			newer: func() *servicecatalog.ServiceInstance {
+				i := getTestInstance()
+				i.Spec.ClusterServiceClassExternalName = ""
+				i.Spec.ClusterServicePlanExternalName = ""
+				i.Spec.ClusterServiceClassName = "test-serviceclass"
+				i.Spec.ClusterServicePlanName = "new plan"
 				return i
 			}(),
 			shouldGenerationIncrement: true,

--- a/plugin/pkg/admission/serviceplan/changevalidator/admission.go
+++ b/plugin/pkg/admission/serviceplan/changevalidator/admission.go
@@ -90,10 +90,7 @@ func (d *denyPlanChangeIfNotUpdatable) Admit(a admission.Attributes) error {
 		return nil
 	}
 
-	planSet := instance.Spec.ClusterServicePlanExternalName != "" ||
-		instance.Spec.ClusterServicePlanExternalID != "" ||
-		instance.Spec.ClusterServicePlanName != ""
-	if planSet {
+	if instance.Spec.GetSpecifiedPlan() != "" {
 		lister := d.instanceLister.ServiceInstances(instance.Namespace)
 		origInstance, err := lister.Get(instance.Name)
 		if err != nil {

--- a/plugin/pkg/admission/serviceplan/changevalidator/admission.go
+++ b/plugin/pkg/admission/serviceplan/changevalidator/admission.go
@@ -79,7 +79,7 @@ func (d *denyPlanChangeIfNotUpdatable) Admit(a admission.Attributes) error {
 	sc, err := d.scLister.Get(instance.Spec.ClusterServiceClassRef.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			glog.V(5).Infof("Could not locate service class %v, can not determine if UpdateablePlan.", instance.Spec.ClusterServiceClassExternalName)
+			glog.V(5).Infof("Could not locate service class %v, can not determine if UpdateablePlan.", instance.Spec.ClusterServiceClassRef.Name)
 			return nil // should this be `return err`? why would we allow the instance in if we cannot determine it is updatable?
 		}
 		glog.Error(err)
@@ -90,15 +90,33 @@ func (d *denyPlanChangeIfNotUpdatable) Admit(a admission.Attributes) error {
 		return nil
 	}
 
-	if instance.Spec.ClusterServicePlanExternalName != "" {
+	planSet := instance.Spec.ClusterServicePlanExternalName != "" ||
+		instance.Spec.ClusterServicePlanExternalID != "" ||
+		instance.Spec.ClusterServicePlanName != ""
+	if planSet {
 		lister := d.instanceLister.ServiceInstances(instance.Namespace)
 		origInstance, err := lister.Get(instance.Name)
 		if err != nil {
 			glog.Errorf("Error locating instance %v/%v", instance.Namespace, instance.Name)
 			return err
 		}
-		if instance.Spec.ClusterServicePlanExternalName != origInstance.Spec.ClusterServicePlanExternalName {
-			glog.V(4).Infof("update Service Instance %v/%v request specified Plan Name %v while original instance had %v", instance.Namespace, instance.Name, instance.Spec.ClusterServicePlanExternalName, origInstance.Spec.ClusterServicePlanExternalName)
+
+		externalPlanNameUpdated := instance.Spec.ClusterServicePlanExternalName != origInstance.Spec.ClusterServicePlanExternalName
+		externalPlanIDUpdated := instance.Spec.ClusterServicePlanExternalID != origInstance.Spec.ClusterServicePlanExternalID
+		k8sPlanUpdated := instance.Spec.ClusterServicePlanName != origInstance.Spec.ClusterServicePlanName
+		if externalPlanNameUpdated || externalPlanIDUpdated || k8sPlanUpdated {
+			var oldPlan, newPlan string
+			if externalPlanNameUpdated {
+				oldPlan = origInstance.Spec.ClusterServicePlanExternalName
+				newPlan = instance.Spec.ClusterServicePlanExternalName
+			} else if externalPlanIDUpdated {
+				oldPlan = origInstance.Spec.ClusterServicePlanExternalID
+				newPlan = instance.Spec.ClusterServicePlanExternalID
+			} else {
+				oldPlan = origInstance.Spec.ClusterServicePlanName
+				newPlan = instance.Spec.ClusterServicePlanName
+			}
+			glog.V(4).Infof("update Service Instance %v/%v request specified Plan %v while original instance had %v", instance.Namespace, instance.Name, newPlan, oldPlan)
 			msg := fmt.Sprintf("The Service Class %v does not allow plan changes.", sc.Name)
 			glog.Error(msg)
 			return admission.NewForbidden(a, errors.New(msg))

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -44,7 +44,9 @@ func TestCreateServiceInstanceNonExistentClusterServiceClassOrPlan(t *testing.T)
 	cases := []struct {
 		name                string
 		classExternalName   string
+		classExternalID     string
 		planExternalName    string
+		planExternalID      string
 		classK8sName        string
 		planK8sName         string
 		expectedErrorReason string
@@ -71,6 +73,30 @@ func TestCreateServiceInstanceNonExistentClusterServiceClassOrPlan(t *testing.T)
 			name:                "non-existent external class and plan name",
 			classExternalName:   "nothereclass",
 			planExternalName:    "nothereplan",
+			expectedErrorReason: "ReferencesNonexistentServiceClass",
+		},
+		{
+			name:                "existent external class and plan id",
+			classExternalID:     testClassExternalID,
+			planExternalID:      testPlanExternalID,
+			expectedErrorReason: "",
+		},
+		{
+			name:                "non-existent external class id",
+			classExternalID:     "nothereclass",
+			planExternalID:      testPlanExternalID,
+			expectedErrorReason: "ReferencesNonexistentServiceClass",
+		},
+		{
+			name:                "non-existent external plan id",
+			classExternalID:     testClassExternalID,
+			planExternalID:      "nothereplan",
+			expectedErrorReason: "ReferencesNonexistentServicePlan",
+		},
+		{
+			name:                "non-existent external class and plan id",
+			classExternalID:     "nothereclass",
+			planExternalID:      "nothereplan",
 			expectedErrorReason: "ReferencesNonexistentServiceClass",
 		},
 		{
@@ -108,6 +134,8 @@ func TestCreateServiceInstanceNonExistentClusterServiceClassOrPlan(t *testing.T)
 					i := getTestInstance()
 					i.Spec.PlanReference.ClusterServiceClassExternalName = tc.classExternalName
 					i.Spec.PlanReference.ClusterServicePlanExternalName = tc.planExternalName
+					i.Spec.PlanReference.ClusterServiceClassExternalID = tc.classExternalID
+					i.Spec.PlanReference.ClusterServicePlanExternalID = tc.planExternalID
 					i.Spec.PlanReference.ClusterServiceClassName = tc.classK8sName
 					i.Spec.PlanReference.ClusterServicePlanName = tc.planK8sName
 					return i

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -61,6 +61,7 @@ const (
 	testClusterServicePlanName            = "test-plan"
 	testNonbindableClusterServicePlanName = "test-nb-plan"
 	testInstanceLastOperation             = "InstanceLastOperation"
+	testClassExternalID                   = "12345"
 	testPlanExternalID                    = "34567"
 	testNonbindablePlanExternalID         = "nb34567"
 	testInstanceName                      = "test-instance"
@@ -1003,7 +1004,7 @@ func getTestCatalogResponse() *osb.CatalogResponse {
 		Services: []osb.Service{
 			{
 				Name:        testClusterServiceClassName,
-				ID:          "12345",
+				ID:          testClassExternalID,
 				Description: "a test service",
 				Bindable:    true,
 				Plans: []osb.Plan{


### PR DESCRIPTION
Closes #1286.

In addition to provisioning by external id, I consolidated logic for interacting with `PlanReference`:

* Add functions to the `PlanReference` type instead of requiring everyone who
works with `PlanReference` to know of the various ways a class/plan could
be specified.
* Implement `fmt.Formatter` so that we can consistently format messages
about the plan. Many of the log messages assumed that a certain field,
like `ClusterServicePlanExternalName` would be set when now there are
multiple fields.

Formatting options for `PlanReference`
* `%c` - Print specified class fields only
  Examples:
    {ClassExternalName:"foo"}
    {ClassExternalID:"foo123"}
    {ClassName:"k8s-foo123"}
* `%b` - Print specified plan fields only
  NOTE: `%p` is a reserved verb so we can't use it, and go vet fails for non-standard verbs
  Examples:
    {PlanExternalName:"bar"}
    {PlanExternalID:"bar456"}
    {PlanName:"k8s-bar456"}
* `%s` - Print a short form of the plan and class
  Examples:
    foo/bar
    foo123/bar456
    k8s-foo123/k8s-bar456
* `%v` - Print all specified fields
  Examples:
    {ClassExternalName:"foo", PlanExternalName:"bar"}
    {ClassExternalID:"foo123", PlanExternalID:"bar456"}
    {ClassName:"k8s-foo123", PlanName:"k8s-bar456"}