### PR TITLE
Add make test-update-goldenfiles target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,10 @@ test-unit: .init build
 	$(DOCKER_CMD) go test -race $(UNIT_TEST_FLAGS) \
 	  $(addprefix $(SC_PKG)/,$(TEST_DIRS)) $(UNIT_TEST_LOG_FLAGS)
 
+test-update-goldenfiles: .init
+	@echo Updating golden files to match current test output
+	$(DOCKER_CMD) go test ./cmd/svcat/... -update
+
 build-integration: .generate_files
 	$(DOCKER_CMD) go test -race github.com/kubernetes-incubator/service-catalog/test/integration/... -c
 

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -242,13 +242,13 @@ output is stored in a file in the testdata directory, `cmd/svcat/testdata`, and
 and then the test's output is compared against the "golden output" stored
 in that file. It helps avoid putting hard coded strings in the tests themselves.
  
-You do not need to manage the golden files by hand. When you need to update the golden
-files, run the tests with the `-update` flag, e.g. `go test ./cmd/svcat/... -update`,
+You do not edit the golden files by hand. When you need to update the golden
+files, run `make test-update-goldenfiles` or `go test ./cmd/svcat/... -update`,
 and the golden files are updated automatically with the results of the test run.
 
 For new tests, first you need to manually create the empty golden file into the destination 
 directory specified in your test, e.g. `touch cmd/svcat/testdata/mygoldenfile.txt`
-before running the tests with `-update`. This flag only manages the contents of the golden files, 
+before updating the golden files. This only manages the contents of the golden files, 
 but doesn't create or delete them.
 
 Keep in mind that golden files help catch errors when the output unexpectedly changes.


### PR DESCRIPTION
This is a follow-on for https://github.com/kubernetes-incubator/service-catalog/pull/2041#issuecomment-389721040.

Add a new make target `test-update-goldenfiles` that runs the svcat tests and updates the golden files and document it in the devguide.

Doc preview available at: https://deploy-preview-2045--svc-cat.netlify.com/docs/devguide/#golden-files
 