### PR TITLE
don't require specifying a plan when creating an instance

### DIFF
--- a/pkg/apis/servicecatalog/validation/instance_test.go
+++ b/pkg/apis/servicecatalog/validation/instance_test.go
@@ -167,7 +167,7 @@ func TestValidateServiceInstance(t *testing.T) {
 				i.Spec.ClusterServicePlanExternalName = ""
 				return i
 			}(),
-			valid: false,
+			valid: true, // plan may be picked by defaultserviceplan admission controller
 		},
 		{
 			name: "invalid planName",
@@ -1215,7 +1215,7 @@ func TestValidatePlanReference(t *testing.T) {
 			name:          "invalid -- empty struct",
 			ref:           servicecatalog.PlanReference{},
 			valid:         false,
-			expectedError: "exactly one of clusterServicePlanExternalName",
+			expectedError: "exactly one of clusterServiceClassExternalName",
 		},
 		{
 			name:  "valid -- external names",
@@ -1267,6 +1267,13 @@ func TestValidatePlanReference(t *testing.T) {
 			},
 			valid:         false,
 			expectedError: "must specify clusterServicePlanName",
+		},
+		{
+			name: "valid -- k8s class, no plan",
+			ref: servicecatalog.PlanReference{
+				ClusterServiceClassName: clusterServiceClassName,
+			},
+			valid: true,
 		},
 		{
 			name: "invalid -- k8s class, external plan id",


### PR DESCRIPTION
closes #2015 

We regressed functionality by enforcing that a plan is specified when an instance is provisioned.  If no plan is specified, the default service plan admission controller will validate and assign the only plan that is associated with the specified class or it will return an error indicating there is no default plan.

@carolynvs could you please review and make sure you agree with this change?