### PR TITLE
allow nill service plan during instance last op poll (#1940)

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -819,8 +819,7 @@ type ServiceInstanceStatus struct {
 	OperationStartTime *metav1.Time
 
 	// InProgressProperties is the properties state of the ServiceInstance when
-	// a Provision or Update is in progress. If the current operation is a
-	// Deprovision, this will be nil.
+	// a Provision, Update or Deprovision is in progress.
 	InProgressProperties *ServiceInstancePropertiesState
 
 	// ExternalProperties is the properties state of the ServiceInstance which the

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -910,8 +910,7 @@ type ServiceInstanceStatus struct {
 	OperationStartTime *metav1.Time `json:"operationStartTime,omitempty"`
 
 	// InProgressProperties is the properties state of the ServiceInstance when
-	// a Provision or Update is in progress. If the current operation is a
-	// Deprovision, this will be nil.
+	// a Provision, Update or Deprovision is in progress.
 	InProgressProperties *ServiceInstancePropertiesState `json:"inProgressProperties,omitempty"`
 
 	// ExternalProperties is the properties state of the ServiceInstance which the

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1545,15 +1545,17 @@ func (c *controller) prepareServiceInstanceLastOperationRequest(instance *v1beta
 		return nil, err
 	}
 
-	planID := ""
-	if instance.Status.InProgressProperties != nil {
-		planID = instance.Status.InProgressProperties.ClusterServicePlanExternalID
+	if instance.Status.InProgressProperties == nil {
+		pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+		err = stderrors.New("Instance.Status.InProgressProperties can not be nil")
+		glog.Errorf(pcb.Message(err.Error()))
+		return nil, err
 	}
 
 	request := &osb.LastOperationRequest{
 		InstanceID:          instance.Spec.ExternalID,
 		ServiceID:           &serviceClass.Spec.ExternalID,
-		PlanID:              &planID,
+		PlanID:              &instance.Status.InProgressProperties.ClusterServicePlanExternalID,
 		OriginatingIdentity: rh.originatingIdentity,
 	}
 	if instance.Status.LastOperation != nil && *instance.Status.LastOperation != "" {

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1545,10 +1545,9 @@ func (c *controller) prepareServiceInstanceLastOperationRequest(instance *v1beta
 		return nil, err
 	}
 
-	// allow for nil ServicePlan which happens if user sets to non-existing plan
 	planID := ""
-	if servicePlan != nil {
-		planID = servicePlan.Spec.ExternalID
+	if instance.Status.InProgressProperties != nil {
+		planID = instance.Status.InProgressProperties.ClusterServicePlanExternalID
 	}
 
 	request := &osb.LastOperationRequest{

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1545,10 +1545,16 @@ func (c *controller) prepareServiceInstanceLastOperationRequest(instance *v1beta
 		return nil, err
 	}
 
+	// allow for nil ServicePlan which happens if user sets to non-existing plan
+	planID := ""
+	if servicePlan != nil {
+		planID = servicePlan.Spec.ExternalID
+	}
+
 	request := &osb.LastOperationRequest{
 		InstanceID:          instance.Spec.ExternalID,
 		ServiceID:           &serviceClass.Spec.ExternalID,
-		PlanID:              &servicePlan.Spec.ExternalID,
+		PlanID:              &planID,
 		OriginatingIdentity: rh.originatingIdentity,
 	}
 	if instance.Status.LastOperation != nil && *instance.Status.LastOperation != "" {

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -2407,9 +2407,8 @@ func TestPollServiceInstanceFailureProvisioningWithOperation(t *testing.T) {
 // in progress.
 func TestPollServiceInstanceInProgressDeprovisioningWithOperationNoFinalizer(t *testing.T) {
 	cases := []struct {
-		name   string
-		setup  func(instance *v1beta1.ServiceInstance)
-		planID func() *string
+		name  string
+		setup func(instance *v1beta1.ServiceInstance)
 	}{
 		{
 			// simulates deprovision after user changed plan to non-existing plan
@@ -2418,16 +2417,10 @@ func TestPollServiceInstanceInProgressDeprovisioningWithOperationNoFinalizer(t *
 				instance.Spec.ClusterServicePlanExternalName = "plan-that-does-not-exist"
 				instance.Spec.ClusterServicePlanRef = nil
 			},
-			planID: func() *string {
-				return strPtr("")
-			},
 		},
 		{
 			name:  "With plan",
 			setup: func(instance *v1beta1.ServiceInstance) {},
-			planID: func() *string {
-				return strPtr(testClusterServicePlanGUID)
-			},
 		},
 	}
 
@@ -2469,7 +2462,7 @@ func TestPollServiceInstanceInProgressDeprovisioningWithOperationNoFinalizer(t *
 			assertPollLastOperation(t, brokerActions[0], &osb.LastOperationRequest{
 				InstanceID:   testServiceInstanceGUID,
 				ServiceID:    strPtr(testClusterServiceClassGUID),
-				PlanID:       tc.planID(),
+				PlanID:       strPtr(testClusterServicePlanGUID),
 				OperationKey: &operationKey,
 			})
 
@@ -2607,8 +2600,8 @@ func TestPollServiceInstanceFailureDeprovisioning(t *testing.T) {
 		updatedServiceInstance,
 		v1beta1.ServiceInstanceOperationDeprovision,
 		errorDeprovisionCalledReason,
-		"", // plan name
-		"", // plan ID
+		testClusterServicePlanName,
+		testClusterServicePlanGUID,
 		instance,
 	)
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -945,9 +945,14 @@ func getTestServiceInstanceAsyncDeprovisioning(operation string) *v1beta1.Servic
 			Message:            "Deprovisioning",
 			LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
 		}},
-		AsyncOpInProgress:    true,
-		OperationStartTime:   &operationStartTime,
-		CurrentOperation:     v1beta1.ServiceInstanceOperationDeprovision,
+		AsyncOpInProgress:  true,
+		OperationStartTime: &operationStartTime,
+		CurrentOperation:   v1beta1.ServiceInstanceOperationDeprovision,
+		InProgressProperties: &v1beta1.ServiceInstancePropertiesState{
+			ClusterServicePlanExternalName: testClusterServicePlanName,
+			ClusterServicePlanExternalID:   testClusterServicePlanGUID,
+		},
+
 		ReconciledGeneration: 1,
 		ObservedGeneration:   2,
 		ExternalProperties: &v1beta1.ServiceInstancePropertiesState{
@@ -2697,10 +2702,9 @@ func assertServiceInstanceRequestRetriableErrorWithParameters(t *testing.T, obj 
 	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.ProvisionStatus)
 	switch operation {
 	case v1beta1.ServiceInstanceOperationProvision, v1beta1.ServiceInstanceOperationUpdate:
+	case v1beta1.ServiceInstanceOperationDeprovision:
 		assertServiceInstanceInProgressPropertiesPlan(t, obj, planName, planID)
 		assertServiceInstanceInProgressPropertiesParameters(t, obj, inProgressParameters, inProgressParametersChecksum)
-	case v1beta1.ServiceInstanceOperationDeprovision:
-		assertServiceInstanceInProgressPropertiesNil(t, obj)
 	}
 	assertServiceInstanceExternalPropertiesUnchanged(t, obj, originalInstance)
 	assertServiceInstanceDeprovisionStatus(t, obj, originalInstance.Status.DeprovisionStatus)
@@ -2748,10 +2752,9 @@ func assertServiceInstanceAsyncStillInProgress(t *testing.T, obj runtime.Object,
 	assertServiceInstanceProvisioned(t, obj, originalInstance.Status.ProvisionStatus)
 	switch operation {
 	case v1beta1.ServiceInstanceOperationProvision, v1beta1.ServiceInstanceOperationUpdate:
+	case v1beta1.ServiceInstanceOperationDeprovision:
 		assertServiceInstanceInProgressPropertiesPlan(t, obj, planName, planID)
 		assertServiceInstanceInProgressPropertiesParameters(t, obj, nil, "")
-	case v1beta1.ServiceInstanceOperationDeprovision:
-		assertServiceInstanceInProgressPropertiesNil(t, obj)
 	}
 	assertAsyncOpInProgressTrue(t, obj)
 	assertServiceInstanceDeprovisionStatus(t, obj, originalInstance.Status.DeprovisionStatus)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2500,7 +2500,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"inProgressProperties": {
 							SchemaProps: spec.SchemaProps{
-								Description: "InProgressProperties is the properties state of the ServiceInstance when a Provision or Update is in progress. If the current operation is a Deprovision, this will be nil.",
+								Description: "InProgressProperties is the properties state of the ServiceInstance when a Provision, Update or Deprovision is in progress.",
 								Ref:         ref("github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1.ServiceInstancePropertiesState"),
 							},
 						},


### PR DESCRIPTION
fixes #1940 
similar issue that is addressed by https://github.com/kubernetes-incubator/service-catalog/pull/1922.  Any async provision/update/deprovision should have the instance.Status.InProgressProperties set during the LastOperation .  Since the Plan set in the instance status may be wrong (ie user changes the plan to a non-existant Plan with an update),  get the Plan from the InProgressProperties.