### PR TITLE
Ensure a Namespaced KeyFunc for ServicePlans

### DIFF
--- a/contrib/examples/apiserver/serviceplan.yaml
+++ b/contrib/examples/apiserver/serviceplan.yaml
@@ -2,6 +2,7 @@ apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ServicePlan
 metadata:
   name: b20ac1c6-f6d5-4dd0-b30c-c33242ad2083
+  namespace: test-ns
 spec:
   serviceBrokerName: test-ns-broker
   externalName: test-serviceplan

--- a/pkg/registry/servicecatalog/serviceplan/storage.go
+++ b/pkg/registry/servicecatalog/serviceplan/storage.go
@@ -129,7 +129,7 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 		NewFunc:     EmptyObject,
 		NewListFunc: NewList,
 		KeyRootFunc: opts.KeyRootFunc(),
-		KeyFunc:     opts.KeyFunc(false),
+		KeyFunc:     opts.KeyFunc(true),
 		// Retrieve the name field of the resource.
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return scmeta.GetAccessor().Name(obj)


### PR DESCRIPTION
Discovered a little bug that prevented ServicePlans from getting correctly listed. This correctly ensures a namespaced keyfunc is used for SP storage.