### PR TITLE
controller: update lastTransitionTime when reason changes

### DIFF
--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -1279,10 +1279,16 @@ func TestSetServiceBindingCondition(t *testing.T) {
 			result:    bindingWithCondition(readyFalse()),
 		},
 		{
-			name:      "not ready -> not ready, reason and message change; no ts update",
+			name:      "not ready -> not ready, reason and message change; ts update",
 			input:     bindingWithCondition(readyFalse()),
 			condition: readyFalsef("DifferentReason", "DifferentMessage"),
-			result:    bindingWithCondition(readyFalsef("DifferentReason", "DifferentMessage")),
+			result:    bindingWithCondition(withNewTs(readyFalsef("DifferentReason", "DifferentMessage"))),
+		},
+		{
+			name:      "not ready -> not ready, message change; no ts update",
+			input:     bindingWithCondition(readyFalse()),
+			condition: readyFalsef("Reason", "DifferentMessage"),
+			result:    bindingWithCondition(readyFalsef("Reason", "DifferentMessage")),
 		},
 		{
 			name:      "not ready -> ready",

--- a/pkg/controller/controller_clusterservicebroker.go
+++ b/pkg/controller/controller_clusterservicebroker.go
@@ -662,13 +662,20 @@ func (c *controller) updateClusterServiceBrokerCondition(broker *v1beta1.Cluster
 	} else {
 		for i, cond := range broker.Status.Conditions {
 			if cond.Type == conditionType {
-				if cond.Status != newCondition.Status {
+				switch {
+				case cond.Status != newCondition.Status:
 					glog.Info(pcb.Messagef(
 						"Found status change for condition %q: %q -> %q; setting lastTransitionTime to %v",
 						conditionType, cond.Status, status, t,
 					))
 					newCondition.LastTransitionTime = metav1.NewTime(t)
-				} else {
+				case cond.Reason != newCondition.Reason:
+					glog.Info(pcb.Messagef(
+						"Found status change for condition %q: %q -> %q; setting lastTransitionTime to %v",
+						conditionType, cond.Reason, reason, t,
+					))
+					newCondition.LastTransitionTime = metav1.NewTime(t)
+				default:
 					newCondition.LastTransitionTime = cond.LastTransitionTime
 				}
 

--- a/pkg/controller/controller_clusterservicebroker_test.go
+++ b/pkg/controller/controller_clusterservicebroker_test.go
@@ -1090,7 +1090,8 @@ func TestReconcileClusterServiceBrokerWithStatusUpdateError(t *testing.T) {
 // The test cases are proving:
 // - broker transitions from unset status to not ready results in status change and new time
 // - broker transitions from not ready to not ready results in no changes
-// - broker transitions from not ready to not ready and with reason & msg updates results in no time change, but reflects new reason & msg
+// - broker transitions from not ready to not ready and with reason and msg updates results in new time and reflects new reason & msg
+// - broker transitions from not ready to not ready and with msg updates results in no time change, but reflects new msg
 // - broker transitions from not ready to ready results in status change & new time
 // - broker transitions from ready to ready results in no status change
 // - broker transitions from ready to not ready results in status change & new time
@@ -1129,6 +1130,13 @@ func TestUpdateServiceBrokerCondition(t *testing.T) {
 			input:                 getTestClusterServiceBrokerWithStatus(v1beta1.ConditionFalse),
 			status:                v1beta1.ConditionFalse,
 			reason:                "foo",
+			message:               "bar",
+			transitionTimeChanged: true,
+		},
+		{
+			name:                  "not ready -> not ready with message change",
+			input:                 getTestClusterServiceBrokerWithStatus(v1beta1.ConditionFalse),
+			status:                v1beta1.ConditionFalse,
 			message:               "bar",
 			transitionTimeChanged: false,
 		},

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -3248,7 +3248,9 @@ func TestReconcileServiceInstanceWithStatusUpdateError(t *testing.T) {
 // - status with existing Ready=False condition accepts new condition of
 //   Ready=False with no timestamp change
 // - status with existing Ready=False condition accepts new condition of
-//   Ready=False  with reason & msg change and results with no timestamp change
+//   Ready=False  with reason & msg change and reflects new timestamp
+// - status with existing Ready=False condition accepts new condition of
+//   Ready=False  with msg change and results with no timestamp change
 // - status with existing Ready=False condition accepts new condition of
 //   Ready=True  and reflects new timestamp
 // - status with existing Ready=True condition accepts new condition of
@@ -3351,10 +3353,16 @@ func TestSetServiceInstanceCondition(t *testing.T) {
 			result:    instanceWithCondition(readyFalse()),
 		},
 		{
-			name:      "not ready -> not ready, reason and message change; no ts update",
+			name:      "not ready -> not ready, reason and message change; ts update",
 			input:     instanceWithCondition(readyFalse()),
 			condition: readyFalsef("DifferentReason", "DifferentMessage"),
-			result:    instanceWithCondition(readyFalsef("DifferentReason", "DifferentMessage")),
+			result:    instanceWithCondition(withNewTs(readyFalsef("DifferentReason", "DifferentMessage"))),
+		},
+		{
+			name:      "not ready -> not ready, message change; no ts update",
+			input:     instanceWithCondition(readyFalse()),
+			condition: readyFalsef("Reason", "DifferentMessage"),
+			result:    instanceWithCondition(readyFalsef("Reason", "DifferentMessage")),
 		},
 		{
 			name:      "not ready -> ready",
@@ -3453,6 +3461,13 @@ func TestUpdateServiceInstanceCondition(t *testing.T) {
 			input:                 getTestServiceInstanceWithStatus(v1beta1.ConditionFalse),
 			status:                v1beta1.ConditionFalse,
 			reason:                "foo",
+			message:               "bar",
+			transitionTimeChanged: true,
+		},
+		{
+			name:                  "not ready -> not ready, message change",
+			input:                 getTestServiceInstanceWithStatus(v1beta1.ConditionFalse),
+			status:                v1beta1.ConditionFalse,
 			message:               "bar",
 			transitionTimeChanged: false,
 		},

--- a/pkg/controller/controller_servicebroker.go
+++ b/pkg/controller/controller_servicebroker.go
@@ -657,13 +657,18 @@ func updateCommonStatusCondition(meta metav1.ObjectMeta, commonStatus *v1beta1.C
 	} else {
 		for i, cond := range commonStatus.Conditions {
 			if cond.Type == conditionType {
-				if cond.Status != newCondition.Status {
-					glog.Info(pcb.Messagef(
-						"Found status change for condition %q: %q -> %q; setting lastTransitionTime to %v",
+				switch {
+				case cond.Status != newCondition.Status:
+					glog.V(3).Info(pcb.Messagef("Found status change, condition %q: %q -> %q; setting lastTransitionTime to %v",
 						conditionType, cond.Status, status, t,
 					))
 					newCondition.LastTransitionTime = metav1.NewTime(t)
-				} else {
+				case cond.Reason != newCondition.Reason:
+					glog.V(3).Info(pcb.Messagef("Found reason change, condition %q: %q -> %q; setting lastTransitionTime to %v",
+						conditionType, cond.Reason, reason, t,
+					))
+					newCondition.LastTransitionTime = metav1.NewTime(t)
+				default:
 					newCondition.LastTransitionTime = cond.LastTransitionTime
 				}
 


### PR DESCRIPTION
Fixes  #1829

Currently, we update `lastTransitionTime` only when `Status` changes in the condition. However, we should also update the `lastTransitionTime` when `Reason` changes because the condition overall is reflected as "changed" to the user (the underlying cause has changed).

More logically, each condition can be viewed in a state diagram. When the reason changes, we move from one state to another. So it makes sense to update the lastTransitionTime`.