### PR TITLE
Catalog Controller should listen on https and serve metrics over TLS secured channel

### DIFF
--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -41,8 +41,8 @@ spec:
               fieldPath: metadata.namespace
         args:
         - controller-manager
-        - --port
-        - "8080"
+        - --secure-port
+        - "8444"
         {{ if .Values.controllerManager.leaderElection.activated -}}
         - "--leader-election-namespace={{ .Release.Namespace }}"
         - "--leader-elect-resource-lock=configmaps"
@@ -79,15 +79,16 @@ spec:
         - AsyncBindingOperations=true
         {{- end }}
         ports:
-        - containerPort: 8080
+        - containerPort: 8444
         volumeMounts:
         - name: service-catalog-cert
-          mountPath: /etc/service-catalog-ssl
+          mountPath: /var/run/kubernetes-service-catalog
           readOnly: true
         readinessProbe:
           httpGet:
-            port: 8080
+            port: 8444
             path: /healthz
+            scheme: HTTPS
           failureThreshold: 1
           initialDelaySeconds: 20
           periodSeconds: 10
@@ -95,8 +96,9 @@ spec:
           timeoutSeconds: 2
         livenessProbe:
           httpGet:
-            port: 8080
+            port: 8444
             path: /healthz
+            scheme: HTTPS
           failureThreshold: 3
           initialDelaySeconds: 20
           periodSeconds: 10
@@ -109,3 +111,9 @@ spec:
           items:
           - key: tls.crt
             path: apiserver.crt
+          - key: tls.key
+            path: apiserver.key
+          {{- if .Values.apiserver.tls.requestHeaderCA }}
+          - key: requestheader-ca.crt
+            path: requestheader-ca.crt
+          {{- end }}

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -43,7 +43,7 @@ const (
 	defaultServiceBrokerRelistInterval            = 24 * time.Hour
 	defaultContentType                            = "application/json"
 	defaultBindAddress                            = "0.0.0.0"
-	defaultPort                                   = 10000
+	defaultPort                                   = 8444
 	defaultK8sKubeconfigPath                      = "./kubeconfig"
 	defaultServiceCatalogKubeconfigPath           = "./service-catalog-kubeconfig"
 	defaultOSBAPIContextProfile                   = true
@@ -62,6 +62,7 @@ func NewControllerManagerServer() *ControllerManagerServer {
 		ControllerManagerConfiguration: componentconfig.ControllerManagerConfiguration{
 			Address:                                defaultBindAddress,
 			Port:                                   defaultPort,
+			SecurePort:                             defaultPort,
 			ContentType:                            defaultContentType,
 			K8sKubeconfigPath:                      defaultK8sKubeconfigPath,
 			ServiceCatalogKubeconfigPath:           defaultServiceCatalogKubeconfigPath,
@@ -85,7 +86,8 @@ func NewControllerManagerServer() *ControllerManagerServer {
 // AddFlags adds flags for a ControllerManagerServer to the specified FlagSet.
 func (s *ControllerManagerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Var(k8scomponentconfig.IPVar{Val: &s.Address}, "address", "The IP address to serve on (set to 0.0.0.0 for all interfaces)")
-	fs.Int32Var(&s.Port, "port", s.Port, "The port that the controller-manager's http service runs on")
+	fs.Int32Var(&s.Port, "port", 0, "DEPRECATED - use secure-port instead")
+	fs.Int32Var(&s.SecurePort, "secure-port", defaultPort, "The port that the controller-manager's https service runs on")
 	fs.StringVar(&s.ContentType, "api-content-type", s.ContentType, "Content type of requests sent to API servers")
 	fs.StringVar(&s.K8sAPIServerURL, "k8s-api-server-url", "", "The URL for the k8s API server")
 	fs.StringVar(&s.K8sKubeconfigPath, "k8s-kubeconfig", "", "Path to k8s core kubeconfig")

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -61,7 +61,7 @@ func NewControllerManagerServer() *ControllerManagerServer {
 	s := ControllerManagerServer{
 		ControllerManagerConfiguration: componentconfig.ControllerManagerConfiguration{
 			Address:                                defaultBindAddress,
-			Port:                                   defaultPort,
+			Port:                                   0,
 			SecurePort:                             defaultPort,
 			ContentType:                            defaultContentType,
 			K8sKubeconfigPath:                      defaultK8sKubeconfigPath,

--- a/contrib/examples/prometheus/prometheus.yml
+++ b/contrib/examples/prometheus/prometheus.yml
@@ -301,38 +301,25 @@ data:
       - source_labels: [__meta_kubernetes_service_name]
         target_label: kubernetes_name
 
-    # Example scrape config for pods
-    #
-    # The relabeling allows the actual pod scrape endpoint to be configured via the
-    # following annotations:
-    #
-    # * `prometheus.io/scrape`: Only scrape pods that have a value of `true`
-    # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
-    # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the
-    # pod's declared ports (default is a port-free target if none are declared).
-    - job_name: 'kubernetes-pods'
+    # Scrape config for Service Catalog
+    - job_name: 'service-catalog'
+      scheme: https
+      # This TLS & bearer token file config is used to connect to the actual scrape
+      # endpoints for cluster components.
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        # If your node certificates are self-signed or use a different CA to the
+        # master CA, then disable certificate verification below.
+        insecure_skip_verify: true
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
       kubernetes_sd_configs:
       - role: pod
+        namespaces:
+          names:
+          - catalog
 
       relabel_configs:
-      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-        action: keep
-        regex: true
-      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-        action: replace
-        target_label: __metrics_path__
-        regex: (.+)
-      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-        action: replace
-        regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: $1:$2
-        target_label: __address__
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
-      - source_labels: [__meta_kubernetes_namespace]
-        action: replace
-        target_label: kubernetes_namespace
       - source_labels: [__meta_kubernetes_pod_name]
-        action: replace
-        target_label: kubernetes_pod_name
+        action: keep
+        regex: (.+)controller-manager-(.+)

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -31,8 +31,12 @@ import (
 type ControllerManagerConfiguration struct {
 	// Address is the IP address to serve on (set to 0.0.0.0 for all interfaces).
 	Address string
-	// Port is the port that the controller's http service runs on.
+
+	// DEPRECATED/Ignored, use SecurePort instead.
 	Port int32
+
+	// SecurePort is the port that the controller's https service runs on.
+	SecurePort int32
 
 	// ContentType is the content type for requests sent to API servers.
 	ContentType string


### PR DESCRIPTION
In a review at Red Hat it was called out that metrics should be pulled from a secured port so monitoring can validate via certificates the controller is really the Service Catalog controller.

This PR changes the Controller to use TLS for accepting requests.  A new prameter --secure-port was added with a default of 8444 which establishes what port to listen on.  The --port parameter is still accepted, but a warning will be logged indicating that the parameter was replaced with secure-port and the parameter is ignored.

Similar to what we do with the Catalog API Server, I made use of the generic api server machinery to setup self signed certs if they are not in place.  Be default the Controller expects to find preconfigured certs in /var/run/kubernetes-service-catalog

Based also on review feedback, I refined the prometheus configuration to look specifically for the Controller pod within the catalog namespace.