### PR TITLE
WIP #1987 Svcat should allow lists in params

### DIFF
--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -41,8 +41,8 @@ func ParseVariableJSON(params string) (map[string]interface{}, error) {
 // into a map of keys and values
 // Example:
 // [a=b c=abc1232===] becomes map[a:b c:abc1232===]
-func ParseVariableAssignments(params []string) (map[string]string, error) {
-	variables := map[string]string{}
+func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
+	var variables map[string]interface{}
 	for _, p := range params {
 
 		parts := strings.SplitN(p, "=", 2)
@@ -54,9 +54,21 @@ func ParseVariableAssignments(params []string) (map[string]string, error) {
 		if variable == "" {
 			return nil, fmt.Errorf("invalid parameter (%s), variable name is required", p)
 		}
+
 		value := strings.TrimSpace(parts[1])
 
-		variables[variable] = value
+		if val, present := variables[variable]; present {
+			valType = reflect.TypeOf(val)
+			var arr []valType
+			append(arr, val)
+			append(arr, value)
+			type i interface{}
+			var i I = arr
+			variables[variable] = I
+		} else {
+			variables[variable] = value
+		}
+
 	}
 
 	return variables, nil

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -58,12 +58,11 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 		value := strings.TrimSpace(parts[1])
 
 		if val, present := variables[variable]; present {
-			valType = reflect.TypeOf(val)
-			var arr []valType
-			append(arr, val)
-			append(arr, value)
+			var arr []string
+			arr = append(arr, val.(string))
+			arr = append(arr, value)
 			type i interface{}
-			var i I = arr
+			var I i = arr
 			variables[variable] = I
 		} else {
 			variables[variable] = value


### PR DESCRIPTION
ParseVariableAssignments will now return a string,interface{} map to allow for lists in params 

What I attempted to do: I check to see if the key already exists, if it already exists, create a string slice to store params. I then append the current value to the array as well as the new value.  I then create an interface, and assign the array that contains the param values to the interface.  Finally I assign the value of the key to the interface. Now I think I have key with an interface as its value that contains a slice of params.

I am looking for input on my syntax, and if the general design idea is correct as I am new to golang and being a contributor.  I haven't quite gotten to testing yet.

ex.
-p color=red -p color=blue -p nums=1--> color["red","blue"]; nums[1]