### PR TITLE
Bump dependency on go-open-service-broker-client to 0.0.3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -539,8 +539,8 @@
     "v2",
     "v2/fake"
   ]
-  revision = "4c53612134f3e9dc633016a9dfe556fe915119d7"
-  version = "0.0.1"
+  revision = "b110ebaf119c4fcf81675ff01d62919d31819fd8"
+  version = "0.0.3"
 
 [[projects]]
   name = "github.com/prometheus/client_golang"
@@ -1177,6 +1177,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "39ba6909fde80c5c33b4e6ba5fac95a20d6bf2b1351e931af01edbaf0a6f17f7"
+  inputs-digest = "110b9a84e7579bd4d2e0730573fdc0cd9e7f6f56041f1e8f83fa679a461eb0bd"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,7 +71,7 @@ required = [
 
 [[constraint]]
   name = "github.com/pmorie/go-open-service-broker-client"
-  version = "~0.0.1"
+  version = "0.0.3"
 
 [prune]
   non-go = true

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/bind.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/bind.go
@@ -47,7 +47,7 @@ func (c *client) Bind(r *BindRequest) (*BindResponse, error) {
 
 	params := map[string]string{}
 	if r.AcceptsIncomplete {
-		params[asyncQueryParamKey] = "true"
+		params[AcceptsIncomplete] = "true"
 	}
 
 	requestBody := &bindRequestBody{

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/client.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/client.go
@@ -30,7 +30,6 @@ const (
 	lastOperationURLFmt        = "%s/v2/service_instances/%s/last_operation"
 	bindingLastOperationURLFmt = "%s/v2/service_instances/%s/service_bindings/%s/last_operation"
 	bindingURLFmt              = "%s/v2/service_instances/%s/service_bindings/%s"
-	asyncQueryParamKey         = "accepts_incomplete"
 )
 
 // NewClient is a CreateFunc for creating a new functional Client and
@@ -64,6 +63,7 @@ func NewClient(config *ClientConfiguration) (Client, error) {
 		URL:                 strings.TrimRight(config.URL, "/"),
 		APIVersion:          config.APIVersion,
 		EnableAlphaFeatures: config.EnableAlphaFeatures,
+		Verbose:             config.Verbose,
 		httpClient:          httpClient,
 	}
 	c.doRequestFunc = c.doRequest

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/constants.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/constants.go
@@ -1,0 +1,25 @@
+package v2
+
+const (
+	// AcceptsIncomplete is the name of a query parameter that indicates that
+	// the client allows a request to complete asynchronously.
+	AcceptsIncomplete = "accepts_incomplete"
+
+	// VarKeyInstanceID is the name to use for a mux var representing an
+	// instance ID.
+	VarKeyInstanceID = "instance_id"
+
+	// VarKeyBindingID is the name to use for a mux var representing a binding
+	// ID.
+	VarKeyBindingID = "binding_id"
+
+	// VarKeyServiceID is the name to use for a mux var representing a service ID.
+	VarKeyServiceID = "service_id"
+
+	// VarKeyPlanID is the name to use for a mux var representing a plan ID.
+	VarKeyPlanID = "plan_id"
+
+	// VarKeyOperation is the name to use for a mux var representing an
+	// operation.
+	VarKeyOperation = "operation"
+)

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/deprovision_instance.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/deprovision_instance.go
@@ -13,11 +13,11 @@ func (c *client) DeprovisionInstance(r *DeprovisionRequest) (*DeprovisionRespons
 	fullURL := fmt.Sprintf(serviceInstanceURLFmt, c.URL, r.InstanceID)
 
 	params := map[string]string{
-		serviceIDKey: string(r.ServiceID),
-		planIDKey:    string(r.PlanID),
+		VarKeyServiceID: string(r.ServiceID),
+		VarKeyPlanID:    string(r.PlanID),
 	}
 	if r.AcceptsIncomplete {
-		params[asyncQueryParamKey] = "true"
+		params[AcceptsIncomplete] = "true"
 	}
 
 	response, err := c.prepareAndDo(http.MethodDelete, fullURL, params, nil, r.OriginatingIdentity)

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/interface.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/interface.go
@@ -64,6 +64,8 @@ type ClientConfiguration struct {
 	// CAData holds PEM-encoded bytes (typically read from a root certificates bundle).
 	// This CA certificate will be added to any specified in TLSConfig.RootCAs.
 	CAData []byte
+	// Verbose is whether the client will log to glog.
+	Verbose bool
 }
 
 // DefaultClientConfiguration returns a default ClientConfiguration:

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/poll_binding_last_operation.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/poll_binding_last_operation.go
@@ -20,15 +20,15 @@ func (c *client) PollBindingLastOperation(r *BindingLastOperationRequest) (*Last
 	params := map[string]string{}
 
 	if r.ServiceID != nil {
-		params[serviceIDKey] = *r.ServiceID
+		params[VarKeyServiceID] = *r.ServiceID
 	}
 	if r.PlanID != nil {
-		params[planIDKey] = *r.PlanID
+		params[VarKeyPlanID] = *r.PlanID
 	}
 	if r.OperationKey != nil {
 		op := *r.OperationKey
 		opStr := string(op)
-		params[operationKey] = opStr
+		params[VarKeyOperation] = opStr
 	}
 
 	response, err := c.prepareAndDo(http.MethodGet, fullURL, params, nil /* request body */, r.OriginatingIdentity)

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/poll_last_operation.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/poll_last_operation.go
@@ -5,12 +5,6 @@ import (
 	"net/http"
 )
 
-const (
-	serviceIDKey = "service_id"
-	planIDKey    = "plan_id"
-	operationKey = "operation"
-)
-
 func (c *client) PollLastOperation(r *LastOperationRequest) (*LastOperationResponse, error) {
 	if err := validateLastOperationRequest(r); err != nil {
 		return nil, err
@@ -20,15 +14,15 @@ func (c *client) PollLastOperation(r *LastOperationRequest) (*LastOperationRespo
 	params := map[string]string{}
 
 	if r.ServiceID != nil {
-		params[serviceIDKey] = *r.ServiceID
+		params[VarKeyServiceID] = *r.ServiceID
 	}
 	if r.PlanID != nil {
-		params[planIDKey] = *r.PlanID
+		params[VarKeyPlanID] = *r.PlanID
 	}
 	if r.OperationKey != nil {
 		op := *r.OperationKey
 		opStr := string(op)
-		params[operationKey] = opStr
+		params[VarKeyOperation] = opStr
 	}
 
 	response, err := c.prepareAndDo(http.MethodGet, fullURL, params, nil /* request body */, r.OriginatingIdentity)

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/provision_instance.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/provision_instance.go
@@ -32,7 +32,7 @@ func (c *client) ProvisionInstance(r *ProvisionRequest) (*ProvisionResponse, err
 
 	params := map[string]string{}
 	if r.AcceptsIncomplete {
-		params[asyncQueryParamKey] = "true"
+		params[AcceptsIncomplete] = "true"
 	}
 
 	requestBody := &provisionRequestBody{

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/unbind.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/unbind.go
@@ -26,10 +26,10 @@ func (c *client) Unbind(r *UnbindRequest) (*UnbindResponse, error) {
 
 	fullURL := fmt.Sprintf(bindingURLFmt, c.URL, r.InstanceID, r.BindingID)
 	params := map[string]string{}
-	params[serviceIDKey] = r.ServiceID
-	params[planIDKey] = r.PlanID
+	params[VarKeyServiceID] = r.ServiceID
+	params[VarKeyPlanID] = r.PlanID
 	if r.AcceptsIncomplete {
-		params[asyncQueryParamKey] = "true"
+		params[AcceptsIncomplete] = "true"
 	}
 
 	response, err := c.prepareAndDo(http.MethodDelete, fullURL, params, nil, r.OriginatingIdentity)

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/update_instance.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/update_instance.go
@@ -23,7 +23,7 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 	fullURL := fmt.Sprintf(serviceInstanceURLFmt, c.URL, r.InstanceID)
 	params := map[string]string{}
 	if r.AcceptsIncomplete {
-		params[asyncQueryParamKey] = "true"
+		params[AcceptsIncomplete] = "true"
 	}
 
 	requestBody := &updateInstanceRequestBody{


### PR DESCRIPTION
Bumps the dependency on the client library to 0.0.3 so we can begin setting Verbose on the client configuration.