### PR TITLE
Update of name in example ServiceClass

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -42,7 +42,7 @@ of available Services (the catalog). Each Service will then have a corresponding
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ClusterServiceClass
 metadata:
-  name: smallDB
+  name: 4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
 spec:
   bindable: true
   clusterServiceBrokerName: ups-broker


### PR DESCRIPTION
Name of the ServiceClass is the same as Id of the Service Object that comes from the Service Broker. This means that name equals the externalId from metadata of the ServiceClass