### PR TITLE
Fix svcat cli publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,7 +399,7 @@ $(BINDIR)/svcat/$(TAG_VERSION)/$(PLATFORM)/$(ARCH)/svcat$(FILE_EXT): .init .gene
 svcat-publish: clean-bin svcat-all
 	# Download the latest client with https://download.svcat.sh/cli/latest/darwin/amd64/svcat
 	# Download an older client with  https://download.svcat.sh/cli/VERSION/darwin/amd64/svcat
-	cp -R $(BINDIR)/svcat/$(TAG_VERSION) $(BINDIR)/svcat/$(MUTABLE_TAG)
+	$(DOCKER_CMD) cp -R $(BINDIR)/svcat/$(TAG_VERSION) $(BINDIR)/svcat/$(MUTABLE_TAG)
 	# AZURE_STORAGE_CONNECTION_STRING will be used for auth in the following command
 	$(DOCKER_CMD) az storage blob upload-batch -d cli -s $(BINDIR)/svcat
 


### PR DESCRIPTION
Use docker to interact with files made by docker. Otherwise on travis, the copy fails with a permission denied error:

```
# Download the latest client with https://download.svcat.sh/cli/latest/darwin/amd64/svcat
# Download an older client with  https://download.svcat.sh/cli/VERSION/darwin/amd64/svcat
cp -R bin/svcat/v0.1.9 bin/svcat/latest
cp: cannot create directory ‘bin/svcat/latest’: Permission denied
make: *** [svcat-publish] Error 1
```
https://travis-ci.org/kubernetes-incubator/service-catalog/jobs/347571501#L2194-L2198