### PR TITLE
Pass correct plan ID in deprovision request (for both deleting and orphan mitigation)

### DIFF
--- a/pkg/apis/servicecatalog/validation/instance.go
+++ b/pkg/apis/servicecatalog/validation/instance.go
@@ -140,13 +140,13 @@ func validateServiceInstanceStatus(status *sc.ServiceInstanceStatus, fldPath *fi
 	}
 
 	switch status.CurrentOperation {
-	case sc.ServiceInstanceOperationProvision, sc.ServiceInstanceOperationUpdate:
+	case sc.ServiceInstanceOperationProvision, sc.ServiceInstanceOperationUpdate, sc.ServiceInstanceOperationDeprovision:
 		if status.InProgressProperties == nil {
-			allErrs = append(allErrs, field.Required(fldPath.Child("inProgressProperties"), `inProgressProperties is required when currentOperation is "Provision" or "Update"`))
+			allErrs = append(allErrs, field.Required(fldPath.Child("inProgressProperties"), `inProgressProperties is required when currentOperation is "Provision", "Update" or "Deprovision"`))
 		}
 	default:
 		if status.InProgressProperties != nil {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("inProgressProperties"), `inProgressProperties must not be present when currentOperation is neither "Provision" nor "Update"`))
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("inProgressProperties"), `inProgressProperties must not be present when currentOperation is not "Provision", "Update" or "Deprovision"`))
 		}
 	}
 

--- a/pkg/apis/servicecatalog/validation/instance_test.go
+++ b/pkg/apis/servicecatalog/validation/instance_test.go
@@ -89,6 +89,7 @@ func validServiceInstanceWithInProgressDeprovision() *servicecatalog.ServiceInst
 	instance.Status.CurrentOperation = servicecatalog.ServiceInstanceOperationDeprovision
 	now := metav1.Now()
 	instance.Status.OperationStartTime = &now
+	instance.Status.InProgressProperties = validServiceInstancePropertiesState()
 	instance.Status.ExternalProperties = validServiceInstancePropertiesState()
 	return instance
 }
@@ -221,7 +222,6 @@ func TestValidateServiceInstance(t *testing.T) {
 			instance: func() *servicecatalog.ServiceInstance {
 				i := validServiceInstanceWithInProgressProvision()
 				i.Status.CurrentOperation = servicecatalog.ServiceInstanceOperationDeprovision
-				i.Status.InProgressProperties = nil
 				return i
 			}(),
 			valid: true,
@@ -315,15 +315,6 @@ func TestValidateServiceInstance(t *testing.T) {
 			instance: func() *servicecatalog.ServiceInstance {
 				i := validServiceInstance()
 				i.Status.InProgressProperties = validServiceInstancePropertiesState()
-				return i
-			}(),
-			valid: false,
-		},
-		{
-			name: "in-progress deprovision with present InProgressProperties",
-			instance: func() *servicecatalog.ServiceInstance {
-				i := validServiceInstanceWithInProgressProvision()
-				i.Status.CurrentOperation = servicecatalog.ServiceInstanceOperationDeprovision
 				return i
 			}(),
 			valid: false,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -263,7 +263,7 @@ func (e *operationError) Error() string { return e.message }
 // The ClusterServicePlan returned will be nil if the ClusterServicePlanRef
 // is nil. This will happen when deleting a ServiceInstance that previously
 // had an update to a non-existent plan.
-func (c *controller) getClusterServiceClassPlanAndClusterServiceBroker(instance *v1beta1.ServiceInstance) (*v1beta1.ClusterServiceClass, *v1beta1.ClusterServicePlan, string, osb.Client, error) {
+func (c *controller) getClusterServiceClassPlanAndClusterServiceBroker(instance *v1beta1.ServiceInstance, fetchPlan bool) (*v1beta1.ClusterServiceClass, *v1beta1.ClusterServicePlan, string, osb.Client, error) {
 	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
 	serviceClass, err := c.serviceClassLister.Get(instance.Spec.ClusterServiceClassRef.Name)
 	if err != nil {
@@ -277,7 +277,7 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBroker(instance 
 	}
 
 	var servicePlan *v1beta1.ClusterServicePlan
-	if instance.Spec.ClusterServicePlanRef != nil {
+	if fetchPlan && instance.Spec.ClusterServicePlanRef != nil {
 		var err error
 		servicePlan, err = c.servicePlanLister.Get(instance.Spec.ClusterServicePlanRef.Name)
 		if nil != err {

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1420,8 +1420,10 @@ func (c *controller) prepareDeprovisionRequest(instance *v1beta1.ServiceInstance
 	// provisioning request instead that we previously stored in status
 	var servicePlanExternalID string
 	if instance.Status.CurrentOperation != "" || instance.Status.OrphanMitigationInProgress {
+		// TODO nilebox: check and return error instead of panicking on nil
 		servicePlanExternalID = instance.Status.InProgressProperties.ClusterServicePlanExternalID
 	} else {
+		// TODO nilebox: check and return error instead of panicking on nil
 		servicePlanExternalID = instance.Status.ExternalProperties.ClusterServicePlanExternalID
 	}
 

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -306,7 +306,7 @@ func (c *controller) reconcileServiceInstanceAdd(instance *v1beta1.ServiceInstan
 
 	glog.V(4).Info(pcb.Message("Processing adding event"))
 
-	serviceClass, servicePlan, brokerName, brokerClient, err := c.getClusterServiceClassPlanAndClusterServiceBroker(instance, true)
+	serviceClass, servicePlan, brokerName, brokerClient, err := c.getClusterServiceClassPlanAndClusterServiceBroker(instance)
 	if err != nil {
 		return c.handleServiceInstanceReconciliationError(instance, err)
 	}
@@ -413,7 +413,7 @@ func (c *controller) reconcileServiceInstanceUpdate(instance *v1beta1.ServiceIns
 
 	glog.V(4).Info(pcb.Message("Processing updating event"))
 
-	serviceClass, servicePlan, brokerName, brokerClient, err := c.getClusterServiceClassPlanAndClusterServiceBroker(instance, true)
+	serviceClass, servicePlan, brokerName, brokerClient, err := c.getClusterServiceClassPlanAndClusterServiceBroker(instance)
 	if err != nil {
 		return c.handleServiceInstanceReconciliationError(instance, err)
 	}
@@ -548,7 +548,7 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1beta1.ServiceIns
 		return c.handleServiceInstanceReconciliationError(instance, err)
 	}
 
-	serviceClass, _, brokerName, brokerClient, err := c.getClusterServiceClassPlanAndClusterServiceBroker(instance, false)
+	serviceClass, brokerName, brokerClient, err := c.getClusterServiceClassAndClusterServiceBroker(instance)
 	if err != nil {
 		return c.handleServiceInstanceReconciliationError(instance, err)
 	}
@@ -613,7 +613,7 @@ func (c *controller) pollServiceInstance(instance *v1beta1.ServiceInstance) erro
 
 	instance = instance.DeepCopy()
 
-	serviceClass, servicePlan, _, brokerClient, err := c.getClusterServiceClassPlanAndClusterServiceBroker(instance, true)
+	serviceClass, servicePlan, _, brokerClient, err := c.getClusterServiceClassPlanAndClusterServiceBroker(instance)
 	if err != nil {
 		return c.handleServiceInstanceReconciliationError(instance, err)
 	}

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -526,6 +526,13 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1beta1.ServiceIns
 		return c.processServiceInstanceGracefulDeletionSuccess(instance)
 	}
 
+	// If the instance is not provisioned, and there is no operation in progress,
+	// and there is no orphan mitigation pending, then no need to
+	// make a request to the broker.
+	if instance.Status.ProvisionStatus != v1beta1.ServiceInstanceProvisionStatusProvisioned && instance.Status.CurrentOperation == "" && !instance.Status.OrphanMitigationInProgress {
+		return c.processServiceInstanceGracefulDeletionSuccess(instance)
+	}
+
 	// At this point, if the deprovision status is not Required, then it is
 	// either an invalid value or there is a logical error in the controller.
 	// Set the deprovision status to Failed and bail out.
@@ -546,7 +553,7 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1beta1.ServiceIns
 		return c.handleServiceInstanceReconciliationError(instance, err)
 	}
 
-	request, err := c.prepareDeprovisionRequest(instance, serviceClass)
+	request, inProgressProperties, err := c.prepareDeprovisionRequest(instance, serviceClass)
 	if err != nil {
 		return c.handleServiceInstanceReconciliationError(instance, err)
 	}
@@ -560,7 +567,7 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1beta1.ServiceIns
 		}
 	} else {
 		if instance.Status.CurrentOperation != v1beta1.ServiceInstanceOperationDeprovision {
-			instance, err = c.recordStartOfServiceInstanceOperation(instance, v1beta1.ServiceInstanceOperationDeprovision, nil)
+			instance, err = c.recordStartOfServiceInstanceOperation(instance, v1beta1.ServiceInstanceOperationDeprovision, inProgressProperties)
 			if err != nil {
 				// There has been an update to the instance. Start reconciliation
 				// over with a fresh view of the instance.
@@ -1176,6 +1183,7 @@ func (c *controller) recordStartOfServiceInstanceOperation(toUpdate *v1beta1.Ser
 	toUpdate.Status.CurrentOperation = operation
 	now := metav1.Now()
 	toUpdate.Status.OperationStartTime = &now
+	toUpdate.Status.InProgressProperties = inProgressProperties
 	reason := ""
 	message := ""
 	switch operation {
@@ -1183,11 +1191,9 @@ func (c *controller) recordStartOfServiceInstanceOperation(toUpdate *v1beta1.Ser
 		reason = provisioningInFlightReason
 		message = provisioningInFlightMessage
 		toUpdate.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
-		toUpdate.Status.InProgressProperties = inProgressProperties
 	case v1beta1.ServiceInstanceOperationUpdate:
 		reason = instanceUpdatingInFlightReason
 		message = instanceUpdatingInFlightMessage
-		toUpdate.Status.InProgressProperties = inProgressProperties
 	case v1beta1.ServiceInstanceOperationDeprovision:
 		reason = deprovisioningInFlightReason
 		message = deprovisioningInFlightMessage
@@ -1289,7 +1295,7 @@ type requestHelper struct {
 
 // prepareRequestHelper is a helper function that generates a struct with
 // properties common to multiple request types.
-func (c *controller) prepareRequestHelper(instance *v1beta1.ServiceInstance, servicePlan *v1beta1.ClusterServicePlan) (*requestHelper, error) {
+func (c *controller) prepareRequestHelper(instance *v1beta1.ServiceInstance, servicePlan *v1beta1.ClusterServicePlan, setInProgressProperties bool) (*requestHelper, error) {
 	rh := &requestHelper{}
 
 	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {
@@ -1318,26 +1324,28 @@ func (c *controller) prepareRequestHelper(instance *v1beta1.ServiceInstance, ser
 	}
 	rh.ns = ns
 
-	parameters, parametersChecksum, rawParametersWithRedaction, err := prepareInProgressPropertyParameters(
-		c.kubeClient,
-		instance.Namespace,
-		instance.Spec.Parameters,
-		instance.Spec.ParametersFrom,
-	)
-	if err != nil {
-		return nil, &operationError{
-			reason:  errorWithParameters,
-			message: err.Error(),
+	if setInProgressProperties {
+		parameters, parametersChecksum, rawParametersWithRedaction, err := prepareInProgressPropertyParameters(
+			c.kubeClient,
+			instance.Namespace,
+			instance.Spec.Parameters,
+			instance.Spec.ParametersFrom,
+		)
+		if err != nil {
+			return nil, &operationError{
+				reason:  errorWithParameters,
+				message: err.Error(),
+			}
 		}
-	}
-	rh.parameters = parameters
+		rh.parameters = parameters
 
-	rh.inProgressProperties = &v1beta1.ServiceInstancePropertiesState{
-		ClusterServicePlanExternalName: servicePlan.Spec.ExternalName,
-		ClusterServicePlanExternalID:   servicePlan.Spec.ExternalID,
-		Parameters:                     rawParametersWithRedaction,
-		ParametersChecksum:             parametersChecksum,
-		UserInfo:                       instance.Spec.UserInfo,
+		rh.inProgressProperties = &v1beta1.ServiceInstancePropertiesState{
+			ClusterServicePlanExternalName: servicePlan.Spec.ExternalName,
+			ClusterServicePlanExternalID:   servicePlan.Spec.ExternalID,
+			Parameters:                     rawParametersWithRedaction,
+			ParametersChecksum:             parametersChecksum,
+			UserInfo:                       instance.Spec.UserInfo,
+		}
 	}
 
 	// osb client handles whether or not to really send this based
@@ -1353,7 +1361,7 @@ func (c *controller) prepareRequestHelper(instance *v1beta1.ServiceInstance, ser
 // prepareProvisionRequest creates a provision request object to be passed to
 // the broker client to provision the given instance.
 func (c *controller) prepareProvisionRequest(instance *v1beta1.ServiceInstance, serviceClass *v1beta1.ClusterServiceClass, servicePlan *v1beta1.ClusterServicePlan) (*osb.ProvisionRequest, *v1beta1.ServiceInstancePropertiesState, error) {
-	rh, err := c.prepareRequestHelper(instance, servicePlan)
+	rh, err := c.prepareRequestHelper(instance, servicePlan, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1376,7 +1384,7 @@ func (c *controller) prepareProvisionRequest(instance *v1beta1.ServiceInstance, 
 // prepareUpdateInstanceRequest creates an update instance request object to be
 // passed to the broker client to update the given instance.
 func (c *controller) prepareUpdateInstanceRequest(instance *v1beta1.ServiceInstance, serviceClass *v1beta1.ClusterServiceClass, servicePlan *v1beta1.ClusterServicePlan) (*osb.UpdateInstanceRequest, *v1beta1.ServiceInstancePropertiesState, error) {
-	rh, err := c.prepareRequestHelper(instance, servicePlan)
+	rh, err := c.prepareRequestHelper(instance, servicePlan, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1410,43 +1418,42 @@ func (c *controller) prepareUpdateInstanceRequest(instance *v1beta1.ServiceInsta
 
 // prepareDeprovisionRequest creates a deprovision request object to be passed
 // to the broker client to deprovision the given instance.
-func (c *controller) prepareDeprovisionRequest(instance *v1beta1.ServiceInstance, serviceClass *v1beta1.ClusterServiceClass) (*osb.DeprovisionRequest, error) {
-	rh, err := c.prepareRequestHelper(instance, nil)
+func (c *controller) prepareDeprovisionRequest(instance *v1beta1.ServiceInstance, serviceClass *v1beta1.ClusterServiceClass) (*osb.DeprovisionRequest, *v1beta1.ServiceInstancePropertiesState, error) {
+	rh, err := c.prepareRequestHelper(instance, nil, false)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// The plan reference in the spec might be updated since the latest
 	// provisioning/update request, thus we need to take values from the original
 	// provisioning request instead that we previously stored in status
-	var servicePlanExternalID string
 	if instance.Status.CurrentOperation != "" || instance.Status.OrphanMitigationInProgress {
 		if instance.Status.InProgressProperties == nil {
-			return nil, stderrors.New("InProgressProperties must be set when there is an operation or orphan mitigation in progress")
+			return nil, nil, stderrors.New("InProgressProperties must be set when there is an operation or orphan mitigation in progress")
 		}
-		servicePlanExternalID = instance.Status.InProgressProperties.ClusterServicePlanExternalID
+		rh.inProgressProperties = instance.Status.InProgressProperties
 	} else {
 		if instance.Status.ExternalProperties == nil {
-			return nil, stderrors.New("ExternalProperties must be set before deprovisioning")
+			return nil, nil, stderrors.New("ExternalProperties must be set before deprovisioning")
 		}
-		servicePlanExternalID = instance.Status.ExternalProperties.ClusterServicePlanExternalID
+		rh.inProgressProperties = instance.Status.ExternalProperties
 	}
 
 	request := &osb.DeprovisionRequest{
 		InstanceID:          instance.Spec.ExternalID,
 		ServiceID:           serviceClass.Spec.ExternalID,
-		PlanID:              servicePlanExternalID,
+		PlanID:              rh.inProgressProperties.ClusterServicePlanExternalID,
 		OriginatingIdentity: rh.originatingIdentity,
 		AcceptsIncomplete:   true,
 	}
 
-	return request, nil
+	return request, rh.inProgressProperties, nil
 }
 
 // preparePollServiceInstanceRequest creates a request object to be passed to
 // the broker client to query the given instance's last operation endpoint.
 func (c *controller) prepareServiceInstanceLastOperationRequest(instance *v1beta1.ServiceInstance, serviceClass *v1beta1.ClusterServiceClass, servicePlan *v1beta1.ClusterServicePlan) (*osb.LastOperationRequest, error) {
-	rh, err := c.prepareRequestHelper(instance, servicePlan)
+	rh, err := c.prepareRequestHelper(instance, servicePlan, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	stderrors "errors"
 	"fmt"
 	"net/url"
 
@@ -1420,10 +1421,14 @@ func (c *controller) prepareDeprovisionRequest(instance *v1beta1.ServiceInstance
 	// provisioning request instead that we previously stored in status
 	var servicePlanExternalID string
 	if instance.Status.CurrentOperation != "" || instance.Status.OrphanMitigationInProgress {
-		// TODO nilebox: check and return error instead of panicking on nil
+		if instance.Status.InProgressProperties == nil {
+			return nil, stderrors.New("InProgressProperties must be set when there is an operation or orphan mitigation in progress")
+		}
 		servicePlanExternalID = instance.Status.InProgressProperties.ClusterServicePlanExternalID
 	} else {
-		// TODO nilebox: check and return error instead of panicking on nil
+		if instance.Status.ExternalProperties == nil {
+			return nil, stderrors.New("ExternalProperties must be set before deprovisioning")
+		}
 		servicePlanExternalID = instance.Status.ExternalProperties.ClusterServicePlanExternalID
 	}
 

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -976,7 +976,7 @@ func TestReconcileServiceInstanceWithProvisionFailure(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceRequestFailingErrorNoOrphanMitigation(
+	assertServiceInstanceProvisionRequestFailingErrorNoOrphanMitigation(
 		t,
 		updatedServiceInstance,
 		v1beta1.ServiceInstanceOperationProvision,
@@ -1743,9 +1743,9 @@ func TestReconcileServiceInstanceDeleteAsynchronous(t *testing.T) {
 }
 
 // TestReconcileServiceInstanceDeleteFailedProvisionWithRequest tests that an
-// instance that failed to provision with a failed provision request that doesn't
-// require orphan mitigation, will not have a deprovision request sent to the broker.
-func TestReconcileServiceInstanceDeleteFailedProvisionWithRequestResult(t *testing.T) {
+// instance that failed to provision but for which a provision request was
+// made will have a deprovision request sent to the broker.
+func TestReconcileServiceInstanceDeleteFailedProvisionWithRequest(t *testing.T) {
 	fakeKubeClient, fakeCatalogClient, fakeClusterServiceBrokerClient, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
 		DeprovisionReaction: &fakeosb.DeprovisionReaction{
 			Response: &osb.DeprovisionResponse{},
@@ -1759,10 +1759,7 @@ func TestReconcileServiceInstanceDeleteFailedProvisionWithRequestResult(t *testi
 	instance := getTestServiceInstanceWithFailedStatus()
 	instance.ObjectMeta.DeletionTimestamp = &metav1.Time{}
 	instance.ObjectMeta.Finalizers = []string{v1beta1.FinalizerServiceCatalog}
-	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{
-		ClusterServicePlanExternalName: testClusterServicePlanName,
-		ClusterServicePlanExternalID:   testClusterServicePlanGUID,
-	}
+	instance.Status.CurrentOperation = v1beta1.ServiceInstanceOperationProvision
 	instance.Status.InProgressProperties = &v1beta1.ServiceInstancePropertiesState{
 		ClusterServicePlanExternalName: testClusterServicePlanName,
 		ClusterServicePlanExternalID:   testClusterServicePlanGUID,
@@ -1784,58 +1781,6 @@ func TestReconcileServiceInstanceDeleteFailedProvisionWithRequestResult(t *testi
 	instance = assertServiceInstanceDeprovisionInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
-
-	err := testController.reconcileServiceInstance(instance)
-	if err != nil {
-		t.Fatalf("Unexpected error from reconcileServiceInstance: %v", err)
-	}
-
-	brokerActions := fakeClusterServiceBrokerClient.Actions()
-	assertNumberOfClusterServiceBrokerActions(t, brokerActions, 0)
-
-	// Verify no core kube actions occurred
-	kubeActions := fakeKubeClient.Actions()
-	assertNumberOfActions(t, kubeActions, 0)
-
-	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
-
-	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertEmptyFinalizers(t, updatedServiceInstance)
-
-	events := getRecordedEvents(testController)
-	assertNumEvents(t, events, 0)
-}
-
-// TestReconcileServiceInstanceDeleteFailedProvisionWithRequest tests that an
-// instance that failed to provision but for which a provision request might have been
-// made (but doesn't have a status updated appropriately) will have a deprovision
-// request sent to the broker.
-func TestReconcileServiceInstanceDeleteFailedProvisionWithoutRequest(t *testing.T) {
-	fakeKubeClient, fakeCatalogClient, fakeClusterServiceBrokerClient, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
-		DeprovisionReaction: &fakeosb.DeprovisionReaction{
-			Response: &osb.DeprovisionResponse{},
-		},
-	})
-
-	sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(getTestClusterServiceBroker())
-	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(getTestClusterServiceClass())
-	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
-
-	instance := getTestServiceInstanceWithProvisioningStarted()
-	instance.ObjectMeta.DeletionTimestamp = &metav1.Time{}
-	instance.ObjectMeta.Finalizers = []string{v1beta1.FinalizerServiceCatalog}
-	instance.Status.ExternalProperties = nil
-	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
-
-	instance.Generation = 2
-	instance.Status.ReconciledGeneration = 1
-	instance.Status.ObservedGeneration = 1
-	instance.Status.ProvisionStatus = v1beta1.ServiceInstanceProvisionStatusNotProvisioned
-
-	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
-		return true, instance, nil
-	})
 
 	err := testController.reconcileServiceInstance(instance)
 	if err != nil {
@@ -2362,7 +2307,7 @@ func TestPollServiceInstanceFailureProvisioningWithOperation(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceRequestFailingErrorNoOrphanMitigation(
+	assertServiceInstanceProvisionRequestFailingErrorNoOrphanMitigation(
 		t,
 		updatedServiceInstance,
 		v1beta1.ServiceInstanceOperationProvision,
@@ -2614,7 +2559,7 @@ func TestPollServiceInstanceFailureDeprovisioningWithReconciliationTimeout(t *te
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceRequestFailingErrorNoOrphanMitigation(
+	assertServiceInstanceUpdateRequestFailingErrorNoOrphanMitigation(
 		t,
 		updatedServiceInstance,
 		v1beta1.ServiceInstanceOperationDeprovision,
@@ -2934,7 +2879,7 @@ func TestReconcileServiceInstanceFailureOnFinalRetry(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceRequestFailingErrorNoOrphanMitigation(
+	assertServiceInstanceProvisionRequestFailingErrorNoOrphanMitigation(
 		t,
 		updatedServiceInstance,
 		v1beta1.ServiceInstanceOperationProvision,
@@ -4721,7 +4666,7 @@ func TestReconcileServiceInstanceWithUpdateFailure(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceRequestFailingErrorNoOrphanMitigation(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, errorUpdateInstanceCallFailedReason, errorUpdateInstanceCallFailedReason, instance)
+	assertServiceInstanceUpdateRequestFailingErrorNoOrphanMitigation(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, errorUpdateInstanceCallFailedReason, errorUpdateInstanceCallFailedReason, instance)
 
 	events := getRecordedEvents(testController)
 
@@ -5160,7 +5105,7 @@ func TestPollServiceInstanceAsyncFailureUpdating(t *testing.T) {
 	assertNumberOfActions(t, actions, 1)
 
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceRequestFailingErrorNoOrphanMitigation(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, errorUpdateInstanceCallFailedReason, errorUpdateInstanceCallFailedReason, instance)
+	assertServiceInstanceUpdateRequestFailingErrorNoOrphanMitigation(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, errorUpdateInstanceCallFailedReason, errorUpdateInstanceCallFailedReason, instance)
 }
 
 func TestCheckClassAndPlanForDeletion(t *testing.T) {

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -1759,7 +1759,14 @@ func TestReconcileServiceInstanceDeleteFailedProvisionWithRequest(t *testing.T) 
 	instance := getTestServiceInstanceWithFailedStatus()
 	instance.ObjectMeta.DeletionTimestamp = &metav1.Time{}
 	instance.ObjectMeta.Finalizers = []string{v1beta1.FinalizerServiceCatalog}
-	instance.Status.ExternalProperties = nil
+	instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{
+		ClusterServicePlanExternalName: testClusterServicePlanName,
+		ClusterServicePlanExternalID:   testClusterServicePlanGUID,
+	}
+	instance.Status.InProgressProperties = &v1beta1.ServiceInstancePropertiesState{
+		ClusterServicePlanExternalName: testClusterServicePlanName,
+		ClusterServicePlanExternalID:   testClusterServicePlanGUID,
+	}
 	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 
 	instance.Generation = 2
@@ -3447,6 +3454,10 @@ func TestReconcileInstanceDeleteUsingOriginatingIdentity(t *testing.T) {
 			instance.Status.ObservedGeneration = 1
 			instance.Status.ProvisionStatus = v1beta1.ServiceInstanceProvisionStatusProvisioned
 			instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
+			instance.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{
+				ClusterServicePlanExternalName: testClusterServicePlanName,
+				ClusterServicePlanExternalID:   testClusterServicePlanGUID,
+			}
 			if tc.includeUserInfo {
 				instance.Spec.UserInfo = testUserInfo
 			}
@@ -3861,6 +3872,10 @@ func TestReconcileServiceInstanceOrphanMitigation(t *testing.T) {
 			instance.Status.CurrentOperation = v1beta1.ServiceInstanceOperationProvision
 			instance.Status.OrphanMitigationInProgress = true
 			instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
+			instance.Status.InProgressProperties = &v1beta1.ServiceInstancePropertiesState{
+				ClusterServicePlanExternalName: testClusterServicePlanName,
+				ClusterServicePlanExternalID:   testClusterServicePlanGUID,
+			}
 
 			if tc.async {
 				instance.Status.AsyncOpInProgress = true
@@ -5203,7 +5218,10 @@ func TestReconcileServiceInstanceDeleteDuringOngoingOperation(t *testing.T) {
 	instance.Status.CurrentOperation = v1beta1.ServiceInstanceOperationProvision
 	startTime := metav1.NewTime(time.Now().Add(-1 * time.Hour))
 	instance.Status.OperationStartTime = &startTime
-	instance.Status.InProgressProperties = &v1beta1.ServiceInstancePropertiesState{}
+	instance.Status.InProgressProperties = &v1beta1.ServiceInstancePropertiesState{
+		ClusterServicePlanExternalName: testClusterServicePlanName,
+		ClusterServicePlanExternalID:   testClusterServicePlanGUID,
+	}
 
 	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		return true, instance, nil
@@ -5281,6 +5299,10 @@ func TestReconcileServiceInstanceDeleteWithOngoingOperation(t *testing.T) {
 	startTime := metav1.NewTime(time.Now().Add(-1 * time.Hour))
 	instance.Status.OperationStartTime = &startTime
 	instance.Status.OrphanMitigationInProgress = true
+	instance.Status.InProgressProperties = &v1beta1.ServiceInstancePropertiesState{
+		ClusterServicePlanExternalName: testClusterServicePlanName,
+		ClusterServicePlanExternalID:   testClusterServicePlanGUID,
+	}
 
 	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		return true, instance, nil

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -695,28 +695,6 @@ func getTestServiceInstanceUpdatingPlan() *v1beta1.ServiceInstance {
 	return instance
 }
 
-func getTestServiceInstanceUpdatingParameters() *v1beta1.ServiceInstance {
-	instance := getTestServiceInstanceWithRefs()
-	instance.Generation = 2
-	instance.Status = v1beta1.ServiceInstanceStatus{
-		Conditions: []v1beta1.ServiceInstanceCondition{{
-			Type:   v1beta1.ServiceInstanceConditionReady,
-			Status: v1beta1.ConditionTrue,
-		}},
-		ExternalProperties: &v1beta1.ServiceInstancePropertiesState{
-			ClusterServicePlanExternalName: testClusterServicePlanName,
-			ClusterServicePlanExternalID:   testClusterServicePlanGUID,
-		},
-		// It's been provisioned successfully.
-		ReconciledGeneration: 1,
-		ObservedGeneration:   1,
-		ProvisionStatus:      v1beta1.ServiceInstanceProvisionStatusProvisioned,
-		DeprovisionStatus:    v1beta1.ServiceInstanceDeprovisionStatusRequired,
-	}
-
-	return instance
-}
-
 func getTestServiceInstanceUpdatingParametersOfDeletedPlan() *v1beta1.ServiceInstance {
 	instance := getTestServiceInstanceWithRefs()
 	instance.Generation = 2
@@ -734,30 +712,6 @@ func getTestServiceInstanceUpdatingParametersOfDeletedPlan() *v1beta1.ServiceIns
 		ObservedGeneration:   1,
 		ProvisionStatus:      v1beta1.ServiceInstanceProvisionStatusProvisioned,
 		DeprovisionStatus:    v1beta1.ServiceInstanceDeprovisionStatusRequired,
-	}
-
-	return instance
-}
-
-func getTestServiceInstanceWithProvisioningStarted() *v1beta1.ServiceInstance {
-	instance := getTestServiceInstanceWithRefs()
-
-	operationStartTime := metav1.NewTime(time.Now().Add(-1 * time.Hour))
-	instance.Status = v1beta1.ServiceInstanceStatus{
-		Conditions: []v1beta1.ServiceInstanceCondition{{
-			Type:               v1beta1.ServiceInstanceConditionReady,
-			Status:             v1beta1.ConditionFalse,
-			Message:            "Provisioning",
-			LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
-		}},
-		OperationStartTime: &operationStartTime,
-		CurrentOperation:   v1beta1.ServiceInstanceOperationProvision,
-		InProgressProperties: &v1beta1.ServiceInstancePropertiesState{
-			ClusterServicePlanExternalName: testClusterServicePlanName,
-			ClusterServicePlanExternalID:   testClusterServicePlanGUID,
-		},
-		ObservedGeneration: instance.Generation,
-		DeprovisionStatus:  v1beta1.ServiceInstanceDeprovisionStatusRequired,
 	}
 
 	return instance
@@ -1173,41 +1127,6 @@ func checkPlan(plan *v1beta1.ClusterServicePlan, planID, planName, planDescripti
 		t.Errorf("Expected plan description to be %q, but was: %q", planDescription, plan.Spec.Description)
 	}
 }
-
-const testCatalogWithMultipleServices = `{
-  "services": [
-    {
-      "name": "service1",
-      "description": "service 1 description",
-      "metadata": {
-        "field1": "value1"
-      },
-      "plans": [{
-        "name": "s1plan1",
-        "id": "s1_plan1_id",
-        "description": "s1 plan1 description"
-      },
-      {
-        "name": "s1plan2",
-        "id": "s1_plan2_id",
-        "description": "s1 plan2 description"
-      }]
-    },
-    {
-      "name": "service2",
-      "description": "service 2 description",
-      "plans": [{
-        "name": "s2plan1",
-        "id": "s2_plan1_id",
-        "description": "s2 plan1 description"
-      },
-      {
-        "name": "s2plan2",
-        "id": "s2_plan2_id",
-        "description": "s2 plan2 description"
-      }]
-    }
-]}`
 
 // FIX: there is an inconsistency between the current broker API types re: the
 // Service.Metadata field.  Our repo types it as `interface{}`, the go-open-

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -739,6 +739,30 @@ func getTestServiceInstanceUpdatingParametersOfDeletedPlan() *v1beta1.ServiceIns
 	return instance
 }
 
+func getTestServiceInstanceWithProvisioningStarted() *v1beta1.ServiceInstance {
+	instance := getTestServiceInstanceWithRefs()
+
+	operationStartTime := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+	instance.Status = v1beta1.ServiceInstanceStatus{
+		Conditions: []v1beta1.ServiceInstanceCondition{{
+			Type:               v1beta1.ServiceInstanceConditionReady,
+			Status:             v1beta1.ConditionFalse,
+			Message:            "Provisioning",
+			LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
+		}},
+		OperationStartTime: &operationStartTime,
+		CurrentOperation:   v1beta1.ServiceInstanceOperationProvision,
+		InProgressProperties: &v1beta1.ServiceInstancePropertiesState{
+			ClusterServicePlanExternalName: testClusterServicePlanName,
+			ClusterServicePlanExternalID:   testClusterServicePlanGUID,
+		},
+		ObservedGeneration: instance.Generation,
+		DeprovisionStatus:  v1beta1.ServiceInstanceDeprovisionStatusRequired,
+	}
+
+	return instance
+}
+
 // getTestServiceInstanceAsync returns an instance in async mode
 func getTestServiceInstanceAsyncProvisioning(operation string) *v1beta1.ServiceInstance {
 	instance := getTestServiceInstanceWithRefs()
@@ -2130,13 +2154,8 @@ func assertServiceInstanceOperationInProgressWithParameters(t *testing.T, obj ru
 	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.ProvisionStatus)
 	assertAsyncOpInProgressFalse(t, obj)
 	assertServiceInstanceOrphanMitigationInProgressFalse(t, obj)
-	switch operation {
-	case v1beta1.ServiceInstanceOperationProvision, v1beta1.ServiceInstanceOperationUpdate:
-		assertServiceInstanceInProgressPropertiesPlan(t, obj, planName, planID)
-		assertServiceInstanceInProgressPropertiesParameters(t, obj, inProgressParameters, inProgressParametersChecksum)
-	case v1beta1.ServiceInstanceOperationDeprovision:
-		assertServiceInstanceInProgressPropertiesNil(t, obj)
-	}
+	assertServiceInstanceInProgressPropertiesPlan(t, obj, planName, planID)
+	assertServiceInstanceInProgressPropertiesParameters(t, obj, inProgressParameters, inProgressParametersChecksum)
 	assertServiceInstanceExternalPropertiesUnchanged(t, obj, originalInstance)
 	assertServiceInstanceDeprovisionStatus(t, obj, v1beta1.ServiceInstanceDeprovisionStatusRequired)
 }
@@ -2297,13 +2316,8 @@ func assertServiceInstanceAsyncStartInProgress(t *testing.T, obj runtime.Object,
 	assertServiceInstanceReconciledGeneration(t, obj, originalInstance.Status.ReconciledGeneration)
 	assertServiceInstanceObservedGeneration(t, obj, originalInstance.Generation)
 	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.ProvisionStatus)
-	switch operation {
-	case v1beta1.ServiceInstanceOperationProvision, v1beta1.ServiceInstanceOperationUpdate:
-		assertServiceInstanceInProgressPropertiesPlan(t, obj, planName, planID)
-		assertServiceInstanceInProgressPropertiesParameters(t, obj, nil, "")
-	case v1beta1.ServiceInstanceOperationDeprovision:
-		assertServiceInstanceInProgressPropertiesNil(t, obj)
-	}
+	assertServiceInstanceInProgressPropertiesPlan(t, obj, planName, planID)
+	assertServiceInstanceInProgressPropertiesParameters(t, obj, nil, "")
 	assertAsyncOpInProgressTrue(t, obj)
 	assertServiceInstanceDeprovisionStatus(t, obj, originalInstance.Status.DeprovisionStatus)
 }

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -1182,7 +1182,6 @@ func TestCreateServiceInstanceAsynchronous(t *testing.T) {
 
 func TestDeleteServiceInstance(t *testing.T) {
 	key := osb.OperationKey(testOperation)
-	_ = key
 
 	cases := []struct {
 		name                         string

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -1182,6 +1182,7 @@ func TestCreateServiceInstanceAsynchronous(t *testing.T) {
 
 func TestDeleteServiceInstance(t *testing.T) {
 	key := osb.OperationKey(testOperation)
+	_ = key
 
 	cases := []struct {
 		name                         string


### PR DESCRIPTION
Address the issue reported by @staebler in #1789:
> There is still a window where a plan change could get in and ruin orphan mitigation.
> 1. Consider a ServiceInstance with an in-flight Provision request.
> 2. User changes plan on ServiceInstance. Orphan mitigation is not in progress, so plan change is accepted.
> 3. Provision request fails in a way that requires orphan mitigation.
> 4. Controller starts orphan mitigation.
> 5. Orphan mitigation reconciliation fails perpetually since there is no plan to use.

See https://github.com/kubernetes-incubator/service-catalog/pull/1789#discussion_r172388391
