### PR TITLE
don't overwrite generated files before verifying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ $(BINDIR)/e2e.test: .init
 # Util targets
 ##############
 .PHONY: verify verify-generated verify-client-gen verify-docs
-verify: .init .generate_files verify-generated verify-client-gen verify-docs verify-vendor
+verify: .init verify-generated verify-client-gen verify-docs verify-vendor
 	@echo Running gofmt:
 	@$(DOCKER_CMD) gofmt -l -s $(TOP_TEST_DIRS) $(TOP_SRC_DIRS)>.out 2>&1||true
 	@[ ! -s .out ] || \
@@ -227,10 +227,10 @@ verify-docs: .init
 	@echo Running href checker$(SKIP_COMMENT):
 	@$(DOCKER_CMD) verify-links.sh -s .pkg -t $(SKIP_HTTP) .
 
-verify-generated: .init .generate_files
+verify-generated: .init .generate_exes
 	$(DOCKER_CMD) $(BUILD_DIR)/update-apiserver-gen.sh --verify-only
 
-verify-client-gen: .init .generate_files
+verify-client-gen: .init .generate_exes
 	$(DOCKER_CMD) $(BUILD_DIR)/verify-client-gen.sh
 
 format: .init

--- a/build/update-apiserver-gen.sh
+++ b/build/update-apiserver-gen.sh
@@ -85,6 +85,6 @@ ${BINDIR}/conversion-gen "$@" \
 ${BINDIR}/openapi-gen "$@" \
 	--v 1 --logtostderr \
 	--go-header-file "vendor/github.com/kubernetes/repo-infra/verify/boilerplate/boilerplate.go.txt" \
-	--input-dirs "${SC_PKG}/pkg/apis/servicecatalog/v1beta1,k8s.io/api/core/v1,k8s.io/apimachinery/pkg/api/resource,k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/apimachinery/pkg/version,k8s.io/apimachinery/pkg/runtime" \ \
+	--input-dirs "${SC_PKG}/pkg/apis/servicecatalog/v1beta1,k8s.io/api/core/v1,k8s.io/apimachinery/pkg/api/resource,k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/apimachinery/pkg/version,k8s.io/apimachinery/pkg/runtime" \
 	--input-dirs "${SC_PKG}/pkg/apis/settings/v1alpha1" \
 	--output-package "${SC_PKG}/pkg/openapi"

--- a/build/update-client-gen.sh
+++ b/build/update-client-gen.sh
@@ -16,6 +16,10 @@
 
 # The only argument this script should ever be called with is '--verify-only'
 
+# The contents of this file are in a specific order
+# Listers depend on the base client
+# Informers depend on listers
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -40,7 +44,7 @@ ${BINDIR}/client-gen "$@" \
 	      --clientset-path "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/" \
 	      --clientset-name "clientset" \
 	      --go-header-file "vendor/github.com/kubernetes/repo-infra/verify/boilerplate/boilerplate.go.txt"
-# generate lister
+# generate listers after having the base client generated, and before informers
 ${BINDIR}/lister-gen "$@" \
 	      --input-dirs="github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog" \
 	      --input-dirs="github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1" \
@@ -48,7 +52,7 @@ ${BINDIR}/lister-gen "$@" \
 	      --input-dirs="github.com/kubernetes-incubator/service-catalog/pkg/apis/settings/v1alpha1" \
 	      --output-package "github.com/kubernetes-incubator/service-catalog/pkg/client/listers_generated" \
 	      --go-header-file "vendor/github.com/kubernetes/repo-infra/verify/boilerplate/boilerplate.go.txt"
-# generate informer
+# generate informers after the listers have been generated
 ${BINDIR}/informer-gen "$@" \
 	      --go-header-file "vendor/github.com/kubernetes/repo-infra/verify/boilerplate/boilerplate.go.txt" \
 	      --input-dirs "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog" \

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -657,7 +657,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"serviceBindingCreateResponseSchema": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Currently, this field is ALPHA: it may change or disappear at any time and its data will not be migrated.when a bind operation stored in the Secret when binding to a ServiceInstance on this plan.\n\nServiceBindingCreateResponseSchema is the schema for the response that will be returned by the broker when binding to a ServiceInstance on this plan. The schema also contains the sub-schema for the credentials part of the broker's response, which allows clients to see what the credentials will look like even before the binding operation is performed.",
+								Description: "Currently, this field is ALPHA: it may change or disappear at any time and its data will not be migrated.when a bind operation stored in the Secret when binding to a ServiceInstance on this plan. The ResponseSchema feature gate needs to be enabled for this field to be populated.\n\nServiceBindingCreateResponseSchema is the schema for the response that will be returned by the broker when binding to a ServiceInstance on this plan. The schema also contains the sub-schema for the credentials part of the broker's response, which allows clients to see what the credentials will look like even before the binding operation is performed.",
 								Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 							},
 						},
@@ -924,7 +924,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"serviceBindingCreateResponseSchema": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Currently, this field is ALPHA: it may change or disappear at any time and its data will not be migrated.when a bind operation stored in the Secret when binding to a ServiceInstance on this plan.\n\nServiceBindingCreateResponseSchema is the schema for the response that will be returned by the broker when binding to a ServiceInstance on this plan. The schema also contains the sub-schema for the credentials part of the broker's response, which allows clients to see what the credentials will look like even before the binding operation is performed.",
+								Description: "Currently, this field is ALPHA: it may change or disappear at any time and its data will not be migrated.when a bind operation stored in the Secret when binding to a ServiceInstance on this plan. The ResponseSchema feature gate needs to be enabled for this field to be populated.\n\nServiceBindingCreateResponseSchema is the schema for the response that will be returned by the broker when binding to a ServiceInstance on this plan. The schema also contains the sub-schema for the credentials part of the broker's response, which allows clients to see what the credentials will look like even before the binding operation is performed.",
 								Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 							},
 						},


### PR DESCRIPTION
.generate_files make target would call the generators to generate before
calling verify. This would write the thing to be verified, and then
verify what it just wrote, vs verify the current state of the files as
they were when verify was initially called.

I don't know if the extra slash is an issue, but it should not be
needed.

comments on client sepcific generator order

generated openapi updates