### PR TITLE
Ensure ServiceBinding gets deleted when ServiceInstance updated to an…

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -426,6 +426,38 @@ func (c *controller) getClusterServiceClassAndClusterServiceBroker(instance *v1b
 // a brokerclient to use for a given ServiceInstance.
 // Sets ClusterServiceClassRef and/or ClusterServicePlanRef if they haven't been already set.
 func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForServiceBinding(instance *v1beta1.ServiceInstance, binding *v1beta1.ServiceBinding) (*v1beta1.ClusterServiceClass, *v1beta1.ClusterServicePlan, string, osb.Client, error) {
+	serviceClass, serviceBrokerName, osbClient, err := c.getClusterServiceClassAndClusterServiceBrokerForServiceBinding(instance, binding)
+	if err != nil {
+		return nil, nil, "", nil, err
+	}
+	servicePlan, err := c.getClusterServicePlanForServiceBinding(instance, binding, serviceClass)
+	if err != nil {
+		return nil, nil, "", nil, err
+	}
+
+	return serviceClass, servicePlan, serviceBrokerName, osbClient, nil
+}
+
+func (c *controller) getClusterServiceClassAndClusterServiceBrokerForServiceBinding(instance *v1beta1.ServiceInstance, binding *v1beta1.ServiceBinding) (*v1beta1.ClusterServiceClass, string, osb.Client, error) {
+	serviceClass, err := c.getClusterServiceClassForServiceBinding(instance, binding)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	serviceBroker, err := c.getClusterServiceBrokerForServiceBinding(instance, binding, serviceClass)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	osbClient, err := c.getBrokerClientForServiceBinding(instance, binding, serviceBroker)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	return serviceClass, serviceBroker.Name, osbClient, nil
+}
+
+func (c *controller) getClusterServiceClassForServiceBinding(instance *v1beta1.ServiceInstance, binding *v1beta1.ServiceBinding) (*v1beta1.ClusterServiceClass, error) {
 	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
 	serviceClass, err := c.clusterServiceClassLister.Get(instance.Spec.ClusterServiceClassRef.Name)
 	if err != nil {
@@ -442,9 +474,13 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 			"The binding references a ClusterServiceClass that does not exist. "+s,
 		)
 		c.recorder.Event(binding, corev1.EventTypeWarning, errorNonexistentClusterServiceClassMessage, s)
-		return nil, nil, "", nil, err
+		return nil, err
 	}
+	return serviceClass, nil
+}
 
+func (c *controller) getClusterServicePlanForServiceBinding(instance *v1beta1.ServiceInstance, binding *v1beta1.ServiceBinding, serviceClass *v1beta1.ClusterServiceClass) (*v1beta1.ClusterServicePlan, error) {
+	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
 	servicePlan, err := c.clusterServicePlanLister.Get(instance.Spec.ClusterServicePlanRef.Name)
 	if nil != err {
 		s := fmt.Sprintf(
@@ -460,8 +496,13 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 			"The ServiceBinding references an ServiceInstance which references ClusterServicePlan that does not exist. "+s,
 		)
 		c.recorder.Event(binding, corev1.EventTypeWarning, errorNonexistentClusterServicePlanReason, s)
-		return nil, nil, "", nil, fmt.Errorf(s)
+		return nil, fmt.Errorf(s)
 	}
+	return servicePlan, nil
+}
+
+func (c *controller) getClusterServiceBrokerForServiceBinding(instance *v1beta1.ServiceInstance, binding *v1beta1.ServiceBinding, serviceClass *v1beta1.ClusterServiceClass) (*v1beta1.ClusterServiceBroker, error) {
+	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
 
 	broker, err := c.brokerLister.Get(serviceClass.Spec.ClusterServiceBrokerName)
 	if err != nil {
@@ -475,9 +516,13 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 			"The binding references a ClusterServiceBroker that does not exist. "+s,
 		)
 		c.recorder.Event(binding, corev1.EventTypeWarning, errorNonexistentClusterServiceBrokerReason, s)
-		return nil, nil, "", nil, err
+		return nil, err
 	}
+	return broker, nil
+}
 
+func (c *controller) getBrokerClientForServiceBinding(instance *v1beta1.ServiceInstance, binding *v1beta1.ServiceBinding, broker *v1beta1.ClusterServiceBroker) (osb.Client, error) {
+	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
 	authConfig, err := getAuthCredentialsFromClusterServiceBroker(c.kubeClient, broker)
 	if err != nil {
 		s := fmt.Sprintf("Error getting broker auth credentials for broker %q: %s", broker.Name, err)
@@ -490,7 +535,7 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 			"Error getting auth credentials. "+s,
 		)
 		c.recorder.Event(binding, corev1.EventTypeWarning, errorAuthCredentialsReason, s)
-		return nil, nil, "", nil, err
+		return nil, err
 	}
 
 	clientConfig := NewClientConfigurationForBroker(broker, authConfig)
@@ -498,10 +543,10 @@ func (c *controller) getClusterServiceClassPlanAndClusterServiceBrokerForService
 	glog.V(4).Infof("Creating client for ClusterServiceBroker %v, URL: %v", broker.Name, broker.Spec.URL)
 	brokerClient, err := c.brokerClientCreateFunc(clientConfig)
 	if err != nil {
-		return nil, nil, "", nil, err
+		return nil, err
 	}
 
-	return serviceClass, servicePlan, broker.Name, brokerClient, nil
+	return brokerClient, nil
 }
 
 // Broker utility methods - move?

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -75,6 +75,7 @@ const (
 	testClusterServiceClassName             = "test-clusterserviceclass"
 	testClusterServicePlanName              = "test-clusterserviceplan"
 	testNonExistentClusterServiceClassName  = "nothere"
+	testNonExistentClusterServicePlanName   = "nothere"
 	testNonbindableClusterServiceClassName  = "test-unbindable-clusterserviceclass"
 	testNonbindableClusterServicePlanName   = "test-unbindable-clusterserviceplan"
 	testRemovedClusterServiceClassName      = "removed-test-clusterserviceclass"
@@ -723,6 +724,15 @@ func getTestServiceInstanceWithRefs() *v1beta1.ServiceInstance {
 	return sc
 }
 
+func getTestServiceInstanceWithRefsAndExternalProperties() *v1beta1.ServiceInstance {
+	sc := getTestServiceInstanceWithRefs()
+	sc.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{
+		ClusterServicePlanExternalID:   testClusterServicePlanGUID,
+		ClusterServicePlanExternalName: testClusterServicePlanName,
+	}
+	return sc
+}
+
 // instance referencing the result of getTestClusterServiceClass()
 // and getTestClusterServicePlan()
 // This version sets:
@@ -799,15 +809,12 @@ func getTestServiceInstanceBindableServiceNonbindablePlan() *v1beta1.ServiceInst
 }
 
 func getTestServiceInstanceWithStatus(status v1beta1.ConditionStatus) *v1beta1.ServiceInstance {
-	instance := getTestServiceInstanceWithRefs()
-	instance.Status = v1beta1.ServiceInstanceStatus{
-		Conditions: []v1beta1.ServiceInstanceCondition{{
-			Type:               v1beta1.ServiceInstanceConditionReady,
-			Status:             status,
-			LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
-		}},
-	}
-
+	instance := getTestServiceInstanceWithRefsAndExternalProperties()
+	instance.Status.Conditions = []v1beta1.ServiceInstanceCondition{{
+		Type:               v1beta1.ServiceInstanceConditionReady,
+		Status:             status,
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
+	}}
 	return instance
 }
 


### PR DESCRIPTION
… invalid plan after a successful bind

Fixes the plan part of #1562 

The reconcileServiceBindingDelete() method, before it sent the unbind
request to the broker, tried to retrieve the ClusterServicePlan referenced
in the ServiceInstance that the ServiceBinding points to. If that plan
did not exist (such as in cases when the user changed the plan on the
instance), the binding could not be deleted. The controller must be able
to perform an unbind even if the plan doesn't exist, so it shouldn't
retrieve the plan at all.

This commit changes the controller so it no longer retrieves the plan.
Additionally, the controller now gets the plan ID from Instance.Status.
ExternalProperties, which holds the correct plan id needed for unbind
(whereas the plan in Instance.Spec.ClusterServicePlanRef may no
longer match the plan ID used when the bind request was performed).



