### PR TITLE
Integrate svcat docs with Service Catalog's

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Afterward, see the topics below.
 
 - [Installation instructions](install.md)
 - [Walkthrough](walkthrough.md)
+- [Service Catalog CLI](cli.md)
 - [The Service Catalog Resources In Depth](./resources.md)
 - [Passing parameters to ServiceInstances and ServiceBindings](parameters.md)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,8 +10,8 @@ Kubernetes cluster.
 
 [agg-api]: https://kubernetes.io/docs/concepts/api-extension/apiserver-aggregation/
 
-This document assumes that you've installed Service Catalog and the Service Catalog CLI, svcat, onto your cluster.
-If you haven't, please see [install.md](install.md).
+This document assumes that you've installed Service Catalog and the Service Catalog CLI
+onto your cluster. If you haven't, please see [install.md](install.md).
 
 ## Plugin
 To use svcat as a plugin, run the following command after downloading:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,9 +42,9 @@ Below are some common tasks made easy with svcat. The example output assumes tha
 * [List all service instances in a namespace](#list-all-service-instances-in-a-namespace)
 * [Bind an instance](#bind-an-instance)
 * [View the details of a service instance](#view-the-details-of-a-service-instance)
-* [Unbind all applications from an instance](#unbind-all-applications-from-an-instance)
-* [Unbind a single application from an instance](#unbind-a-single-application-from-an-instance)
-* [Delete a service instance](#delete-a-service-instance)
+* [Unbind all applications from an instance](#remove-all-bindings-from-an-instance)
+* [Unbind a single application from an instance](#remove-a-single-binding-from-an-instance)
+* [Delete a service instance](#remove-a-single-binding-from-an-instance)
 
 ## Find brokers installed on the cluster
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,7 +14,7 @@ This document assumes that you've installed Service Catalog and the Service Cata
 onto your cluster. If you haven't, please see [install.md](install.md).
 
 ## Plugin
-To use svcat as a plugin, run the following command after downloading:
+To use svcat as a kubectl plugin, run the following command after downloading:
 
 ```console
 $ svcat install plugin
@@ -194,14 +194,14 @@ $ svcat describe instance -n test-ns ups-instance
     ups-binding   Ready
 ```
 
-## Unbind all applications from an instance
+## Remove all bindings from an instance
 
 ```console
 $ svcat unbind -n test-ns ups-instance
 deleted ups-binding
 ```
 
-## Unbind a single application from an instance
+## Remove a single binding from an instance
 
 ```console
 $ svcat unbind -n test-ns --name ups-binding
@@ -211,6 +211,7 @@ deleted ups-binding
 ## Delete a service instance
 
 Deprovisioning is the process of preparing an instance to be removed, and then deleting it.
+You must unbind delete all bindings before deprovisioning an instance.
 
 ```
 svcat deprovision ups-instance

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,70 +1,23 @@
 # Service Catalog CLI
 
-This is a command-line interface (CLI) for interacting with
-[Kubernetes Service Catalog](../../README.md)
+This is a command-line interface (CLI) for interacting with Service Catalog
 resources. svcat is a domain-specific tool to make interacting with the Service Catalog easier.
 While many of its commands have analogs to `kubectl`, our goal is to streamline and optimize
-the operator experience, contributing useful code back upstream to Kubernetes where applicable.
+the operator experience.
 
 svcat communicates with the Service Catalog API through the [aggregated API][agg-api] endpoint on a
 Kubernetes cluster.
 
 [agg-api]: https://kubernetes.io/docs/concepts/api-extension/apiserver-aggregation/
 
-# Prerequisites
-In order to use svcat, you will need:
-
-* A Kubernetes cluster running v1.7+ or higher
-* A broker compatible with the Open Service Broker API installed on the cluster, such as:
-  * [User Provided Service Broker](../../charts/ups-broker)
-  * [Open Service Broke for Azure](https://github.com/Azure/helm-charts/tree/master/open-service-broker-azure)
-* The [Service Catalog](../../docs/install.md) installed on the cluster.
-
-# Install
-Follow the appropriate instructions for your shell to download svcat. The binary
-can be used by itself, or as kubectl plugin.
-
-## MacOS
-```
-curl -sLO https://download.svcat.sh/cli/latest/darwin/amd64/svcat
-chmod +x ./svcat
-mv ./svcat /usr/local/bin/
-svcat --version
-```
-
-## Linux
-```
-curl -sLO https://download.svcat.sh/cli/latest/linux/amd64/svcat
-chmod +x ./svcat
-mv ./svcat /usr/local/bin/
-svcat --version
-```
-
-## Windows
-
-```
-iwr 'https://download.svcat.sh/cli/latest/windows/amd64/svcat.exe' -UseBasicParsing -OutFile svcat.exe
-mkdir -f ~\bin
-$env:PATH += ";${pwd}\bin"
-svcat --version
-```
-
-The snippet above adds a directory to your PATH for the current session only.
-You will need to find a permanent location for it and add it to your PATH.
-
-## Manual
-1. Download the appropriate binary for your operating system:
-    * macOS: https://download.svcat.sh/cli/latest/darwin/amd64/svcat
-    * Windows: https://download.svcat.sh/cli/latest/windows/amd64/svcat.exe
-    * Linux: https://download.svcat.sh/cli/latest/linux/amd64/svcat
-1. Make the binary executable.
-1. Move the binary to a directory on your PATH.
+This document assumes that you've installed Service Catalog and the Service Catalog CLI, svcat, onto your cluster.
+If you haven't, please see [install.md](install.md).
 
 ## Plugin
 To use svcat as a plugin, run the following command after downloading:
 
 ```console
-$ ./svcat install plugin
+$ svcat install plugin
 Plugin has been installed to ~/.kube/plugins/svcat. Run kubectl plugin svcat --help for help using the plugin.
 ```
 
@@ -75,9 +28,23 @@ when running in plugin mode, so instead of using `--flag` you must specify a val
 
 # Use
 
-Run `svcat -h` to see the available commands.
+Run `svcat --help` to see the available commands.
 
-Below are some common tasks made easy with svcat. The example output assumes that [User Provided Service Broker](../../charts/ups-broker) is installed on the cluster.
+Below are some common tasks made easy with svcat. The example output assumes that the 
+[User Provided Service Broker](../charts/ups-broker) is installed on the cluster.
+
+* [Find brokers installed on the cluster](#find-brokers-installed-on-the-cluster)
+* [Trigger a sync of a broker's catalog](#trigger-a-sync-of-a-brokers-catalog)
+* [List available service classes](#list-available-service-classes)
+* [View service plans associated with a class](#view-service-plans-associated-with-a-class)
+* [Provision a service](#provision-a-service)
+* [View all instances of a service plan on the cluster](#view-all-instances-of-a-service-plan-on-the-cluster)
+* [List all service instances in a namespace](#list-all-service-instances-in-a-namespace)
+* [Bind an instance](#bind-an-instance)
+* [View the details of a service instance](#view-the-details-of-a-service-instance)
+* [Unbind all applications from an instance](#unbind-all-applications-from-an-instance)
+* [Unbind a single application from an instance](#unbind-a-single-application-from-an-instance)
+* [Delete a service instance](#delete-a-service-instance)
 
 ## Find brokers installed on the cluster
 
@@ -99,9 +66,10 @@ Successfully fetched catalog entries from the ups-broker broker
 
 ```console
 $ svcat get classes
-          NAME                  DESCRIPTION                         UUID
-+-----------------------+-------------------------+--------------------------------------+
-  user-provided-service   A user provided service   4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
+                NAME                        DESCRIPTION                         UUID
++-----------------------------------+-------------------------+--------------------------------------+
+  user-provided-service               A user provided service   4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
+  user-provided-service-single-plan   A user provided service   5f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
 ```
 
 ## View service plans associated with a class
@@ -163,20 +131,22 @@ svcat provision secure-instance --class mysqldb --plan secureDB --params-json '{
 Note: You may not combine the `--params-json` flag with individual `--param` flags.
 
 ## View all instances of a service plan on the cluster
+When there is more than one plan with the same name, the class can be provided either as a prefix to the plan name,
+`CLASS/PLAN`, or specified with the class flag, `--class CLASS`.
 
 ```console
-$ svcat describe plan premium
-  Name:          premium
-  Description:   Premium plan
-  UUID:          cc0d7529-18e8-416d-8946-6f7456acd589
-  Status:        Active
-  Free:          false
-  Class:         user-provided-service
+$ svcat describe plan user-provided-service/default
+    Name:          default
+    Description:   Sample plan description
+    UUID:          86064792-7ea2-467b-af93-ac9694d96d52
+    Status:        Active
+    Free:          true
+    Class:         user-provided-service
   
-Instances:
-      NAME       NAMESPACE   STATUS
-+--------------+-----------+--------+
-  ups-instance   test-ns     Ready
+  Instances:
+        NAME       NAMESPACE   STATUS
+  +--------------+-----------+--------+
+    ups-instance   test-ns     Ready
 ```
 
 ## List all service instances in a namespace
@@ -212,16 +182,16 @@ $ svcat bind ups
 
 ```console
 $ svcat describe instance -n test-ns ups-instance
-  Name:        ups-instance
-  Namespace:   test-ns
-  Status:      Ready - The instance was provisioned successfully @ 2018-01-11 14:59:47 -0600 CST
-  Class:       user-provided-service
-  Plan:        default
-
-Bindings:
-     NAME       STATUS
-+-------------+--------+
-  ups-binding   Ready
+    Name:        ups-instance
+    Namespace:   test-ns
+    Status:      Ready - The instance was provisioned successfully @ 2018-03-02 16:24:55 +0000 UTC
+    Class:       user-provided-service
+    Plan:        default
+  
+  Bindings:
+       NAME       STATUS
+  +-------------+--------+
+    ups-binding   Ready
 ```
 
 ## Unbind all applications from an instance

--- a/docs/install.md
+++ b/docs/install.md
@@ -166,3 +166,58 @@ Service Catalog is simple:
 helm install svc-cat/catalog \
     --name catalog --namespace catalog
 ```
+
+# Installing the Service Catalog CLI
+
+Follow the appropriate instructions for your operating system to install svcat. The binary
+can be used by itself, or as a kubectl plugin.
+
+## MacOS
+
+```
+curl -sLO https://download.svcat.sh/cli/latest/darwin/amd64/svcat
+chmod +x ./svcat
+mv ./svcat /usr/local/bin/
+svcat --version
+```
+
+## Linux
+
+```
+curl -sLO https://download.svcat.sh/cli/latest/linux/amd64/svcat
+chmod +x ./svcat
+mv ./svcat /usr/local/bin/
+svcat --version
+```
+
+## Windows
+
+The snippet below adds a directory to your PATH for the current session only.
+You will need to find a permanent location for it and add it to your PATH.
+
+```
+iwr 'https://download.svcat.sh/cli/latest/windows/amd64/svcat.exe' -UseBasicParsing -OutFile svcat.exe
+mkdir -f ~\bin
+$env:PATH += ";${pwd}\bin"
+svcat --version
+```
+
+## Manual
+1. Download the appropriate binary for your operating system:
+    * macOS: https://download.svcat.sh/cli/latest/darwin/amd64/svcat
+    * Windows: https://download.svcat.sh/cli/latest/windows/amd64/svcat.exe
+    * Linux: https://download.svcat.sh/cli/latest/linux/amd64/svcat
+1. Make the binary executable.
+1. Move the binary to a directory on your PATH.
+
+## Plugin
+To use svcat as a plugin, run the following command after downloading:
+
+```console
+$ ./svcat install plugin
+Plugin has been installed to ~/.kube/plugins/svcat. Run kubectl plugin svcat --help for help using the plugin.
+```
+
+When operating as a plugin, the commands are the same with the addition of the global
+kubectl configuration flags. One exception is that boolean flags aren't supported
+when running in plugin mode, so instead of using `--flag` you must specify a value `--flag=true`.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -1,6 +1,6 @@
 # Service Catalog Demonstration Walkthrough
 
-This document assumes that you've installed Service Catalog onto your cluster.
+This document assumes that you've installed Service Catalog and the Service Catalog CLI, svcat, onto your cluster.
 If you haven't, please see [install.md](./install.md).
 
 All commands in this document assume that you're operating out of the root
@@ -30,11 +30,12 @@ helm install charts/ups-broker --name ups-broker --namespace ups-broker
 # Step 2 - Creating a `ClusterServiceBroker` Resource
 
 Because we haven't created any resources in the service-catalog API server yet,
-`kubectl get` will return an empty list of resources.
+querying service catalog returns an empty list of resources:
 
 ```console
-$ kubectl get clusterservicebrokers,clusterserviceclasses,serviceinstances,servicebindings
-No resources found.
+$ svcat get brokers
+  NAME   URL   STATUS
++------+-----+--------+
 ```
 
 We'll register a broker server with the catalog by creating a new
@@ -50,79 +51,50 @@ When we create this `ClusterServiceBroker` resource, the service catalog control
 by querying the broker server to see what services it offers and creates a
 `ClusterServiceClass` for each.
 
-We can check the status of the broker using `kubectl get`:
+We can check the status of the broker using `svcat describe`:
 
 ```console
-$ kubectl get clusterservicebrokers ups-broker -o yaml
-apiVersion: servicecatalog.k8s.io/v1beta1
-kind: ClusterServiceBroker
-metadata:
-  creationTimestamp: 2017-11-01T14:11:29Z
-  finalizers:
-  - kubernetes-incubator/service-catalog
-  generation: 1
-  name: ups-broker
-  resourceVersion: "6"
-  selfLink: /apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers/ups-broker
-  uid: 8df4e501-bf0e-11e7-9e29-0242ac110004
-spec:
-  relistBehavior: Duration
-  relistDuration: 15m0s
-  relistRequests: 0
-  url: http://ups-broker-ups-broker.ups-broker.svc.cluster.local
-status:
-  conditions:
-  - lastTransitionTime: 2017-11-01T14:12:30Z
-    message: Successfully fetched catalog entries from broker.
-    reason: FetchedCatalog
-    status: "True"
-    type: Ready
-  reconciledGeneration: 1
+$ svcat describe broker ups-broker
+  Name:     ups-broker
+  URL:      http://ups-broker-ups-broker.ups-broker.svc.cluster.local
+  Status:   Ready - Successfully fetched catalog entries from broker @ 2018-03-02 16:03:52 +0000 UTC
 ```
 
-Notice that the `status` field has been set to reflect that the broker server's
+Notice that the status reflects that the broker's
 catalog of service offerings has been successfully added to our cluster's
 service catalog.
 
 # Step 3 - Viewing `ClusterServiceClass`es and `ClusterServicePlan`s
 
 The controller created a `ClusterServiceClass` for each service that the UPS broker
-provides. We can view the `ClusterServiceClass` resources available in the cluster by
-executing:
+provides. We can view the `ClusterServiceClass` resources available by executing:
 
 ```console
-$ kubectl get clusterserviceclasses -o=custom-columns=NAME:.metadata.name,EXTERNAL\ NAME:.spec.externalName
-NAME                                   EXTERNAL NAME
-4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468   user-provided-service
+$ svcat get classes
+                NAME                        DESCRIPTION                         UUID
++-----------------------------------+-------------------------+--------------------------------------+
+  user-provided-service               A user provided service   4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
+  user-provided-service-single-plan   A user provided service   5f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
 ```
-
-**NOTE:** The above command uses a custom set of columns.  The `NAME` field is
-the Kubernetes name of the `ClusterServiceClass` and the `EXTERNAL NAME` field is the
-human-readable name for the service that the broker returns.
 
 The UPS broker provides a service with the external name
 `user-provided-service`. Run the following command to see the details of this
 offering:
 
 ```console
-$ kubectl get clusterserviceclasses 4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468 -o yaml
-apiVersion: servicecatalog.k8s.io/v1beta1
-kind: ClusterServiceClass
-metadata:
-  creationTimestamp: 2017-11-01T14:12:29Z
-  name: 4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
-  resourceVersion: "4"
-  selfLink: /apis/servicecatalog.k8s.io/v1beta1/clusterserviceclasses/4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
-  uid: b1e764ba-bf0e-11e7-9e29-0242ac110004
-spec:
-  bindable: true
-  clusterServiceBrokerName: ups-broker
-  description: A user provided service
-  externalID: 4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
-  externalName: user-provided-service
-  planUpdatable: false
-status:
-  removedFromBrokerCatalog: false
+$ svcat describe class user-provided-service
+  Name:          user-provided-service
+  Description:   A user provided service
+  UUID:          4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
+  Status:        Active
+  Tags:
+  Broker:        ups-broker
+
+Plans:
+   NAME           DESCRIPTION
++---------+-------------------------+
+  default   Sample plan description
+  premium   Premium plan
 ```
 
 Additionally, the controller created a `ClusterServicePlan` for each of the
@@ -130,38 +102,27 @@ plans for the broker's services. We can view the `ClusterServicePlan`
 resources available in the cluster by executing:
 
 ```console
-$ kubectl get clusterserviceplans -o=custom-columns=NAME:.metadata.name,EXTERNAL\ NAME:.spec.externalName
-NAME                                   EXTERNAL NAME
-86064792-7ea2-467b-af93-ac9694d96d52   default
+$ svcat get plans
+   NAME                   CLASS                       DESCRIPTION                         UUID
++---------+-----------------------------------+-------------------------+--------------------------------------+
+  default   user-provided-service               Sample plan description   86064792-7ea2-467b-af93-ac9694d96d52
+  premium   user-provided-service               Premium plan              cc0d7529-18e8-416d-8946-6f7456acd589
+  default   user-provided-service-single-plan   Sample plan description   96064792-7ea2-467b-af93-ac9694d96d52
 ```
 
-**NOTE:** Just like in the command above, we used a custom set of columns.
-The `NAME` field is the Kubernetes name of the `ClusterServicePlan` and the
-`EXTERNAL NAME` field is the human-readable name for the service that the
-broker returns.
-
-You can view the details of this `ClusterServicePlan` with this command:
+You can view the details of a `ClusterServicePlan` with this command:
 
 ```console
-$ kubectl get clusterserviceplans 86064792-7ea2-467b-af93-ac9694d96d52 -o yaml
-apiVersion: servicecatalog.k8s.io/v1beta1
-kind: ClusterServicePlan
-metadata:
-  creationTimestamp: 2017-11-01T14:12:29Z
-  name: 86064792-7ea2-467b-af93-ac9694d96d52
-  resourceVersion: "5"
-  selfLink: /apis/servicecatalog.k8s.io/v1beta1/clusterserviceplans/86064792-7ea2-467b-af93-ac9694d96d52
-  uid: b1e7f049-bf0e-11e7-9e29-0242ac110004
-spec:
-  clusterServiceBrokerName: ups-broker
-  clusterServiceClassRef:
-    name: 4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
-  description: Sample plan description
-  externalID: 86064792-7ea2-467b-af93-ac9694d96d52
-  externalName: default
-  free: true
-status:
-  removedFromBrokerCatalog: false
+$ svcat describe plan user-provided-service/default
+    Name:          default
+    Description:   Sample plan description
+    UUID:          86064792-7ea2-467b-af93-ac9694d96d52
+    Status:        Active
+    Free:          true
+    Class:         user-provided-service
+  
+  Instances:
+  No instances defined
 ```
 
 # Step 4 - Creating a New `ServiceInstance`
@@ -171,11 +132,11 @@ cluster's service catalog, we can create a `ServiceInstance` that points to
 it.
 
 Unlike `ClusterServiceBroker` and `ClusterServiceClass` resources, `ServiceInstance` 
-resources must be namespaced, so we'll need to create a namespace to start.
-Do so with this command:
+resources must be namespaced. Create a namespace with the following command:
 
-```
-kubectl create namespace test-ns
+```console
+$ kubectl create namespace test-ns
+namespace "test-ns" created
 ```
 
 Then, create the `ServiceInstance`:
@@ -190,55 +151,21 @@ communicate with the appropriate broker server to initiate provisioning.
 Check the status of that process with this command:
 
 ```console
-$ kubectl get serviceinstances -n test-ns ups-instance -o yaml
-apiVersion: servicecatalog.k8s.io/v1beta1
-kind: ServiceInstance
-metadata:
-  creationTimestamp: 2017-11-01T14:21:46Z
-  finalizers:
-  - kubernetes-incubator/service-catalog
-  generation: 1
-  name: ups-instance
-  namespace: test-ns
-  resourceVersion: "12"
-  selfLink: /apis/servicecatalog.k8s.io/v1beta1/namespaces/test-ns/serviceinstances/ups-instance
-  uid: fe143fee-bf0f-11e7-9e29-0242ac110004
-spec:
-  clusterServiceClassExternalName: user-provided-service
-  clusterServiceClassRef:
-    name: 4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
-  clusterServicePlanExternalName: default
-  clusterServicePlanRef:
-    name: 86064792-7ea2-467b-af93-ac9694d96d52
-  externalID: 10ca3610-8200-4b5d-b788-897365f191fa
-  parameters:
-    param-1: value-1
-    param-2: value-2
-  updateRequests: 0
-status:
-  asyncOpInProgress: false
-  conditions:
-  - lastTransitionTime: 2017-11-01T14:21:46Z
-    message: The instance was provisioned successfully
-    reason: ProvisionedSuccessfully
-    status: "True"
-    type: Ready
-  deprovisionStatus: Required
-  externalProperties:
-    clusterServicePlanExternalName: default
-    parameterChecksum: e65c764db8429f9afef45f1e8f71bcbf9fdbe9a13306b86fd5dcc3c5d11e5dd3
-    parameters:
-      param-1: value-1
-      param-2: value-2
-  orphanMitigationInProgress: false
-  reconciledGeneration: 1
+$ svcat describe instance -n test-ns ups-instance
+  Name:        ups-instance
+  Namespace:   test-ns
+  Status:      Ready - The instance was provisioned successfully @ 2018-03-02 16:07:09 +0000 UTC
+  Class:       user-provided-service
+  Plan:        default
+
+Bindings:
+No bindings defined
 ```
 
 # Step 5 - Requesting a `ServiceBinding` to use the `ServiceInstance`
 
-Now that our `ServiceInstance` has been created, we can bind to it. To accomplish this,
-we'll create a `ServiceBinding` resource. Do so with the following
-command:
+Now that our `ServiceInstance` has been created, we can bind to it.
+Create a `ServiceBinding` resource with the following command:
 
 ```console
 $ kubectl create -f contrib/examples/walkthrough/ups-binding.yaml
@@ -252,34 +179,11 @@ service catalog controller will insert into a Kubernetes `Secret`. We can check
 the status of this process like so:
 
 ```console
-$ kubectl get servicebindings -n test-ns ups-binding -o yaml
-apiVersion: servicecatalog.k8s.io/v1beta1
-kind: ServiceBinding
-metadata:
-  creationTimestamp: 2017-11-01T14:26:29Z
-  finalizers:
-  - kubernetes-incubator/service-catalog
-  generation: 1
-  name: ups-binding
-  namespace: test-ns
-  resourceVersion: "16"
-  selfLink: /apis/servicecatalog.k8s.io/v1beta1/namespaces/test-ns/servicebindings/ups-binding
-  uid: a6823f15-bf10-11e7-9e29-0242ac110004
-spec:
-  externalID: a8bb795a-711d-4854-adbb-5654428274f9
-  instanceRef:
-    name: ups-instance
-  secretName: ups-binding
-status:
-  conditions:
-  - lastTransitionTime: 2017-11-01T14:26:29Z
-    message: Injected bind result
-    reason: InjectedBindResult
-    status: "True"
-    type: Ready
-  externalProperties: {}
-  orphanMitigationInProgress: false
-  reconciledGeneration: 1
+$ svcat describe binding -n test-ns ups-binding
+  Name:        ups-binding
+  Namespace:   test-ns
+  Status:      Ready - Injected bind result @ 2018-03-02 16:11:25 +0000 UTC
+  Instance:    ups-instance
 ```
 
 Notice that the status has a `Ready` condition set.  This means our binding is
@@ -297,11 +201,10 @@ Notice that a new `Secret` named `ups-binding` has been created.
 
 # Step 6 - Deleting the `ServiceBinding`
 
-Now, let's unbind from the instance. To do this, we simply *delete* the
-`ServiceBinding` resource that we previously created:
+Now, let's unbind the instance:
 
 ```
-kubectl delete -n test-ns servicebindings ups-binding
+svcat unbind -n test-ns ups-instance
 ```
 
 After the deletion is complete, we should see that the `Secret` is gone:
@@ -314,11 +217,10 @@ default-token-3k61z   kubernetes.io/service-account-token   3         30m
 
 # Step 7 - Deleting the `ServiceInstance`
 
-Now, we can deprovision the instance. To do this, we simply *delete* the
-`ServiceInstance` resource that we previously created:
+Now, we can deprovision the instance:
 
 ```
-kubectl delete -n test-ns serviceinstances ups-instance
+svcat deprovision -n test-ns ups-instance
 ```
 
 # Step 8 - Deleting the `ClusterServiceBroker`
@@ -332,11 +234,12 @@ kubectl delete clusterservicebrokers ups-broker
 ```
 
 We should then see that all the `ClusterServiceClass` resources that came from that
-broker have also been deleted:
+broker have also been deleted by running the following command:
 
 ```console
-$ kubectl get clusterserviceclasses
-No resources found.
+$ svcat get classes
+  NAME   DESCRIPTION   UUID
++------+-------------+------+
 ```
 
 # Step 9 - Final Cleanup
@@ -368,7 +271,7 @@ kubectl delete ns catalog
 ## Firewall rules
 
 If you are using Google Cloud Platform, you may need to run the following
-commands to setup proper firewall rules to allow your traffic get in.
+command to setup proper firewall rules to allow your traffic get in.
 
 ```
 gcloud compute firewall-rules create allow-service-catalog-secure --allow tcp:30443 --description "Allow incoming traffic on 30443 port."

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -229,7 +229,7 @@ serviceinstance "ups-instance" created
 
 After the `ServiceInstance` is created, the service catalog controller will 
 communicate with the appropriate broker server to initiate provisioning. 
-Check the status of that process with this command:
+Check the status of that process:
 
 ```console
 $ svcat describe instance -n test-ns ups-instance

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -27,7 +27,7 @@ Otherwise, to install with sensible defaults, run the following command:
 helm install charts/ups-broker --name ups-broker --namespace ups-broker
 ```
 
-# Step 2 - Creating a `ClusterServiceBroker` Resource
+# Step 2 - Creating a ClusterServiceBroker Resource
 
 Because we haven't created any resources in the service-catalog API server yet,
 querying service catalog returns an empty list of resources:
@@ -64,7 +64,7 @@ Notice that the status reflects that the broker's
 catalog of service offerings has been successfully added to our cluster's
 service catalog.
 
-# Step 3 - Viewing `ClusterServiceClass`es and `ClusterServicePlan`s
+# Step 3 - Viewing ClusterServiceClasses and ClusterServicePlans
 
 The controller created a `ClusterServiceClass` for each service that the UPS broker
 provides. We can view the `ClusterServiceClass` resources available by executing:
@@ -125,7 +125,7 @@ $ svcat describe plan user-provided-service/default
   No instances defined
 ```
 
-# Step 4 - Creating a New `ServiceInstance`
+# Step 4 - Creating a New ServiceInstance
 
 Now that a `ClusterServiceClass` named `user-provided-service` exists within our
 cluster's service catalog, we can create a `ServiceInstance` that points to
@@ -162,7 +162,7 @@ Bindings:
 No bindings defined
 ```
 
-# Step 5 - Requesting a `ServiceBinding` to use the `ServiceInstance`
+# Step 5 - Requesting a ServiceBinding to use the ServiceInstance
 
 Now that our `ServiceInstance` has been created, we can bind to it.
 Create a `ServiceBinding` resource with the following command:
@@ -199,7 +199,7 @@ ups-binding                       Opaque                                2       
 
 Notice that a new `Secret` named `ups-binding` has been created.
 
-# Step 6 - Deleting the `ServiceBinding`
+# Step 6 - Deleting the ServiceBinding
 
 Now, let's unbind the instance:
 
@@ -215,7 +215,7 @@ NAME                  TYPE                                  DATA      AGE
 default-token-3k61z   kubernetes.io/service-account-token   3         30m
 ```
 
-# Step 7 - Deleting the `ServiceInstance`
+# Step 7 - Deleting the ServiceInstance
 
 Now, we can deprovision the instance:
 
@@ -223,7 +223,7 @@ Now, we can deprovision the instance:
 svcat deprovision -n test-ns ups-instance
 ```
 
-# Step 8 - Deleting the `ClusterServiceBroker`
+# Step 8 - Deleting the ClusterServiceBroker
 
 Next, we should remove the `ClusterServiceBroker` resource. This tells the service
 catalog to remove the broker's services from the catalog. Do so with this
@@ -244,7 +244,7 @@ $ svcat get classes
 
 # Step 9 - Final Cleanup
 
-## Cleaning up the UPS Service Broker Server
+## Cleaning up the User Provided Service Broker
 
 To clean up, delete the helm deployment:
 


### PR DESCRIPTION
Fixes #1682.

* Move the contents of the svcat README into the install guide and a new cli doc under /docs.
* Update the walkthrough to use svcat where appropriate.