### PR TITLE
add required plan name fields in e2e

### DIFF
--- a/test/e2e/walkthrough.go
+++ b/test/e2e/walkthrough.go
@@ -240,6 +240,7 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 			Spec: v1beta1.ServiceInstanceSpec{
 				PlanReference: v1beta1.PlanReference{
 					ClusterServiceClassExternalName: serviceclassNameWithSinglePlan,
+					ClusterServicePlanExternalName:  "default",
 				},
 			},
 		}
@@ -313,6 +314,7 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 			Spec: v1beta1.ServiceInstanceSpec{
 				PlanReference: v1beta1.PlanReference{
 					ClusterServiceClassName: serviceclassIDWithSinglePlan,
+					ClusterServicePlanName:  serviceplanID,
 				},
 			},
 		}


### PR DESCRIPTION
It appears recent validation was added in 0d741d5fb05 to ensure a plan
is specified. This updates the e2e to be compliant.

Sidenote: why are e2e tests still disabled?