### PR TITLE
Fix broken links on doc site

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -94,7 +94,7 @@ the basic concepts of the OSB API.
 
 ## Service Catalog Design
 
-<img src="images/current.png" width="75%" height="75%">
+<img src="/docs/images/current.png" width="75%" height="75%">
 
 The above is the high level architecture of Service Catalog.
 

--- a/docsite/index.html
+++ b/docsite/index.html
@@ -28,7 +28,7 @@ cid: home
     <main>
         <div class="image-wrapper"><img src="images/flower.png"></div>
         <div class="content">
-            <h3><a href="/concepts/service-catalog">Service Catalog</a> lets you
+            <h3><a href="/docs/concepts/#introduction">Service Catalog</a> lets you
                 provision cloud services directly from the comfort of native Kubernetes tooling.
             </h3>
             <p>
@@ -69,13 +69,13 @@ cid: home
 
         <div class="feature-box">
             <div>
-                <h4><a href="/concepts/service-classes">Cloud Native Services</a></h4>
+                <h4><a href="/docs/design/#overview">Cloud Native Services</a></h4>
                 <p>Your cloud native apps deserve a cloud native cluster.
                     Provision managed services from your cloud provider directly
                     from native Kubernetes tooling.</p>
             </div>
             <div>
-                <h4><a href="/concepts/secrets">Smart Secrets</a></h4>
+                <h4><a href="/docs/resources/#whats-in-the-secrets">Smart Secrets</a></h4>
                 <p>Credentials are parsed and injected into Kubernetes secrets, ready for
                 your app to load as environment variables.</p>
             </div>
@@ -83,12 +83,12 @@ cid: home
 
         <div class="feature-box">
             <div>
-                <h4><a href="/concepts/parameters">Powerful Configuration</a></h4>
+                <h4><a href="/docs/resources/#service-instance-parameters">Powerful Configuration</a></h4>
                 <p>The same configuration options that you see in your cloud portal
                 are available for configuration through Service Catalog.</p>
             </div>
             <div>
-                <h4><a href="/concepts/osbapi">Open Service Broker Compatible</a></h4>
+                <h4><a href="http://openservicebrokerapi.org">Open Service Broker Compatible</a></h4>
                 <p>Every major cloud provider supports the Open Service Broker standards,
                 so regardless of who's powering your cluster, you will be able to tap into
                 the full suite of services.</p>
@@ -104,7 +104,7 @@ cid: home
                 and have many active contributors from the wider community.</p>
             </div>
             <div>
-                <h4><a href="/concepts/operator">Operator Friendly</a></h4>
+                <h4><a href="/docs/cli">Operator Friendly</a></h4>
                 <p>Install a broker at the cluster or in a single names, control
                 which services you'd like to make available, and provide sensible
                 defaults for provisioning cloud services.</p>


### PR DESCRIPTION
Fixes #2000.

Preview at [https://deploy-preview-2004--svc-cat.netlify.com](https://deploy-preview-2004--svc-cat.netlify.com)

@duglin The link checker didn't catch these broken links, is that because they aren't in markdown files?