### PR TITLE
Add enhanced parameter options to provision

### DIFF
--- a/cmd/svcat/README.md
+++ b/cmd/svcat/README.md
@@ -139,10 +139,10 @@ Additional parameters and secrets can be provided using the `--param` and `--sec
 --param p1=foo --param p2=bar --secret creds[db]
 ```
 
-You can also provide provision parameters in the form of a JSON string using the `--params` flag:
+You can also provide provision parameters in the form of a JSON string using the `--params-json` flag:
 
-```console
-svcat provision secure-instance --class mysqldb --plan secureDB --params '{
+```
+svcat provision secure-instance --class mysqldb --plan secureDB --params-json '{
     "encrypt" : true,
     "firewallRules" : [
         {
@@ -160,7 +160,7 @@ svcat provision secure-instance --class mysqldb --plan secureDB --params '{
 '
 ```
 
-Note: You may not combine the `--params` flag with individual `--param` flags.
+Note: You may not combine the `--params-json` flag with individual `--param` flags.
 
 ## View all instances of a service plan on the cluster
 

--- a/cmd/svcat/README.md
+++ b/cmd/svcat/README.md
@@ -139,6 +139,29 @@ Additional parameters and secrets can be provided using the `--param` and `--sec
 --param p1=foo --param p2=bar --secret creds[db]
 ```
 
+You can also provide provision parameters in the form of a JSON string using the `--params` flag:
+
+```console
+svcat provision secure-instance --class mysqldb --plan secureDB --params '{
+    "encrypt" : true,
+    "firewallRules" : [
+        {
+            "name": "AllowSome",
+            "startIPAddress": "75.70.113.50",
+            "endIPAddress" : "75.70.113.131"
+        },
+        {
+            "name": "AllowMore",
+            "startIPAddress": "13.54.0.0",
+            "endIPAddress" : "13.56.0.0"
+        }
+    ]
+}
+'
+```
+
+Note: You may not combine the `--params` flag with individual `--param` flags.
+
 ## View all instances of a service plan on the cluster
 
 ```console

--- a/cmd/svcat/instance/provision_cmd.go
+++ b/cmd/svcat/instance/provision_cmd.go
@@ -47,23 +47,22 @@ func NewProvisionCmd(cxt *command.Context) *cobra.Command {
 		Example: `
   svcat provision wordpress-mysql-instance --class mysqldb --plan free -p location=eastus -p sslEnforcement=disabled
   svcat provision wordpress-mysql-instance --class mysqldb --plan free -s mysecret[dbparams]
-  svcat provision secure-instance --class mysqldb --plan secure -params '{
-	"resourceGroup" : "demo",
-	 "location" : "eastus",
-	 "firewallRules" : [
-		 {
-			 "name": "officeA",
-			 "startIPAddress": "35.0.0.1",
-			 "endIPAddress" : "35.0.0.255"
-		 },
-		 {
-			 "name: "officeB",
-			 "startIPAddress": "67.23.10.24",
-			 "endIPAddress" : "67.23.10.255"
-		 }
-	 ]
- }
- '
+  svcat provision secure-instance --class mysqldb --plan secureDB --params '{
+    "encrypt" : true,
+    "firewallRules" : [
+        {
+            "name": "AllowSome",
+            "startIPAddress": "75.70.113.50",
+            "endIPAddress" : "75.70.113.131"
+        },
+        {
+            "name": "AllowMore",
+            "startIPAddress": "13.54.0.0",
+            "endIPAddress" : "13.56.0.0"
+        }
+    ]
+}
+'
 `,
 		PreRunE: command.PreRunE(provisionCmd),
 		RunE:    command.RunE(provisionCmd),
@@ -77,10 +76,11 @@ func NewProvisionCmd(cxt *command.Context) *cobra.Command {
 		"The plan name (Required)")
 	cmd.MarkFlagRequired("plan")
 	cmd.Flags().StringSliceVarP(&provisionCmd.rawParams, "param", "p", nil,
-		"Additional parameter to use when provisioning the service, format: NAME=VALUE")
+		"Additional parameter to use when provisioning the service, format: NAME=VALUE. Cannot be combined with --params")
 	cmd.Flags().StringSliceVarP(&provisionCmd.rawSecrets, "secret", "s", nil,
 		"Additional parameter, whose value is stored in a secret, to use when provisioning the service, format: SECRET[KEY]")
-	cmd.Flags().StringVar(&provisionCmd.jsonParams, "params", "", "Additional parameters to use when provisioning the service, provided as a JSON object")
+	cmd.Flags().StringVar(&provisionCmd.jsonParams, "params", "",
+		"Additional parameters to use when provisioning the service, provided as a JSON object. Cannot be combined with --param")
 	return cmd
 }
 

--- a/cmd/svcat/instance/provision_cmd.go
+++ b/cmd/svcat/instance/provision_cmd.go
@@ -47,7 +47,7 @@ func NewProvisionCmd(cxt *command.Context) *cobra.Command {
 		Example: `
   svcat provision wordpress-mysql-instance --class mysqldb --plan free -p location=eastus -p sslEnforcement=disabled
   svcat provision wordpress-mysql-instance --class mysqldb --plan free -s mysecret[dbparams]
-  svcat provision secure-instance --class mysqldb --plan secureDB --params '{
+  svcat provision secure-instance --class mysqldb --plan secureDB --params-json '{
     "encrypt" : true,
     "firewallRules" : [
         {
@@ -76,10 +76,10 @@ func NewProvisionCmd(cxt *command.Context) *cobra.Command {
 		"The plan name (Required)")
 	cmd.MarkFlagRequired("plan")
 	cmd.Flags().StringSliceVarP(&provisionCmd.rawParams, "param", "p", nil,
-		"Additional parameter to use when provisioning the service, format: NAME=VALUE. Cannot be combined with --params")
+		"Additional parameter to use when provisioning the service, format: NAME=VALUE. Cannot be combined with --params-json")
 	cmd.Flags().StringSliceVarP(&provisionCmd.rawSecrets, "secret", "s", nil,
 		"Additional parameter, whose value is stored in a secret, to use when provisioning the service, format: SECRET[KEY]")
-	cmd.Flags().StringVar(&provisionCmd.jsonParams, "params", "",
+	cmd.Flags().StringVar(&provisionCmd.jsonParams, "params-json", "",
 		"Additional parameters to use when provisioning the service, provided as a JSON object. Cannot be combined with --param")
 	return cmd
 }
@@ -91,6 +91,10 @@ func (c *provisonCmd) Validate(args []string) error {
 	c.instanceName = args[0]
 
 	var err error
+
+	if c.jsonParams != "" && len(c.rawParams) > 0 {
+		return fmt.Errorf("--params-json cannot be used with --param")
+	}
 
 	if c.jsonParams != "" {
 		c.params, err = parameters.ParseVariableJSON(c.jsonParams)

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -25,8 +25,9 @@ import (
 
 var keymapRegex = regexp.MustCompile(`^([^\[]+)\[(.+)\]\s*$`)
 
-// ParseVariableJSON converts a JSON string of variable assignments
-// into a map of keys and values
+// ParseVariableJSON converts a JSON object into a map of keys and values
+// Example:
+// `{ "location" : "east", "group" : "demo" }' becomes map[location:east group:demo]
 func ParseVariableJSON(params string) (map[string]interface{}, error) {
 	var p map[string]interface{}
 	err := json.Unmarshal([]byte(params), &p)

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -17,6 +17,7 @@ limitations under the License.
 package parameters
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -24,14 +25,25 @@ import (
 
 var keymapRegex = regexp.MustCompile(`^([^\[]+)\[(.+)\]\s*$`)
 
+// ParseVariableJSON converts a JSON string of variable assignments
+// into a map of keys and values
+func ParseVariableJSON(params string) (map[string]interface{}, error) {
+	var p map[string]interface{}
+	err := json.Unmarshal([]byte(params), &p)
+	if err != nil {
+		return nil, fmt.Errorf("invalid parameters (%s)", params)
+	}
+	return p, nil
+}
+
 // ParseVariableAssignments converts a string array of variable assignments
 // into a map of keys and values
 // Example:
 // [a=b c=abc1232===] becomes map[a:b c:abc1232===]
 func ParseVariableAssignments(params []string) (map[string]string, error) {
 	variables := map[string]string{}
-
 	for _, p := range params {
+
 		parts := strings.SplitN(p, "=", 2)
 		if len(parts) < 2 {
 			return nil, fmt.Errorf("invalid parameter (%s), must be in name=value format", p)
@@ -39,7 +51,7 @@ func ParseVariableAssignments(params []string) (map[string]string, error) {
 
 		variable := strings.TrimSpace(parts[0])
 		if variable == "" {
-			return nil, fmt.Errorf("invalid parameter (%s), variable name is requried", p)
+			return nil, fmt.Errorf("invalid parameter (%s), variable name is required", p)
 		}
 		value := strings.TrimSpace(parts[1])
 
@@ -64,7 +76,7 @@ func ParseKeyMaps(params []string) (map[string]string, error) {
 
 		mapName := strings.TrimSpace(parts[1])
 		if mapName == "" {
-			return nil, fmt.Errorf("invalid parameter (%s), map is requried", p)
+			return nil, fmt.Errorf("invalid parameter (%s), map is required", p)
 		}
 
 		key := strings.TrimSpace(parts[2])

--- a/cmd/svcat/svcat_test.go
+++ b/cmd/svcat/svcat_test.go
@@ -55,6 +55,9 @@ func TestCommandValidation(t *testing.T) {
 		{"unbind requires arg", "unbind", "instance or binding name is required"},
 		{"sync requires names", "sync broker", "name is required"},
 		{"deprovision requires name", "deprovision", "name is required"},
+		{"provision does not accept --param and --params-json",
+			`provision name --class class --plan plan --params-json '{}' --param k=v`,
+			"--params-json cannot be used with --param"},
 	}
 
 	for _, tc := range testcases {

--- a/cmd/svcat/testdata/plugin.yaml
+++ b/cmd/svcat/testdata/plugin.yaml
@@ -113,7 +113,11 @@ tree:
     desc: The class name (Required)
   - name: param
     shorthand: p
-    desc: 'Additional parameter to use when provisioning the service, format: NAME=VALUE'
+    desc: 'Additional parameter to use when provisioning the service, format: NAME=VALUE.
+      Cannot be combined with --params-json'
+  - name: params-json
+    desc: Additional parameters to use when provisioning the service, provided as
+      a JSON object. Cannot be combined with --param
   - name: plan
     desc: The plan name (Required)
   - name: secret

--- a/pkg/svcat/service-catalog/instance.go
+++ b/pkg/svcat/service-catalog/instance.go
@@ -142,7 +142,7 @@ func (sdk *SDK) InstanceToServiceClassAndPlan(instance *v1beta1.ServiceInstance,
 
 // Provision creates an instance of a service class and plan.
 func (sdk *SDK) Provision(namespace, instanceName, className, planName string,
-	params map[string]string, secrets map[string]string) (*v1beta1.ServiceInstance, error) {
+	params interface{}, secrets map[string]string) (*v1beta1.ServiceInstance, error) {
 
 	request := &v1beta1.ServiceInstance{
 		ObjectMeta: v1.ObjectMeta{

--- a/pkg/svcat/service-catalog/parameters.go
+++ b/pkg/svcat/service-catalog/parameters.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// BuildGenericParameters converts a gneric map to o a byte encoded json document,
+// BuildParameters converts a map of variable assignments to a byte encoded json document,
 // which is what the ServiceCatalog API consumes.
 func BuildParameters(params interface{}) *runtime.RawExtension {
 	paramsJSON, err := json.Marshal(params)
@@ -36,19 +36,6 @@ func BuildParameters(params interface{}) *runtime.RawExtension {
 
 	return &runtime.RawExtension{Raw: paramsJSON}
 }
-
-// // BuildParameters converts a map of variable assignments to a byte encoded json document,
-// // which is what the ServiceCatalog API consumes.
-// func BuildParameters(params map[string]string) *runtime.RawExtension {
-// 	paramsJSON, err := json.Marshal(params)
-// 	if err != nil {
-// 		// This should never be hit because marshalling a map[string]string is pretty safe
-// 		// I'd rather throw a panic then force handling of an error that I don't think is possible.
-// 		panic(fmt.Errorf("unable to marshal the request parameters %v (%s)", params, err))
-// 	}
-
-// 	return &runtime.RawExtension{Raw: paramsJSON}
-// }
 
 // BuildParametersFrom converts a map of secrets names to secret keys to the
 // type consumed by the ServiceCatalog API.

--- a/pkg/svcat/service-catalog/parameters.go
+++ b/pkg/svcat/service-catalog/parameters.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// BuildParameters converts a map of variable assignments to a byte encoded json document,
+// BuildGenericParameters converts a gneric map to o a byte encoded json document,
 // which is what the ServiceCatalog API consumes.
-func BuildParameters(params map[string]string) *runtime.RawExtension {
+func BuildParameters(params interface{}) *runtime.RawExtension {
 	paramsJSON, err := json.Marshal(params)
 	if err != nil {
 		// This should never be hit because marshalling a map[string]string is pretty safe
@@ -36,6 +36,19 @@ func BuildParameters(params map[string]string) *runtime.RawExtension {
 
 	return &runtime.RawExtension{Raw: paramsJSON}
 }
+
+// // BuildParameters converts a map of variable assignments to a byte encoded json document,
+// // which is what the ServiceCatalog API consumes.
+// func BuildParameters(params map[string]string) *runtime.RawExtension {
+// 	paramsJSON, err := json.Marshal(params)
+// 	if err != nil {
+// 		// This should never be hit because marshalling a map[string]string is pretty safe
+// 		// I'd rather throw a panic then force handling of an error that I don't think is possible.
+// 		panic(fmt.Errorf("unable to marshal the request parameters %v (%s)", params, err))
+// 	}
+
+// 	return &runtime.RawExtension{Raw: paramsJSON}
+// }
 
 // BuildParametersFrom converts a map of secrets names to secret keys to the
 // type consumed by the ServiceCatalog API.


### PR DESCRIPTION
This PR enables the user to specify a `--params` option that receives a JSON string containing the provisioning parameters. This is especially useful for complicated provision requests that cannot be expressed as KEY=VALUE pairs. 

This also incidentally fixes two typos in the cmd/svcat/parameters/parameters.go file. 

Closes #1767 