### PR TITLE
Publish canary builds of the svcat cli

### DIFF
--- a/contrib/travis/deploy.sh
+++ b/contrib/travis/deploy.sh
@@ -27,7 +27,7 @@ if [[ "${TRAVIS_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[a-z]*(-(r|R)(c|C)[0-9]+)*$ ]];
     VERSION="${TRAVIS_TAG}" MUTABLE_TAG="latest" make release-push svcat-publish
 elif [[ "${TRAVIS_BRANCH}" == "master" ]]; then
     echo "Pushing images with default tags (git sha and 'canary')."
-    make push
+    make push svcat-publish
 else
     echo "Nothing to deploy"
 fi

--- a/docs/install.md
+++ b/docs/install.md
@@ -179,6 +179,17 @@ helm install svc-cat/catalog \
 Follow the appropriate instructions for your operating system to install svcat. The binary
 can be used by itself, or as a kubectl plugin.
 
+The snippets below install the latest version of svcat. We also publish binaries for
+our canary (master) builds, and tags using the following prefixes:
+
+* Latest release: https://download.svcat.sh/cli/latest
+* Tagged releases: https://download.svcat.sh/cli/VERSION
+  where `VERSION` is the release, for example `v0.1.20`.
+* Canary builds: https://download.svcat.sh/cli/canary
+* Previous canary builds: https://download.svcat.sh/cli/VERSION-GITDESCRIBE 
+  where `GITDESCRIBE` is the result of calling `git describe --tags`, for example `v0.1.20-1-g203c8ad`.
+
+
 ## MacOS
 
 ```


### PR DESCRIPTION
The URLs are

* https://download.svcat.sh/cli/canary/darwin/amd64/svcat
* https://download.svcat.sh/cli/VERSION/darwin/amd64/svcat where VERSION is `vX.Y.Z-gCOMMIT`, for example `v0.1.20-1-g203c8ad`.

Preview available at: https://deploy-preview-2072--svc-cat.netlify.com/docs/install/#installing-the-service-catalog-cli

Closes #1998 