### PR TITLE
Fixed fetch message for broker synchronization

### DIFF
--- a/cmd/svcat/broker/sync_cmd.go
+++ b/cmd/svcat/broker/sync_cmd.go
@@ -59,6 +59,6 @@ func (c *syncCmd) sync() error {
 		return err
 	}
 
-	fmt.Fprintf(c.Output, "Successfully fetched catalog entries from the %s broker\n", c.name)
+	fmt.Fprintf(c.Output, "Synchronization requested for broker: %s\n", c.name)
 	return nil
 }


### PR DESCRIPTION
Currently the message printed does not accurately reflect what is going on under the covers.  The new message more accurately reflects what is happening.