### PR TITLE
cache mounted into docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ services:
 - docker
 cache:
   directories:
-    - $GOPATH/pkg/dep
+    # ${GOPATH}/pkg is mounted in DOCKER_CMD in Makefile
+    - .pkg
 stages:
   - test
   - name: deploy


### PR DESCRIPTION
${GOPATH} does not exist outside of the docker build to be cached

While looking at travis for #2062 I noticed that we were not caching anything. No idea if it helps. I might be reading it wrong.
![screen shot 2018-05-25 at 16 34 33](https://user-images.githubusercontent.com/13337345/40569806-8c720b2c-6039-11e8-9d22-9f98aad56b0c.png)
