### PR TITLE
fix hyperkube to run from goland.

### DIFF
--- a/cmd/service-catalog/main.go
+++ b/cmd/service-catalog/main.go
@@ -22,6 +22,7 @@ package main
 import (
 	"os"
 
+	"github.com/kubernetes-incubator/service-catalog/cmd/service-catalog/server"
 	"github.com/kubernetes-incubator/service-catalog/pkg/hyperkube"
 )
 
@@ -31,8 +32,8 @@ func main() {
 		Long: "This is an all-in-one binary that can run any of the various Kubernetes service-catalog servers.",
 	}
 
-	hk.AddServer(NewAPIServer())
-	hk.AddServer(NewControllerManager())
+	hk.AddServer(server.NewAPIServer())
+	hk.AddServer(server.NewControllerManager())
 
 	hk.RunToExit(os.Args)
 }

--- a/cmd/service-catalog/server/apiserver.go
+++ b/cmd/service-catalog/server/apiserver.go
@@ -14,28 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package server
 
 import (
-	"github.com/kubernetes-incubator/service-catalog/cmd/controller-manager/app"
-	"github.com/kubernetes-incubator/service-catalog/cmd/controller-manager/app/options"
+	"github.com/kubernetes-incubator/service-catalog/cmd/apiserver/app/server"
 	"github.com/kubernetes-incubator/service-catalog/pkg/hyperkube"
 )
 
-// NewControllerManager creates a new hyperkube Server object that includes the
+// NewAPIServer creates a new hyperkube Server object that includes the
 // description and flags.
-func NewControllerManager() *hyperkube.Server {
-	s := options.NewControllerManagerServer()
+func NewAPIServer() *hyperkube.Server {
+	s := server.NewServiceCatalogServerOptions()
 
 	hks := hyperkube.Server{
-		PrimaryName:     "controller-manager",
-		AlternativeName: "service-catalog-controller-manager",
-		SimpleUsage:     "controller-manager",
-		Long:            `The service-catalog controller manager is a daemon that embeds the core control loops shipped with the service catalog.`,
+		PrimaryName:     "apiserver",
+		AlternativeName: "service-catalog-apiserver",
+		SimpleUsage:     "apiserver",
+		Long:            "The main API entrypoint and interface to the storage system.  The API server is also the focal point for all authorization decisions.",
 		Run: func(_ *hyperkube.Server, args []string, stopCh <-chan struct{}) error {
-			return app.Run(s)
+			return server.Run(s, stopCh)
 		},
-		RespectsStopCh: false,
+		RespectsStopCh: true,
 	}
 	s.AddFlags(hks.Flags())
 	return &hks

--- a/cmd/service-catalog/server/controller-manager.go
+++ b/cmd/service-catalog/server/controller-manager.go
@@ -14,27 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package server
 
 import (
-	"github.com/kubernetes-incubator/service-catalog/cmd/apiserver/app/server"
+	"github.com/kubernetes-incubator/service-catalog/cmd/controller-manager/app"
+	"github.com/kubernetes-incubator/service-catalog/cmd/controller-manager/app/options"
 	"github.com/kubernetes-incubator/service-catalog/pkg/hyperkube"
 )
 
-// NewAPIServer creates a new hyperkube Server object that includes the
+// NewControllerManager creates a new hyperkube Server object that includes the
 // description and flags.
-func NewAPIServer() *hyperkube.Server {
-	s := server.NewServiceCatalogServerOptions()
+func NewControllerManager() *hyperkube.Server {
+	s := options.NewControllerManagerServer()
 
 	hks := hyperkube.Server{
-		PrimaryName:     "apiserver",
-		AlternativeName: "service-catalog-apiserver",
-		SimpleUsage:     "apiserver",
-		Long:            "The main API entrypoint and interface to the storage system.  The API server is also the focal point for all authorization decisions.",
+		PrimaryName:     "controller-manager",
+		AlternativeName: "service-catalog-controller-manager",
+		SimpleUsage:     "controller-manager",
+		Long:            `The service-catalog controller manager is a daemon that embeds the core control loops shipped with the service catalog.`,
 		Run: func(_ *hyperkube.Server, args []string, stopCh <-chan struct{}) error {
-			return server.Run(s, stopCh)
+			return app.Run(s)
 		},
-		RespectsStopCh: true,
+		RespectsStopCh: false,
 	}
 	s.AddFlags(hks.Flags())
 	return &hks

--- a/pkg/hyperkube/hyperkube.go
+++ b/pkg/hyperkube/hyperkube.go
@@ -166,7 +166,7 @@ RunAgain:
 	s, err := hk.FindServer(serverName)
 	if err != nil {
 		if len(args) > 0 {
-			goto RunAgain // let's keep trying.
+			goto RunAgain // the first args was popped off at start of Run, try again with new args
 		}
 		hk.Printf("Error: %v\n\n", err)
 		hk.Usage()

--- a/pkg/hyperkube/hyperkube.go
+++ b/pkg/hyperkube/hyperkube.go
@@ -126,6 +126,7 @@ func (hk *HyperKube) Printf(format string, i ...interface{}) {
 func (hk *HyperKube) Run(args []string, stopCh <-chan struct{}) error {
 	// If we are called directly, parse all flags up to the first real
 	// argument.  That should be the server to run.
+RunAgain:
 	command := args[0]
 	serverName := path.Base(command)
 	args = args[1:]
@@ -164,6 +165,9 @@ func (hk *HyperKube) Run(args []string, stopCh <-chan struct{}) error {
 
 	s, err := hk.FindServer(serverName)
 	if err != nil {
+		if len(args) > 0 {
+			goto RunAgain // let's keep trying.
+		}
 		hk.Printf("Error: %v\n\n", err)
 		hk.Usage()
 		return err


### PR DESCRIPTION
Until https://github.com/kubernetes-incubator/service-catalog/issues/1983 is fixed, I wanted a way to be able to run the api server in debug mode from goland. This was impossible with the current setup so I fixed it to work.