### PR TITLE
Add behavior to print deleted instance name

### DIFF
--- a/cmd/svcat/binding/unbind_cmd.go
+++ b/cmd/svcat/binding/unbind_cmd.go
@@ -83,7 +83,7 @@ func (c *unbindCmd) Run() error {
 func (c *unbindCmd) deleteBinding() error {
 	err := c.App.DeleteBinding(c.ns, c.bindingName)
 	if err == nil {
-		output.WriteDeletedBindingName(c.Output, c.bindingName)
+		output.WriteDeletedResourceName(c.Output, c.bindingName)
 	}
 	return err
 }

--- a/cmd/svcat/instance/deprovision_cmd.go
+++ b/cmd/svcat/instance/deprovision_cmd.go
@@ -18,6 +18,7 @@ package instance
 
 import (
 	"fmt"
+	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/output"
 
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
 	"github.com/spf13/cobra"
@@ -60,5 +61,9 @@ func (c *deprovisonCmd) Run() error {
 }
 
 func (c *deprovisonCmd) deprovision() error {
-	return c.App.Deprovision(c.ns, c.instanceName)
+	err := c.App.Deprovision(c.ns, c.instanceName)
+	if err == nil {
+		output.WriteDeletedResourceName(c.Output, c.instanceName)
+	}
+	return err
 }

--- a/cmd/svcat/output/binding.go
+++ b/cmd/svcat/output/binding.go
@@ -101,11 +101,6 @@ func WriteAssociatedBindings(w io.Writer, bindings []v1beta1.ServiceBinding) {
 // WriteDeletedBindingNames prints the names of a list of bindings
 func WriteDeletedBindingNames(w io.Writer, bindings []v1beta1.ServiceBinding) {
 	for _, binding := range bindings {
-		WriteDeletedBindingName(w, binding.Name)
+		WriteDeletedResourceName(w, binding.Name)
 	}
-}
-
-// WriteDeletedBindingName prints the name of a binding
-func WriteDeletedBindingName(w io.Writer, bindingName string) {
-	fmt.Fprintf(w, "deleted %s\n", bindingName)
 }

--- a/cmd/svcat/output/output.go
+++ b/cmd/svcat/output/output.go
@@ -18,6 +18,7 @@ package output
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
@@ -44,4 +45,9 @@ func formatStatusFull(condition string, conditionStatus v1beta1.ConditionStatus,
 
 	message = strings.TrimRight(message, ".")
 	return fmt.Sprintf("%s - %s @ %s", status, message, timestamp.UTC())
+}
+
+// WriteDeletedResourceName prints the name of a deleted resource
+func WriteDeletedResourceName(w io.Writer, bindingName string) {
+	fmt.Fprintf(w, "deleted %s\n", bindingName)
 }

--- a/cmd/svcat/output/output.go
+++ b/cmd/svcat/output/output.go
@@ -48,6 +48,6 @@ func formatStatusFull(condition string, conditionStatus v1beta1.ConditionStatus,
 }
 
 // WriteDeletedResourceName prints the name of a deleted resource
-func WriteDeletedResourceName(w io.Writer, bindingName string) {
-	fmt.Fprintf(w, "deleted %s\n", bindingName)
+func WriteDeletedResourceName(w io.Writer, resourceName string) {
+	fmt.Fprintf(w, "deleted %s\n", resourceName)
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -213,6 +213,7 @@ deleted ups-binding
 Deprovisioning is the process of preparing an instance to be removed, and then deleting it.
 You must unbind delete all bindings before deprovisioning an instance.
 
-```
-svcat deprovision ups-instance
+```console
+$ svcat deprovision ups-instance
+deleted ups-instance
 ```


### PR DESCRIPTION
1.) Slight refactor to output pkg to rename the function that printed deleted binding (WriteDeletedBindingNam)  into a more generic function (WriteDeletedResourceName)
2.) Added conditional to cmd/svcat/instance/deprovision_cmd.go to print deleted instance on success
3.) Updated README.md to convert the sample deprovision command to a console block with output

Closes: #1805