### PR TITLE
Add ServiceClass control loop

### DIFF
--- a/pkg/controller/controller_serviceclass.go
+++ b/pkg/controller/controller_serviceclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/controller_serviceclass.go
+++ b/pkg/controller/controller_serviceclass.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/golang/glog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/pretty"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/tools/cache"
+)
+
+func (c *controller) serviceClassAdd(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		return
+	}
+	c.serviceClassQueue.Add(key)
+}
+
+func (c *controller) serviceClassUpdate(oldObj, newObj interface{}) {
+	c.serviceClassAdd(newObj)
+}
+
+func (c *controller) serviceClassDelete(obj interface{}) {
+	serviceClass, ok := obj.(*v1beta1.ServiceClass)
+	if serviceClass == nil || !ok {
+		return
+	}
+
+	glog.V(4).Infof("Received delete event for ServiceClass %v; no further processing will occur", serviceClass.Name)
+}
+
+// reconcileServiceClassKey reconciles a ServiceClass due to controller resync
+// or an event on the ServiceClass.  Note that this is NOT the main
+// reconciliation loop for ServiceClass. ServiceClasses are primarily
+// reconciled in a separate flow when a ServiceBroker is reconciled.
+func (c *controller) reconcileServiceClassKey(key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+	pcb := pretty.NewContextBuilder(pretty.ServiceClass, namespace, name, "")
+	class, err := c.serviceClassLister.ServiceClasses(namespace).Get(name)
+	if errors.IsNotFound(err) {
+		glog.Info(pcb.Message("Not doing work because the ServiceClass has been deleted"))
+		return nil
+	}
+	if err != nil {
+		glog.Infof(pcb.Message("Unable to retrieve"))
+		return err
+	}
+
+	return c.reconcileServiceClass(class)
+}
+
+func (c *controller) reconcileServiceClass(serviceClass *v1beta1.ServiceClass) error {
+	pcb := pretty.NewContextBuilder(pretty.ServiceClass, serviceClass.Namespace, serviceClass.Name, "")
+	glog.Info(pcb.Message("Processing"))
+
+	if !serviceClass.Status.RemovedFromBrokerCatalog {
+		return nil
+	}
+
+	glog.Info(pcb.Message("Removed from broker catalog; determining whether there are instances remaining"))
+
+	serviceInstances, err := c.findServiceInstancesOnServiceClass(serviceClass)
+	if err != nil {
+		return err
+	}
+
+	if len(serviceInstances.Items) != 0 {
+		return nil
+	}
+
+	glog.Info(pcb.Message("Removed from broker catalog and has zero instances remaining; deleting"))
+	return c.serviceCatalogClient.ServiceClasses(serviceClass.Namespace).Delete(serviceClass.Name, &metav1.DeleteOptions{})
+}
+
+func (c *controller) findServiceInstancesOnServiceClass(serviceClass *v1beta1.ServiceClass) (*v1beta1.ServiceInstanceList, error) {
+	fieldSet := fields.Set{
+		"spec.serviceClassRef.name": serviceClass.Name,
+	}
+	fieldSelector := fields.SelectorFromSet(fieldSet).String()
+	listOpts := metav1.ListOptions{FieldSelector: fieldSelector}
+
+	return c.serviceCatalogClient.ServiceInstances(serviceClass.Namespace).List(listOpts)
+}

--- a/pkg/controller/controller_serviceclass_test.go
+++ b/pkg/controller/controller_serviceclass_test.go
@@ -30,16 +30,16 @@ import (
 	"reflect"
 )
 
-func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
-	getRemovedServiceClass := func() *v1beta1.ClusterServiceClass {
-		p := getTestClusterServiceClass()
+func TestReconcileServiceClassRemovedFromCatalog(t *testing.T) {
+	getRemovedServiceClass := func() *v1beta1.ServiceClass {
+		p := getTestServiceClass()
 		p.Status.RemovedFromBrokerCatalog = true
 		return p
 	}
 
 	cases := []struct {
 		name                    string
-		serviceClass            *v1beta1.ClusterServiceClass
+		serviceClass            *v1beta1.ServiceClass
 		instances               []v1beta1.ServiceInstance
 		catalogClientPrepFunc   func(*fake.Clientset)
 		shouldError             bool
@@ -48,7 +48,7 @@ func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
 	}{
 		{
 			name:         "not removed from catalog",
-			serviceClass: getTestClusterServiceClass(),
+			serviceClass: getTestServiceClass(),
 			shouldError:  false,
 		},
 		{
@@ -59,7 +59,7 @@ func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
 			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
-					Fields: fields.OneTermEqualSelector("spec.clusterServiceClassRef.name", "CSCGUID"),
+					Fields: fields.OneTermEqualSelector("spec.serviceClassRef.name", "SCGUID"),
 				}
 
 				expectNumberOfActions(t, name, actions, 1)
@@ -74,7 +74,7 @@ func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
 			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
-					Fields: fields.OneTermEqualSelector("spec.clusterServiceClassRef.name", "CSCGUID"),
+					Fields: fields.OneTermEqualSelector("spec.serviceClassRef.name", "SCGUID"),
 				}
 
 				expectNumberOfActions(t, name, actions, 2)
@@ -88,7 +88,7 @@ func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
 			instances:    nil,
 			shouldError:  true,
 			catalogClientPrepFunc: func(client *fake.Clientset) {
-				client.AddReactor("delete", "clusterserviceclasses", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+				client.AddReactor("delete", "serviceclasses", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 					return true, nil, errors.New("oops")
 				})
 			},
@@ -96,7 +96,7 @@ func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
 			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
-					Fields: fields.OneTermEqualSelector("spec.clusterServiceClassRef.name", "CSCGUID"),
+					Fields: fields.OneTermEqualSelector("spec.serviceClassRef.name", "SCGUID"),
 				}
 
 				expectNumberOfActions(t, name, actions, 2)
@@ -117,7 +117,7 @@ func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
 			tc.catalogClientPrepFunc(fakeCatalogClient)
 		}
 
-		err := reconcileClusterServiceClass(t, testController, tc.serviceClass)
+		err := reconcileServiceClass(t, testController, tc.serviceClass)
 		if err != nil {
 			if !tc.shouldError {
 				t.Errorf("%v: unexpected error from method under test: %v", tc.name, err)
@@ -138,11 +138,11 @@ func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
 	}
 }
 
-func reconcileClusterServiceClass(t *testing.T, testController *controller, clusterServiceClass *v1beta1.ClusterServiceClass) error {
-	clone := clusterServiceClass.DeepCopy()
-	err := testController.reconcileClusterServiceClass(clusterServiceClass)
-	if !reflect.DeepEqual(clusterServiceClass, clone) {
-		t.Errorf("reconcileClusterServiceClass shouldn't mutate input, but it does: %s", expectedGot(clone, clusterServiceClass))
+func reconcileServiceClass(t *testing.T, testController *controller, serviceClass *v1beta1.ServiceClass) error {
+	clone := serviceClass.DeepCopy()
+	err := testController.reconcileServiceClass(serviceClass)
+	if !reflect.DeepEqual(serviceClass, clone) {
+		t.Errorf("reconcileServiceClass shouldn't mutate input, but it does: %s", expectedGot(clone, serviceClass))
 	}
 	return err
 }

--- a/pkg/controller/controller_serviceclass_test.go
+++ b/pkg/controller/controller_serviceclass_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/test/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	clientgotesting "k8s.io/client-go/testing"
+	"reflect"
+)
+
+func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
+	getRemovedServiceClass := func() *v1beta1.ClusterServiceClass {
+		p := getTestClusterServiceClass()
+		p.Status.RemovedFromBrokerCatalog = true
+		return p
+	}
+
+	cases := []struct {
+		name                    string
+		serviceClass            *v1beta1.ClusterServiceClass
+		instances               []v1beta1.ServiceInstance
+		catalogClientPrepFunc   func(*fake.Clientset)
+		shouldError             bool
+		errText                 *string
+		catalogActionsCheckFunc func(t *testing.T, name string, actions []clientgotesting.Action)
+	}{
+		{
+			name:         "not removed from catalog",
+			serviceClass: getTestClusterServiceClass(),
+			shouldError:  false,
+		},
+		{
+			name:         "removed from catalog, instances left",
+			serviceClass: getRemovedServiceClass(),
+			instances:    []v1beta1.ServiceInstance{*getTestServiceInstance()},
+			shouldError:  false,
+			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+				listRestrictions := clientgotesting.ListRestrictions{
+					Labels: labels.Everything(),
+					Fields: fields.OneTermEqualSelector("spec.clusterServiceClassRef.name", "CSCGUID"),
+				}
+
+				expectNumberOfActions(t, name, actions, 1)
+				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
+			},
+		},
+		{
+			name:         "removed from catalog, no instances left",
+			serviceClass: getRemovedServiceClass(),
+			instances:    nil,
+			shouldError:  false,
+			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+				listRestrictions := clientgotesting.ListRestrictions{
+					Labels: labels.Everything(),
+					Fields: fields.OneTermEqualSelector("spec.clusterServiceClassRef.name", "CSCGUID"),
+				}
+
+				expectNumberOfActions(t, name, actions, 2)
+				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
+				assertDelete(t, actions[1], getRemovedServiceClass())
+			},
+		},
+		{
+			name:         "removed from catalog, no instances left, delete fails",
+			serviceClass: getRemovedServiceClass(),
+			instances:    nil,
+			shouldError:  true,
+			catalogClientPrepFunc: func(client *fake.Clientset) {
+				client.AddReactor("delete", "clusterserviceclasses", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("oops")
+				})
+			},
+			errText: strPtr("oops"),
+			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+				listRestrictions := clientgotesting.ListRestrictions{
+					Labels: labels.Everything(),
+					Fields: fields.OneTermEqualSelector("spec.clusterServiceClassRef.name", "CSCGUID"),
+				}
+
+				expectNumberOfActions(t, name, actions, 2)
+				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
+				assertDelete(t, actions[1], getRemovedServiceClass())
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		_, fakeCatalogClient, _, testController, _ := newTestController(t, noFakeActions())
+
+		fakeCatalogClient.AddReactor("list", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			return true, &v1beta1.ServiceInstanceList{Items: tc.instances}, nil
+		})
+
+		if tc.catalogClientPrepFunc != nil {
+			tc.catalogClientPrepFunc(fakeCatalogClient)
+		}
+
+		err := reconcileClusterServiceClass(t, testController, tc.serviceClass)
+		if err != nil {
+			if !tc.shouldError {
+				t.Errorf("%v: unexpected error from method under test: %v", tc.name, err)
+				continue
+			} else if tc.errText != nil && *tc.errText != err.Error() {
+				t.Errorf("%v: unexpected error text from method under test; expected %v, got %v", tc.name, tc.errText, err.Error())
+				continue
+			}
+		}
+
+		actions := fakeCatalogClient.Actions()
+
+		if tc.catalogActionsCheckFunc != nil {
+			tc.catalogActionsCheckFunc(t, tc.name, actions)
+		} else {
+			expectNumberOfActions(t, tc.name, actions, 0)
+		}
+	}
+}
+
+func reconcileClusterServiceClass(t *testing.T, testController *controller, clusterServiceClass *v1beta1.ClusterServiceClass) error {
+	clone := clusterServiceClass.DeepCopy()
+	err := testController.reconcileClusterServiceClass(clusterServiceClass)
+	if !reflect.DeepEqual(clusterServiceClass, clone) {
+		t.Errorf("reconcileClusterServiceClass shouldn't mutate input, but it does: %s", expectedGot(clone, clusterServiceClass))
+	}
+	return err
+}

--- a/pkg/controller/controller_serviceclass_test.go
+++ b/pkg/controller/controller_serviceclass_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Depends on #1993 

~~TODO: Needs tests, also relies on `ServiceInstance` supporting `ServiceClassRef.Name` for filtered lookups.~~

All the dependencies for this PR have been merged, so this should be ready for review/merge.