### PR TITLE
re-enable Jenkins to run e2e

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,7 +122,6 @@ node {
               --create-artifacts
         """
 
-	/*
         ansiColor('xterm-darker-gray') {
           // Run the e2e test framework
           sh """${env.ROOT}/contrib/jenkins/run_e2e.sh \
@@ -132,7 +131,6 @@ node {
                 --create-artifacts
           """
         }
-	*/
 
         echo 'Run succeeded.'
       }
@@ -142,7 +140,7 @@ node {
       currentBuild.result = 'FAILURE'
     } finally {
       archiveArtifacts artifacts: 'walkthrough*.txt', fingerprint: true
-      // archiveArtifacts artifacts: 'e2e*.txt', fingerprint: true
+      archiveArtifacts artifacts: 'e2e*.txt', fingerprint: true
       try {
         sh "rm -rf ${certFolder}"
         sh """${env.ROOT}/contrib/jenkins/cleanup_cluster.sh --kubeconfig ${KUBECONFIG}"""

--- a/test/e2e/walkthrough.go
+++ b/test/e2e/walkthrough.go
@@ -240,7 +240,6 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 			Spec: v1beta1.ServiceInstanceSpec{
 				PlanReference: v1beta1.PlanReference{
 					ClusterServiceClassExternalName: serviceclassNameWithSinglePlan,
-					ClusterServicePlanExternalName:  "default",
 				},
 			},
 		}
@@ -314,7 +313,6 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 			Spec: v1beta1.ServiceInstanceSpec{
 				PlanReference: v1beta1.PlanReference{
 					ClusterServiceClassName: serviceclassIDWithSinglePlan,
-					ClusterServicePlanName:  serviceplanID,
 				},
 			},
 		}

--- a/test/e2e/walkthrough.go
+++ b/test/e2e/walkthrough.go
@@ -240,6 +240,7 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 			Spec: v1beta1.ServiceInstanceSpec{
 				PlanReference: v1beta1.PlanReference{
 					ClusterServiceClassExternalName: serviceclassNameWithSinglePlan,
+					ClusterServicePlanExternalName:  "default",
 				},
 			},
 		}
@@ -313,6 +314,7 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 			Spec: v1beta1.ServiceInstanceSpec{
 				PlanReference: v1beta1.PlanReference{
 					ClusterServiceClassName: serviceclassIDWithSinglePlan,
+					ClusterServicePlanName:  serviceplanID,
 				},
 			},
 		}


### PR DESCRIPTION
This PR re-enables e2e in the Jenkins job.  I ran jenkins tests a total of 6 times with this PR with no issues.  **This depends on ~#2010 or~ #2016 first being merged**   and then I'll need to rebase to pick up those changes to pass Jenkins.

Re-enabling e2e looks to add no more then 3-5 minutes max with prep, running the tests, and then teardown and collection of logs.  Total runs of the Jenkins job comes in around 33-36 minutes.