### PR TITLE
Fix NamespaceScoped doc text for ns resources

### DIFF
--- a/pkg/registry/servicecatalog/binding/strategy.go
+++ b/pkg/registry/servicecatalog/binding/strategy.go
@@ -80,7 +80,7 @@ func (bindingRESTStrategy) Canonicalize(obj runtime.Object) {
 	}
 }
 
-// NamespaceScoped returns false as bindings are not scoped to a namespace.
+// NamespaceScoped returns true as bindings are scoped to a namespace.
 func (bindingRESTStrategy) NamespaceScoped() bool {
 	return true
 }

--- a/pkg/registry/servicecatalog/instance/strategy.go
+++ b/pkg/registry/servicecatalog/instance/strategy.go
@@ -94,7 +94,7 @@ func (instanceRESTStrategy) Canonicalize(obj runtime.Object) {
 	}
 }
 
-// NamespaceScoped returns false as instances are not scoped to a namespace.
+// NamespaceScoped returns true as instances are scoped to a namespace.
 func (instanceRESTStrategy) NamespaceScoped() bool {
 	return true
 }


### PR DESCRIPTION
Noticed this doc text was incorrect for namespaced types.