### PR TITLE
Bring back root CA certificates to a Service Catalog Docker image

### DIFF
--- a/build/service-catalog/Dockerfile
+++ b/build/service-catalog/Dockerfile
@@ -12,7 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Build a Debian-based image to copy root CA certificates from it
+# to a scratch-based image using Docker multi-stage builds
+FROM BASEIMAGE as base
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install ca-certificates -y && \
+    rm -rf /var/lib/apt/lists/*
+
+# Build actual scratch-based Service Catalog image with root CA certificates
 FROM scratch
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ADD tmp /tmp
 


### PR DESCRIPTION
The PR #2003 that changed base Docker image from Debian to scratch has also removed root CA certificates from it (see https://github.com/kubernetes-incubator/service-catalog/pull/2003/files#diff-e355acdaa4066a6dea138158e98252fbL19).
This change brings them back via Docker multi-stage build.

/cc @MHBauer @jboyd01 