### PR TITLE
update debian base from jessie to stretch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ FILE_EXT=
 endif
 
 # TODO: Consider using busybox instead of debian
-BASEIMAGE?=gcr.io/google-containers/debian-base-$(ARCH):0.2
+BASEIMAGE?=gcr.io/google-containers/debian-base-$(ARCH):0.3
 
 GO_BUILD       = env GOOS=$(PLATFORM) GOARCH=$(ARCH) go build -i $(GOFLAGS) \
                    -ldflags "-X $(SC_PKG)/pkg.VERSION=$(VERSION) $(BUILD_LDFLAGS)"


### PR DESCRIPTION
Upstream has been using it for about 5 months.
https://github.com/kubernetes/kubernetes/tree/master/build/debian-base
