### PR TITLE
Increase jenkins build timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ def test_account = params.TEST_ACCOUNT
 def test_zone    = params.TEST_ZONE ?: 'us-west1-b'
 def namespace    = 'catalog'
 def root_path    = 'src/github.com/kubernetes-incubator/service-catalog'
-def timeoutMin   = 50
+def timeoutMin   = 70
 def certFolder   = '/tmp/sc-certs'
 
 node {


### PR DESCRIPTION
Hopefully we can identify the cause of the build time increase, it started with
https://service-catalog-jenkins.appspot.com/job/service-catalog-master-testing/555/
jumping from 33 to 50. This is a bandaid so the builds don't keep failing
on master in the meantime.