### PR TITLE
OrphanMitigation condition and different handling of retry timeout

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -524,7 +524,6 @@ type ServiceInstanceStatus struct {
 
 	// OrphanMitigationInProgress is set to true if there is an ongoing orphan
 	// mitigation operation against this ServiceInstance in progress.
-	// Deprecated: Use OrphanMitigation condition instead.
 	OrphanMitigationInProgress bool
 
 	// LastOperation is the string that the broker may have returned when

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -524,6 +524,7 @@ type ServiceInstanceStatus struct {
 
 	// OrphanMitigationInProgress is set to true if there is an ongoing orphan
 	// mitigation operation against this ServiceInstance in progress.
+	// Deprecated: Use OrphanMitigation condition instead.
 	OrphanMitigationInProgress bool
 
 	// LastOperation is the string that the broker may have returned when
@@ -603,6 +604,10 @@ const (
 	// ServiceInstanceConditionFailed represents information about a final failure
 	// that should not be retried.
 	ServiceInstanceConditionFailed ServiceInstanceConditionType = "Failed"
+
+	// ServiceInstanceConditionOrphanMitigation represents information about an
+	// orphan mitigation that is required after failed provisioning.
+	ServiceInstanceConditionOrphanMitigation ServiceInstanceConditionType = "OrphanMitigation"
 )
 
 // ServiceInstanceOperation represents a type of operation the controller can

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -590,6 +590,7 @@ type ServiceInstanceStatus struct {
 
 	// OrphanMitigationInProgress is set to true if there is an ongoing orphan
 	// mitigation operation against this ServiceInstance in progress.
+	// Deprecated: Use OrphanMitigation condition instead.
 	OrphanMitigationInProgress bool `json:"orphanMitigationInProgress"`
 
 	// LastOperation is the string that the broker may have returned when
@@ -669,6 +670,10 @@ const (
 	// ServiceInstanceConditionFailed represents information about a final failure
 	// that should not be retried.
 	ServiceInstanceConditionFailed ServiceInstanceConditionType = "Failed"
+
+	// ServiceInstanceConditionOrphanMitigation represents information about an
+	// orphan mitigation that is required after failed provisioning.
+	ServiceInstanceConditionOrphanMitigation ServiceInstanceConditionType = "OrphanMitigation"
 )
 
 // ServiceInstanceOperation represents a type of operation the controller can

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -590,7 +590,6 @@ type ServiceInstanceStatus struct {
 
 	// OrphanMitigationInProgress is set to true if there is an ongoing orphan
 	// mitigation operation against this ServiceInstance in progress.
-	// Deprecated: Use OrphanMitigation condition instead.
 	OrphanMitigationInProgress bool `json:"orphanMitigationInProgress"`
 
 	// LastOperation is the string that the broker may have returned when

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -627,6 +627,12 @@ func isServiceInstanceFailed(instance *v1beta1.ServiceInstance) bool {
 	return isServiceInstanceConditionTrue(instance, v1beta1.ServiceInstanceConditionFailed)
 }
 
+// isServiceInstanceOrphanMitigation returns whether the given instance has an
+// orphan mitigation condition with status true.
+func isServiceInstanceOrphanMitigation(instance *v1beta1.ServiceInstance) bool {
+	return isServiceInstanceConditionTrue(instance, v1beta1.ServiceInstanceConditionOrphanMitigation)
+}
+
 // NewClientConfigurationForBroker creates a new ClientConfiguration for connecting
 // to the specified Broker
 func NewClientConfigurationForBroker(broker *v1beta1.ClusterServiceBroker, authConfig *osb.AuthConfig) *osb.ClientConfiguration {

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1598,19 +1598,15 @@ func (c *controller) processProvisionFailure(instance *v1beta1.ServiceInstance, 
 	// requeue this resource.
 	var err error
 	if shouldMitigateOrphan {
-		// Copy failure reason/message to a new OrphanMitigation condition
-		orphanMitigationCond := newServiceInstanceOrphanMitigationCondition(v1beta1.ConditionTrue, readyCond.Reason, readyCond.Message)
-		c.recorder.Event(instance, corev1.EventTypeWarning, orphanMitigationCond.Reason, orphanMitigationCond.Message)
+		// Copy original failure reason/message to a new OrphanMitigation condition
+		c.recorder.Event(instance, corev1.EventTypeWarning, readyCond.Reason, readyCond.Message)
 		setServiceInstanceCondition(instance, v1beta1.ServiceInstanceConditionOrphanMitigation,
-			orphanMitigationCond.Status,
-			orphanMitigationCond.Reason,
-			orphanMitigationCond.Message)
+			v1beta1.ConditionTrue, readyCond.Reason, readyCond.Message)
 		// Overwrite Ready condition reason/message with reporting on orphan mitigation
-		readyCond := newServiceInstanceReadyCondition(v1beta1.ConditionFalse, startingInstanceOrphanMitigationReason, startingInstanceOrphanMitigationMessage)
 		setServiceInstanceCondition(instance, v1beta1.ServiceInstanceConditionReady,
-			readyCond.Status,
-			readyCond.Reason,
-			readyCond.Message)
+			v1beta1.ConditionFalse,
+			startingInstanceOrphanMitigationReason,
+			startingInstanceOrphanMitigationMessage)
 
 		instance.Status.OperationStartTime = nil
 		instance.Status.AsyncOpInProgress = false

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -522,13 +522,6 @@ func (c *controller) reconcileServiceInstanceUpdate(instance *v1beta1.ServiceIns
 // reconcileServiceInstanceDelete is responsible for handling any instance whose
 // deletion timestamp is set.
 func (c *controller) reconcileServiceInstanceDelete(instance *v1beta1.ServiceInstance) error {
-	// nothing to do...
-	if instance.DeletionTimestamp == nil && !instance.Status.OrphanMitigationInProgress {
-		// TODO nilebox: shouldn't we throw an error instead?
-		// We shouldn't have this method invoked if this condition is true.
-		return nil
-	}
-
 	if finalizers := sets.NewString(instance.Finalizers...); !finalizers.Has(v1beta1.FinalizerServiceCatalog) {
 		return nil
 	}

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -3796,7 +3796,6 @@ func TestReconcileServiceInstanceOrphanMitigation(t *testing.T) {
 				},
 			},
 			async: true,
-			// TODO nilebox: Should instance remain in orphan mitigation or not?
 			finishedOrphanMitigation:     false,
 			retryDurationExceeded:        true,
 			expectedReadyConditionStatus: v1beta1.ConditionUnknown,

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -3006,9 +3006,9 @@ func TestPollServiceInstanceFailureOnFinalRetry(t *testing.T) {
 		t,
 		updatedServiceInstance,
 		v1beta1.ServiceInstanceOperationProvision,
-		asyncProvisioningReason,
-		errorReconciliationRetryTimeoutReason,
 		startingInstanceOrphanMitigationReason,
+		errorReconciliationRetryTimeoutReason,
+		asyncProvisioningReason,
 		instance,
 	)
 
@@ -3667,8 +3667,8 @@ func TestReconcileServiceInstanceTimeoutTriggersOrphanMitigation(t *testing.T) {
 		fatalf(t, "Couldn't convert object %+v into a *v1beta1.ServiceInstance", updatedObject)
 	}
 
-	assertServiceInstanceReadyCondition(t, updatedServiceInstance, v1beta1.ConditionFalse, errorErrorCallingProvisionReason)
-	assertServiceInstanceOrphanMitigationTrue(t, updatedServiceInstance)
+	assertServiceInstanceReadyCondition(t, updatedServiceInstance, v1beta1.ConditionFalse, startingInstanceOrphanMitigationReason)
+	assertServiceInstanceOrphanMitigationTrue(t, updatedServiceInstance, errorErrorCallingProvisionReason)
 	assertServiceInstanceOrphanMitigationInProgressTrue(t, updatedServiceInstance)
 }
 
@@ -3918,7 +3918,7 @@ func TestReconcileServiceInstanceOrphanMitigation(t *testing.T) {
 			if tc.finishedOrphanMitigation {
 				assertServiceInstanceOrphanMitigationMissing(t, updatedServiceInstance)
 			} else {
-				assertServiceInstanceOrphanMitigationTrue(t, updatedServiceInstance)
+				assertServiceInstanceOrphanMitigationTrue(t, updatedServiceInstance, startingInstanceOrphanMitigationReason)
 			}
 
 			//TODO(mkibbe): change asserts to expects

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1876,6 +1876,14 @@ func assertServiceInstanceReadyCondition(t *testing.T, obj runtime.Object, statu
 	assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionReady, status, reason...)
 }
 
+func assertServiceInstanceOrphanMitigationCondition(t *testing.T, obj runtime.Object, status v1beta1.ConditionStatus, reason ...string) {
+	assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionOrphanMitigation, status, reason...)
+}
+
+func assertServiceInstanceOrphanMitigationTrue(t *testing.T, obj runtime.Object, reason ...string) {
+	assertServiceInstanceOrphanMitigationCondition(t, obj, v1beta1.ConditionTrue, reason...)
+}
+
 func assertServiceInstanceCondition(t *testing.T, obj runtime.Object, conditionType v1beta1.ServiceInstanceConditionType, status v1beta1.ConditionStatus, reason ...string) {
 	instance, ok := obj.(*v1beta1.ServiceInstance)
 	if !ok {
@@ -2021,7 +2029,7 @@ func testServiceInstanceOrphanMitigationInProgress(t *testing.T, name string, f 
 		f(t, "%vCouldn't convert object %+v into a *v1beta1.ServiceInstance", obj)
 	}
 
-	actual := instance.Status.OrphanMitigationInProgress
+	actual := isServiceInstanceOrphanMitigation(instance)
 	if actual != expected {
 		f(t, "%vexpected OrphanMitigationInProgress to be %v but was %v", logContext, expected, actual)
 		return false
@@ -2096,7 +2104,7 @@ func assertServiceInstanceOperationInProgressWithParameters(t *testing.T, obj ru
 		expectedObservedGeneration = originalInstance.Generation
 	case v1beta1.ServiceInstanceOperationDeprovision:
 		reason = deprovisioningInFlightReason
-		if originalInstance.Status.OrphanMitigationInProgress {
+		if isServiceInstanceOrphanMitigation(originalInstance) {
 			expectedObservedGeneration = originalInstance.Status.ObservedGeneration
 		} else {
 			expectedObservedGeneration = originalInstance.Generation
@@ -2118,11 +2126,12 @@ func assertServiceInstanceOperationInProgressWithParameters(t *testing.T, obj ru
 
 func assertServiceInstanceStartingOrphanMitigation(t *testing.T, obj runtime.Object, originalInstance *v1beta1.ServiceInstance) {
 	assertServiceInstanceCurrentOperation(t, obj, v1beta1.ServiceInstanceOperationProvision)
-	assertServiceInstanceReadyFalse(t, obj, startingInstanceOrphanMitigationReason)
+	assertServiceInstanceReadyFalse(t, obj, errorProvisionCallFailedReason)
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
 	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.ProvisionStatus)
+	assertServiceInstanceOrphanMitigationTrue(t, obj, startingInstanceOrphanMitigationReason)
 	assertServiceInstanceOrphanMitigationInProgressTrue(t, obj)
 	assertServiceInstanceDeprovisionStatus(t, obj, v1beta1.ServiceInstanceDeprovisionStatusRequired)
 }
@@ -2157,7 +2166,7 @@ func assertServiceInstanceOperationSuccessWithParameters(t *testing.T, obj runti
 		reason = successDeprovisionReason
 		readyStatus = v1beta1.ConditionFalse
 		deprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusSucceeded
-		if originalInstance.Status.OrphanMitigationInProgress {
+		if isServiceInstanceOrphanMitigation(originalInstance) {
 			observedGeneration = originalInstance.Status.ObservedGeneration
 		} else {
 			observedGeneration = originalInstance.Generation
@@ -2231,12 +2240,13 @@ func assertServiceInstanceUpdateRequestFailingErrorNoOrphanMitigation(t *testing
 	assertServiceInstanceInProgressPropertiesNil(t, obj)
 }
 
-func assertServiceInstanceRequestFailingErrorStartOrphanMitigation(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, readyReason string, failureReason string, originalInstance *v1beta1.ServiceInstance) {
+func assertServiceInstanceRequestFailingErrorStartOrphanMitigation(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, readyReason string, failureReason string, orphanMitigationReason string, originalInstance *v1beta1.ServiceInstance) {
 	assertServiceInstanceRequestFailingError(t, obj, operation, readyReason, failureReason, true, originalInstance)
 	assertServiceInstanceCurrentOperation(t, obj, v1beta1.ServiceInstanceOperationProvision)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
 	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.ProvisionStatus)
+	assertServiceInstanceOrphanMitigationCondition(t, obj, v1beta1.ConditionTrue, orphanMitigationReason)
 	assertServiceInstanceOrphanMitigationInProgressTrue(t, obj)
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1876,8 +1876,8 @@ func assertServiceInstanceReadyCondition(t *testing.T, obj runtime.Object, statu
 	assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionReady, status, reason...)
 }
 
-func assertServiceInstanceOrphanMitigationTrue(t *testing.T, obj runtime.Object) {
-	assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionOrphanMitigation, v1beta1.ConditionTrue, startingInstanceOrphanMitigationReason)
+func assertServiceInstanceOrphanMitigationTrue(t *testing.T, obj runtime.Object, reason string) {
+	assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionOrphanMitigation, v1beta1.ConditionTrue, reason)
 }
 
 func assertServiceInstanceCondition(t *testing.T, obj runtime.Object, conditionType v1beta1.ServiceInstanceConditionType, status v1beta1.ConditionStatus, reason ...string) {
@@ -2140,12 +2140,12 @@ func assertServiceInstanceOperationInProgressWithParameters(t *testing.T, obj ru
 
 func assertServiceInstanceStartingOrphanMitigation(t *testing.T, obj runtime.Object, originalInstance *v1beta1.ServiceInstance) {
 	assertServiceInstanceCurrentOperation(t, obj, v1beta1.ServiceInstanceOperationProvision)
-	assertServiceInstanceReadyFalse(t, obj, errorProvisionCallFailedReason)
+	assertServiceInstanceReadyFalse(t, obj, startingInstanceOrphanMitigationReason)
 	assertServiceInstanceOperationStartTimeSet(t, obj, false)
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
 	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.ProvisionStatus)
-	assertServiceInstanceOrphanMitigationTrue(t, obj)
+	assertServiceInstanceOrphanMitigationTrue(t, obj, errorProvisionCallFailedReason)
 	assertServiceInstanceOrphanMitigationInProgressTrue(t, obj)
 	assertServiceInstanceDeprovisionStatus(t, obj, v1beta1.ServiceInstanceDeprovisionStatusRequired)
 }
@@ -2260,7 +2260,7 @@ func assertServiceInstanceRequestFailingErrorStartOrphanMitigation(t *testing.T,
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
 	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.ProvisionStatus)
-	assertServiceInstanceOrphanMitigationTrue(t, obj)
+	assertServiceInstanceOrphanMitigationTrue(t, obj, orphanMitigationReason)
 	assertServiceInstanceOrphanMitigationInProgressTrue(t, obj)
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1876,12 +1876,8 @@ func assertServiceInstanceReadyCondition(t *testing.T, obj runtime.Object, statu
 	assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionReady, status, reason...)
 }
 
-func assertServiceInstanceOrphanMitigationCondition(t *testing.T, obj runtime.Object, status v1beta1.ConditionStatus, reason ...string) {
-	assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionOrphanMitigation, status, reason...)
-}
-
-func assertServiceInstanceOrphanMitigationTrue(t *testing.T, obj runtime.Object, reason ...string) {
-	assertServiceInstanceOrphanMitigationCondition(t, obj, v1beta1.ConditionTrue, reason...)
+func assertServiceInstanceOrphanMitigationTrue(t *testing.T, obj runtime.Object) {
+	assertServiceInstanceCondition(t, obj, v1beta1.ServiceInstanceConditionOrphanMitigation, v1beta1.ConditionTrue, startingInstanceOrphanMitigationReason)
 }
 
 func assertServiceInstanceCondition(t *testing.T, obj runtime.Object, conditionType v1beta1.ServiceInstanceConditionType, status v1beta1.ConditionStatus, reason ...string) {
@@ -1905,6 +1901,24 @@ func assertServiceInstanceCondition(t *testing.T, obj runtime.Object, conditionT
 
 	if !foundCondition {
 		fatalf(t, "%v condition not found", conditionType)
+	}
+}
+
+func assertServiceInstanceOrphanMitigationMissing(t *testing.T, obj runtime.Object, reason ...string) {
+	assertServiceInstanceConditionMissing(t, obj, v1beta1.ServiceInstanceConditionOrphanMitigation)
+}
+
+func assertServiceInstanceConditionMissing(t *testing.T, obj runtime.Object, conditionType v1beta1.ServiceInstanceConditionType) {
+	instance, ok := obj.(*v1beta1.ServiceInstance)
+	if !ok {
+		fatalf(t, "Couldn't convert object %+v into a *v1beta1.ServiceInstance", obj)
+	}
+
+	for _, condition := range instance.Status.Conditions {
+		if condition.Type == conditionType {
+			fatalf(t, "%v condition expected to be missing", conditionType)
+			return
+		}
 	}
 }
 
@@ -2131,7 +2145,7 @@ func assertServiceInstanceStartingOrphanMitigation(t *testing.T, obj runtime.Obj
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
 	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.ProvisionStatus)
-	assertServiceInstanceOrphanMitigationTrue(t, obj, startingInstanceOrphanMitigationReason)
+	assertServiceInstanceOrphanMitigationTrue(t, obj)
 	assertServiceInstanceOrphanMitigationInProgressTrue(t, obj)
 	assertServiceInstanceDeprovisionStatus(t, obj, v1beta1.ServiceInstanceDeprovisionStatusRequired)
 }
@@ -2246,7 +2260,7 @@ func assertServiceInstanceRequestFailingErrorStartOrphanMitigation(t *testing.T,
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
 	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.ProvisionStatus)
-	assertServiceInstanceOrphanMitigationCondition(t, obj, v1beta1.ConditionTrue, orphanMitigationReason)
+	assertServiceInstanceOrphanMitigationTrue(t, obj)
 	assertServiceInstanceOrphanMitigationInProgressTrue(t, obj)
 }
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -218,7 +218,7 @@ func WaitForInstanceProcessedGeneration(client v1beta1servicecatalog.Servicecata
 
 			if instance.Status.ObservedGeneration >= processedGeneration &&
 				(isServiceInstanceReady(instance) || isServiceInstanceFailed(instance)) &&
-				!instance.Status.OrphanMitigationInProgress {
+				!isServiceInstanceOrphanMitigation(instance) {
 				return true, nil
 			}
 
@@ -249,6 +249,12 @@ func isServiceInstanceReady(instance *v1beta1.ServiceInstance) bool {
 // status true.
 func isServiceInstanceFailed(instance *v1beta1.ServiceInstance) bool {
 	return isServiceInstanceConditionTrue(instance, v1beta1.ServiceInstanceConditionFailed)
+}
+
+// isServiceInstanceOrphanMitigation returns whether the given instance has an
+// orphan mitigation condition with status true.
+func isServiceInstanceOrphanMitigation(instance *v1beta1.ServiceInstance) bool {
+	return isServiceInstanceConditionTrue(instance, v1beta1.ServiceInstanceConditionOrphanMitigation)
 }
 
 // WaitForBindingCondition waits for the status of the named binding to contain

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -218,7 +218,7 @@ func WaitForInstanceProcessedGeneration(client v1beta1servicecatalog.Servicecata
 
 			if instance.Status.ObservedGeneration >= processedGeneration &&
 				(isServiceInstanceReady(instance) || isServiceInstanceFailed(instance)) &&
-				!isServiceInstanceOrphanMitigation(instance) {
+				!instance.Status.OrphanMitigationInProgress {
 				return true, nil
 			}
 
@@ -249,12 +249,6 @@ func isServiceInstanceReady(instance *v1beta1.ServiceInstance) bool {
 // status true.
 func isServiceInstanceFailed(instance *v1beta1.ServiceInstance) bool {
 	return isServiceInstanceConditionTrue(instance, v1beta1.ServiceInstanceConditionFailed)
-}
-
-// isServiceInstanceOrphanMitigation returns whether the given instance has an
-// orphan mitigation condition with status true.
-func isServiceInstanceOrphanMitigation(instance *v1beta1.ServiceInstance) bool {
-	return isServiceInstanceConditionTrue(instance, v1beta1.ServiceInstanceConditionOrphanMitigation)
 }
 
 // WaitForBindingCondition waits for the status of the named binding to contain


### PR DESCRIPTION
Fixes #1771

Switching from `OrphanMitigationInProgress` boolean flag to `OrphanMitigation` condition is actually more of a cosmetic change, it just allows us to have a human-readable `reason` and `message` along with the boolean flag.

The more important change is that now the `OrphanMitigation` condition gets reset only after we have successfully completed the orphan mitigation.
I.e. even we exceed the retry timeout, the `OrphanMitigation` remains set to `True`.
This will allow us to properly support retries in #1765.