### PR TITLE
Fix common validations regression

### DIFF
--- a/pkg/apis/servicecatalog/validation/broker.go
+++ b/pkg/apis/servicecatalog/validation/broker.go
@@ -90,7 +90,7 @@ func validateClusterServiceBrokerSpec(spec *sc.ClusterServiceBrokerSpec, fldPath
 	commonErrs := validateCommonServiceBrokerSpec(&spec.CommonServiceBrokerSpec, fldPath)
 
 	if len(commonErrs) != 0 {
-		allErrs = append(commonErrs)
+		allErrs = append(allErrs, commonErrs...)
 	}
 
 	return allErrs

--- a/pkg/apis/servicecatalog/validation/serviceclass.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass.go
@@ -108,7 +108,7 @@ func validateClusterServiceClassSpec(spec *sc.ClusterServiceClassSpec, fldPath *
 	commonErrs := validateCommonServiceClassSpec(&spec.CommonServiceClassSpec, fldPath, create)
 
 	if len(commonErrs) != 0 {
-		allErrs = append(commonErrs)
+		allErrs = append(allErrs, commonErrs...)
 	}
 
 	return allErrs


### PR DESCRIPTION
Discovered a regression that snuck in with my common validation refactoring. ClusterT specific validation errors were getting thrown away due to a bad `commonErrs` append. This correctly appends to the original `allErrs` slice.