### PR TITLE
Ensure examples are included in svcat's plugin.yaml

### DIFF
--- a/cmd/svcat/completion/completion_cmd.go
+++ b/cmd/svcat/completion/completion_cmd.go
@@ -50,7 +50,7 @@ brew install bash-completion
 printf "\n# Bash completion support\nsource $(brew --prefix)/etc/bash_completion\n" >> $HOME/.bash_profile
 source $HOME/.bash_profile
 
-# Load the svcat completion code for for the specified shell (bash or zsh)
+# Load the svcat completion code for the specified shell (bash or zsh)
 source <(svcat completion bash)
 
 # Write bash completion code to a file and source if from .bash_profile

--- a/cmd/svcat/plugin/manifest.go
+++ b/cmd/svcat/plugin/manifest.go
@@ -119,6 +119,7 @@ func (m *Manifest) convertToPlugin(cmd *cobra.Command) Plugin {
 	}
 	p.LongDesc = cmd.Long
 	p.Command = "./" + cmd.CommandPath()
+	p.Example = cmd.Example
 
 	p.Flags = []Flag{}
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {

--- a/cmd/svcat/testdata/plugin.yaml
+++ b/cmd/svcat/testdata/plugin.yaml
@@ -53,7 +53,7 @@ tree:
     printf "\n# Bash completion support\nsource $(brew --prefix)/etc/bash_completion\n" >> $HOME/.bash_profile
     source $HOME/.bash_profile
 
-    # Load the svcat completion code for for the specified shell (bash or zsh)
+    # Load the svcat completion code for the specified shell (bash or zsh)
     source <(svcat completion bash)
 
     # Write bash completion code to a file and source if from .bash_profile

--- a/cmd/svcat/testdata/plugin.yaml
+++ b/cmd/svcat/testdata/plugin.yaml
@@ -5,6 +5,11 @@ tree:
 - name: bind
   shortDesc: Binds an instance's metadata to a secret, which can then be used by an
     application to connect to the instance
+  example: "\n  svcat bind wordpress\n  svcat bind wordpress-mysql-instance --name
+    wordpress-mysql-binding --secret-name wordpress-mysql-secret\n  svcat bind wordpress-mysql-instance
+    --name wordpress-mysql-binding --external-id c8ca2fcc-4398-11e8-842f-0ed5f89f718b\n
+    \ svcat bind wordpress-instance --params type=admin\n  svcat bind wordpress-instance
+    --params-json '{\n\t\"type\": \"admin\",\n\t\"teams\": [\n\t\t\"news\",\n\t\t\"weather\",\n\t\t\"sports\"\n\t]\n}\n'\n"
   command: ./svcat bind
   flags:
   - name: external-id
@@ -41,9 +46,26 @@ tree:
     installed, bash_completion must be evaluated. This can be done by adding the\nfollowing
     line to the .bash_profile\n\n\t$ source $(brew --prefix)/etc/bash_completion\n\nNote
     for zsh users: zsh completions are only supported in versions of zsh >= 5.2\n"
+  example: |2
+
+    # Install bash completion on a Mac using homebrew
+    brew install bash-completion
+    printf "\n# Bash completion support\nsource $(brew --prefix)/etc/bash_completion\n" >> $HOME/.bash_profile
+    source $HOME/.bash_profile
+
+    # Load the svcat completion code for for the specified shell (bash or zsh)
+    source <(svcat completion bash)
+
+    # Write bash completion code to a file and source if from .bash_profile
+    svcat completion bash > ~/.svcat/svcat_completion.bash.inc
+    printf "\n# Svcat shell completion\nsource '$HOME/.svcat/svcat_completion.bash.inc'\n" >> $HOME/.bash_profile
+    source $HOME/.bash_profile
   command: ./svcat completion
 - name: deprovision
   shortDesc: Deletes an instance of a service
+  example: |2
+
+      svcat deprovision wordpress-mysql-instance
   command: ./svcat deprovision
   flags:
   - name: interval
@@ -60,6 +82,9 @@ tree:
   tree:
   - name: binding
     shortDesc: Show details of a specific binding
+    example: |2
+
+        svcat describe binding wordpress-mysql-binding
     command: ./svcat describe binding
     flags:
     - name: show-secrets
@@ -67,9 +92,16 @@ tree:
         is displayed
   - name: broker
     shortDesc: Show details of a specific broker
+    example: |2
+
+        svcat describe broker asb
     command: ./svcat describe broker
   - name: class
     shortDesc: Show details of a specific class
+    example: |2
+
+        svcat describe class mysqldb
+        svcat describe class -uuid 997b8372-8dac-40ac-ae65-758b4a5075a5
     command: ./svcat describe class
     flags:
     - name: uuid
@@ -77,9 +109,16 @@ tree:
       desc: Whether or not to get the class by UUID (the default is by name)
   - name: instance
     shortDesc: Show details of a specific instance
+    example: |2
+
+        svcat describe instance wordpress-mysql-instance
     command: ./svcat describe instance
   - name: plan
     shortDesc: Show details of a specific plan
+    example: |2
+
+        svcat describe plan standard800
+        svcat describe plan --uuid 08e4b43a-36bc-447e-a81f-8202b13e339c
     command: ./svcat describe plan
     flags:
     - name: show-schemas
@@ -93,6 +132,12 @@ tree:
   tree:
   - name: bindings
     shortDesc: List bindings, optionally filtered by name
+    example: |2
+
+        svcat get bindings
+        svcat get bindings --all-namespaces
+        svcat get binding wordpress-mysql-binding
+        svcat get binding -n ci concourse-postgres-binding
     command: ./svcat get bindings
     flags:
     - name: all-namespaces
@@ -104,6 +149,10 @@ tree:
         present, defaults to table
   - name: brokers
     shortDesc: List brokers, optionally filtered by name
+    example: |2
+
+        svcat get brokers
+        svcat get broker asb
     command: ./svcat get brokers
     flags:
     - name: output
@@ -112,6 +161,11 @@ tree:
         present, defaults to table
   - name: classes
     shortDesc: List classes, optionally filtered by name
+    example: |2
+
+        svcat get classes
+        svcat get class mysqldb
+        svcat get class --uuid 997b8372-8dac-40ac-ae65-758b4a5075a5
     command: ./svcat get classes
     flags:
     - name: output
@@ -123,6 +177,12 @@ tree:
       desc: Whether or not to get the class by UUID (the default is by name)
   - name: instances
     shortDesc: List instances, optionally filtered by name
+    example: |2
+
+        svcat get instances
+        svcat get instances --all-namespaces
+        svcat get instance wordpress-mysql-instance
+        svcat get instance -n ci concourse-postgres-instance
     command: ./svcat get instances
     flags:
     - name: all-namespaces
@@ -134,6 +194,16 @@ tree:
         present, defaults to table
   - name: plans
     shortDesc: List plans, optionally filtered by name or class
+    example: |2
+
+        svcat get plans
+        svcat get plan PLAN_NAME
+        svcat get plan CLASS_NAME/PLAN_NAME
+        svcat get plan --uuid PLAN_UUID
+        svcat get plans --class CLASS_NAME
+        svcat get plan --class CLASS_NAME PLAN_NAME
+        svcat get plans --uuid --class CLASS_UUID
+        svcat get plan --uuid --class CLASS_UUID PLAN_UUID
     command: ./svcat get plans
     flags:
     - name: class
@@ -149,6 +219,27 @@ tree:
       desc: Whether or not to get the plan by UUID (the default is by name)
 - name: provision
   shortDesc: Create a new instance of a service
+  example: |2
+
+      svcat provision wordpress-mysql-instance --class mysqldb --plan free -p location=eastus -p sslEnforcement=disabled
+      svcat provision wordpress-mysql-instance --external-id a7c00676-4398-11e8-842f-0ed5f89f718b --class mysqldb --plan free
+      svcat provision wordpress-mysql-instance --class mysqldb --plan free -s mysecret[dbparams]
+      svcat provision secure-instance --class mysqldb --plan secureDB --params-json '{
+        "encrypt" : true,
+        "firewallRules" : [
+            {
+                "name": "AllowSome",
+                "startIPAddress": "75.70.113.50",
+                "endIPAddress" : "75.70.113.131"
+            },
+            {
+                "name": "AllowMore",
+                "startIPAddress": "13.54.0.0",
+                "endIPAddress" : "13.56.0.0"
+            }
+        ]
+    }
+    '
   command: ./svcat provision
   flags:
   - name: class
@@ -191,10 +282,15 @@ tree:
     longDesc: "Touch instance will increment the updateRequests field on the instance.
       \nThen, service catalog will process the instance's spec again. It might do
       an update, a delete, or \nnothing."
+    example: svcat touch instance wordpress-mysql-instance --namespace mynamespace
     command: ./svcat touch instance
 - name: unbind
   shortDesc: Unbinds an instance. When an instance name is specified, all of its bindings
     are removed, otherwise use --name to remove a specific binding
+  example: |2
+
+      svcat unbind wordpress-mysql-instance
+      svcat unbind --name wordpress-mysql-binding
   command: ./svcat unbind
   flags:
   - name: interval
@@ -209,6 +305,10 @@ tree:
     desc: Wait until the operation completes.
 - name: version
   shortDesc: Provides the version for the Service Catalog client and server
+  example: |2
+
+      svcat version
+      svcat version --client
   command: ./svcat version
   flags:
   - name: client


### PR DESCRIPTION
Sadly, the indentation in the examples gets lost, because kubectl trims the string here: https://github.com/kubernetes/kubernetes/blob/2b178ad608bd443efeaf3e9ea7c700e72ab68de1/pkg/kubectl/cmd/templates/normalizers.go#L42

This needs to be fixed there.