### PR TITLE
Ensure the controller never performs a no-op status update

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -423,7 +423,7 @@ func (c *controller) getClusterServiceClassAndClusterServiceBroker(instance *v1b
 // done to validate service plan, service class exist, and handles creating
 // a brokerclient to use for a given ServiceInstance.
 // Sets ClusterServiceClassRef and/or ClusterServicePlanRef if they haven't been already set.
-func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForServiceBinding(instance *v1beta1.ServiceInstance, binding *v1beta1.ServiceBinding) (*v1beta1.ClusterServiceClass, *v1beta1.ClusterServicePlan, string, osb.Client, error) {
+func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForServiceBinding(instance *v1beta1.ServiceInstance, original, binding *v1beta1.ServiceBinding) (*v1beta1.ClusterServiceClass, *v1beta1.ClusterServicePlan, string, osb.Client, error) {
 	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
 	serviceClass, err := c.serviceClassLister.Get(instance.Spec.ClusterServiceClassRef.Name)
 	if err != nil {
@@ -433,6 +433,7 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 		)
 		glog.Warning(pcb.Message(s))
 		c.updateServiceBindingCondition(
+			original,
 			binding,
 			v1beta1.ServiceBindingConditionReady,
 			v1beta1.ConditionFalse,
@@ -451,6 +452,7 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 		)
 		glog.Warning(pcb.Message(s))
 		c.updateServiceBindingCondition(
+			original,
 			binding,
 			v1beta1.ServiceBindingConditionReady,
 			v1beta1.ConditionFalse,
@@ -466,6 +468,7 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 		s := fmt.Sprintf("References a non-existent ClusterServiceBroker %q", serviceClass.Spec.ClusterServiceBrokerName)
 		glog.Warning(pcb.Message(s))
 		c.updateServiceBindingCondition(
+			original,
 			binding,
 			v1beta1.ServiceBindingConditionReady,
 			v1beta1.ConditionFalse,
@@ -481,6 +484,7 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 		s := fmt.Sprintf("Error getting broker auth credentials for broker %q: %s", broker.Name, err)
 		glog.Warning(pcb.Message(s))
 		c.updateServiceBindingCondition(
+			original,
 			binding,
 			v1beta1.ServiceBindingConditionReady,
 			v1beta1.ConditionFalse,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -423,7 +423,7 @@ func (c *controller) getClusterServiceClassAndClusterServiceBroker(instance *v1b
 // done to validate service plan, service class exist, and handles creating
 // a brokerclient to use for a given ServiceInstance.
 // Sets ClusterServiceClassRef and/or ClusterServicePlanRef if they haven't been already set.
-func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForServiceBinding(instance *v1beta1.ServiceInstance, original, binding *v1beta1.ServiceBinding) (*v1beta1.ClusterServiceClass, *v1beta1.ClusterServicePlan, string, osb.Client, error) {
+func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForServiceBinding(instance *v1beta1.ServiceInstance, originalBinding, binding *v1beta1.ServiceBinding) (*v1beta1.ClusterServiceClass, *v1beta1.ClusterServicePlan, string, osb.Client, error) {
 	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
 	serviceClass, err := c.serviceClassLister.Get(instance.Spec.ClusterServiceClassRef.Name)
 	if err != nil {
@@ -433,7 +433,7 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 		)
 		glog.Warning(pcb.Message(s))
 		c.updateServiceBindingCondition(
-			original,
+			originalBinding,
 			binding,
 			v1beta1.ServiceBindingConditionReady,
 			v1beta1.ConditionFalse,
@@ -452,7 +452,7 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 		)
 		glog.Warning(pcb.Message(s))
 		c.updateServiceBindingCondition(
-			original,
+			originalBinding,
 			binding,
 			v1beta1.ServiceBindingConditionReady,
 			v1beta1.ConditionFalse,
@@ -468,7 +468,7 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 		s := fmt.Sprintf("References a non-existent ClusterServiceBroker %q", serviceClass.Spec.ClusterServiceBrokerName)
 		glog.Warning(pcb.Message(s))
 		c.updateServiceBindingCondition(
-			original,
+			originalBinding,
 			binding,
 			v1beta1.ServiceBindingConditionReady,
 			v1beta1.ConditionFalse,
@@ -484,7 +484,7 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 		s := fmt.Sprintf("Error getting broker auth credentials for broker %q: %s", broker.Name, err)
 		glog.Warning(pcb.Message(s))
 		c.updateServiceBindingCondition(
-			original,
+			originalBinding,
 			binding,
 			v1beta1.ServiceBindingConditionReady,
 			v1beta1.ConditionFalse,

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -596,7 +596,7 @@ func setServiceBindingConditionInternal(toUpdate *v1beta1.ServiceBinding,
 func (c *controller) updateServiceBindingStatus(originalBinding, toUpdate *v1beta1.ServiceBinding) (*v1beta1.ServiceBinding, error) {
 	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, toUpdate.Namespace, toUpdate.Name)
 	if reflect.DeepEqual(originalBinding, toUpdate) {
-		glog.V(4).Info(pcb.Message("Not updating status, because it wasn't modified"))
+		glog.V(5).Info(pcb.Message("Not updating status, because it wasn't modified"))
 		return toUpdate, nil
 	}
 	glog.V(4).Info(pcb.Message("Updating status"))
@@ -624,7 +624,7 @@ func (c *controller) updateServiceBindingCondition(
 
 	setServiceBindingCondition(binding, conditionType, status, reason, message)
 	if reflect.DeepEqual(originalBinding, binding) {
-		glog.V(4).Info(pcb.Message("Not updating condition, because it wasn't modified"))
+		glog.V(5).Info(pcb.Message("Not updating condition, because it wasn't modified"))
 		return nil
 	}
 	glog.V(4).Info(pcb.Messagef(

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -1735,16 +1735,17 @@ func TestUpdateServiceBindingCondition(t *testing.T) {
 	for _, tc := range cases {
 		_, fakeCatalogClient, _, testController, _ := newTestController(t, noFakeActions())
 
+		original := tc.input.DeepCopy()
 		inputClone := tc.input.DeepCopy()
 
-		err := testController.updateServiceBindingCondition(tc.input, v1beta1.ServiceBindingConditionReady, tc.status, tc.reason, tc.message)
+		err := testController.updateServiceBindingCondition(original, tc.input, v1beta1.ServiceBindingConditionReady, tc.status, tc.reason, tc.message)
 		if err != nil {
 			t.Errorf("%v: error updating broker condition: %v", tc.name, err)
 			continue
 		}
 
-		if !reflect.DeepEqual(tc.input, inputClone) {
-			t.Errorf("%v: updating broker condition mutated input: %s", tc.name, expectedGot(inputClone, tc.input))
+		if !reflect.DeepEqual(original, inputClone) {
+			t.Errorf("%v: updating broker condition mutated original: %s", tc.name, expectedGot(inputClone, original))
 			continue
 		}
 

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1211,7 +1211,7 @@ func (c *controller) updateServiceInstanceReferences(toUpdate *v1beta1.ServiceIn
 func (c *controller) updateServiceInstanceStatus(originalInstance, toUpdate *v1beta1.ServiceInstance) (*v1beta1.ServiceInstance, error) {
 	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, toUpdate.Namespace, toUpdate.Name)
 	if reflect.DeepEqual(originalInstance, toUpdate) {
-		glog.V(4).Info(pcb.Message("Not updating status, because it wasn't modified"))
+		glog.V(5).Info(pcb.Message("Not updating status, because it wasn't modified"))
 		return toUpdate, nil
 	}
 	glog.V(4).Info(pcb.Message("Updating status"))
@@ -1235,7 +1235,7 @@ func (c *controller) updateServiceInstanceCondition(
 
 	setServiceInstanceCondition(instance, conditionType, status, reason, message)
 	if reflect.DeepEqual(originalInstance, instance) {
-		glog.V(4).Info(pcb.Message("Not updating condition, because it wasn't modified"))
+		glog.V(5).Info(pcb.Message("Not updating condition, because it wasn't modified"))
 		return nil
 	}
 


### PR DESCRIPTION
Prior to this commit, the controller would, in some cases, post a status
update to the API server where the object's status would be exactly the
same as the object's existing status.

The biggest problem with these no-op status updates is that they result
in the "the object has been modified; please apply your changes to the
latest version and try again" error being logged during
integration tests. The error is logged because the test deletes the
object while the controller is performing a no-op status update.