### PR TITLE
reset RemovedFromBroker flag on plans that are re-added by broker

### DIFF
--- a/pkg/controller/controller_broker.go
+++ b/pkg/controller/controller_broker.go
@@ -613,9 +613,26 @@ func (c *controller) reconcileClusterServicePlanFromClusterServiceBrokerCatalog(
 	toUpdate.Spec.ServiceInstanceUpdateParameterSchema = servicePlan.Spec.ServiceInstanceUpdateParameterSchema
 	toUpdate.Spec.ServiceBindingCreateParameterSchema = servicePlan.Spec.ServiceBindingCreateParameterSchema
 
-	if _, err := c.serviceCatalogClient.ClusterServicePlans().Update(toUpdate); err != nil {
+	updatedPlan, err := c.serviceCatalogClient.ClusterServicePlans().Update(toUpdate)
+	if err != nil {
 		glog.Error(pcb.Messagef("Error updating %s: %v", pretty.ClusterServicePlanName(servicePlan), err))
 		return err
+	}
+
+	if updatedPlan.Status.RemovedFromBrokerCatalog {
+		updatedPlan.Status.RemovedFromBrokerCatalog = false
+		glog.V(4).Info(pcb.Messagef("Resetting RemovedFromBrokerCatalog status on %s", pretty.ClusterServicePlanName(updatedPlan)))
+
+		_, err := c.serviceCatalogClient.ClusterServicePlans().UpdateStatus(updatedPlan)
+		if err != nil {
+			s := fmt.Sprintf("Error updating status of %s: %v", pretty.ClusterServicePlanName(updatedPlan), err)
+			glog.Error(pcb.Message(s))
+			c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
+			if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason, errorSyncingCatalogMessage+s); err != nil {
+				return err
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1829,15 +1829,15 @@ func testActionFor(t *testing.T, name string, f failfFunc, action clientgotestin
 	return fakeRtObject, true
 }
 
-func assertRemovedFromBrokerCatalogFalse(t *testing.T, obj runtime.Object) {
-	assertRemovedFromBrokerCatalog(t, obj, false)
+func assertClassRemovedFromBrokerCatalogFalse(t *testing.T, obj runtime.Object) {
+	assertClassRemovedFromBrokerCatalog(t, obj, false)
 }
 
-func assertRemovedFromBrokerCatalogTrue(t *testing.T, obj runtime.Object) {
-	assertRemovedFromBrokerCatalog(t, obj, true)
+func assertClassRemovedFromBrokerCatalogTrue(t *testing.T, obj runtime.Object) {
+	assertClassRemovedFromBrokerCatalog(t, obj, true)
 }
 
-func assertRemovedFromBrokerCatalog(t *testing.T, obj runtime.Object, condition bool) {
+func assertClassRemovedFromBrokerCatalog(t *testing.T, obj runtime.Object, condition bool) {
 	clusterServiceClass, ok := obj.(*v1beta1.ClusterServiceClass)
 	if !ok {
 		fatalf(t, "Couldn't convert object %+v into a *v1beta1.ClusterServiceClass", obj)
@@ -1845,6 +1845,25 @@ func assertRemovedFromBrokerCatalog(t *testing.T, obj runtime.Object, condition 
 
 	if clusterServiceClass.Status.RemovedFromBrokerCatalog != condition {
 		fatalf(t, "ClusterServiceClass.RemovedFromBrokerCatalog!=%v", condition)
+	}
+}
+
+func assertPlanRemovedFromBrokerCatalogFalse(t *testing.T, obj runtime.Object) {
+	assertPlanRemovedFromBrokerCatalog(t, obj, false)
+}
+
+func assertPlanRemovedFromBrokerCatalogTrue(t *testing.T, obj runtime.Object) {
+	assertPlanRemovedFromBrokerCatalog(t, obj, true)
+}
+
+func assertPlanRemovedFromBrokerCatalog(t *testing.T, obj runtime.Object, condition bool) {
+	clusterServicePlan, ok := obj.(*v1beta1.ClusterServicePlan)
+	if !ok {
+		fatalf(t, "Couldn't convert object %+v into a *v1beta1.ClusterServicePlan", obj)
+	}
+
+	if clusterServicePlan.Status.RemovedFromBrokerCatalog != condition {
+		fatalf(t, "ClusterServicePlan.RemovedFromBrokerCatalog!=%v", condition)
 	}
 }
 


### PR DESCRIPTION
related to https://github.com/kubernetes-incubator/service-catalog/issues/1757 but this issue was with Plans not being reset after the broker adds the Plan back into the getCatalog response.

scenario:
1) broker removes a plan that it has previously listed
2) controller does a getCatalog, updates existing ClusterServicePlans setting RemovedFromBroker=true
3) broker re-adds the plan
4) next time controller fetches catalog, it sees plan has been re-added & must reset any RemovedFromBroker flags for matching plans.