### PR TITLE
Add all-namespaces flag to svcat

### DIFF
--- a/cmd/svcat/binding/get_cmd.go
+++ b/cmd/svcat/binding/get_cmd.go
@@ -24,8 +24,9 @@ import (
 
 type getCmd struct {
 	*command.Context
-	ns   string
-	name string
+	ns            string
+	name          string
+	allNamespaces bool
 }
 
 // NewGetCmd builds a "svcat get bindings" command
@@ -37,6 +38,7 @@ func NewGetCmd(cxt *command.Context) *cobra.Command {
 		Short:   "List bindings, optionally filtered by name",
 		Example: `
   svcat get bindings
+  svcat get bindings --all-namespaces
   svcat get binding wordpress-mysql-binding
   svcat get binding -n ci concourse-postgres-binding
 `,
@@ -50,6 +52,13 @@ func NewGetCmd(cxt *command.Context) *cobra.Command {
 		"n",
 		"default",
 		"The namespace from which to get the bindings",
+	)
+	cmd.Flags().BoolVarP(
+		&getCmd.allNamespaces,
+		"all-namespaces",
+		"",
+		false,
+		"List all bindings across namespaces",
 	)
 	return cmd
 }
@@ -71,6 +80,10 @@ func (c *getCmd) Run() error {
 }
 
 func (c *getCmd) getAll() error {
+	if c.allNamespaces {
+		c.ns = ""
+	}
+
 	bindings, err := c.App.RetrieveBindings(c.ns)
 	if err != nil {
 		return err

--- a/cmd/svcat/instance/get_cmd.go
+++ b/cmd/svcat/instance/get_cmd.go
@@ -24,8 +24,9 @@ import (
 
 type getCmd struct {
 	*command.Context
-	ns   string
-	name string
+	ns            string
+	name          string
+	allNamespaces bool
 }
 
 // NewGetCmd builds a "svcat get instances" command
@@ -37,6 +38,7 @@ func NewGetCmd(cxt *command.Context) *cobra.Command {
 		Short:   "List instances, optionally filtered by name",
 		Example: `
   svcat get instances
+  svcat get instances --all-namespaces
   svcat get instance wordpress-mysql-instance
   svcat get instance -n ci concourse-postgres-instance
 `,
@@ -49,6 +51,13 @@ func NewGetCmd(cxt *command.Context) *cobra.Command {
 		"n",
 		"default",
 		"The namespace in which to get the ServiceInstance",
+	)
+	cmd.Flags().BoolVarP(
+		&getCmd.allNamespaces,
+		"all-namespaces",
+		"",
+		false,
+		"List all instances across namespaces",
 	)
 	return cmd
 }
@@ -70,6 +79,10 @@ func (c *getCmd) Run() error {
 }
 
 func (c *getCmd) getAll() error {
+	if c.allNamespaces {
+		c.ns = ""
+	}
+
 	instances, err := c.App.RetrieveInstances(c.ns)
 	if err != nil {
 		return err

--- a/cmd/svcat/svcat_test.go
+++ b/cmd/svcat/svcat_test.go
@@ -91,11 +91,13 @@ func TestCommandOutput(t *testing.T) {
 		{name: "describe plan with schemas", cmd: "describe plan premium", golden: "output/describe-plan-with-schemas.txt"},
 		{name: "describe plan without schemas", cmd: "describe plan premium --show-schemas=false", golden: "output/describe-plan-without-schemas.txt"},
 
-		{name: "list all instances", cmd: "get instances -n test-ns", golden: "output/get-instances.txt"},
+		{name: "list all test-ns instances", cmd: "get instances -n test-ns", golden: "output/get-instances.txt"},
+		{name: "list all instances", cmd: "get instances --all-namespaces", golden: "output/get-instances-all-namespaces.txt"},
 		{name: "get instance", cmd: "get instance ups-instance -n test-ns", golden: "output/get-instance.txt"},
 		{name: "describe instance", cmd: "describe instance ups-instance -n test-ns", golden: "output/describe-instance.txt"},
 
 		{name: "list all bindings", cmd: "get bindings -n test-ns", golden: "output/get-bindings.txt"},
+		{name: "list all instances", cmd: "get bindings --all-namespaces", golden: "output/get-bindings-all-namespaces.txt"},
 		{name: "get binding", cmd: "get binding ups-binding -n test-ns", golden: "output/get-binding.txt"},
 		{name: "describe binding", cmd: "describe binding ups-binding -n test-ns", golden: "output/describe-binding.txt"},
 	}

--- a/cmd/svcat/testdata/output/get-bindings-all-namespaces.txt
+++ b/cmd/svcat/testdata/output/get-bindings-all-namespaces.txt
@@ -1,0 +1,4 @@
+     NAME       NAMESPACE     INSTANCE     STATUS  
++-------------+-----------+--------------+--------+
+  ups-binding   test-ns     ups-instance   Ready   
+  ups-binding   default     ups-instance   Ready   

--- a/cmd/svcat/testdata/output/get-instances-all-namespaces.txt
+++ b/cmd/svcat/testdata/output/get-instances-all-namespaces.txt
@@ -1,0 +1,4 @@
+      NAME       NAMESPACE           CLASS            PLAN     STATUS  
++--------------+-----------+-----------------------+---------+--------+
+  ups-instance   test-ns     user-provided-service   default   Ready   
+  ups-instance   default     user-provided-service   default   Ready   

--- a/cmd/svcat/testdata/plugin.yaml
+++ b/cmd/svcat/testdata/plugin.yaml
@@ -73,6 +73,9 @@ tree:
   - name: bindings
     shortDesc: List bindings, optionally filtered by name
     command: ./svcat get bindings
+    flags:
+    - name: all-namespaces
+      desc: List all bindings across namespaces
   - name: brokers
     shortDesc: List brokers, optionally filtered by name
     command: ./svcat get brokers
@@ -86,6 +89,9 @@ tree:
   - name: instances
     shortDesc: List instances, optionally filtered by name
     command: ./svcat get instances
+    flags:
+    - name: all-namespaces
+      desc: List all instances across namespaces
   - name: plans
     shortDesc: List plans, optionally filtered by name
     command: ./svcat get plans

--- a/cmd/svcat/testdata/responses/namespaces/default/servicebindings.json
+++ b/cmd/svcat/testdata/responses/namespaces/default/servicebindings.json
@@ -1,0 +1,51 @@
+{
+  "kind": "ServiceBindingList",
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "metadata": {
+    "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/namespaces/default/servicebindings",
+    "resourceVersion": "121"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "ups-binding",
+        "namespace": "default",
+        "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/namespaces/default/servicebindings/ups-binding",
+        "uid": "456aefa0-f712-11e7-aa44-0242ac110005",
+        "resourceVersion": "16",
+        "generation": 1,
+        "creationTimestamp": "2018-01-11T21:00:47Z",
+        "finalizers": [
+          "kubernetes-incubator/service-catalog"
+        ]
+      },
+      "spec": {
+        "instanceRef": {
+          "name": "ups-instance"
+        },
+        "parameters": {},
+        "secretName": "ups-binding",
+        "externalID": "061e1d78-d27e-4958-97b8-e9f5aa2f99d7"
+      },
+      "status": {
+        "conditions": [
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastTransitionTime": "2018-01-11T21:00:47Z",
+            "reason": "InjectedBindResult",
+            "message": "Injected bind result"
+          }
+        ],
+        "asyncOpInProgress": false,
+        "reconciledGeneration": 1,
+        "externalProperties": {
+          "parameters": {},
+          "parameterChecksum": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+        },
+        "orphanMitigationInProgress": false,
+        "unbindStatus": "Required"
+      }
+    }
+  ]
+}

--- a/cmd/svcat/testdata/responses/namespaces/default/servicebindings/ups-binding.json
+++ b/cmd/svcat/testdata/responses/namespaces/default/servicebindings/ups-binding.json
@@ -1,0 +1,43 @@
+{
+  "kind": "ServiceBinding",
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "metadata": {
+    "name": "ups-binding",
+    "namespace": "default",
+    "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/namespaces/default/servicebindings/ups-binding",
+    "uid": "456aefa0-f712-11e7-aa44-0242ac110005",
+    "resourceVersion": "16",
+    "generation": 1,
+    "creationTimestamp": "2018-01-11T21:00:47Z",
+    "finalizers": [
+      "kubernetes-incubator/service-catalog"
+    ]
+  },
+  "spec": {
+    "instanceRef": {
+      "name": "ups-instance"
+    },
+    "parameters": {},
+    "secretName": "ups-binding",
+    "externalID": "061e1d78-d27e-4958-97b8-e9f5aa2f99d7"
+  },
+  "status": {
+    "conditions": [
+      {
+        "type": "Ready",
+        "status": "True",
+        "lastTransitionTime": "2018-01-11T21:00:47Z",
+        "reason": "InjectedBindResult",
+        "message": "Injected bind result"
+      }
+    ],
+    "asyncOpInProgress": false,
+    "reconciledGeneration": 1,
+    "externalProperties": {
+      "parameters": {},
+      "parameterChecksum": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+    },
+    "orphanMitigationInProgress": false,
+    "unbindStatus": "Required"
+  }
+}

--- a/cmd/svcat/testdata/responses/namespaces/default/serviceinstances.json
+++ b/cmd/svcat/testdata/responses/namespaces/default/serviceinstances.json
@@ -1,0 +1,58 @@
+{
+  "kind": "ServiceInstanceList",
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "metadata": {
+    "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/serviceinstances",
+    "resourceVersion": "109"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "ups-instance",
+        "namespace": "default",
+        "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/namespaces/default/serviceinstances/ups-instance",
+        "uid": "1237fd85-f712-11e7-aa44-0242ac110006",
+        "resourceVersion": "13",
+        "generation": 1,
+        "creationTimestamp": "2018-01-11T20:59:47Z",
+        "finalizers": [
+          "kubernetes-incubator/service-catalog"
+        ]
+      },
+      "spec": {
+        "clusterServiceClassExternalName": "user-provided-service",
+        "clusterServicePlanExternalName": "default",
+        "clusterServiceClassRef": {
+          "name": "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
+        },
+        "clusterServicePlanRef": {
+          "name": "86064792-7ea2-467b-af93-ac9694d96d52"
+        },
+        "parameters": {},
+        "externalID": "7e2c42f3-6d94-4409-bb15-7610d60af544",
+        "updateRequests": 0
+      },
+      "status": {
+        "conditions": [
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastTransitionTime": "2018-01-11T20:59:47Z",
+            "reason": "ProvisionedSuccessfully",
+            "message": "The instance was provisioned successfully"
+          }
+        ],
+        "asyncOpInProgress": false,
+        "orphanMitigationInProgress": false,
+        "reconciledGeneration": 1,
+        "externalProperties": {
+          "clusterServicePlanExternalName": "default",
+          "clusterServicePlanExternalID": "86064792-7ea2-467b-af93-ac9694d96d52",
+          "parameters": {},
+          "parameterChecksum": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+        },
+        "deprovisionStatus": "Required"
+      }
+    }
+  ]
+}

--- a/cmd/svcat/testdata/responses/namespaces/default/serviceinstances/ups-instance.json
+++ b/cmd/svcat/testdata/responses/namespaces/default/serviceinstances/ups-instance.json
@@ -1,0 +1,50 @@
+{
+  "kind": "ServiceInstance",
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "metadata": {
+    "name": "ups-instance",
+    "namespace": "default",
+    "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/namespaces/default/serviceinstances/ups-instance",
+    "uid": "1237fd85-f712-11e7-aa44-0242ac110006",
+    "resourceVersion": "13",
+    "generation": 1,
+    "creationTimestamp": "2018-01-11T20:59:47Z",
+    "finalizers": [
+      "kubernetes-incubator/service-catalog"
+    ]
+  },
+  "spec": {
+    "clusterServiceClassExternalName": "user-provided-service",
+    "clusterServicePlanExternalName": "default",
+    "clusterServiceClassRef": {
+      "name": "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
+    },
+    "clusterServicePlanRef": {
+      "name": "86064792-7ea2-467b-af93-ac9694d96d52"
+    },
+    "parameters": {},
+    "externalID": "7e2c42f3-6d94-4409-bb15-7610d60af544",
+    "updateRequests": 0
+  },
+  "status": {
+    "conditions": [
+      {
+        "type": "Ready",
+        "status": "True",
+        "lastTransitionTime": "2018-01-11T20:59:47Z",
+        "reason": "ProvisionedSuccessfully",
+        "message": "The instance was provisioned successfully"
+      }
+    ],
+    "asyncOpInProgress": false,
+    "orphanMitigationInProgress": false,
+    "reconciledGeneration": 1,
+    "externalProperties": {
+      "clusterServicePlanExternalName": "default",
+      "clusterServicePlanExternalID": "86064792-7ea2-467b-af93-ac9694d96d52",
+      "parameters": {},
+      "parameterChecksum": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+    },
+    "deprovisionStatus": "Required"
+  }
+}

--- a/cmd/svcat/testdata/responses/namespaces/test-ns/serviceinstances/ups-binding.json
+++ b/cmd/svcat/testdata/responses/namespaces/test-ns/serviceinstances/ups-binding.json
@@ -1,0 +1,43 @@
+{
+  "kind": "ServiceBinding",
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "metadata": {
+    "name": "ups-binding",
+    "namespace": "test-ns",
+    "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/namespaces/test-ns/servicebindings/ups-binding",
+    "uid": "7f2aefa0-f712-11e7-aa44-0242ac110005",
+    "resourceVersion": "16",
+    "generation": 1,
+    "creationTimestamp": "2018-01-11T21:00:47Z",
+    "finalizers": [
+      "kubernetes-incubator/service-catalog"
+    ]
+  },
+  "spec": {
+    "instanceRef": {
+      "name": "ups-instance"
+    },
+    "parameters": {},
+    "secretName": "ups-binding",
+    "externalID": "061e1d78-d27e-4958-97b8-e9f5aa2f99d7"
+  },
+  "status": {
+    "conditions": [
+      {
+        "type": "Ready",
+        "status": "True",
+        "lastTransitionTime": "2018-01-11T21:00:47Z",
+        "reason": "InjectedBindResult",
+        "message": "Injected bind result"
+      }
+    ],
+    "asyncOpInProgress": false,
+    "reconciledGeneration": 1,
+    "externalProperties": {
+      "parameters": {},
+      "parameterChecksum": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+    },
+    "orphanMitigationInProgress": false,
+    "unbindStatus": "Required"
+  }
+}

--- a/cmd/svcat/testdata/responses/servicebindings.json
+++ b/cmd/svcat/testdata/responses/servicebindings.json
@@ -1,0 +1,92 @@
+{
+  "kind": "ServiceBindingList",
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "metadata": {
+    "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/namespaces/test-ns/servicebindings",
+    "resourceVersion": "121"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "ups-binding",
+        "namespace": "test-ns",
+        "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/namespaces/test-ns/servicebindings/ups-binding",
+        "uid": "7f2aefa0-f712-11e7-aa44-0242ac110005",
+        "resourceVersion": "16",
+        "generation": 1,
+        "creationTimestamp": "2018-01-11T21:00:47Z",
+        "finalizers": [
+          "kubernetes-incubator/service-catalog"
+        ]
+      },
+      "spec": {
+        "instanceRef": {
+          "name": "ups-instance"
+        },
+        "parameters": {},
+        "secretName": "ups-binding",
+        "externalID": "061e1d78-d27e-4958-97b8-e9f5aa2f99d7"
+      },
+      "status": {
+        "conditions": [
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastTransitionTime": "2018-01-11T21:00:47Z",
+            "reason": "InjectedBindResult",
+            "message": "Injected bind result"
+          }
+        ],
+        "asyncOpInProgress": false,
+        "reconciledGeneration": 1,
+        "externalProperties": {
+          "parameters": {},
+          "parameterChecksum": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+        },
+        "orphanMitigationInProgress": false,
+        "unbindStatus": "Required"
+      }
+    },
+    {
+      "metadata": {
+        "name": "ups-binding",
+        "namespace": "default",
+        "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/namespaces/default/servicebindings/ups-binding",
+        "uid": "456aefa0-f712-11e7-aa44-0242ac110005",
+        "resourceVersion": "16",
+        "generation": 1,
+        "creationTimestamp": "2018-01-11T21:00:47Z",
+        "finalizers": [
+          "kubernetes-incubator/service-catalog"
+        ]
+      },
+      "spec": {
+        "instanceRef": {
+          "name": "ups-instance"
+        },
+        "parameters": {},
+        "secretName": "ups-binding",
+        "externalID": "061e1d78-d27e-4958-97b8-e9f5aa2f99d7"
+      },
+      "status": {
+        "conditions": [
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastTransitionTime": "2018-01-11T21:00:47Z",
+            "reason": "InjectedBindResult",
+            "message": "Injected bind result"
+          }
+        ],
+        "asyncOpInProgress": false,
+        "reconciledGeneration": 1,
+        "externalProperties": {
+          "parameters": {},
+          "parameterChecksum": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+        },
+        "orphanMitigationInProgress": false,
+        "unbindStatus": "Required"
+      }
+    }
+  ]
+}

--- a/cmd/svcat/testdata/responses/serviceinstances.json
+++ b/cmd/svcat/testdata/responses/serviceinstances.json
@@ -1,0 +1,106 @@
+{
+  "kind": "ServiceInstanceList",
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "metadata": {
+    "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/serviceinstances",
+    "resourceVersion": "109"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "ups-instance",
+        "namespace": "test-ns",
+        "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/namespaces/test-ns/serviceinstances/ups-instance",
+        "uid": "5b47fd85-f712-11e7-aa44-0242ac110005",
+        "resourceVersion": "13",
+        "generation": 1,
+        "creationTimestamp": "2018-01-11T20:59:47Z",
+        "finalizers": [
+          "kubernetes-incubator/service-catalog"
+        ]
+      },
+      "spec": {
+        "clusterServiceClassExternalName": "user-provided-service",
+        "clusterServicePlanExternalName": "default",
+        "clusterServiceClassRef": {
+          "name": "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
+        },
+        "clusterServicePlanRef": {
+          "name": "86064792-7ea2-467b-af93-ac9694d96d52"
+        },
+        "parameters": {},
+        "externalID": "7e2c42f3-6d94-4409-bb15-7610d60af544",
+        "updateRequests": 0
+      },
+      "status": {
+        "conditions": [
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastTransitionTime": "2018-01-11T20:59:47Z",
+            "reason": "ProvisionedSuccessfully",
+            "message": "The instance was provisioned successfully"
+          }
+        ],
+        "asyncOpInProgress": false,
+        "orphanMitigationInProgress": false,
+        "reconciledGeneration": 1,
+        "externalProperties": {
+          "clusterServicePlanExternalName": "default",
+          "clusterServicePlanExternalID": "86064792-7ea2-467b-af93-ac9694d96d52",
+          "parameters": {},
+          "parameterChecksum": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+        },
+        "deprovisionStatus": "Required"
+      }
+    },
+    {
+      "metadata": {
+        "name": "ups-instance",
+        "namespace": "default",
+        "selfLink": "/apis/servicecatalog.k8s.io/v1beta1/namespaces/test-ns/serviceinstances/ups-instance",
+        "uid": "1237fd85-f712-11e7-aa44-0242ac110006",
+        "resourceVersion": "13",
+        "generation": 1,
+        "creationTimestamp": "2018-01-11T20:59:47Z",
+        "finalizers": [
+          "kubernetes-incubator/service-catalog"
+        ]
+      },
+      "spec": {
+        "clusterServiceClassExternalName": "user-provided-service",
+        "clusterServicePlanExternalName": "default",
+        "clusterServiceClassRef": {
+          "name": "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
+        },
+        "clusterServicePlanRef": {
+          "name": "86064792-7ea2-467b-af93-ac9694d96d52"
+        },
+        "parameters": {},
+        "externalID": "7e2c42f3-6d94-4409-bb15-7610d60af544",
+        "updateRequests": 0
+      },
+      "status": {
+        "conditions": [
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastTransitionTime": "2018-01-11T20:59:47Z",
+            "reason": "ProvisionedSuccessfully",
+            "message": "The instance was provisioned successfully"
+          }
+        ],
+        "asyncOpInProgress": false,
+        "orphanMitigationInProgress": false,
+        "reconciledGeneration": 1,
+        "externalProperties": {
+          "clusterServicePlanExternalName": "default",
+          "clusterServicePlanExternalID": "86064792-7ea2-467b-af93-ac9694d96d52",
+          "parameters": {},
+          "parameterChecksum": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+        },
+        "deprovisionStatus": "Required"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
* Closes #1766

* Add all-namespaces flag to svcat get bindings/instances commands

When set retrieves all bindings/instances across namespaces, overriding
the value of the ns flag.

* Add tests for all-namespaces flag

Add testdata and tests for both `svcat get bindings --all-namespaces`
and `svcat get instances --all-namespaces`