### PR TITLE
prevent artificial delays due to ridiculously low client attempts

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -17,8 +17,8 @@ limitations under the License.
 package framework
 
 import (
-	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -63,12 +63,16 @@ func (f *Framework) BeforeEach() {
 	By("Creating a kubernetes client")
 	kubeConfig, err := LoadConfig(TestContext.KubeConfig, TestContext.KubeContext)
 	Expect(err).NotTo(HaveOccurred())
+	kubeConfig.QPS = 50
+	kubeConfig.Burst = 100
 	f.KubeClientSet, err = kubernetes.NewForConfig(kubeConfig)
 	Expect(err).NotTo(HaveOccurred())
 	By("Creating a service catalog client")
-	serviceCatatlogConfig, err := LoadConfig(TestContext.ServiceCatalogConfig, TestContext.ServiceCatalogContext)
+	serviceCatalogConfig, err := LoadConfig(TestContext.ServiceCatalogConfig, TestContext.ServiceCatalogContext)
 	Expect(err).NotTo(HaveOccurred())
-	f.ServiceCatalogClientSet, err = clientset.NewForConfig(serviceCatatlogConfig)
+	serviceCatalogConfig.QPS = 50
+	serviceCatalogConfig.Burst = 100
+	f.ServiceCatalogClientSet, err = clientset.NewForConfig(serviceCatalogConfig)
 	Expect(err).NotTo(HaveOccurred())
 	By("Building a namespace api object")
 	namespace, err := CreateKubeNamespace(f.BaseName, f.KubeClientSet)

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -1385,6 +1385,14 @@ func TestDeleteServiceInstance(t *testing.T) {
 				if err := util.WaitForInstanceCondition(ct.client, testNamespace, testInstanceName, condition); err != nil {
 					ct.t.Fatalf("error waiting for instance condition: %v", err)
 				}
+				// instance can't be deleted later, as we've
+				// already started deleting it now.  Instance is
+				// still in "deleted" mode at the end, the
+				// reconciler will pick it up and delete
+				// it. Thus we should null it out before the
+				// test runner goes and tries to do automated
+				// cleanup.
+				ct.instance = nil
 			},
 		},
 		{

--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -130,7 +130,7 @@ func withConfigGetFreshApiserverAndClient(
 		t.Fatalf("%v", err)
 	}
 
-	config := &restclient.Config{}
+	config := &restclient.Config{QPS: 50, Burst: 100}
 	config.Host = secureAddr
 	config.Insecure = true
 	config.CertFile = secureServingOptions.ServerCert.CertKey.CertFile


### PR DESCRIPTION
per https://github.com/kubernetes/kubernetes/pull/22281

I can't test this in my travis anymore, but locally I see throttling all the time.