### PR TITLE
disable tests for Deploy stage in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ jobs:
     # Test is implicit from the build matrix
     # Deploy
     - stage: deploy
+      script: skip
       deploy:
         skip_cleanup: true
         provider: script


### PR DESCRIPTION
Currently Travis has been running the test suite in both the Test and Deploy stages. This will make it only run in the Test stage.

Worked on my local fork: https://travis-ci.org/kibbles-n-bytes/service-catalog/jobs/354449637