### PR TITLE
Set ExternalID in strategy, not defaults

### DIFF
--- a/pkg/apis/servicecatalog/v1beta1/defaults.go
+++ b/pkg/apis/servicecatalog/v1beta1/defaults.go
@@ -21,7 +21,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -43,18 +42,6 @@ func setCommonServiceBrokerDefaults(spec *CommonServiceBrokerSpec) {
 
 	if spec.RelistBehavior == ServiceBrokerRelistBehaviorDuration && spec.RelistDuration == nil {
 		spec.RelistDuration = &metav1.Duration{Duration: 15 * time.Minute}
-	}
-}
-
-func SetDefaults_ServiceInstanceSpec(spec *ServiceInstanceSpec) {
-	if spec.ExternalID == "" {
-		spec.ExternalID = string(uuid.NewUUID())
-	}
-}
-
-func SetDefaults_ServiceBindingSpec(spec *ServiceBindingSpec) {
-	if spec.ExternalID == "" {
-		spec.ExternalID = string(uuid.NewUUID())
 	}
 }
 

--- a/pkg/apis/servicecatalog/v1beta1/defaults_test.go
+++ b/pkg/apis/servicecatalog/v1beta1/defaults_test.go
@@ -127,23 +127,3 @@ func TestSetDefaultClusterServiceBroker(t *testing.T) {
 		}
 	}
 }
-
-func TestSetDefaultServiceInstance(t *testing.T) {
-	i := &versioned.ServiceInstance{}
-	obj2 := roundTrip(t, runtime.Object(i))
-	i2 := obj2.(*versioned.ServiceInstance)
-
-	if i2.Spec.ExternalID == "" {
-		t.Error("Expected a default ExternalID, but got none")
-	}
-}
-
-func TestSetDefaultServiceBinding(t *testing.T) {
-	b := &versioned.ServiceBinding{}
-	obj2 := roundTrip(t, runtime.Object(b))
-	b2 := obj2.(*versioned.ServiceBinding)
-
-	if b2.Spec.ExternalID == "" {
-		t.Error("Expected a default ExternalID, but got none")
-	}
-}

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.defaults.go
@@ -34,8 +34,6 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 	scheme.AddTypeDefaultingFunc(&ServiceBindingList{}, func(obj interface{}) { SetObjectDefaults_ServiceBindingList(obj.(*ServiceBindingList)) })
 	scheme.AddTypeDefaultingFunc(&ServiceBroker{}, func(obj interface{}) { SetObjectDefaults_ServiceBroker(obj.(*ServiceBroker)) })
 	scheme.AddTypeDefaultingFunc(&ServiceBrokerList{}, func(obj interface{}) { SetObjectDefaults_ServiceBrokerList(obj.(*ServiceBrokerList)) })
-	scheme.AddTypeDefaultingFunc(&ServiceInstance{}, func(obj interface{}) { SetObjectDefaults_ServiceInstance(obj.(*ServiceInstance)) })
-	scheme.AddTypeDefaultingFunc(&ServiceInstanceList{}, func(obj interface{}) { SetObjectDefaults_ServiceInstanceList(obj.(*ServiceInstanceList)) })
 	return nil
 }
 
@@ -52,7 +50,6 @@ func SetObjectDefaults_ClusterServiceBrokerList(in *ClusterServiceBrokerList) {
 
 func SetObjectDefaults_ServiceBinding(in *ServiceBinding) {
 	SetDefaults_ServiceBinding(in)
-	SetDefaults_ServiceBindingSpec(&in.Spec)
 }
 
 func SetObjectDefaults_ServiceBindingList(in *ServiceBindingList) {
@@ -70,16 +67,5 @@ func SetObjectDefaults_ServiceBrokerList(in *ServiceBrokerList) {
 	for i := range in.Items {
 		a := &in.Items[i]
 		SetObjectDefaults_ServiceBroker(a)
-	}
-}
-
-func SetObjectDefaults_ServiceInstance(in *ServiceInstance) {
-	SetDefaults_ServiceInstanceSpec(&in.Spec)
-}
-
-func SetObjectDefaults_ServiceInstanceList(in *ServiceInstanceList) {
-	for i := range in.Items {
-		a := &in.Items[i]
-		SetObjectDefaults_ServiceInstance(a)
 	}
 }

--- a/pkg/registry/servicecatalog/binding/strategy.go
+++ b/pkg/registry/servicecatalog/binding/strategy.go
@@ -23,6 +23,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -87,10 +88,15 @@ func (bindingRESTStrategy) NamespaceScoped() bool {
 
 // PrepareForCreate receives a the incoming ServiceBinding and clears it's
 // Status. Status is not a user settable field.
+// It also creates a UUID if the user hasn't specified one.
 func (bindingRESTStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
 	binding, ok := obj.(*sc.ServiceBinding)
 	if !ok {
 		glog.Fatal("received a non-binding object to create")
+	}
+
+	if binding.Spec.ExternalID == "" {
+		binding.Spec.ExternalID = string(uuid.NewUUID())
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {

--- a/pkg/registry/servicecatalog/binding/strategy_test.go
+++ b/pkg/registry/servicecatalog/binding/strategy_test.go
@@ -138,3 +138,25 @@ func TestInstanceCredentialUserInfo(t *testing.T) {
 		t.Errorf("unexpected user info in deleted spec: expected %q, got %q", e, a)
 	}
 }
+
+// TestExternalIDSet checks that we set the ExternalID if the user doesn't provide it.
+func TestExternalIDSet(t *testing.T) {
+	createdInstanceCredential := getTestInstanceCredential()
+	bindingRESTStrategies.PrepareForCreate(nil, createdInstanceCredential)
+
+	if createdInstanceCredential.Spec.ExternalID == "" {
+		t.Error("Expected an ExternalID to be set, but got none")
+	}
+}
+
+// TestExternalIDUserProvided makes sure we don't modify a user-specified ExternalID.
+func TestExternalIDUserProvided(t *testing.T) {
+	userExternalID := "my-id"
+	createdInstanceCredential := getTestInstanceCredential()
+	createdInstanceCredential.Spec.ExternalID = userExternalID
+	bindingRESTStrategies.PrepareForCreate(nil, createdInstanceCredential)
+
+	if createdInstanceCredential.Spec.ExternalID != userExternalID {
+		t.Errorf("Modified user provided ExternalID to %q", createdInstanceCredential.Spec.ExternalID)
+	}
+}

--- a/pkg/registry/servicecatalog/instance/strategy.go
+++ b/pkg/registry/servicecatalog/instance/strategy.go
@@ -23,6 +23,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -101,10 +102,15 @@ func (instanceRESTStrategy) NamespaceScoped() bool {
 
 // PrepareForCreate receives a the incoming ServiceInstance and clears it's
 // Status and Service[Class|Plan]Ref fields. These are not user settable fields.
+// It also creates a UUID if the user hasn't specified one.
 func (instanceRESTStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
 	instance, ok := obj.(*sc.ServiceInstance)
 	if !ok {
 		glog.Fatal("received a non-instance object to create")
+	}
+
+	if instance.Spec.ExternalID == "" {
+		instance.Spec.ExternalID = string(uuid.NewUUID())
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {

--- a/pkg/registry/servicecatalog/instance/strategy_test.go
+++ b/pkg/registry/servicecatalog/instance/strategy_test.go
@@ -254,3 +254,26 @@ func TestInstanceUpdateForUpdateRequests(t *testing.T) {
 		}
 	}
 }
+
+// TestExternalIDSet checks that we set the ExternalID if the user doesn't provide it.
+func TestExternalIDSet(t *testing.T) {
+	createdInstanceCredential := getTestInstance()
+	instanceRESTStrategies.PrepareForCreate(nil, createdInstanceCredential)
+
+	if createdInstanceCredential.Spec.ExternalID == "" {
+		t.Error("Expected an ExternalID to be set, but got none")
+	}
+}
+
+// TestExternalIDUserProvided makes sure we don't modify a user-specified ExternalID.
+func TestExternalIDUserProvided(t *testing.T) {
+	userExternalID := "my-id"
+	createdInstanceCredential := getTestInstance()
+	createdInstanceCredential.Spec.ExternalID = userExternalID
+	instanceRESTStrategies.PrepareForCreate(nil, createdInstanceCredential)
+
+	if createdInstanceCredential.Spec.ExternalID != userExternalID {
+		t.Errorf("Modified user provided ExternalID to %q", createdInstanceCredential.Spec.ExternalID)
+	}
+
+}


### PR DESCRIPTION
See #1928
This allows admission controller to detect whether the user has set the UUID or not.