### PR TITLE
gitignore integration.test binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ vendor/github.com/petar/GoLLRB/doc/*
 contrib/examples/consumer/Gopkg.lock
 contrib/examples/consumer
 contrib/examples/vendor/*
+integration.test*


### PR DESCRIPTION
Noticed I had a integration.test bin at my projct root after running the
integration tests and it was not ignored by git.