### PR TITLE
Reset RemovedFromBrokerCatalog when broker re-adds a removed service class

### DIFF
--- a/pkg/controller/controller_broker.go
+++ b/pkg/controller/controller_broker.go
@@ -17,12 +17,11 @@ limitations under the License.
 package controller
 
 import (
+	stderrors "errors"
 	"fmt"
 	"time"
 
 	"github.com/golang/glog"
-
-	stderrors "errors"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/metrics"

--- a/pkg/controller/controller_broker.go
+++ b/pkg/controller/controller_broker.go
@@ -17,11 +17,12 @@ limitations under the License.
 package controller
 
 import (
-	stderrors "errors"
 	"fmt"
 	"time"
 
 	"github.com/golang/glog"
+
+	stderrors "errors"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/metrics"
@@ -540,9 +541,25 @@ func (c *controller) reconcileClusterServiceClassFromClusterServiceBrokerCatalog
 	toUpdate.Spec.ExternalName = serviceClass.Spec.ExternalName
 	toUpdate.Spec.ExternalMetadata = serviceClass.Spec.ExternalMetadata
 
-	if _, err := c.serviceCatalogClient.ClusterServiceClasses().Update(toUpdate); err != nil {
+	updatedServiceClass, err := c.serviceCatalogClient.ClusterServiceClasses().Update(toUpdate)
+	if err != nil {
 		glog.Error(pcb.Messagef("Error updating %s: %v", pretty.ClusterServiceClassName(serviceClass), err))
 		return err
+	}
+
+	if updatedServiceClass.Status.RemovedFromBrokerCatalog {
+		glog.V(4).Info(pcb.Messagef("Resetting RemovedFromBrokerCatalog status on %s", pretty.ClusterServiceClassName(serviceClass)))
+		updatedServiceClass.Status.RemovedFromBrokerCatalog = false
+		_, err := c.serviceCatalogClient.ClusterServiceClasses().UpdateStatus(updatedServiceClass)
+		if err != nil {
+			s := fmt.Sprintf("Error updating status of %s: %v", pretty.ClusterServiceClassName(updatedServiceClass), err)
+			glog.Warning(pcb.Message(s))
+			c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
+			if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason, errorSyncingCatalogMessage+s); err != nil {
+				return err
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1818,6 +1818,25 @@ func testActionFor(t *testing.T, name string, f failfFunc, action clientgotestin
 	return fakeRtObject, true
 }
 
+func assertRemovedFromBrokerCatalogFalse(t *testing.T, obj runtime.Object) {
+	assertRemovedFromBrokerCatalog(t, obj, false)
+}
+
+func assertRemovedFromBrokerCatalogTrue(t *testing.T, obj runtime.Object) {
+	assertRemovedFromBrokerCatalog(t, obj, true)
+}
+
+func assertRemovedFromBrokerCatalog(t *testing.T, obj runtime.Object, condition bool) {
+	clusterServiceClass, ok := obj.(*v1beta1.ClusterServiceClass)
+	if !ok {
+		fatalf(t, "Couldn't convert object %+v into a *v1beta1.ClusterServiceClass", obj)
+	}
+
+	if clusterServiceClass.Status.RemovedFromBrokerCatalog != condition {
+		fatalf(t, "ClusterServiceClass.RemovedFromBrokerCatalog!=%v", condition)
+	}
+}
+
 func assertClusterServiceBrokerReadyTrue(t *testing.T, obj runtime.Object) {
 	assertClusterServiceBrokerCondition(t, obj, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionTrue)
 }


### PR DESCRIPTION
fixes #1757 

Reconciliation loop was not resetting the RemovedFromBrokerCatalog status when the broker re-adds a previously delisted Cluster Service Class.  Fixed and added unit test.