### PR TITLE
prometheus: only return catalog specific metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -74,11 +74,11 @@ var (
 	)
 )
 
-func register() {
+func register(registry *prometheus.Registry) {
 	registerMetrics.Do(func() {
-		prometheus.MustRegister(BrokerServiceClassCount)
-		prometheus.MustRegister(BrokerServicePlanCount)
-		prometheus.MustRegister(OSBRequestCount)
+		registry.MustRegister(BrokerServiceClassCount)
+		registry.MustRegister(BrokerServicePlanCount)
+		registry.MustRegister(OSBRequestCount)
 	})
 }
 
@@ -86,7 +86,8 @@ func register() {
 // objects with Prometheus and installs the Prometheus http handler at the
 // default context.
 func RegisterMetricsAndInstallHandler(m *http.ServeMux) {
-	register()
-	m.Handle("/metrics", promhttp.Handler())
-	glog.V(4).Info("Registered /metrics with promhttp")
+	registry := prometheus.NewRegistry()
+	register(registry)
+	m.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}))
+	glog.V(4).Info("Registered /metrics with prometheus")
 }


### PR DESCRIPTION
We were using the default Prometheus Registry which included 40+ metrics from Go and Process details.  In discussing with other upstream kube teams this is a lot of overhead for metrics already commonly provided by cAdvisor.  It was recommended we limit the metrics to Service Catalog specifics.

This change drops the 40+ go and process related metrics from the scrape and leaves us with the service catalog specific metrics only.

