### PR TITLE
scratch instead of debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,8 @@ define build-and-tag # (service, image, mutable_image, prefix)
 	$(eval build_path := "$(4)build/$(1)")
 	$(eval tmp_build_path := "$(build_path)/tmp")
 	mkdir -p $(tmp_build_path)
+	# scratch image needs an empty directory to have as /tmp
+	mkdir -p $(tmp_build_path)/tmp
 	cp $(BINDIR)/$(1) $(tmp_build_path)
 	cp $(build_path)/Dockerfile $(tmp_build_path)
 	# -i.bak is required for cross-platform compat: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux

--- a/build/service-catalog/Dockerfile
+++ b/build/service-catalog/Dockerfile
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM BASEIMAGE
+FROM scratch
 
-RUN export DEBIAN_FRONTEND=noninteractive && \
-    apt-get update && \
-    apt-get install ca-certificates -y && \
-    rm -rf /var/lib/apt/lists/*
+ADD tmp /tmp
 
 ADD service-catalog opt/services/
 


### PR DESCRIPTION
The build produces static binaries, so we can use the empty scratch image.

During testing, some kube infrastructure attepmts to write to `/tmp`, so I made sure that directory exists inside of the image.

This is needed for us to pass some automated scanning tools that see vulnerabilities in our base image and installed utilities.