### PR TITLE
Only validate status on updates

### DIFF
--- a/pkg/apis/servicecatalog/validation/binding.go
+++ b/pkg/apis/servicecatalog/validation/binding.go
@@ -72,7 +72,6 @@ func internalValidateServiceBinding(binding *sc.ServiceBinding, create bool) fie
 		validateServiceBindingName,
 		field.NewPath("metadata"))...)
 	allErrs = append(allErrs, validateServiceBindingSpec(&binding.Spec, field.NewPath("spec"), create)...)
-	allErrs = append(allErrs, validateServiceBindingStatus(&binding.Status, field.NewPath("status"), create)...)
 	if create {
 		allErrs = append(allErrs, validateServiceBindingCreate(binding)...)
 	} else {
@@ -244,5 +243,6 @@ func ValidateServiceBindingUpdate(new *sc.ServiceBinding, old *sc.ServiceBinding
 func ValidateServiceBindingStatusUpdate(new *sc.ServiceBinding, old *sc.ServiceBinding) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, internalValidateServiceBinding(new, false)...)
+	allErrs = append(allErrs, validateServiceBindingStatus(&new.Status, field.NewPath("status"), false)...)
 	return allErrs
 }

--- a/pkg/apis/servicecatalog/validation/binding_test.go
+++ b/pkg/apis/servicecatalog/validation/binding_test.go
@@ -21,6 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 )
@@ -567,6 +568,7 @@ func TestValidateServiceBinding(t *testing.T) {
 
 	for _, tc := range cases {
 		errs := internalValidateServiceBinding(tc.binding, tc.create)
+		errs = append(errs, validateServiceBindingStatus(&tc.binding.Status, field.NewPath("status"), false)...)
 		if len(errs) != 0 && tc.valid {
 			t.Errorf("%v: unexpected error: %v", tc.name, errs)
 			continue


### PR DESCRIPTION
This basically ensures that spec validations don't include status.

Closes #1960