### PR TITLE
cluster-info configmap role namespace issues

### DIFF
--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -43,6 +43,7 @@ spec:
         - controller-manager
         - --secure-port
         - "8444"
+        - "--cluster-id-configmap-namespace={{ .Release.Namespace }}"
         {{ if .Values.controllerManager.leaderElection.activated -}}
         - "--leader-election-namespace={{ .Release.Namespace }}"
         - "--leader-elect-resource-lock=configmaps"

--- a/charts/catalog/templates/rbac.yaml
+++ b/charts/catalog/templates/rbac.yaml
@@ -126,7 +126,7 @@ items:
   kind: Role
   metadata:
     name: "servicecatalog.k8s.io:cluster-info-configmap"
-    namespace: default
+    namespace: "{{ .Release.Namespace }}"
   rules:
   - apiGroups:     [""]
     resources:     ["configmaps"]


### PR DESCRIPTION
closes #1973
The role's namespace was "default", should be "catalog".  Also need to specify the namespace to use for the configmap as an argument for the controller.