### PR TITLE
Add SECURITY_CONTACTS file

### DIFF
--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -1,0 +1,11 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Product Security Team to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/


### PR DESCRIPTION
Owners who want to take on the responsibility of triaging security issues and agree to abide by the embargo policy should submit a PR adding their github handle to this file.

Related to #2068. We will close that issue when we have at least one contact in the file. I am not adding people directly myself because I want them to do it explicitly to indicate their agreement.