### PR TITLE
Enable verbose logging in svcat

### DIFF
--- a/cmd/svcat/main.go
+++ b/cmd/svcat/main.go
@@ -17,9 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
+	_ "github.com/golang/glog" // Initialize glog flags
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/binding"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/broker"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/class"
@@ -52,6 +54,12 @@ func main() {
 }
 
 func buildRootCommand(cxt *command.Context) *cobra.Command {
+	// Make cobra aware of select glog flags
+	// Enabling all flags causes unwanted deprecation warnings from glog to always print in plugin mode
+	pflag.CommandLine.AddGoFlag(flag.CommandLine.Lookup("v"))
+	pflag.CommandLine.AddGoFlag(flag.CommandLine.Lookup("logtostderr"))
+	pflag.CommandLine.Set("logtostderr", "true")
+
 	// root command flags
 	var opts struct {
 		KubeConfig  string

--- a/cmd/svcat/plugin/plugin.go
+++ b/cmd/svcat/plugin/plugin.go
@@ -40,6 +40,12 @@ const (
 	// kubectl flags and environment variables.
 	EnvPluginNamespace = "KUBECTL_PLUGINS_CURRENT_NAMESPACE"
 
+	// EnvPluginGlobalFlagPrefix contains the prefix applied to any global kubectl flags
+	EnvPluginGlobalFlagPrefix = "KUBECTL_PLUGINS_GLOBAL_FLAG"
+
+	// EnvPluginVerbose is the -v=LEVEL flag
+	EnvPluginVerbose = EnvPluginGlobalFlagPrefix + "_V"
+
 	// EnvPluginPath overrides where plugins should be installed.
 	EnvPluginPath = "KUBECTL_PLUGINS_PATH"
 )
@@ -55,6 +61,9 @@ func BindEnvironmentVariables(vip *viper.Viper) {
 	// KUBECTL_PLUGINS_CURRENT_NAMESPACE provides the final namespace
 	// computed by kubectl.
 	vip.BindEnv("namespace", EnvPluginNamespace)
+
+	// Manually bind relevant glog variables
+	vip.BindEnv("v", EnvPluginVerbose)
 
 	// kubectl intercepts all flags passed to a plugin, and replaces them
 	// with prefixed environment variables


### PR DESCRIPTION
Support the `-v=LEVEL` flag in svcat, in both standalone and plugin mode.

```console
$ svcat get brokers
     NAME                                  URL                                STATUS
+------------+--------------------------------------------------------------+--------+
  osba         http://osba-open-service-broker-azure.osba.svc.cluster.local   Ready
  ups-broker   http://ups-broker-ups-broker.ups-broker.svc.cluster.local      Ready

$ svcat get brokers -v=7
I0308 11:01:38.160902   25537 loader.go:357] Config loaded from file /Users/carolynvs/.kube/config
I0308 11:01:38.161965   25537 round_trippers.go:414] GET https://192.168.99.100:8443/apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers
I0308 11:01:38.161976   25537 round_trippers.go:421] Request Headers:
I0308 11:01:38.161980   25537 round_trippers.go:424]     Accept: application/json, */*
I0308 11:01:38.161985   25537 round_trippers.go:424]     User-Agent: svcat/v0.0.0 (darwin/amd64) kubernetes/$Format
I0308 11:01:38.213083   25537 round_trippers.go:439] Response Status: 200 OK in 51 milliseconds
     NAME                                  URL                                STATUS
+------------+--------------------------------------------------------------+--------+
  osba         http://osba-open-service-broker-azure.osba.svc.cluster.local   Ready
  ups-broker   http://ups-broker-ups-broker.ups-broker.svc.cluster.local      Ready


$ kubectl plugin svcat get brokers
     NAME                                  URL                                STATUS
+------------+--------------------------------------------------------------+--------+
  osba         http://osba-open-service-broker-azure.osba.svc.cluster.local   Ready
  ups-broker   http://ups-broker-ups-broker.ups-broker.svc.cluster.local      Ready

$ kubectl plugin svcat get brokers -v=7
I0308 11:01:56.875976   25562 loader.go:357] Config loaded from file /Users/carolynvs/.kube/config
I0308 11:01:56.935255   25563 loader.go:357] Config loaded from file /Users/carolynvs/.kube/config
I0308 11:01:56.936384   25563 round_trippers.go:414] GET https://192.168.99.100:8443/apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers
I0308 11:01:56.936396   25563 round_trippers.go:421] Request Headers:
I0308 11:01:56.936404   25563 round_trippers.go:424]     Accept: application/json, */*
I0308 11:01:56.936410   25563 round_trippers.go:424]     User-Agent: svcat/v0.0.0 (darwin/amd64) kubernetes/$Format
I0308 11:01:57.013942   25563 round_trippers.go:439] Response Status: 200 OK in 77 milliseconds
     NAME                                  URL                                STATUS
+------------+--------------------------------------------------------------+--------+
  osba         http://osba-open-service-broker-azure.osba.svc.cluster.local   Ready
  ups-broker   http://ups-broker-ups-broker.ups-broker.svc.cluster.local      Ready
```

/cc @jberkhahn 