### PR TITLE
Print deleted bindings

### DIFF
--- a/cmd/svcat/README.md
+++ b/cmd/svcat/README.md
@@ -204,11 +204,13 @@ Bindings:
 ## Unbind all applications from an instance
 ```
 svcat unbind -n test-ns ups-instance
+deleted ups-binding
 ```
 
 ## Unbind a single application from an instance
 ```
 svcat unbind -n test-ns --name ups-binding
+deleted ups-binding
 ```
 
 ## Delete a service instance

--- a/cmd/svcat/README.md
+++ b/cmd/svcat/README.md
@@ -202,18 +202,21 @@ Bindings:
 ```
 
 ## Unbind all applications from an instance
-```
-svcat unbind -n test-ns ups-instance
+
+```console
+$ svcat unbind -n test-ns ups-instance
 deleted ups-binding
 ```
 
 ## Unbind a single application from an instance
-```
-svcat unbind -n test-ns --name ups-binding
+
+```console
+$ svcat unbind -n test-ns --name ups-binding
 deleted ups-binding
 ```
 
 ## Delete a service instance
+
 Deprovisioning is the process of preparing an instance to be removed, and then deleting it.
 
 ```

--- a/cmd/svcat/binding/unbind_cmd.go
+++ b/cmd/svcat/binding/unbind_cmd.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
+	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/output"
 	"github.com/spf13/cobra"
 )
 
@@ -80,9 +81,15 @@ func (c *unbindCmd) Run() error {
 }
 
 func (c *unbindCmd) deleteBinding() error {
-	return c.App.DeleteBinding(c.ns, c.bindingName)
+	err := c.App.DeleteBinding(c.ns, c.bindingName)
+	if err == nil {
+		output.WriteDeletedBindingName(c.Output, c.bindingName)
+	}
+	return err
 }
 
 func (c *unbindCmd) unbindInstance() error {
-	return c.App.Unbind(c.ns, c.instanceName)
+	bindings, err := c.App.Unbind(c.ns, c.instanceName)
+	output.WriteDeletedBindingNames(c.Output, bindings)
+	return err
 }

--- a/cmd/svcat/output/binding.go
+++ b/cmd/svcat/output/binding.go
@@ -107,6 +107,5 @@ func WriteDeletedBindingNames(w io.Writer, bindings []v1beta1.ServiceBinding) {
 
 // WriteDeletedBindingName prints the name of a binding
 func WriteDeletedBindingName(w io.Writer, bindingName string) {
-	message := fmt.Sprintf("deleted %s", bindingName)
-	fmt.Fprintln(w, message)
+	fmt.Fprintf(w, "deleted %s\n", bindingName)
 }

--- a/cmd/svcat/output/binding.go
+++ b/cmd/svcat/output/binding.go
@@ -97,3 +97,16 @@ func WriteAssociatedBindings(w io.Writer, bindings []v1beta1.ServiceBinding) {
 	}
 	t.Render()
 }
+
+// WriteDeletedBindingNames prints the names of a list of bindings
+func WriteDeletedBindingNames(w io.Writer, bindings []v1beta1.ServiceBinding) {
+	for _, binding := range bindings {
+		WriteDeletedBindingName(w, binding.Name)
+	}
+}
+
+// WriteDeletedBindingName prints the name of a binding
+func WriteDeletedBindingName(w io.Writer, bindingName string) {
+	message := fmt.Sprintf("deleted %s", bindingName)
+	fmt.Fprintln(w, message)
+}

--- a/pkg/svcat/service-catalog/binding.go
+++ b/pkg/svcat/service-catalog/binding.go
@@ -115,6 +115,7 @@ func (sdk *SDK) Unbind(ns, instanceName string) error {
 		go func(binding v1beta1.ServiceBinding) {
 			defer g.Done()
 			errs <- sdk.DeleteBinding(binding.Namespace, binding.Name)
+			fmt.Printf("deleted %s", binding.Name)
 		}(binding)
 	}
 
@@ -140,6 +141,7 @@ func (sdk *SDK) DeleteBinding(ns, bindingName string) error {
 	if err != nil {
 		return fmt.Errorf("remove binding %s/%s failed (%s)", ns, bindingName, err)
 	}
+	fmt.Printf("deleted %s", bindingName)
 	return nil
 }
 

--- a/pkg/svcat/service-catalog/binding.go
+++ b/pkg/svcat/service-catalog/binding.go
@@ -98,29 +98,33 @@ func (sdk *SDK) Bind(namespace, bindingName, instanceName, secretName string,
 }
 
 // Unbind deletes all bindings associated to an instance.
-func (sdk *SDK) Unbind(ns, instanceName string) error {
+func (sdk *SDK) Unbind(ns, instanceName string) ([]v1beta1.ServiceBinding, error) {
 	instance, err := sdk.RetrieveInstance(ns, instanceName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	bindings, err := sdk.RetrieveBindingsByInstance(instance)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
 	var g sync.WaitGroup
 	errs := make(chan error, len(bindings))
+	deletedBindings := make(chan v1beta1.ServiceBinding, len(bindings))
 	for _, binding := range bindings {
 		g.Add(1)
 		go func(binding v1beta1.ServiceBinding) {
 			defer g.Done()
-			errs <- sdk.DeleteBinding(binding.Namespace, binding.Name)
-			fmt.Printf("deleted %s", binding.Name)
+			err := sdk.DeleteBinding(binding.Namespace, binding.Name)
+			if err == nil {
+				deletedBindings <- binding
+			}
+			errs <- err
 		}(binding)
 	}
 
 	g.Wait()
 	close(errs)
+	close(deletedBindings)
 
 	// Collect any errors that occurred into a single formatted error
 	bindErr := &multierror.Error{
@@ -132,7 +136,12 @@ func (sdk *SDK) Unbind(ns, instanceName string) error {
 		bindErr = multierror.Append(bindErr, err)
 	}
 
-	return bindErr.ErrorOrNil()
+	//Range over the deleted bindings to build a slice to return
+	deleted := []v1beta1.ServiceBinding{}
+	for b := range deletedBindings {
+		deleted = append(deleted, b)
+	}
+	return deleted, bindErr.ErrorOrNil()
 }
 
 // DeleteBinding by name.
@@ -141,7 +150,6 @@ func (sdk *SDK) DeleteBinding(ns, bindingName string) error {
 	if err != nil {
 		return fmt.Errorf("remove binding %s/%s failed (%s)", ns, bindingName, err)
 	}
-	fmt.Printf("deleted %s", bindingName)
 	return nil
 }
 

--- a/pkg/svcat/service-catalog/binding_test.go
+++ b/pkg/svcat/service-catalog/binding_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Binding", func() {
 			}
 
 			deleted, err := sdk.Unbind(instanceNamespace, instanceName)
-			fmt.Printf("Deleted : %v", len(deleted))
+
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(deleted)).To(Equal(1))
 			Expect(linkedClient.Actions()[0].Matches("get", "serviceinstances")).To(BeTrue())
@@ -211,7 +211,7 @@ var _ = Describe("Binding", func() {
 			}
 
 			deleted, err := sdk.Unbind(instanceNamespace, instanceName)
-			fmt.Printf("Deleted : %v", len(deleted))
+
 			Expect(err).To(HaveOccurred())
 			Expect(len(deleted)).To(Equal(0))
 			Expect(err.Error()).To(ContainSubstring(errorMessage))
@@ -230,7 +230,7 @@ var _ = Describe("Binding", func() {
 			}
 
 			deleted, err := sdk.Unbind(instanceNamespace, instanceName)
-			fmt.Printf("Deleted : %d", len(deleted))
+
 			Expect(err).To(HaveOccurred())
 			Expect(len(deleted)).To(Equal(0))
 			Expect(err.Error()).To(ContainSubstring("unable to get instance"))

--- a/pkg/svcat/service-catalog/binding_test.go
+++ b/pkg/svcat/service-catalog/binding_test.go
@@ -181,9 +181,10 @@ var _ = Describe("Binding", func() {
 				ServiceCatalogClient: linkedClient,
 			}
 
-			err := sdk.Unbind(instanceNamespace, instanceName)
-
+			deleted, err := sdk.Unbind(instanceNamespace, instanceName)
+			fmt.Printf("Deleted : %v", len(deleted))
 			Expect(err).NotTo(HaveOccurred())
+			Expect(len(deleted)).To(Equal(1))
 			Expect(linkedClient.Actions()[0].Matches("get", "serviceinstances")).To(BeTrue())
 			Expect(linkedClient.Actions()[1].Matches("list", "servicebindings")).To(BeTrue())
 			Expect(linkedClient.Actions()[2].Matches("delete", "servicebindings")).To(BeTrue())
@@ -194,6 +195,7 @@ var _ = Describe("Binding", func() {
 			errorMessage := "error deleting binding"
 			si := &v1beta1.ServiceInstance{ObjectMeta: metav1.ObjectMeta{Name: instanceName, Namespace: instanceNamespace}}
 			sb.Spec.ServiceInstanceRef.Name = si.Name
+
 			badClient := &fake.Clientset{}
 			badClient.AddReactor("get", "serviceinstances", func(action testing.Action) (bool, runtime.Object, error) {
 				return true, si, nil
@@ -208,9 +210,10 @@ var _ = Describe("Binding", func() {
 				ServiceCatalogClient: badClient,
 			}
 
-			err := sdk.Unbind(instanceNamespace, instanceName)
-
+			deleted, err := sdk.Unbind(instanceNamespace, instanceName)
+			fmt.Printf("Deleted : %v", len(deleted))
 			Expect(err).To(HaveOccurred())
+			Expect(len(deleted)).To(Equal(0))
 			Expect(err.Error()).To(ContainSubstring(errorMessage))
 			Expect(badClient.Actions()[0].Matches("get", "serviceinstances")).To(BeTrue())
 			Expect(badClient.Actions()[1].Matches("list", "servicebindings")).To(BeTrue())
@@ -226,10 +229,51 @@ var _ = Describe("Binding", func() {
 				ServiceCatalogClient: noInstanceClient,
 			}
 
-			err := sdk.Unbind(instanceNamespace, instanceName)
+			deleted, err := sdk.Unbind(instanceNamespace, instanceName)
+			fmt.Printf("Deleted : %d", len(deleted))
 			Expect(err).To(HaveOccurred())
+			Expect(len(deleted)).To(Equal(0))
 			Expect(err.Error()).To(ContainSubstring("unable to get instance"))
 			Expect(noInstanceClient.Actions()[0].Matches("get", "serviceinstances")).To(BeTrue())
+		})
+		It("Returns only successfully deleted bindings", func() {
+			instanceNamespace := sb.Namespace
+			instanceName := "apple_instance"
+			errorMessage := "error deleting binding"
+			si := &v1beta1.ServiceInstance{ObjectMeta: metav1.ObjectMeta{Name: instanceName, Namespace: instanceNamespace}}
+			sb.Spec.ServiceInstanceRef.Name = si.Name
+			sb2.Spec.ServiceInstanceRef.Name = si.Name
+			badClient := &fake.Clientset{}
+			badClient.AddReactor("get", "serviceinstances", func(action testing.Action) (bool, runtime.Object, error) {
+				return true, si, nil
+			})
+			badClient.AddReactor("list", "servicebindings", func(action testing.Action) (bool, runtime.Object, error) {
+				return true, &v1beta1.ServiceBindingList{Items: []v1beta1.ServiceBinding{*sb, *sb2}}, nil
+			})
+			badClient.AddReactor("delete", "servicebindings", func(action testing.Action) (bool, runtime.Object, error) {
+				da, ok := action.(testing.DeleteAction)
+				if !ok {
+					return true, nil, fmt.Errorf("internal error occurred")
+				}
+				switch da.GetName() {
+				case sb2.Name:
+					return true, nil, fmt.Errorf(errorMessage)
+				default:
+					return true, sb, nil
+				}
+			})
+			sdk = &SDK{
+				ServiceCatalogClient: badClient,
+			}
+
+			deleted, err := sdk.Unbind(instanceNamespace, instanceName)
+
+			Expect(err).To(HaveOccurred())
+			Expect(len(deleted)).To(Equal(1))
+			Expect(err.Error()).To(ContainSubstring(errorMessage))
+			Expect(badClient.Actions()[0].Matches("get", "serviceinstances")).To(BeTrue())
+			Expect(badClient.Actions()[1].Matches("list", "servicebindings")).To(BeTrue())
+			Expect(badClient.Actions()[2].Matches("delete", "servicebindings")).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
This PR enhances the `unbind` command in `svcat` to print out the bindings that were deleted. This appleis to both `unbind <INSTANCE>` and `unbind --name <binding>`.

To accomplish this:

* Modified pkg/svcat/binding.go to return a slice of bindings when Unbind is invoked. These represent the successfully deleted bindings. Relevant testing enhanced to exercise this.
* Added methods to the cmd/svcat/output package to print deleted bindings. 
* Modified cmd/svcat/binding/unbind.go to use these new capabilities
* Updated README.md to include sample output.

Closes #1783 