### PR TITLE
Return dashboard url in responses to update service-instance requests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -539,8 +539,8 @@
     "v2",
     "v2/fake"
   ]
-  revision = "c231fb93adc6181e4ba491bdb4b651f1d6fa08fc"
-  version = "0.0.7"
+  revision = "dca737037ce636eb282e84e3a1c7479c9692e884"
+  version = "0.0.10"
 
 [[projects]]
   name = "github.com/prometheus/client_golang"
@@ -1172,6 +1172,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "36d2da55a036bc45278e6ad00e633e60e94b9091df1106f53e672336f8d974cb"
+  inputs-digest = "e56ac6c46e6cf8dd43ac8ba2acd47ae5abeba78305c4268496128a9d50ee06b9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,7 +71,7 @@ required = [
 
 [[constraint]]
   name = "github.com/pmorie/go-open-service-broker-client"
-  version = "=0.0.7"
+  version = "=0.0.10"
 
 [prune]
   non-go = true

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -536,6 +536,11 @@ func (c *controller) reconcileServiceInstanceUpdate(instance *v1beta1.ServiceIns
 		return c.processServiceInstanceOperationError(instance, readyCond)
 	}
 
+	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.UpdateDashboardURL) {
+		if *response.DashboardURL != "" {
+			instance.Status.DashboardURL = response.DashboardURL
+		}
+	}
 	if response.Async {
 		return c.processUpdateServiceInstanceAsyncResponse(instance, response)
 	}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -58,6 +58,12 @@ const (
 	// owner: @luksa
 	// alpha: v0.1.12
 	ResponseSchema utilfeature.Feature = "ResponseSchema"
+
+	// UpdateDashboardURL enables the update of DashboardURL in response
+	// to update service instance requests to brokers.
+	// owner: @jberkhahn
+	// alpha: v0.1.13
+	UpdateDashboardURL utilfeature.Feature = "UpdateDashboardURL"
 )
 
 func init() {
@@ -73,4 +79,5 @@ var defaultServiceCatalogFeatureGates = map[utilfeature.Feature]utilfeature.Feat
 	AsyncBindingOperations:  {Default: false, PreRelease: utilfeature.Alpha},
 	NamespacedServiceBroker: {Default: false, PreRelease: utilfeature.Alpha},
 	ResponseSchema:          {Default: false, PreRelease: utilfeature.Alpha},
+	UpdateDashboardURL:      {Default: false, PreRelease: utilfeature.Alpha},
 }

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/provision_instance.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/provision_instance.go
@@ -59,6 +59,10 @@ func (c *client) ProvisionInstance(r *ProvisionRequest) (*ProvisionResponse, err
 			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
+		if !c.APIVersion.AtLeast(Version2_13()) || !c.EnableAlphaFeatures {
+			userResponse.ExtensionAPIs = nil
+		}
+
 		return userResponse, nil
 	case http.StatusAccepted:
 		if !r.AcceptsIncomplete {

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/types.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/types.go
@@ -203,6 +203,43 @@ type ProvisionResponse struct {
 	// OperationKey is an extra identifier supplied by the broker to identify
 	// asynchronous operations.
 	OperationKey *OperationKey `json:"operation,omitempty"`
+	// ExtensionAPIs is a list of extension APIs for this instance.
+	//
+	// ExtensionsAPI is an ALPHA API attribute and may change. Alpha
+	// features must be enabled and the client must be using the
+	// latest API Version in order to use this.
+	ExtensionAPIs []ExtensionAPI `json:"extension_apis,omitempty"`
+}
+
+// ExtensionAPI contains information about an API endpoint that describes
+// extension operations on a ServiceInstance.
+//
+// ExtensionAPI is an ALPHA API attribute and may change. Alpha
+// features must be enabled and the client must be using the
+// latest API Version in order to use this.
+type ExtensionAPI struct {
+	// DiscoveryURL is a URI pointing to a valid OpenAPI 3.0+ document
+	// describing the API extension(s) to the Open Service Broker API including,
+	// endpoints, parameters, authentication mechanism and any other detail the
+	// platform needs for invocation. The location of the API extension
+	// endpoint(s) can be local to the Service Broker or on a remote server. If
+	// local to the Service Broker the same authentication method for normal
+	// Service Broker calls must be used.
+	DiscoveryURL string `json:"discovery_url,omitempty"`
+	// ServerURL is a URI pointing to a remote server where API extensions will
+	// run. This URI will be used as the basepath for the paths objects
+	// described by the `discovery_url` OpenAPI document. If ServerURL is
+	// missing, it means that the paths are invoked relative to the service
+	// broker URL.
+	ServerURL string `json:"server_url,omitempty"`
+	// Credentials is a set of authentication details for running any of the
+	// extension API calls, especially for those running on remote servers.
+	//
+	// The information in Credentials should be treated as SECRET.
+	Credentials map[string]interface{} `json:"credentials,omitempty"`
+	// AdheresTo is a URI refering to a specification detailing the interface
+	// the OpenAPI document hosted at the `discovery_url` adheres to.
+	AdheresTo string `json:"adheres_to,omitempty"`
 }
 
 // OperationKey is an extra identifier from the broker in order to provide extra
@@ -264,6 +301,13 @@ type UpdateInstanceResponse struct {
 	// Async indicates whether the broker is handling the update request
 	// asynchronously.
 	Async bool `json:"async"`
+	// DashboardURL is an ALPHA API attribute and may change. Alpha
+	// features must be enabled and the client must be using the latest
+	// API Version in order to use this.
+	//
+	// DashboardURL is the URL of a web-based management user interface for
+	// the service instance.
+	DashboardURL *string `json:"dashboard_url,omitempty"`
 	// OperationKey is an extra identifier supplied by the broker to identify
 	// asynchronous operations.
 	OperationKey *OperationKey `json:"operation,omitempty"`

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/update_instance.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/update_instance.go
@@ -15,6 +15,11 @@ type updateInstanceRequestBody struct {
 	PreviousValues *PreviousValues        `json:"previous_values,omitempty"`
 }
 
+type updateInstanceResponseBody struct {
+	DashboardURL *string `json:"dashboard_url"`
+	Operation    *string `json:"operation"`
+}
+
 func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceResponse, error) {
 	if err := validateUpdateInstanceRequest(r); err != nil {
 		return nil, err
@@ -43,11 +48,20 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 	}
 	switch response.StatusCode {
 	case http.StatusOK:
-		if err := c.unmarshalResponse(response, &struct{}{}); err != nil {
+		responseBodyObj := &updateInstanceResponseBody{}
+		if err := c.unmarshalResponse(response, responseBodyObj); err != nil {
 			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
-		return &UpdateInstanceResponse{}, nil
+		userResponse := &UpdateInstanceResponse{
+			Async:        false,
+			OperationKey: nil,
+		}
+		if c.validateAlphaAPIMethodsAllowed() == nil {
+			userResponse.DashboardURL = responseBodyObj.DashboardURL
+		}
+
+		return userResponse, nil
 	case http.StatusAccepted:
 		if !r.AcceptsIncomplete {
 			// If the client did not signify that it could handle asynchronous
@@ -55,7 +69,7 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 			return nil, c.handleFailureResponse(response)
 		}
 
-		responseBodyObj := &asyncSuccessResponseBody{}
+		responseBodyObj := &updateInstanceResponseBody{}
 		if err := c.unmarshalResponse(response, responseBodyObj); err != nil {
 			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
@@ -70,6 +84,9 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 		userResponse := &UpdateInstanceResponse{
 			Async:        true,
 			OperationKey: opPtr,
+		}
+		if c.validateAlphaAPIMethodsAllowed() == nil {
+			userResponse.DashboardURL = responseBodyObj.DashboardURL
 		}
 
 		// TODO: fix op key handling


### PR DESCRIPTION
This is a validation through implementation of [OSB #437](https://github.com/openservicebrokerapi/servicebroker/pull/437).

Also bumps [pmorie/go-open-service-broker-client](https://github.com/pmorie/go-open-service-broker-client).

