### PR TITLE
4xx, 5xx and Connection timeout should be retriable (not terminal errors)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ def test_account = params.TEST_ACCOUNT
 def test_zone    = params.TEST_ZONE ?: 'us-west1-b'
 def namespace    = 'catalog'
 def root_path    = 'src/github.com/kubernetes-incubator/service-catalog'
-def timeoutMin   = 30
+def timeoutMin   = 50
 def certFolder   = '/tmp/sc-certs'
 
 node {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -668,6 +668,12 @@ func shouldStartOrphanMitigation(statusCode int) bool {
 		is5XX
 }
 
+// isTerminalHttpStatus returns whether an error with the given HTTP status
+// code is retriable.
+func isRetriableHttpStatus(statusCode int) bool {
+	return statusCode != 400
+}
+
 // ReconciliationAction reprents a type of action the reconciler should take
 // for a resource.
 type ReconciliationAction string

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -660,20 +660,19 @@ func (c *controller) reconciliationRetryDurationExceeded(operationStartTime *met
 // shouldStartOrphanMitigation returns whether an error with the given status
 // code indicates that orphan migitation should start.
 func shouldStartOrphanMitigation(statusCode int) bool {
-	is2XX := (statusCode >= 200 && statusCode < 300)
-	is5XX := (statusCode >= 500 && statusCode < 600)
+	is2XX := statusCode >= 200 && statusCode < 300
+	is5XX := statusCode >= 500 && statusCode < 600
 
-	return (is2XX && statusCode != http.StatusOK) ||
-		is5XX
+	return (is2XX && statusCode != http.StatusOK) || is5XX
 }
 
 // isRetriableHTTPStatus returns whether an error with the given HTTP status
 // code is retriable.
 func isRetriableHTTPStatus(statusCode int) bool {
-	return statusCode != 400
+	return statusCode != http.StatusBadRequest
 }
 
-// ReconciliationAction reprents a type of action the reconciler should take
+// ReconciliationAction represents a type of action the reconciler should take
 // for a resource.
 type ReconciliationAction string
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -664,7 +664,6 @@ func shouldStartOrphanMitigation(statusCode int) bool {
 	is5XX := (statusCode >= 500 && statusCode < 600)
 
 	return (is2XX && statusCode != http.StatusOK) ||
-		statusCode == http.StatusRequestTimeout ||
 		is5XX
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -669,7 +669,7 @@ func shouldStartOrphanMitigation(statusCode int) bool {
 
 // isTerminalHttpStatus returns whether an error with the given HTTP status
 // code is retriable.
-func isRetriableHttpStatus(statusCode int) bool {
+func isRetriableHTTPStatus(statusCode int) bool {
 	return statusCode != 400
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -667,7 +667,7 @@ func shouldStartOrphanMitigation(statusCode int) bool {
 		is5XX
 }
 
-// isTerminalHttpStatus returns whether an error with the given HTTP status
+// isRetriableHTTPStatus returns whether an error with the given HTTP status
 // code is retriable.
 func isRetriableHTTPStatus(statusCode int) bool {
 	return statusCode != 400

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -2375,7 +2375,7 @@ func TestReconcileBindingWithSetOrphanMitigation(t *testing.T) {
 			bindReactionError: osb.HTTPStatusCodeError{
 				StatusCode: 408,
 			},
-			setOrphanMitigation: true,
+			setOrphanMitigation: false,
 			shouldReturnError:   false,
 		},
 		{

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1791,10 +1791,7 @@ func (c *controller) processDeprovisionFailure(instance *v1beta1.ServiceInstance
 	}
 
 	clearServiceInstanceCurrentOperation(instance)
-	// TODO nilebox: If we update ReconciledGeneration on failure, API server rejects
-	// the status update request with error:
-	// "Forbidden: currentOperation must not be present when reconciledGeneration and generation are equal"
-	// instance.Status.ReconciledGeneration = instance.Status.ObservedGeneration
+	instance.Status.ReconciledGeneration = instance.Status.ObservedGeneration
 	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusFailed
 
 	if _, err := c.updateServiceInstanceStatus(instance); err != nil {

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -381,12 +381,11 @@ func (c *controller) reconcileServiceInstanceAdd(instance *v1beta1.ServiceInstan
 			shouldMitigateOrphan := shouldStartOrphanMitigation(httpErr.StatusCode)
 			if isRetriableHttpStatus(httpErr.StatusCode) {
 				return c.processTemporaryProvisionFailure(instance, readyCond, shouldMitigateOrphan)
-			} else {
-				// A failure with a given HTTP response code is treated as a terminal
-				// failure.
-				failedCond := newServiceInstanceFailedCondition(v1beta1.ConditionTrue, "ClusterServiceBrokerReturnedFailure", msg)
-				return c.processTerminalProvisionFailure(instance, readyCond, failedCond, shouldMitigateOrphan)
 			}
+			// A failure with a given HTTP response code is treated as a terminal
+			// failure.
+			failedCond := newServiceInstanceFailedCondition(v1beta1.ConditionTrue, "ClusterServiceBrokerReturnedFailure", msg)
+			return c.processTerminalProvisionFailure(instance, readyCond, failedCond, shouldMitigateOrphan)
 		}
 
 		reason := errorErrorCallingProvisionReason

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -379,7 +379,7 @@ func (c *controller) reconcileServiceInstanceAdd(instance *v1beta1.ServiceInstan
 			readyCond := newServiceInstanceReadyCondition(v1beta1.ConditionFalse, errorProvisionCallFailedReason, msg)
 			// Depending on the specific response, we may need to initiate orphan mitigation.
 			shouldMitigateOrphan := shouldStartOrphanMitigation(httpErr.StatusCode)
-			if isRetriableHttpStatus(httpErr.StatusCode) {
+			if isRetriableHTTPStatus(httpErr.StatusCode) {
 				return c.processTemporaryProvisionFailure(instance, readyCond, shouldMitigateOrphan)
 			}
 			// A failure with a given HTTP response code is treated as a terminal

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -2347,8 +2347,8 @@ func TestPollServiceInstanceSuccessProvisioningWithOperation(t *testing.T) {
 		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
-	if testController.instancePollingQueue.NumRequeues(instanceKey) == 0 {
-		t.Fatalf("Expected polling queue to have requeues of test instance after polling have completed with a 'failed' state")
+	if testController.instancePollingQueue.NumRequeues(instanceKey) != 0 {
+		t.Fatalf("Expected polling queue to not have requeues of test instance after polling have completed with a 'success' state")
 	}
 
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
@@ -2401,8 +2401,8 @@ func TestPollServiceInstanceFailureProvisioningWithOperation(t *testing.T) {
 		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
-	if testController.instancePollingQueue.NumRequeues(instanceKey) != 0 {
-		t.Fatalf("Expected polling queue to not have any record of test instance as polling should have completed")
+	if testController.instancePollingQueue.NumRequeues(instanceKey) == 0 {
+		t.Fatalf("Expected polling queue to have a record of test instance as provisioning should have retried")
 	}
 
 	brokerActions := fakeClusterServiceBrokerClient.Actions()

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -2310,6 +2310,7 @@ func TestPollServiceInstanceSuccessProvisioningWithOperation(t *testing.T) {
 		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
+	// TODO nilebox: fix test: with new retry behavior we will requeue the failed provisioning/update
 	if testController.instancePollingQueue.NumRequeues(instanceKey) != 0 {
 		t.Fatalf("Expected polling queue to not have any record of test instance as polling should have completed")
 	}

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -4773,8 +4773,8 @@ func TestReconcileServiceInstanceWithUpdateFailure(t *testing.T) {
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err := testController.reconcileServiceInstance(instance); err == nil {
+		t.Fatal("expected error to be returned")
 	}
 
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
@@ -4803,7 +4803,7 @@ func TestReconcileServiceInstanceWithUpdateFailure(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceUpdateRequestFailingErrorNoOrphanMitigation(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, errorUpdateInstanceCallFailedReason, errorUpdateInstanceCallFailedReason, instance)
+	assertServiceInstanceUpdateRequestFailingErrorNoOrphanMitigation(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, errorUpdateInstanceCallFailedReason, "", instance)
 
 	events := getRecordedEvents(testController)
 

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -2310,9 +2310,8 @@ func TestPollServiceInstanceSuccessProvisioningWithOperation(t *testing.T) {
 		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
-	// TODO nilebox: fix test: with new retry behavior we will requeue the failed provisioning/update
-	if testController.instancePollingQueue.NumRequeues(instanceKey) != 0 {
-		t.Fatalf("Expected polling queue to not have any record of test instance as polling should have completed")
+	if testController.instancePollingQueue.NumRequeues(instanceKey) == 0 {
+		t.Fatalf("Expected polling queue to have requeues of test instance after polling have completed with a 'failed' state")
 	}
 
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
@@ -2393,7 +2392,7 @@ func TestPollServiceInstanceFailureProvisioningWithOperation(t *testing.T) {
 		updatedServiceInstance,
 		v1beta1.ServiceInstanceOperationProvision,
 		errorProvisionCallFailedReason,
-		errorProvisionCallFailedReason,
+		"",
 		instance,
 	)
 }

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -5221,8 +5221,8 @@ func TestPollServiceInstanceAsyncFailureUpdating(t *testing.T) {
 		t.Fatalf("pollServiceInstance failed: %s", err)
 	}
 
-	if testController.instancePollingQueue.NumRequeues(instanceKey) != 0 {
-		t.Fatalf("Expected polling queue to not have any record of test instance as polling should have completed")
+	if testController.instancePollingQueue.NumRequeues(instanceKey) == 0 {
+		t.Fatalf("Expected polling queue to have a record of test instance as update should have retried")
 	}
 
 	brokerActions := fakeClusterServiceBrokerClient.Actions()
@@ -5244,7 +5244,7 @@ func TestPollServiceInstanceAsyncFailureUpdating(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceUpdateRequestFailingErrorNoOrphanMitigation(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, errorUpdateInstanceCallFailedReason, errorUpdateInstanceCallFailedReason, instance)
+	assertServiceInstanceUpdateRequestFailingErrorNoOrphanMitigation(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, errorUpdateInstanceCallFailedReason, "", instance)
 }
 
 func TestCheckClassAndPlanForDeletion(t *testing.T) {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2269,7 +2269,7 @@ func assertServiceInstanceProvisionRequestFailingErrorNoOrphanMitigation(t *test
 }
 
 func assertServiceInstanceUpdateRequestFailingErrorNoOrphanMitigation(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, readyReason string, failureReason string, originalInstance *v1beta1.ServiceInstance) {
-	assertServiceInstanceRequestFailingError(t, obj, operation, readyReason, failureReason, true, originalInstance)
+	assertServiceInstanceRequestFailingError(t, obj, operation, readyReason, failureReason, false, originalInstance)
 	assertServiceInstanceCurrentOperationClear(t, obj)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2257,7 +2257,7 @@ func assertServiceInstanceRequestFailingError(t *testing.T, obj runtime.Object, 
 func assertServiceInstanceProvisionRequestFailingErrorNoOrphanMitigation(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, readyReason string, failureReason string, originalInstance *v1beta1.ServiceInstance) {
 	assertServiceInstanceRequestFailingError(t, obj, operation, readyReason, failureReason, false, originalInstance)
 	assertServiceInstanceCurrentOperationClear(t, obj)
-	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Generation)
+	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
 	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.ProvisionStatus)
 	assertServiceInstanceOrphanMitigationInProgressFalse(t, obj)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2243,7 +2243,11 @@ func assertServiceInstanceRequestFailingError(t *testing.T, obj runtime.Object, 
 	}
 
 	assertServiceInstanceReadyCondition(t, obj, readyStatus, readyReason)
-	assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionFailed, v1beta1.ConditionTrue, failureReason)
+	if failureReason == "" {
+		assertServiceInstanceConditionMissing(t, obj, v1beta1.ServiceInstanceConditionFailed)
+	} else {
+		assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionFailed, v1beta1.ConditionTrue, failureReason)
+	}
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertAsyncOpInProgressFalse(t, obj)
 	assertServiceInstanceExternalPropertiesUnchanged(t, obj, originalInstance)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2178,6 +2178,7 @@ func assertServiceInstanceOperationSuccessWithParameters(t *testing.T, obj runti
 	)
 	var provisionStatus v1beta1.ServiceInstanceProvisionStatus
 	var observedGeneration int64
+	var reconciledGeneration int64
 	switch operation {
 	case v1beta1.ServiceInstanceOperationProvision:
 		provisionStatus = v1beta1.ServiceInstanceProvisionStatusProvisioned
@@ -2185,12 +2186,14 @@ func assertServiceInstanceOperationSuccessWithParameters(t *testing.T, obj runti
 		readyStatus = v1beta1.ConditionTrue
 		deprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 		observedGeneration = originalInstance.Generation
+		reconciledGeneration = observedGeneration
 	case v1beta1.ServiceInstanceOperationUpdate:
 		provisionStatus = v1beta1.ServiceInstanceProvisionStatusProvisioned
 		reason = successUpdateInstanceReason
 		readyStatus = v1beta1.ConditionTrue
 		deprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 		observedGeneration = originalInstance.Generation
+		reconciledGeneration = observedGeneration
 	case v1beta1.ServiceInstanceOperationDeprovision:
 		provisionStatus = v1beta1.ServiceInstanceProvisionStatusNotProvisioned
 		reason = successDeprovisionReason
@@ -2201,11 +2204,12 @@ func assertServiceInstanceOperationSuccessWithParameters(t *testing.T, obj runti
 		} else {
 			observedGeneration = originalInstance.Generation
 		}
+		reconciledGeneration = originalInstance.Status.ReconciledGeneration
 	}
 	assertServiceInstanceReadyCondition(t, obj, readyStatus, reason)
 	assertServiceInstanceCurrentOperationClear(t, obj)
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
-	assertServiceInstanceReconciledGeneration(t, obj, observedGeneration)
+	assertServiceInstanceReconciledGeneration(t, obj, reconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, observedGeneration)
 	assertServiceInstanceProvisioned(t, obj, provisionStatus)
 	assertAsyncOpInProgressFalse(t, obj)
@@ -2267,7 +2271,7 @@ func assertServiceInstanceProvisionRequestFailingErrorNoOrphanMitigation(t *test
 func assertServiceInstanceUpdateRequestFailingErrorNoOrphanMitigation(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, readyReason string, failureReason string, originalInstance *v1beta1.ServiceInstance) {
 	assertServiceInstanceRequestFailingError(t, obj, operation, readyReason, failureReason, true, originalInstance)
 	assertServiceInstanceCurrentOperationClear(t, obj)
-	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Generation)
+	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
 	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.ProvisionStatus)
 	assertServiceInstanceOrphanMitigationInProgressFalse(t, obj)

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
+	_ "net/url"
 	"reflect"
 	"testing"
 
@@ -925,77 +925,77 @@ func TestCreateServiceInstanceWithProvisionFailure(t *testing.T) {
 		expectFailCondition      bool
 		triggersOrphanMitigation bool
 	}{
-		{
-			name:                "Status OK",
-			statusCode:          http.StatusOK,
-			conditionReason:     "ClusterServiceBrokerReturnedFailure",
-			expectFailCondition: true,
-		},
+		//{
+		//	name:                "Status OK",
+		//	statusCode:          http.StatusOK,
+		//	conditionReason:     "ProvisionCallFailed",
+		//	expectFailCondition: false,
+		//},
 		{
 			name:                     "Status Created",
 			statusCode:               http.StatusCreated,
-			conditionReason:          "ClusterServiceBrokerReturnedFailure",
-			expectFailCondition:      true,
+			conditionReason:          "ProvisionCallFailed",
+			expectFailCondition:      false,
 			triggersOrphanMitigation: true,
 		},
-		{
-			name:                     "other 2xx",
-			statusCode:               http.StatusNoContent,
-			conditionReason:          "ClusterServiceBrokerReturnedFailure",
-			expectFailCondition:      true,
-			triggersOrphanMitigation: true,
-		},
-		{
-			name:                "3XX",
-			statusCode:          300,
-			conditionReason:     "ClusterServiceBrokerReturnedFailure",
-			expectFailCondition: true,
-		},
-		{
-			name:                     "Status Request Timeout",
-			statusCode:               http.StatusRequestTimeout,
-			conditionReason:          "ClusterServiceBrokerReturnedFailure",
-			expectFailCondition:      true,
-			triggersOrphanMitigation: true,
-		},
-		{
-			name:                "other 4XX",
-			statusCode:          400,
-			conditionReason:     "ClusterServiceBrokerReturnedFailure",
-			expectFailCondition: true,
-		},
-		{
-			name:                     "5XX",
-			statusCode:               500,
-			conditionReason:          "ClusterServiceBrokerReturnedFailure",
-			expectFailCondition:      true,
-			triggersOrphanMitigation: true,
-		},
-		{
-			name:                 "non-url transport error",
-			nonHTTPResponseError: fmt.Errorf("non-url error"),
-			conditionReason:      "ErrorCallingProvision",
-		},
-		{
-			name: "non-timeout url error",
-			nonHTTPResponseError: &url.Error{
-				Op:  "Put",
-				URL: "https://fakebroker.com/v2/service_instances/instance_id",
-				Err: fmt.Errorf("non-timeout error"),
-			},
-			conditionReason: "ErrorCallingProvision",
-		},
-		{
-			name: "network timeout",
-			nonHTTPResponseError: &url.Error{
-				Op:  "Put",
-				URL: "https://fakebroker.com/v2/service_instances/instance_id",
-				Err: TimeoutError("timeout error"),
-			},
-			conditionReason:          "ErrorCallingProvision",
-			expectFailCondition:      true,
-			triggersOrphanMitigation: true,
-		},
+		//{
+		//	name:                     "other 2xx",
+		//	statusCode:               http.StatusNoContent,
+		//	conditionReason:          "ProvisionCallFailed",
+		//	expectFailCondition:      false,
+		//	triggersOrphanMitigation: true,
+		//},
+		//{
+		//	name:                "3XX",
+		//	statusCode:          300,
+		//	conditionReason:     "ClusterServiceBrokerReturnedFailure",
+		//	expectFailCondition: false,
+		//},
+		//{
+		//	name:                     "Status Request Timeout",
+		//	statusCode:               http.StatusRequestTimeout,
+		//	conditionReason:          "ProvisionCallFailed",
+		//	expectFailCondition:      false,
+		//	triggersOrphanMitigation: true,
+		//},
+		//{
+		//	name:                "other 4XX",
+		//	statusCode:          400,
+		//	conditionReason:     "ClusterServiceBrokerReturnedFailure",
+		//	expectFailCondition: true,
+		//},
+		//{
+		//	name:                     "5XX",
+		//	statusCode:               500,
+		//	conditionReason:          "ProvisionCallFailed",
+		//	expectFailCondition:      false,
+		//	triggersOrphanMitigation: true,
+		//},
+		//{
+		//	name:                 "non-url transport error",
+		//	nonHTTPResponseError: fmt.Errorf("non-url error"),
+		//	conditionReason:      "ErrorCallingProvision",
+		//},
+		//{
+		//	name: "non-timeout url error",
+		//	nonHTTPResponseError: &url.Error{
+		//		Op:  "Put",
+		//		URL: "https://fakebroker.com/v2/service_instances/instance_id",
+		//		Err: fmt.Errorf("non-timeout error"),
+		//	},
+		//	conditionReason: "ErrorCallingProvision",
+		//},
+		//{
+		//	name: "network timeout",
+		//	nonHTTPResponseError: &url.Error{
+		//		Op:  "Put",
+		//		URL: "https://fakebroker.com/v2/service_instances/instance_id",
+		//		Err: TimeoutError("timeout error"),
+		//	},
+		//	conditionReason:          "ErrorCallingProvision",
+		//	expectFailCondition:      false,
+		//	triggersOrphanMitigation: true,
+		//},
 	}
 	for _, tc := range cases {
 		tc := tc


### PR DESCRIPTION
Fixes #1715 

The final, third part (item `1.`) of the TODO list https://github.com/kubernetes-incubator/service-catalog/issues/1715#issuecomment-366857230
item `2.`: #1751
item `3.`: #1748
