### PR TITLE
Wait for caches to sync before starting up the controller (fixes #1907)

### DIFF
--- a/cmd/controller-manager/app/controller_manager.go
+++ b/cmd/controller-manager/app/controller_manager.go
@@ -370,11 +370,14 @@ func StartControllers(s *options.ControllerManagerServer,
 		return err
 	}
 
-	glog.V(5).Info("Running controller")
-	go serviceCatalogController.Run(s.ConcurrentSyncs, stop)
-
 	glog.V(1).Info("Starting shared informers")
 	informerFactory.Start(stop)
+
+	glog.V(5).Info("Waiting for caches to sync")
+	informerFactory.WaitForCacheSync(stop)
+
+	glog.V(5).Info("Running controller")
+	go serviceCatalogController.Run(s.ConcurrentSyncs, stop)
 
 	select {}
 }


### PR DESCRIPTION
Fixes #1907 

If the controller starts reconciling service bindings before the
service instance cache is synced, it won't be able to retrieve the
instance from the cache, making it appear as though the instance
does not exist at all. The controller should therefore wait for all
caches to be synced before performing any work.