### PR TITLE
Workaround golint hosting problem

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -24,7 +24,11 @@ RUN curl -sSL https://github.com/coreos/etcd/releases/download/v3.1.10/etcd-v3.1
     | tar -vxz -C /usr/local/bin --strip=1 etcd-v3.1.10-linux-amd64/etcd
 
 # Install the golint, use this to check our source for niceness
-RUN go get -u github.com/golang/lint/golint
+# Workaround https://github.com/golang/lint/issues/397
+RUN mkdir -p $GOPATH/src/golang.org/x && \
+    git clone --depth=1 https://github.com/golang/lint.git $GOPATH/src/golang.org/x/lint && \
+    go get -u golang.org/x/lint/golint
+#RUN go get -u github.com/golang/lint/golint
 
 # Install the href checker for our md files, update PATH to include it
 RUN git clone https://github.com/duglin/vlinker.git /vlinker


### PR DESCRIPTION
golint is not returning the metadata required by go get at the moment and it's causing our build to fail. This installs golint without go get until it's fixed.

See https://github.com/golang/lint/issues/397