### PR TITLE
Wait for caches to sync before starting up the controller

### DIFF
--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -802,13 +802,19 @@ func newControllerTestTestController(ct *controllerTest) (
 	}
 
 	stopCh := make(chan struct{})
+
+	glog.V(4).Info("Waiting for caches to sync")
+	informerFactory.Start(stopCh)
+
+	glog.V(4).Info("Waiting for caches to sync")
+	informerFactory.WaitForCacheSync(stopCh)
+
 	controllerStopped := make(chan struct{})
+
 	go func() {
 		testController.Run(1, stopCh)
 		controllerStopped <- struct{}{}
 	}()
-	informerFactory.Start(stopCh)
-	t.Log("informers start")
 
 	shutdownController := func() {
 		close(stopCh)


### PR DESCRIPTION
like #1915, but during the tests

not sure if it causes problems or not, but it would seem safe to do the right thing.