### PR TITLE
Add tests and fix controller so it never mutates input

### DIFF
--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -64,7 +64,7 @@ func TestReconcileServiceBindingNonExistingServiceInstance(t *testing.T) {
 		},
 	}
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err == nil {
 		t.Fatal("binding nothere was found and it should not be found")
 	}
@@ -127,7 +127,7 @@ func TestReconcileServiceBindingUnresolvedClusterServiceClassReference(t *testin
 		},
 	}
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err == nil {
 		t.Fatal("serviceclassref was nil and reconcile should return an error")
 	}
@@ -179,7 +179,7 @@ func TestReconcileServiceBindingUnresolvedClusterServicePlanReference(t *testing
 		},
 	}
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err == nil {
 		t.Fatal("serviceclass nothere was found and it should not be found")
 	}
@@ -233,7 +233,7 @@ func TestReconcileServiceBindingNonExistingClusterServiceClass(t *testing.T) {
 		},
 	}
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err == nil {
 		t.Fatal("serviceclass nothere was found and it should not be found")
 	}
@@ -304,7 +304,7 @@ func TestReconcileServiceBindingWithSecretConflict(t *testing.T) {
 		},
 	}
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	binding = assertServiceBindingBindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
@@ -315,7 +315,7 @@ func TestReconcileServiceBindingWithSecretConflict(t *testing.T) {
 
 	assertNumberOfClusterServiceBrokerActions(t, fakeClusterServiceBrokerClient.Actions(), 0)
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err == nil {
 		t.Fatalf("a binding should fail to create a secret: %v", err)
 	}
@@ -410,7 +410,7 @@ func TestReconcileServiceBindingWithParameters(t *testing.T) {
 	}
 	binding.Spec.Parameters = &runtime.RawExtension{Raw: b}
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -431,7 +431,7 @@ func TestReconcileServiceBindingWithParameters(t *testing.T) {
 
 	assertNumberOfClusterServiceBrokerActions(t, fakeClusterServiceBrokerClient.Actions(), 0)
 
-	err = testController.reconcileServiceBinding(binding)
+	err = reconcileServiceBinding(t, testController, binding)
 	if err != nil {
 		t.Fatalf("a valid binding should not fail: %v", err)
 	}
@@ -651,7 +651,7 @@ func TestReconcileServiceBindingNonbindableClusterServiceClass(t *testing.T) {
 		},
 	}
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err != nil {
 		t.Fatalf("binding should fail against a non-bindable ClusterServiceClass")
 	}
@@ -731,7 +731,7 @@ func TestReconcileServiceBindingNonbindableClusterServiceClassBindablePlan(t *te
 		},
 	}
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	binding = assertServiceBindingBindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
@@ -742,7 +742,7 @@ func TestReconcileServiceBindingNonbindableClusterServiceClassBindablePlan(t *te
 
 	assertNumberOfClusterServiceBrokerActions(t, fakeClusterServiceBrokerClient.Actions(), 0)
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err != nil {
 		t.Fatalf("A bindable plan overrides the bindability of a service class: %v", err)
 	}
@@ -826,7 +826,7 @@ func TestReconcileServiceBindingBindableClusterServiceClassNonbindablePlan(t *te
 		},
 	}
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err != nil {
 		t.Fatalf("binding against a nonbindable plan should fail")
 	}
@@ -886,7 +886,7 @@ func TestReconcileServiceBindingServiceInstanceNotReady(t *testing.T) {
 		},
 	}
 
-	if err := testController.reconcileServiceBinding(binding); err == nil {
+	if err := reconcileServiceBinding(t, testController, binding); err == nil {
 		t.Fatalf("a binding cannot be created against an instance that is not prepared")
 	}
 
@@ -945,7 +945,7 @@ func TestReconcileServiceBindingNamespaceError(t *testing.T) {
 		},
 	}
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err == nil {
 		t.Fatalf("ServiceBindings are namespaced. If we cannot get the namespace we cannot find the binding")
 	}
@@ -1010,7 +1010,7 @@ func TestReconcileServiceBindingDelete(t *testing.T) {
 		return true, binding, nil
 	})
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	binding = assertServiceBindingUnbindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
@@ -1021,7 +1021,7 @@ func TestReconcileServiceBindingDelete(t *testing.T) {
 
 	assertNumberOfClusterServiceBrokerActions(t, fakeClusterServiceBrokerClient.Actions(), 0)
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -1099,7 +1099,7 @@ func TestReconcileServiceBindingDeleteUnresolvedClusterServiceClassReference(t *
 		},
 	}
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err != nil {
 		t.Fatal("should have deleted the binding")
 	}
@@ -1282,7 +1282,7 @@ func TestReconcileServiceBindingDeleteFailedServiceBinding(t *testing.T) {
 		return true, binding, nil
 	})
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	binding = assertServiceBindingUnbindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
@@ -1293,7 +1293,7 @@ func TestReconcileServiceBindingDeleteFailedServiceBinding(t *testing.T) {
 
 	assertNumberOfClusterServiceBrokerActions(t, fakeClusterServiceBrokerClient.Actions(), 0)
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -1375,13 +1375,13 @@ func TestReconcileServiceBindingWithClusterServiceBrokerError(t *testing.T) {
 		},
 	}
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	binding = assertServiceBindingBindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
 	fakeCatalogClient.ClearActions()
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err == nil {
 		t.Fatal("reconcileServiceBinding should have returned an error")
 	}
@@ -1441,13 +1441,13 @@ func TestReconcileServiceBindingWithClusterServiceBrokerHTTPError(t *testing.T) 
 		},
 	}
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	binding = assertServiceBindingBindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
 	fakeCatalogClient.ClearActions()
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err != nil {
 		t.Fatal("reconcileServiceBinding should not have returned an error")
 	}
@@ -1483,7 +1483,7 @@ func TestReconcileServiceBindingWithFailureCondition(t *testing.T) {
 
 	binding := getTestServiceBindingWithFailedStatus()
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -1516,7 +1516,7 @@ func TestReconcileServiceBindingWithServiceBindingCallFailure(t *testing.T) {
 
 	binding := getTestServiceBinding()
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	binding = assertServiceBindingBindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
@@ -1527,7 +1527,7 @@ func TestReconcileServiceBindingWithServiceBindingCallFailure(t *testing.T) {
 
 	assertNumberOfClusterServiceBrokerActions(t, fakeClusterServiceBrokerClient.Actions(), 0)
 
-	if err := testController.reconcileServiceBinding(binding); err == nil {
+	if err := reconcileServiceBinding(t, testController, binding); err == nil {
 		t.Fatal("ServiceBinding creation should fail")
 	}
 
@@ -1590,7 +1590,7 @@ func TestReconcileServiceBindingWithServiceBindingFailure(t *testing.T) {
 
 	binding := getTestServiceBinding()
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	binding = assertServiceBindingBindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
@@ -1601,7 +1601,7 @@ func TestReconcileServiceBindingWithServiceBindingFailure(t *testing.T) {
 
 	assertNumberOfClusterServiceBrokerActions(t, fakeClusterServiceBrokerClient.Actions(), 0)
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("ServiceBinding creation should complete: %v", err)
 	}
 
@@ -1830,13 +1830,13 @@ func TestReconcileUnbindingWithClusterServiceBrokerError(t *testing.T) {
 		t.Fatalf("Finalizer error: %v", err)
 	}
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	binding = assertServiceBindingUnbindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
 	fakeCatalogClient.ClearActions()
 
-	if err := testController.reconcileServiceBinding(binding); err == nil {
+	if err := reconcileServiceBinding(t, testController, binding); err == nil {
 		t.Fatal("reconcileServiceBinding should have returned an error")
 	}
 
@@ -1898,13 +1898,13 @@ func TestReconcileUnbindingWithClusterServiceBrokerHTTPError(t *testing.T) {
 		t.Fatalf("Finalizer error: %v", err)
 	}
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	binding = assertServiceBindingUnbindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
 	fakeCatalogClient.ClearActions()
 
-	if err := testController.reconcileServiceBinding(binding); err == nil {
+	if err := reconcileServiceBinding(t, testController, binding); err == nil {
 		t.Fatalf("reconcileServiceBinding should have returned an error")
 	}
 
@@ -1953,7 +1953,7 @@ func TestReconcileBindingUsingOriginatingIdentity(t *testing.T) {
 				binding.Spec.UserInfo = testUserInfo
 			}
 
-			if err := testController.reconcileServiceBinding(binding); err != nil {
+			if err := reconcileServiceBinding(t, testController, binding); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			binding = assertServiceBindingBindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
@@ -1964,7 +1964,7 @@ func TestReconcileBindingUsingOriginatingIdentity(t *testing.T) {
 
 			assertNumberOfClusterServiceBrokerActions(t, fakeBrokerClient.Actions(), 0)
 
-			err := testController.reconcileServiceBinding(binding)
+			err := reconcileServiceBinding(t, testController, binding)
 			if err != nil {
 				t.Fatalf("%v: a valid binding should not fail: %v", tc.name, err)
 			}
@@ -2017,7 +2017,7 @@ func TestReconcileBindingDeleteUsingOriginatingIdentity(t *testing.T) {
 				binding.Spec.UserInfo = testUserInfo
 			}
 
-			if err := testController.reconcileServiceBinding(binding); err != nil {
+			if err := reconcileServiceBinding(t, testController, binding); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			binding = assertServiceBindingUnbindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
@@ -2028,7 +2028,7 @@ func TestReconcileBindingDeleteUsingOriginatingIdentity(t *testing.T) {
 
 			assertNumberOfClusterServiceBrokerActions(t, fakeBrokerClient.Actions(), 0)
 
-			err := testController.reconcileServiceBinding(binding)
+			err := reconcileServiceBinding(t, testController, binding)
 			if err != nil {
 				t.Fatalf("%v: a valid binding should not fail: %v", tc.name, err)
 			}
@@ -2077,7 +2077,7 @@ func TestReconcileBindingSuccessOnFinalRetry(t *testing.T) {
 	binding.Status.OperationStartTime = &startTime
 	binding.Status.InProgressProperties = &v1beta1.ServiceBindingPropertiesState{}
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("a valid binding should not fail: %v", err)
 	}
 
@@ -2134,7 +2134,7 @@ func TestReconcileBindingFailureOnFinalRetry(t *testing.T) {
 	startTime := metav1.NewTime(time.Now().Add(-7 * 24 * time.Hour))
 	binding.Status.OperationStartTime = &startTime
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("Should have return no error because the retry duration has elapsed: %v", err)
 	}
 
@@ -2202,7 +2202,7 @@ func TestReconcileBindingWithSecretConflictFailedAfterFinalRetry(t *testing.T) {
 		},
 	}
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("reconciliation should complete since the retry duration has elapsed: %v", err)
 	}
 
@@ -2267,7 +2267,7 @@ func TestReconcileServiceBindingWithStatusUpdateError(t *testing.T) {
 		return true, nil, errors.New("update error")
 	})
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err == nil {
 		t.Fatalf("expected error from but got none")
 	}
@@ -2359,7 +2359,7 @@ func TestReconcileServiceBindingWithSecretParameters(t *testing.T) {
 		},
 	}
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -2383,7 +2383,7 @@ func TestReconcileServiceBindingWithSecretParameters(t *testing.T) {
 
 	assertNumberOfClusterServiceBrokerActions(t, fakeClusterServiceBrokerClient.Actions(), 0)
 
-	err = testController.reconcileServiceBinding(binding)
+	err = reconcileServiceBinding(t, testController, binding)
 	if err != nil {
 		t.Fatalf("a valid binding should not fail: %v", err)
 	}
@@ -2551,7 +2551,7 @@ func TestReconcileBindingWithSetOrphanMitigation(t *testing.T) {
 			startTime := metav1.NewTime(time.Now().Add(-7 * 24 * time.Hour))
 			binding.Status.OperationStartTime = &startTime
 
-			if err := testController.reconcileServiceBinding(binding); err != nil {
+			if err := reconcileServiceBinding(t, testController, binding); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			binding = assertServiceBindingBindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
@@ -2563,7 +2563,7 @@ func TestReconcileBindingWithSetOrphanMitigation(t *testing.T) {
 
 			assertNumberOfClusterServiceBrokerActions(t, fakeServiceBrokerClient.Actions(), 0)
 
-			if err := testController.reconcileServiceBinding(binding); tc.shouldReturnError && err == nil || !tc.shouldReturnError && err != nil {
+			if err := reconcileServiceBinding(t, testController, binding); tc.shouldReturnError && err == nil || !tc.shouldReturnError && err != nil {
 				t.Fatalf("expected to return %v from reconciliation attempt, got %v", tc.shouldReturnError, err)
 			}
 
@@ -2643,7 +2643,7 @@ func TestReconcileBindingWithOrphanMitigationInProgress(t *testing.T) {
 	binding.Status.OperationStartTime = nil
 	binding.Status.OrphanMitigationInProgress = true
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("reconciliation should complete since the retry duration has elapsed: %v", err)
 	}
 	assertDeleteSecretAction(t, fakeKubeClient.Actions(), binding.Spec.SecretName)
@@ -2716,7 +2716,7 @@ func TestReconcileBindingWithOrphanMitigationReconciliationRetryTimeOut(t *testi
 	binding.Status.OperationStartTime = &startTime
 	binding.Status.OrphanMitigationInProgress = true
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("reconciliation should complete since the retry duration has elapsed: %v", err)
 	}
 	assertDeleteSecretAction(t, fakeKubeClient.Actions(), binding.Spec.SecretName)
@@ -2790,7 +2790,7 @@ func TestReconcileServiceBindingDeleteDuringOngoingOperation(t *testing.T) {
 
 	timeOfReconciliation := metav1.Now()
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	binding = assertServiceBindingUnbindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
@@ -2811,7 +2811,7 @@ func TestReconcileServiceBindingDeleteDuringOngoingOperation(t *testing.T) {
 
 	assertNumberOfClusterServiceBrokerActions(t, fakeClusterServiceBrokerClient.Actions(), 0)
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -2886,7 +2886,7 @@ func TestReconcileServiceBindingDeleteDuringOrphanMitigation(t *testing.T) {
 
 	timeOfReconciliation := metav1.Now()
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	binding = assertServiceBindingUnbindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
@@ -2907,7 +2907,7 @@ func TestReconcileServiceBindingDeleteDuringOrphanMitigation(t *testing.T) {
 
 	assertNumberOfClusterServiceBrokerActions(t, fakeClusterServiceBrokerClient.Actions(), 0)
 
-	err := testController.reconcileServiceBinding(binding)
+	err := reconcileServiceBinding(t, testController, binding)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -2973,7 +2973,7 @@ func TestReconcileServiceBindingAsynchronousBind(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test binding")
 	}
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	binding = assertServiceBindingBindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
@@ -2984,7 +2984,7 @@ func TestReconcileServiceBindingAsynchronousBind(t *testing.T) {
 
 	assertNumberOfClusterServiceBrokerActions(t, fakeServiceBrokerClient.Actions(), 0)
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("a valid binding should not fail: %v", err)
 	}
 
@@ -3066,7 +3066,7 @@ func TestReconcileServiceBindingAsynchronousUnbind(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test binding")
 	}
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	binding = assertServiceBindingUnbindInProgressIsTheOnlyCatalogAction(t, fakeCatalogClient, binding)
@@ -3077,7 +3077,7 @@ func TestReconcileServiceBindingAsynchronousUnbind(t *testing.T) {
 
 	assertNumberOfClusterServiceBrokerActions(t, fakeServiceBrokerClient.Actions(), 0)
 
-	if err := testController.reconcileServiceBinding(binding); err != nil {
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
 		t.Fatalf("a valid binding should not fail: %v", err)
 	}
 
@@ -3831,4 +3831,13 @@ func assertActionEquals(t *testing.T, action clientgotesting.Action, expectedVer
 	if e, a := expectedResource, action.GetResource().Resource; e != a {
 		t.Fatalf("Unexpected resource on action; %s", expectedGot(e, a))
 	}
+}
+
+func reconcileServiceBinding(t *testing.T, testController *controller, binding *v1beta1.ServiceBinding) error {
+	clone := binding.DeepCopy()
+	err := testController.reconcileServiceBinding(binding)
+	if !reflect.DeepEqual(binding, clone) {
+		t.Errorf("reconcileServiceBinding shouldn't mutate input, but it does: %s", expectedGot(clone, binding))
+	}
+	return err
 }

--- a/pkg/controller/controller_broker_test.go
+++ b/pkg/controller/controller_broker_test.go
@@ -241,7 +241,7 @@ func TestReconcileClusterServiceBrokerExistingServiceClassAndServicePlan(t *test
 		}, nil
 	})
 
-	if err := testController.reconcileClusterServiceBroker(getTestClusterServiceBroker()); err != nil {
+	if err := reconcileClusterServiceBroker(t, testController, getTestClusterServiceBroker()); err != nil {
 		t.Fatalf("This should not fail: %v", err)
 	}
 
@@ -290,7 +290,7 @@ func TestReconcileClusterServiceBrokerRemovedClusterServiceClass(t *testing.T) {
 		}, nil
 	})
 
-	if err := testController.reconcileClusterServiceBroker(getTestClusterServiceBroker()); err != nil {
+	if err := reconcileClusterServiceBroker(t, testController, getTestClusterServiceBroker()); err != nil {
 		t.Fatalf("This should not fail: %v", err)
 	}
 
@@ -358,7 +358,7 @@ func TestReconcileClusterServiceBrokerRemovedAndRestoredClusterServiceClass(t *t
 		return true, testClusterServicePlan, nil
 	})
 
-	if err := testController.reconcileClusterServiceBroker(getTestClusterServiceBroker()); err != nil {
+	if err := reconcileClusterServiceBroker(t, testController, getTestClusterServiceBroker()); err != nil {
 		t.Fatalf("This should not fail: %v", err)
 	}
 
@@ -415,7 +415,7 @@ func TestReconcileClusterServiceBrokerRemovedClusterServicePlan(t *testing.T) {
 		}, nil
 	})
 
-	if err := testController.reconcileClusterServiceBroker(getTestClusterServiceBroker()); err != nil {
+	if err := reconcileClusterServiceBroker(t, testController, getTestClusterServiceBroker()); err != nil {
 		t.Fatalf("This should not fail: %v", err)
 	}
 
@@ -456,7 +456,7 @@ func TestReconcileClusterServiceBrokerExistingClusterServiceClassDifferentBroker
 
 	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(testClusterServiceClass)
 
-	if err := testController.reconcileClusterServiceBroker(getTestClusterServiceBroker()); err == nil {
+	if err := reconcileClusterServiceBroker(t, testController, getTestClusterServiceBroker()); err == nil {
 		t.Fatal("The same service class should not belong to two different brokers.")
 	}
 
@@ -508,7 +508,7 @@ func TestReconcileClusterServiceBrokerExistingClusterServicePlanDifferentClass(t
 
 	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(testClusterServicePlan)
 
-	if err := testController.reconcileClusterServiceBroker(getTestClusterServiceBroker()); err == nil {
+	if err := reconcileClusterServiceBroker(t, testController, getTestClusterServiceBroker()); err == nil {
 		t.Fatal("The same service class should not belong to two different brokers.")
 	}
 
@@ -576,7 +576,7 @@ func TestReconcileClusterServiceBrokerDelete(t *testing.T) {
 		}, nil
 	})
 
-	err := testController.reconcileClusterServiceBroker(broker)
+	err := reconcileClusterServiceBroker(t, testController, broker)
 	if err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
@@ -637,7 +637,7 @@ func TestReconcileClusterServiceBrokerErrorFetchingCatalog(t *testing.T) {
 
 	broker := getTestClusterServiceBroker()
 
-	if err := testController.reconcileClusterServiceBroker(broker); err == nil {
+	if err := reconcileClusterServiceBroker(t, testController, broker); err == nil {
 		t.Fatal("Should have failed to get the catalog.")
 	}
 
@@ -689,7 +689,7 @@ func TestReconcileClusterServiceBrokerZeroServices(t *testing.T) {
 		}, nil
 	})
 
-	err := testController.reconcileClusterServiceBroker(broker)
+	err := reconcileClusterServiceBroker(t, testController, broker)
 	if err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
@@ -834,7 +834,7 @@ func testReconcileClusterServiceBrokerWithAuth(t *testing.T, authInfo *v1beta1.C
 		},
 	}
 
-	err := testController.reconcileClusterServiceBroker(broker)
+	err := reconcileClusterServiceBroker(t, testController, broker)
 	if shouldSucceed && err != nil {
 		t.Fatal("Should have succeeded to get the catalog for the broker. got error: ", err)
 	}
@@ -898,7 +898,7 @@ func TestReconcileClusterServiceBrokerWithReconcileError(t *testing.T) {
 		return true, nil, errors.New("error creating serviceclass")
 	})
 
-	if err := testController.reconcileClusterServiceBroker(broker); err == nil {
+	if err := reconcileClusterServiceBroker(t, testController, broker); err == nil {
 		t.Fatal("There should have been an error.")
 	}
 
@@ -955,7 +955,7 @@ func TestReconcileClusterServiceBrokerSuccessOnFinalRetry(t *testing.T) {
 	startTime := metav1.NewTime(time.Now().Add(-7 * 24 * time.Hour))
 	broker.Status.OperationStartTime = &startTime
 
-	if err := testController.reconcileClusterServiceBroker(broker); err != nil {
+	if err := reconcileClusterServiceBroker(t, testController, broker); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -1002,7 +1002,7 @@ func TestReconcileClusterServiceBrokerFailureOnFinalRetry(t *testing.T) {
 	startTime := metav1.NewTime(time.Now().Add(-7 * 24 * time.Hour))
 	broker.Status.OperationStartTime = &startTime
 
-	if err := testController.reconcileClusterServiceBroker(broker); err != nil {
+	if err := reconcileClusterServiceBroker(t, testController, broker); err != nil {
 		t.Fatalf("Should have return no error because the retry duration has elapsed: %v", err)
 	}
 
@@ -1049,7 +1049,7 @@ func TestReconcileClusterServiceBrokerWithStatusUpdateError(t *testing.T) {
 		return true, nil, errors.New("update error")
 	})
 
-	err := testController.reconcileClusterServiceBroker(broker)
+	err := reconcileClusterServiceBroker(t, testController, broker)
 	if err == nil {
 		t.Fatalf("expected error from but got none")
 	}
@@ -1310,4 +1310,13 @@ func TestReconcileClusterServicePlanFromClusterServiceBrokerCatalog(t *testing.T
 			tc.catalogActionsCheckFunc(t, tc.name, actions)
 		}
 	}
+}
+
+func reconcileClusterServiceBroker(t *testing.T, testController *controller, broker *v1beta1.ClusterServiceBroker) error {
+	clone := broker.DeepCopy()
+	err := testController.reconcileClusterServiceBroker(broker)
+	if !reflect.DeepEqual(broker, clone) {
+		t.Errorf("reconcileClusterServiceBroker shouldn't mutate input, but it does: %s", expectedGot(clone, broker))
+	}
+	return err
 }

--- a/pkg/controller/controller_clusterserviceclass_test.go
+++ b/pkg/controller/controller_clusterserviceclass_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	clientgotesting "k8s.io/client-go/testing"
+	"reflect"
 )
 
 func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
@@ -116,7 +117,7 @@ func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
 			tc.catalogClientPrepFunc(fakeCatalogClient)
 		}
 
-		err := testController.reconcileClusterServiceClass(tc.serviceClass)
+		err := reconcileClusterServiceClass(t, testController, tc.serviceClass)
 		if err != nil {
 			if !tc.shouldError {
 				t.Errorf("%v: unexpected error from method under test: %v", tc.name, err)
@@ -135,4 +136,13 @@ func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
 			expectNumberOfActions(t, tc.name, actions, 0)
 		}
 	}
+}
+
+func reconcileClusterServiceClass(t *testing.T, testController *controller, clusterServiceClass *v1beta1.ClusterServiceClass) error {
+	clone := clusterServiceClass.DeepCopy()
+	err := testController.reconcileClusterServiceClass(clusterServiceClass)
+	if !reflect.DeepEqual(clusterServiceClass, clone) {
+		t.Errorf("reconcileClusterServiceClass shouldn't mutate input, but it does: %s", expectedGot(clone, clusterServiceClass))
+	}
+	return err
 }

--- a/pkg/controller/controller_clusterserviceplan_test.go
+++ b/pkg/controller/controller_clusterserviceplan_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	clientgotesting "k8s.io/client-go/testing"
+	"reflect"
 )
 
 func TestReconcileClusterServicePlanRemovedFromCatalog(t *testing.T) {
@@ -116,7 +117,7 @@ func TestReconcileClusterServicePlanRemovedFromCatalog(t *testing.T) {
 			tc.catalogClientPrepFunc(fakeCatalogClient)
 		}
 
-		err := testController.reconcileClusterServicePlan(tc.plan)
+		err := reconcileClusterServicePlan(t, testController, tc.plan)
 		if err != nil {
 			if !tc.shouldError {
 				t.Errorf("%v: unexpected error from method under test: %v", tc.name, err)
@@ -135,4 +136,13 @@ func TestReconcileClusterServicePlanRemovedFromCatalog(t *testing.T) {
 			expectNumberOfActions(t, tc.name, actions, 0)
 		}
 	}
+}
+
+func reconcileClusterServicePlan(t *testing.T, testController *controller, clusterServicePlan *v1beta1.ClusterServicePlan) error {
+	clone := clusterServicePlan.DeepCopy()
+	err := testController.reconcileClusterServicePlan(clusterServicePlan)
+	if !reflect.DeepEqual(clusterServicePlan, clone) {
+		t.Errorf("reconcileClusterServicePlan shouldn't mutate input, but it does: %s", expectedGot(clone, clusterServicePlan))
+	}
+	return err
 }

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -308,6 +308,7 @@ func (c *controller) initObservedGeneration(instance *v1beta1.ServiceInstance) (
 // more processing needed).
 func (c *controller) initOrphanMitigationCondition(instance *v1beta1.ServiceInstance) (bool, error) {
 	if !isServiceInstanceOrphanMitigation(instance) && instance.Status.OrphanMitigationInProgress {
+		instance := instance.DeepCopy()
 		reason := startingInstanceOrphanMitigationReason
 		message := startingInstanceOrphanMitigationMessage
 		c.recorder.Event(instance, corev1.EventTypeWarning, reason, message)

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -283,6 +283,7 @@ func (c *controller) reconcileServiceInstance(instance *v1beta1.ServiceInstance)
 // more processing needed).
 func (c *controller) initObservedGeneration(instance *v1beta1.ServiceInstance) (bool, error) {
 	if instance.Status.ObservedGeneration == 0 && instance.Status.ReconciledGeneration != 0 {
+		instance = instance.DeepCopy()
 		instance.Status.ObservedGeneration = instance.Status.ReconciledGeneration
 		// Before we implement https://github.com/kubernetes-incubator/service-catalog/issues/1715
 		// and switch to non-terminal errors, the "Failed":"True" is a sign that the provisioning failed

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -69,7 +69,7 @@ func TestReconcileServiceInstanceNonExistentClusterServiceClass(t *testing.T) {
 		},
 	}
 
-	if err := testController.reconcileServiceInstance(instance); err == nil {
+	if err := reconcileServiceInstance(t, testController, instance); err == nil {
 		t.Fatal("nothere is a service class that cannot be referenced by the service instance as it does not exist.")
 	}
 
@@ -119,7 +119,7 @@ func TestReconcileServiceInstanceNonExistentClusterServiceClassWithK8SName(t *te
 		},
 	}
 
-	if err := testController.reconcileServiceInstance(instance); err == nil {
+	if err := reconcileServiceInstance(t, testController, instance); err == nil {
 		t.Fatal("nothere is a service class that cannot be referenced by the service instance as it does not exist.")
 	}
 
@@ -153,7 +153,7 @@ func TestReconcileServiceInstanceNonExistentClusterServiceBroker(t *testing.T) {
 
 	instance := getTestServiceInstanceWithRefs()
 
-	if err := testController.reconcileServiceInstance(instance); err == nil {
+	if err := reconcileServiceInstance(t, testController, instance); err == nil {
 		t.Fatal("The broker referenced by the instance exists when it should not.")
 	}
 
@@ -202,7 +202,7 @@ func TestReconcileServiceInstanceWithAuthError(t *testing.T) {
 		return true, nil, errors.New("no secret defined")
 	})
 
-	if err := testController.reconcileServiceInstance(instance); err == nil {
+	if err := reconcileServiceInstance(t, testController, instance); err == nil {
 		t.Fatal("There was no secret to be found, but does_not_exist/auth-name was found.")
 	}
 
@@ -263,7 +263,7 @@ func TestReconcileServiceInstanceNonExistentClusterServicePlan(t *testing.T) {
 		},
 	}
 
-	if err := testController.reconcileServiceInstance(instance); err == nil {
+	if err := reconcileServiceInstance(t, testController, instance); err == nil {
 		t.Fatal("The service plan nothere should not exist to be referenced.")
 	}
 
@@ -325,7 +325,7 @@ func TestReconcileServiceInstanceNonExistentClusterServicePlanK8SName(t *testing
 		},
 	}
 
-	if err := testController.reconcileServiceInstance(instance); err == nil {
+	if err := reconcileServiceInstance(t, testController, instance); err == nil {
 		t.Fatal("The service plan nothere should not exist to be referenced.")
 	}
 
@@ -599,7 +599,7 @@ func TestReconcileServiceInstanceWithParameters(t *testing.T) {
 			//////////////////////////////////////
 			// Check 1st reconcilliation iteration (prepare/validate request & set status to in progress)
 
-			err := testController.reconcileServiceInstance(instance)
+			err := reconcileServiceInstance(t, testController, instance)
 			if tc.expectedError {
 				if err == nil {
 					t.Fatalf("Reconcile expected to fail")
@@ -663,7 +663,7 @@ func TestReconcileServiceInstanceWithParameters(t *testing.T) {
 			fakeKubeClient.ClearActions()
 			instance = updatedServiceInstance.(*v1beta1.ServiceInstance)
 
-			err = testController.reconcileServiceInstance(instance)
+			err = reconcileServiceInstance(t, testController, instance)
 			if err != nil {
 				t.Fatalf("Reconcile not expected to fail : %v", err)
 			}
@@ -735,7 +735,7 @@ func TestReconcileServiceInstanceResolvesReferences(t *testing.T) {
 		return true, &v1beta1.ClusterServicePlanList{Items: spItems}, nil
 	})
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -811,7 +811,7 @@ func TestReconcileServiceInstanceResolvesReferencesClusterServiceClassRefAlready
 		return true, &v1beta1.ClusterServicePlanList{Items: spItems}, nil
 	})
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -863,7 +863,7 @@ func TestReconcileServiceInstanceWithProvisionCallFailure(t *testing.T) {
 
 	instance := getTestServiceInstanceWithRefs()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -871,7 +871,7 @@ func TestReconcileServiceInstanceWithProvisionCallFailure(t *testing.T) {
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	if err := testController.reconcileServiceInstance(instance); err == nil {
+	if err := reconcileServiceInstance(t, testController, instance); err == nil {
 		t.Fatalf("Should not be able to make the ServiceInstance")
 	}
 
@@ -934,7 +934,7 @@ func TestReconcileServiceInstanceWithTemporaryProvisionFailure(t *testing.T) {
 	//////////////////////////////////////
 	// Check 1st reconcilliation iteration (prepare/validate request & set status to in progress)
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("Reconcile not expected to fail : %v", err)
 	}
 
@@ -970,7 +970,7 @@ func TestReconcileServiceInstanceWithTemporaryProvisionFailure(t *testing.T) {
 	fakeKubeClient.ClearActions()
 	instance = updatedServiceInstance.(*v1beta1.ServiceInstance)
 
-	if err := testController.reconcileServiceInstance(instance); err == nil {
+	if err := reconcileServiceInstance(t, testController, instance); err == nil {
 		t.Fatalf("Should not be able to make the ServiceInstance")
 	}
 
@@ -1045,7 +1045,7 @@ func TestReconcileServiceInstanceWithTerminalProvisionFailure(t *testing.T) {
 
 	instance := getTestServiceInstanceWithRefs()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -1053,7 +1053,7 @@ func TestReconcileServiceInstanceWithTerminalProvisionFailure(t *testing.T) {
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -1121,7 +1121,7 @@ func TestReconcileServiceInstance(t *testing.T) {
 
 	instance := getTestServiceInstanceWithRefs()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -1131,7 +1131,7 @@ func TestReconcileServiceInstance(t *testing.T) {
 	assertNumberOfClusterServiceBrokerActions(t, fakeClusterServiceBrokerClient.Actions(), 0)
 	fakeKubeClient.ClearActions()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -1192,7 +1192,7 @@ func TestReconcileServiceInstanceFailsWithDeletedPlan(t *testing.T) {
 
 	instance := getTestServiceInstanceWithRefs()
 
-	if err := testController.reconcileServiceInstance(instance); err == nil {
+	if err := reconcileServiceInstance(t, testController, instance); err == nil {
 		t.Fatalf("This should fail")
 	}
 
@@ -1242,7 +1242,7 @@ func TestReconcileServiceInstanceFailsWithDeletedClass(t *testing.T) {
 
 	instance := getTestServiceInstanceWithRefs()
 
-	if err := testController.reconcileServiceInstance(instance); err == nil {
+	if err := reconcileServiceInstance(t, testController, instance); err == nil {
 		t.Fatalf("This should have failed")
 	}
 
@@ -1295,7 +1295,7 @@ func TestReconcileServiceInstanceSuccessWithK8SNames(t *testing.T) {
 
 	instance := getTestServiceInstanceK8SNames()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -1318,7 +1318,7 @@ func TestReconcileServiceInstanceSuccessWithK8SNames(t *testing.T) {
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -1326,7 +1326,7 @@ func TestReconcileServiceInstanceSuccessWithK8SNames(t *testing.T) {
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -1396,7 +1396,7 @@ func TestReconcileServiceInstanceAsynchronous(t *testing.T) {
 	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
 
 	instance := getTestServiceInstanceWithRefs()
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -1410,7 +1410,7 @@ func TestReconcileServiceInstanceAsynchronous(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -1466,7 +1466,7 @@ func TestReconcileServiceInstanceAsynchronousNoOperation(t *testing.T) {
 
 	instance := getTestServiceInstanceWithRefs()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -1480,7 +1480,7 @@ func TestReconcileServiceInstanceAsynchronousNoOperation(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -1529,7 +1529,7 @@ func TestReconcileServiceInstanceNamespaceError(t *testing.T) {
 
 	instance := getTestServiceInstanceWithRefs()
 
-	if err := testController.reconcileServiceInstance(instance); err == nil {
+	if err := reconcileServiceInstance(t, testController, instance); err == nil {
 		t.Fatalf("There should not be a namespace for the ServiceInstance to be created in")
 	}
 
@@ -1593,14 +1593,14 @@ func TestReconcileServiceInstanceDelete(t *testing.T) {
 		return true, instance, nil
 	})
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	instance = assertServiceInstanceDeprovisionInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	err := testController.reconcileServiceInstance(instance)
+	err := reconcileServiceInstance(t, testController, instance)
 	if err != nil {
 		t.Fatalf("This should not fail")
 	}
@@ -1668,7 +1668,7 @@ func TestReconcileServiceInstanceDeleteBlockedByCredentials(t *testing.T) {
 		return true, instance, nil
 	})
 
-	if err := testController.reconcileServiceInstance(instance); err == nil {
+	if err := reconcileServiceInstance(t, testController, instance); err == nil {
 		t.Fatalf("expected reconcileServiceInstance to return an error, but there was none")
 	}
 
@@ -1702,14 +1702,14 @@ func TestReconcileServiceInstanceDeleteBlockedByCredentials(t *testing.T) {
 	// credentials were removed, verify the next reconcilation removes
 	// the instance
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	instance = assertServiceInstanceDeprovisionInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -1784,14 +1784,14 @@ func TestReconcileServiceInstanceDeleteAsynchronous(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	instance = assertServiceInstanceDeprovisionInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	err := testController.reconcileServiceInstance(instance)
+	err := reconcileServiceInstance(t, testController, instance)
 	if err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
@@ -1862,14 +1862,14 @@ func TestReconcileServiceInstanceDeleteFailedProvisionWithRequest(t *testing.T) 
 		return true, instance, nil
 	})
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	instance = assertServiceInstanceDeprovisionInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	err := testController.reconcileServiceInstance(instance)
+	err := reconcileServiceInstance(t, testController, instance)
 	if err != nil {
 		t.Fatalf("Unexpected error from reconcileServiceInstance: %v", err)
 	}
@@ -1972,7 +1972,7 @@ func TestReconsileServiceInstanceDeleteWithParameters(t *testing.T) {
 				return true, instance, nil
 			})
 
-			err := testController.reconcileServiceInstance(instance)
+			err := reconcileServiceInstance(t, testController, instance)
 			if err != nil {
 				t.Fatalf("Unexpected error from reconcileServiceInstance: %v", err)
 			}
@@ -2022,7 +2022,7 @@ func TestReconcileServiceInstanceDeleteWhenAlreadyDeprovisionedUnsuccessfully(t 
 		return true, instance, nil
 	})
 
-	err := testController.reconcileServiceInstance(instance)
+	err := reconcileServiceInstance(t, testController, instance)
 	if err != nil {
 		t.Fatalf("Unexpected error from reconcileServiceInstance: %v", err)
 	}
@@ -2073,14 +2073,14 @@ func TestReconcileServiceInstanceDeleteFailedUpdate(t *testing.T) {
 		return true, instance, nil
 	})
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	instance = assertServiceInstanceDeprovisionInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	err := testController.reconcileServiceInstance(instance)
+	err := reconcileServiceInstance(t, testController, instance)
 	if err != nil {
 		t.Fatalf("Unexpected error from reconcileServiceInstance: %v", err)
 	}
@@ -2138,7 +2138,7 @@ func TestReconcileServiceInstanceDeleteDoesNotInvokeClusterServiceBroker(t *test
 		return true, instance, nil
 	})
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -2177,14 +2177,14 @@ func TestReconcileServiceInstanceWithFailedCondition(t *testing.T) {
 
 	instance := getTestServiceInstanceWithFailedStatus()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	instance = assertServiceInstanceProvisionInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -2875,7 +2875,7 @@ func TestReconcileServiceInstanceSuccessOnFinalRetry(t *testing.T) {
 	startTime := metav1.NewTime(time.Now().Add(-7 * 24 * time.Hour))
 	instance.Status.OperationStartTime = &startTime
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -2930,7 +2930,7 @@ func TestReconcileServiceInstanceFailureOnFinalRetry(t *testing.T) {
 	instance.Status.OperationStartTime = &startTime
 	instance.Status.ObservedGeneration = instance.Generation
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("Should have returned no error because the retry duration has elapsed: %v", err)
 	}
 
@@ -3114,7 +3114,7 @@ func TestReconcileServiceInstanceWithStatusUpdateError(t *testing.T) {
 		return true, nil, errors.New("update error")
 	})
 
-	err := testController.reconcileServiceInstance(instance)
+	err := reconcileServiceInstance(t, testController, instance)
 	if err == nil {
 		t.Fatalf("expected error from but got none")
 	}
@@ -3471,7 +3471,7 @@ func TestReconcileInstanceUsingOriginatingIdentity(t *testing.T) {
 				instance.Spec.UserInfo = testUserInfo
 			}
 
-			if err := testController.reconcileServiceInstance(instance); err != nil {
+			if err := reconcileServiceInstance(t, testController, instance); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
@@ -3481,7 +3481,7 @@ func TestReconcileInstanceUsingOriginatingIdentity(t *testing.T) {
 
 			instance = updatedServiceInstance.(*v1beta1.ServiceInstance)
 
-			if err := testController.reconcileServiceInstance(instance); err != nil {
+			if err := reconcileServiceInstance(t, testController, instance); err != nil {
 				t.Fatalf("This should not fail : %v", err)
 			}
 
@@ -3541,14 +3541,14 @@ func TestReconcileInstanceDeleteUsingOriginatingIdentity(t *testing.T) {
 				return true, instance, nil
 			})
 
-			if err := testController.reconcileServiceInstance(instance); err != nil {
+			if err := reconcileServiceInstance(t, testController, instance); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
 			instance = assertServiceInstanceDeprovisionInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
 			fakeCatalogClient.ClearActions()
 
-			err := testController.reconcileServiceInstance(instance)
+			err := reconcileServiceInstance(t, testController, instance)
 			if err != nil {
 				t.Fatalf("This should not fail")
 			}
@@ -3675,14 +3675,14 @@ func TestReconcileServiceInstanceWithHTTPStatusCodeErrorOrphanMitigation(t *test
 		sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
 
 		instance := getTestServiceInstanceWithRefs()
-		if err := testController.reconcileServiceInstance(instance); err != nil {
+		if err := reconcileServiceInstance(t, testController, instance); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
 		instance = assertServiceInstanceProvisionInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
 		fakeCatalogClient.ClearActions()
 
-		err := testController.reconcileServiceInstance(instance)
+		err := reconcileServiceInstance(t, testController, instance)
 
 		// The action should be:
 		// 0. Updating the status
@@ -3733,14 +3733,14 @@ func TestReconcileServiceInstanceTimeoutTriggersOrphanMitigation(t *testing.T) {
 	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
 
 	instance := getTestServiceInstanceWithRefs()
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	instance = assertServiceInstanceProvisionInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
 	fakeCatalogClient.ClearActions()
 
-	if err := testController.reconcileServiceInstance(instance); err == nil {
+	if err := reconcileServiceInstance(t, testController, instance); err == nil {
 		t.Fatal("Reconciler should return error for timeout so that instance is orphan mitigated")
 	}
 
@@ -3981,7 +3981,7 @@ func TestReconcileServiceInstanceOrphanMitigation(t *testing.T) {
 				return true, instance, nil
 			})
 
-			err := testController.reconcileServiceInstance(instance)
+			err := reconcileServiceInstance(t, testController, instance)
 
 			// The action should be:
 			// 0. Updating the status
@@ -4070,7 +4070,7 @@ func TestReconcileServiceInstanceWithSecretParameters(t *testing.T) {
 		},
 	}
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -4091,7 +4091,7 @@ func TestReconcileServiceInstanceWithSecretParameters(t *testing.T) {
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	if err = testController.reconcileServiceInstance(instance); err != nil {
+	if err = reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -4279,7 +4279,7 @@ func TestReconcileServiceInstanceUpdateParameters(t *testing.T) {
 	}
 	instance.Spec.Parameters = &runtime.RawExtension{Raw: b}
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -4296,7 +4296,7 @@ func TestReconcileServiceInstanceUpdateParameters(t *testing.T) {
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	if err = testController.reconcileServiceInstance(instance); err != nil {
+	if err = reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -4392,14 +4392,14 @@ func TestReconcileServiceInstanceDeleteParameters(t *testing.T) {
 		ParametersChecksum:             generateChecksumOfParametersOrFail(t, oldParameters),
 	}
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	instance = assertServiceInstanceUpdateInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	if err = testController.reconcileServiceInstance(instance); err != nil {
+	if err = reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -4724,7 +4724,7 @@ func TestReconcileServiceInstanceUpdatePlan(t *testing.T) {
 	}
 	instance.Spec.Parameters = &runtime.RawExtension{Raw: b}
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -4732,7 +4732,7 @@ func TestReconcileServiceInstanceUpdatePlan(t *testing.T) {
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	if err = testController.reconcileServiceInstance(instance); err != nil {
+	if err = reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -4797,14 +4797,14 @@ func TestReconcileServiceInstanceWithUpdateCallFailure(t *testing.T) {
 
 	instance := getTestServiceInstanceUpdatingPlan()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	instance = assertServiceInstanceUpdateInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	if err := testController.reconcileServiceInstance(instance); err == nil {
+	if err := reconcileServiceInstance(t, testController, instance); err == nil {
 		t.Fatalf("Should not be able to make the ServiceInstance.")
 	}
 
@@ -4861,14 +4861,14 @@ func TestReconcileServiceInstanceWithUpdateFailure(t *testing.T) {
 
 	instance := getTestServiceInstanceUpdatingPlan()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	instance = assertServiceInstanceUpdateInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	if err := testController.reconcileServiceInstance(instance); err == nil {
+	if err := reconcileServiceInstance(t, testController, instance); err == nil {
 		t.Fatal("expected error to be returned")
 	}
 
@@ -5129,14 +5129,14 @@ func TestReconcileServiceInstanceUpdateAsynchronous(t *testing.T) {
 		t.Fatalf("Expected polling queue to not have any record of test instance")
 	}
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	instance = assertServiceInstanceUpdateInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -5452,7 +5452,7 @@ func TestReconcileServiceInstanceDeleteDuringOngoingOperation(t *testing.T) {
 
 	timeOfReconciliation := metav1.Now()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -5470,7 +5470,7 @@ func TestReconcileServiceInstanceDeleteDuringOngoingOperation(t *testing.T) {
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	err := testController.reconcileServiceInstance(instance)
+	err := reconcileServiceInstance(t, testController, instance)
 	if err != nil {
 		t.Fatalf("This should not fail")
 	}
@@ -5536,7 +5536,7 @@ func TestReconcileServiceInstanceDeleteWithOngoingOperation(t *testing.T) {
 
 	timeOfReconciliation := metav1.Now()
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -5554,7 +5554,7 @@ func TestReconcileServiceInstanceDeleteWithOngoingOperation(t *testing.T) {
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	err := testController.reconcileServiceInstance(instance)
+	err := reconcileServiceInstance(t, testController, instance)
 	if err != nil {
 		t.Fatalf("This should not fail")
 	}
@@ -5619,7 +5619,7 @@ func TestReconcileServiceInstanceDeleteWithNonExistentPlan(t *testing.T) {
 		return true, instance, nil
 	})
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -5627,7 +5627,7 @@ func TestReconcileServiceInstanceDeleteWithNonExistentPlan(t *testing.T) {
 	fakeCatalogClient.ClearActions()
 	fakeKubeClient.ClearActions()
 
-	err := testController.reconcileServiceInstance(instance)
+	err := reconcileServiceInstance(t, testController, instance)
 	if err != nil {
 		t.Fatalf("This should not fail")
 	}
@@ -5686,7 +5686,7 @@ func TestReconcileServiceInstanceUpdateMissingObservedGeneration(t *testing.T) {
 		ClusterServicePlanExternalID:   testClusterServicePlanGUID,
 	}
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -5734,7 +5734,7 @@ func TestReconcileServiceInstanceUpdateMissingOrphanMitigation(t *testing.T) {
 		ClusterServicePlanExternalID:   testClusterServicePlanGUID,
 	}
 
-	if err := testController.reconcileServiceInstance(instance); err != nil {
+	if err := reconcileServiceInstance(t, testController, instance); err != nil {
 		t.Fatalf("This should not fail : %v", err)
 	}
 
@@ -5781,4 +5781,13 @@ func assertServiceInstanceOperationInProgressWithParametersIsTheOnlyCatalogClien
 	updateObject := assertUpdateStatus(t, actions[0], instance)
 	assertServiceInstanceOperationInProgressWithParameters(t, updateObject, operation, planName, planGUID, parameters, parametersChecksum, instance)
 	return updateObject.(*v1beta1.ServiceInstance)
+}
+
+func reconcileServiceInstance(t *testing.T, testController *controller, instance *v1beta1.ServiceInstance) error {
+	clone := instance.DeepCopy()
+	err := testController.reconcileServiceInstance(instance)
+	if !reflect.DeepEqual(instance, clone) {
+		t.Errorf("reconcileServiceInstance shouldn't mutate input, but it does: %s", expectedGot(clone, instance))
+	}
+	return err
 }

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -5700,7 +5700,7 @@ func TestReconcileServiceInstanceUpdateMissingObservedGeneration(t *testing.T) {
 	if updatedServiceInstance.Status.ObservedGeneration == 0 || updatedServiceInstance.Status.ObservedGeneration != instance.Status.ReconciledGeneration {
 		t.Fatalf("Unexpected ObservedGeneration value: %d", updatedServiceInstance.Status.ObservedGeneration)
 	}
-	if instance.Status.ProvisionStatus != v1beta1.ServiceInstanceProvisionStatusProvisioned {
+	if updatedServiceInstance.Status.ProvisionStatus != v1beta1.ServiceInstanceProvisionStatusProvisioned {
 		t.Fatalf("The instance was expected to be marked as Provisioned")
 	}
 }


### PR DESCRIPTION
I noticed that `initOrphanMitigation()` doesn't create a copy of the input object, so I added a check to all the tests to see if the controller mutates the input object. This confirmed that `initOrphanMitigation()` and `initObservedGeneration()` both mutate the input object coming from the informer. This is forbidden.