### PR TITLE
Float docs TOC navbar when scrolling

### DIFF
--- a/docsite/_sass/_base.sass
+++ b/docsite/_sass/_base.sass
@@ -604,17 +604,12 @@ section
 	overflow: hidden
 	font-size: 14px
 
-
-	& > div
-		height: 100%
-
 #docsToc
 	position: fixed
 	background-color: white
 	top: 0
 	left: 0
 	width: 0
-	height: 100vh
 	overflow: hidden
 	padding: 50px 0
 	z-index: 999999

--- a/docsite/_sass/_desktop.sass
+++ b/docsite/_sass/_desktop.sass
@@ -78,10 +78,10 @@ $video-section-height: 550px
 		clear: both
 
 	#docsToc
-		position: relative
-		float: left
+		position: fixed
+		top: 15em
+		left: 7em
 		padding: 0 20px
-		left: 0
 		width: 350px
 		z-index: auto
 


### PR DESCRIPTION
Some of the doc pages, like the walkthrough, have a navigation bar linking to the subheaders on the page. This changes that sidebar to float with you as you scroll, so that you don't have to jump back up to the top to navigate to another section in the page.

Preview available at https://deploy-preview-1994--svc-cat.netlify.com/docs/walkthrough/