### PR TITLE
Log the resourceVersion of the object we're processing

### DIFF
--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -70,11 +70,11 @@ var bindingControllerKind = v1beta1.SchemeGroupVersion.WithKind("ServiceBinding"
 func (c *controller) bindingAdd(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		pcb := pretty.NewContextBuilder(pretty.ServiceBinding, "", "")
+		pcb := pretty.NewContextBuilder(pretty.ServiceBinding, "", "", "")
 		glog.Errorf(pcb.Messagef("Couldn't get key for object %+v: %v", obj, err))
 		return
 	}
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, "", key)
+	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, "", key, "")
 
 	acc, err := meta.Accessor(obj)
 	if err != nil {
@@ -106,7 +106,7 @@ func (c *controller) bindingDelete(obj interface{}) {
 		return
 	}
 
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
+	pcb := pretty.NewBindingContextBuilder(binding)
 	glog.V(4).Info(pcb.Messagef("Received DELETE event; no further processing will occur; resourceVersion %v", binding.ResourceVersion))
 }
 
@@ -115,7 +115,7 @@ func (c *controller) reconcileServiceBindingKey(key string) error {
 	if err != nil {
 		return err
 	}
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, namespace, name)
+	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, namespace, name, "")
 	binding, err := c.bindingLister.ServiceBindings(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
 		glog.Info(pcb.Message("Not doing work because the ServiceBinding has been deleted"))
@@ -155,7 +155,7 @@ func getReconciliationActionForServiceBinding(binding *v1beta1.ServiceBinding) R
 // An error is returned to indicate that the binding has not been fully
 // processed and should be resubmitted at a later time.
 func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) error {
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
+	pcb := pretty.NewBindingContextBuilder(binding)
 	glog.V(6).Info(pcb.Messagef(`beginning to process resourceVersion: %v`, binding.ResourceVersion))
 
 	reconciliationAction := getReconciliationActionForServiceBinding(binding)
@@ -174,7 +174,7 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 // reconcileServiceBindingAdd is responsible for handling the creation of new
 // service bindings.
 func (c *controller) reconcileServiceBindingAdd(binding *v1beta1.ServiceBinding) error {
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
+	pcb := pretty.NewBindingContextBuilder(binding)
 
 	if isServiceBindingFailed(binding) {
 		glog.V(4).Info(pcb.Message("not processing event; status showed that it has failed"))
@@ -299,7 +299,7 @@ func (c *controller) reconcileServiceBindingAdd(binding *v1beta1.ServiceBinding)
 
 func (c *controller) reconcileServiceBindingDelete(binding *v1beta1.ServiceBinding) error {
 	var err error
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
+	pcb := pretty.NewBindingContextBuilder(binding)
 
 	if binding.DeletionTimestamp == nil && !binding.Status.OrphanMitigationInProgress {
 		// nothing to do...
@@ -427,7 +427,7 @@ func isPlanBindable(serviceClass *v1beta1.ClusterServiceClass, plan *v1beta1.Clu
 }
 
 func (c *controller) injectServiceBinding(binding *v1beta1.ServiceBinding, credentials map[string]interface{}) error {
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
+	pcb := pretty.NewBindingContextBuilder(binding)
 	glog.V(5).Info(pcb.Messagef(`Creating/updating Secret "%s/%s" with %d keys`,
 		binding.Namespace, binding.Spec.SecretName, len(credentials),
 	))
@@ -548,7 +548,7 @@ func evaluateJSONPath(jsonPath string, credentials map[string]interface{}) (stri
 
 func (c *controller) ejectServiceBinding(binding *v1beta1.ServiceBinding) error {
 	var err error
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
+	pcb := pretty.NewBindingContextBuilder(binding)
 	glog.V(5).Info(pcb.Messagef(`Deleting Secret "%s/%s"`,
 		binding.Namespace, binding.Spec.SecretName,
 	))
@@ -585,7 +585,7 @@ func setServiceBindingConditionInternal(toUpdate *v1beta1.ServiceBinding,
 	status v1beta1.ConditionStatus,
 	reason, message string,
 	t metav1.Time) {
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, toUpdate.Namespace, toUpdate.Name)
+	pcb := pretty.NewBindingContextBuilder(toUpdate)
 	glog.Info(pcb.Message(message))
 	glog.V(5).Info(pcb.Messagef(
 		"Setting condition %q to %v",
@@ -635,7 +635,7 @@ func setServiceBindingConditionInternal(toUpdate *v1beta1.ServiceBinding,
 }
 
 func (c *controller) updateServiceBindingStatus(toUpdate *v1beta1.ServiceBinding) (*v1beta1.ServiceBinding, error) {
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, toUpdate.Namespace, toUpdate.Name)
+	pcb := pretty.NewBindingContextBuilder(toUpdate)
 	glog.V(4).Info(pcb.Message("Updating status"))
 	updatedBinding, err := c.serviceCatalogClient.ServiceBindings(toUpdate.Namespace).UpdateStatus(toUpdate)
 	if err != nil {
@@ -657,7 +657,7 @@ func (c *controller) updateServiceBindingCondition(
 	status v1beta1.ConditionStatus,
 	reason, message string) error {
 
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
+	pcb := pretty.NewBindingContextBuilder(binding)
 	toUpdate := binding.DeepCopy()
 
 	setServiceBindingCondition(toUpdate, conditionType, status, reason, message)
@@ -784,7 +784,7 @@ func (c *controller) finishPollingServiceBinding(binding *v1beta1.ServiceBinding
 }
 
 func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Name, binding.Namespace)
+	pcb := pretty.NewBindingContextBuilder(binding)
 	glog.V(4).Infof(pcb.Message("Processing"))
 
 	binding = binding.DeepCopy()
@@ -1284,7 +1284,7 @@ func (c *controller) processServiceBindingGracefulDeletionSuccess(binding *v1bet
 		return err
 	}
 
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
+	pcb := pretty.NewBindingContextBuilder(binding)
 	glog.Info(pcb.Message("Cleared finalizer"))
 
 	return nil
@@ -1381,7 +1381,7 @@ func (c *controller) handleServiceBindingPollingError(binding *v1beta1.ServiceBi
 	//	2) attempt to requeue in the polling queue
 	//		- if successful, we can return nil to avoid regular queue
 	//		- if failure, return err to fall back to regular queue
-	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, binding.Namespace, binding.Name)
+	pcb := pretty.NewBindingContextBuilder(binding)
 	glog.V(4).Info(pcb.Messagef("Error during polling: %v", err))
 	return c.continuePollingServiceBinding(binding)
 }

--- a/pkg/controller/controller_clusterservicebroker.go
+++ b/pkg/controller/controller_clusterservicebroker.go
@@ -94,7 +94,7 @@ func (c *controller) clusterServiceBrokerDelete(obj interface{}) {
 // the controller's broker relist interval has not elapsed since the broker's
 // ready condition became true, or if the broker's RelistBehavior is set to Manual.
 func shouldReconcileClusterServiceBroker(broker *v1beta1.ClusterServiceBroker, now time.Time) bool {
-	pcb := pretty.NewContextBuilder(pretty.ClusterServiceBroker, "", broker.Name)
+	pcb := pretty.NewClusterServiceBrokerContextBuilder(broker)
 	if broker.Status.ReconciledGeneration != broker.Generation {
 		// If the spec has changed, we should reconcile the broker.
 		return true
@@ -152,7 +152,7 @@ func shouldReconcileClusterServiceBroker(broker *v1beta1.ClusterServiceBroker, n
 
 func (c *controller) reconcileClusterServiceBrokerKey(key string) error {
 	broker, err := c.clusterServiceBrokerLister.Get(key)
-	pcb := pretty.NewContextBuilder(pretty.ClusterServiceBroker, "", key)
+	pcb := pretty.NewContextBuilder(pretty.ClusterServiceBroker, "", key, "")
 	if errors.IsNotFound(err) {
 		glog.Info(pcb.Message("Not doing work because it has been deleted"))
 		return nil
@@ -169,7 +169,7 @@ func (c *controller) reconcileClusterServiceBrokerKey(key string) error {
 // error is returned to indicate that the binding has not been fully
 // processed and should be resubmitted at a later time.
 func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServiceBroker) error {
-	pcb := pretty.NewContextBuilder(pretty.ClusterServiceBroker, "", broker.Name)
+	pcb := pretty.NewClusterServiceBrokerContextBuilder(broker)
 	glog.V(4).Infof(pcb.Message("Processing"))
 
 	// * If the broker's ready condition is true and the RelistBehavior has been
@@ -475,7 +475,7 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 // catalog payload. The existingServiceClass parameter is the serviceClass
 // that already exists for the given broker with this serviceClass' k8s name.
 func (c *controller) reconcileClusterServiceClassFromClusterServiceBrokerCatalog(broker *v1beta1.ClusterServiceBroker, serviceClass, existingServiceClass *v1beta1.ClusterServiceClass) error {
-	pcb := pretty.NewContextBuilder(pretty.ClusterServiceBroker, "", broker.Name)
+	pcb := pretty.NewClusterServiceBrokerContextBuilder(broker)
 	serviceClass.Spec.ClusterServiceBrokerName = broker.Name
 
 	if existingServiceClass == nil {
@@ -558,7 +558,7 @@ func (c *controller) reconcileClusterServiceClassFromClusterServiceBrokerCatalog
 // reconcileClusterServicePlanFromClusterServiceBrokerCatalog reconciles a
 // ServicePlan after the ServiceClass's catalog has been re-listed.
 func (c *controller) reconcileClusterServicePlanFromClusterServiceBrokerCatalog(broker *v1beta1.ClusterServiceBroker, servicePlan, existingServicePlan *v1beta1.ClusterServicePlan) error {
-	pcb := pretty.NewContextBuilder(pretty.ClusterServiceBroker, "", broker.Name)
+	pcb := pretty.NewClusterServiceBrokerContextBuilder(broker)
 	servicePlan.Spec.ClusterServiceBrokerName = broker.Name
 
 	if existingServicePlan == nil {
@@ -644,7 +644,7 @@ func (c *controller) reconcileClusterServicePlanFromClusterServiceBrokerCatalog(
 // updateClusterServiceBrokerCondition updates the ready condition for the given Broker
 // with the given status, reason, and message.
 func (c *controller) updateClusterServiceBrokerCondition(broker *v1beta1.ClusterServiceBroker, conditionType v1beta1.ServiceBrokerConditionType, status v1beta1.ConditionStatus, reason, message string) error {
-	pcb := pretty.NewContextBuilder(pretty.ClusterServiceBroker, "", broker.Name)
+	pcb := pretty.NewClusterServiceBrokerContextBuilder(broker)
 	toUpdate := broker.DeepCopy()
 	newCondition := v1beta1.ServiceBrokerCondition{
 		Type:    conditionType,
@@ -701,7 +701,7 @@ func (c *controller) updateClusterServiceBrokerCondition(broker *v1beta1.Cluster
 func (c *controller) updateClusterServiceBrokerFinalizers(
 	broker *v1beta1.ClusterServiceBroker,
 	finalizers []string) error {
-	pcb := pretty.NewContextBuilder(pretty.ClusterServiceBroker, "", broker.Name)
+	pcb := pretty.NewClusterServiceBrokerContextBuilder(broker)
 
 	// Get the latest version of the broker so that we can avoid conflicts
 	// (since we have probably just updated the status of the broker and are

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -119,7 +119,7 @@ func (c *controller) instanceDelete(obj interface{}) {
 		return
 	}
 
-	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+	pcb := pretty.NewInstanceContextBuilder(instance)
 	glog.V(4).Info(pcb.Message("Received delete event; no further processing will occur"))
 }
 
@@ -158,7 +158,7 @@ func (c *controller) requeueServiceInstanceForPoll(key string) error {
 func (c *controller) beginPollingServiceInstance(instance *v1beta1.ServiceInstance) error {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(instance)
 	if err != nil {
-		pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+		pcb := pretty.NewInstanceContextBuilder(instance)
 		s := fmt.Sprintf("Couldn't create a key for object %+v: %v", instance, err)
 		glog.Errorf(pcb.Message(s))
 		return fmt.Errorf(s)
@@ -180,7 +180,7 @@ func (c *controller) continuePollingServiceInstance(instance *v1beta1.ServiceIns
 func (c *controller) finishPollingServiceInstance(instance *v1beta1.ServiceInstance) error {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(instance)
 	if err != nil {
-		pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+		pcb := pretty.NewInstanceContextBuilder(instance)
 		s := fmt.Sprintf("Couldn't create a key for object %+v: %v", instance, err)
 		glog.Errorf(pcb.Message(s))
 		return fmt.Errorf(s)
@@ -196,7 +196,7 @@ func (c *controller) finishPollingServiceInstance(instance *v1beta1.ServiceInsta
 func (c *controller) resetPollingRateLimiterForServiceInstance(instance *v1beta1.ServiceInstance) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(instance)
 	if err != nil {
-		pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+		pcb := pretty.NewInstanceContextBuilder(instance)
 		s := fmt.Sprintf("Couldn't create a key for object %+v: %v", instance, err)
 		glog.Errorf(pcb.Message(s))
 		return
@@ -227,7 +227,7 @@ func (c *controller) reconcileServiceInstanceKey(key string) error {
 	if err != nil {
 		return err
 	}
-	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, namespace, name)
+	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, namespace, name, "")
 	instance, err := c.instanceLister.ServiceInstances(namespace).Get(name)
 	if errors.IsNotFound(err) {
 		glog.Info(pcb.Messagef("Not doing work for %v because it has been deleted", key))
@@ -274,7 +274,7 @@ func (c *controller) reconcileServiceInstance(instance *v1beta1.ServiceInstance)
 	case reconcilePoll:
 		return c.pollServiceInstance(instance)
 	default:
-		pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+		pcb := pretty.NewInstanceContextBuilder(instance)
 		return fmt.Errorf(pcb.Messagef("Unknown reconciliation action %v", reconciliationAction))
 	}
 }
@@ -332,7 +332,7 @@ func (c *controller) initOrphanMitigationCondition(instance *v1beta1.ServiceInst
 // reconcileServiceInstanceAdd is responsible for handling the provisioning
 // of new service instances.
 func (c *controller) reconcileServiceInstanceAdd(instance *v1beta1.ServiceInstance) error {
-	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+	pcb := pretty.NewInstanceContextBuilder(instance)
 
 	if isServiceInstanceProcessedAlready(instance) {
 		glog.V(4).Info(pcb.Message("Not processing event because status showed there is no work to do"))
@@ -442,7 +442,7 @@ func (c *controller) reconcileServiceInstanceAdd(instance *v1beta1.ServiceInstan
 // reconcileServiceInstanceUpdate is responsible for handling updating the plan
 // or parameters of a service instance.
 func (c *controller) reconcileServiceInstanceUpdate(instance *v1beta1.ServiceInstance) error {
-	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+	pcb := pretty.NewInstanceContextBuilder(instance)
 
 	if isServiceInstanceProcessedAlready(instance) {
 		glog.V(4).Info(pcb.Message("Not processing event because status showed there is no work to do"))
@@ -559,7 +559,7 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1beta1.ServiceIns
 		return nil
 	}
 
-	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+	pcb := pretty.NewInstanceContextBuilder(instance)
 
 	// If deprovisioning has already failed, do not do anything more
 	if instance.Status.DeprovisionStatus == v1beta1.ServiceInstanceDeprovisionStatusFailed {
@@ -567,7 +567,11 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1beta1.ServiceIns
 		return nil
 	}
 
-	glog.V(4).Info(pcb.Message("Processing deleting event"))
+	if instance.Status.OrphanMitigationInProgress {
+		glog.V(4).Info(pcb.Message("Performing orphan mitigation"))
+	} else {
+		glog.V(4).Info(pcb.Message("Processing deleting event"))
+	}
 
 	instance = instance.DeepCopy()
 	// Any status updates from this point should have an updated observed generation
@@ -666,8 +670,8 @@ func (c *controller) reconcileServiceInstanceDelete(instance *v1beta1.ServiceIns
 }
 
 func (c *controller) pollServiceInstance(instance *v1beta1.ServiceInstance) error {
-	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
-	glog.V(4).Info(pcb.Message("Processing"))
+	pcb := pretty.NewInstanceContextBuilder(instance)
+	glog.V(4).Info(pcb.Message("Processing poll event"))
 
 	instance = instance.DeepCopy()
 
@@ -911,7 +915,7 @@ func (c *controller) resolveClusterServiceClassRef(instance *v1beta1.ServiceInst
 		return nil, nil, fmt.Errorf("ServiceInstance %s/%s is in invalid state, neither ClusterServiceClassExternalName, ClusterServiceClassExternalID, nor ClusterServiceClassName is set", instance.Namespace, instance.Name)
 	}
 
-	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+	pcb := pretty.NewInstanceContextBuilder(instance)
 	var sc *v1beta1.ClusterServiceClass
 
 	if instance.Spec.ClusterServiceClassName != "" {
@@ -992,7 +996,7 @@ func (c *controller) resolveClusterServicePlanRef(instance *v1beta1.ServiceInsta
 		return nil, fmt.Errorf("ServiceInstance %s/%s is in invalid state, neither ClusterServicePlanExternalName, ClusterServicePlanExternalID, nor ClusterServicePlanName is set", instance.Namespace, instance.Name)
 	}
 
-	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+	pcb := pretty.NewInstanceContextBuilder(instance)
 
 	if instance.Spec.ClusterServicePlanName != "" {
 		sp, err := c.clusterServicePlanLister.Get(instance.Spec.ClusterServicePlanName)
@@ -1096,7 +1100,7 @@ func newServiceInstanceOrphanMitigationCondition(status v1beta1.ConditionStatus,
 // instance's status if it exists.
 func removeServiceInstanceCondition(toUpdate *v1beta1.ServiceInstance,
 	conditionType v1beta1.ServiceInstanceConditionType) {
-	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, toUpdate.Namespace, toUpdate.Name)
+	pcb := pretty.NewInstanceContextBuilder(toUpdate)
 	glog.V(5).Info(pcb.Messagef(
 		"Removing condition %q", conditionType,
 	))
@@ -1139,7 +1143,7 @@ func setServiceInstanceConditionInternal(toUpdate *v1beta1.ServiceInstance,
 	message string,
 	t metav1.Time) {
 
-	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, toUpdate.Namespace, toUpdate.Name)
+	pcb := pretty.NewInstanceContextBuilder(toUpdate)
 	glog.Info(pcb.Message(message))
 	glog.V(5).Info(pcb.Messagef(
 		"Setting condition %q to %v",
@@ -1189,7 +1193,7 @@ func setServiceInstanceConditionInternal(toUpdate *v1beta1.ServiceInstance,
 
 // updateServiceInstanceReferences updates the refs for the given instance.
 func (c *controller) updateServiceInstanceReferences(toUpdate *v1beta1.ServiceInstance) (*v1beta1.ServiceInstance, error) {
-	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, toUpdate.Namespace, toUpdate.Name)
+	pcb := pretty.NewInstanceContextBuilder(toUpdate)
 	glog.V(4).Info(pcb.Message("Updating references"))
 	status := toUpdate.Status
 	updatedInstance, err := c.serviceCatalogClient.ServiceInstances(toUpdate.Namespace).UpdateReferences(toUpdate)
@@ -1207,8 +1211,7 @@ func (c *controller) updateServiceInstanceReferences(toUpdate *v1beta1.ServiceIn
 // Note: objects coming from informers should never be mutated; the instance
 // passed to this method should always be a deep copy.
 func (c *controller) updateServiceInstanceStatus(instance *v1beta1.ServiceInstance) (*v1beta1.ServiceInstance, error) {
-	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
-	glog.V(4).Info(pcb.Message("Updating status"))
+	pcb := pretty.NewInstanceContextBuilder(instance)
 
 	const interval = 100 * time.Millisecond
 	const timeout = 10 * time.Second
@@ -1216,11 +1219,13 @@ func (c *controller) updateServiceInstanceStatus(instance *v1beta1.ServiceInstan
 
 	instanceToUpdate := instance
 	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		glog.V(4).Info(pcb.Message("Updating status"))
 		upd, err := c.serviceCatalogClient.ServiceInstances(instanceToUpdate.Namespace).UpdateStatus(instanceToUpdate)
 		if err != nil {
 			if !errors.IsConflict(err) {
 				return false, err
 			}
+			glog.V(4).Info(pcb.Message("Couldn't update status because the resource was stale"))
 			// Fetch a fresh instance to resolve the update conflict and retry
 			instanceToUpdate, err = c.serviceCatalogClient.ServiceInstances(instance.Namespace).Get(instance.Name, metav1.GetOptions{})
 			if err != nil {
@@ -1249,7 +1254,7 @@ func (c *controller) updateServiceInstanceCondition(
 	status v1beta1.ConditionStatus,
 	reason,
 	message string) error {
-	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+	pcb := pretty.NewInstanceContextBuilder(instance)
 	toUpdate := instance.DeepCopy()
 
 	setServiceInstanceCondition(toUpdate, conditionType, status, reason, message)
@@ -1603,7 +1608,7 @@ func (c *controller) prepareServiceInstanceLastOperationRequest(instance *v1beta
 	}
 
 	if instance.Status.InProgressProperties == nil {
-		pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+		pcb := pretty.NewInstanceContextBuilder(instance)
 		err = stderrors.New("Instance.Status.InProgressProperties can not be nil")
 		glog.Errorf(pcb.Message(err.Error()))
 		return nil, err
@@ -1635,7 +1640,7 @@ func (c *controller) processServiceInstanceGracefulDeletionSuccess(instance *v1b
 		return err
 	}
 
-	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+	pcb := pretty.NewInstanceContextBuilder(instance)
 	glog.Info(pcb.Message("Cleared finalizer"))
 
 	return nil
@@ -1953,7 +1958,7 @@ func (c *controller) handleServiceInstancePollingError(instance *v1beta1.Service
 	//	2) attempt to requeue in the polling queue
 	//		- if successful, we can return nil to avoid regular queue
 	//		- if failure, return err to fall back to regular queue
-	pcb := pretty.NewContextBuilder(pretty.ServiceInstance, instance.Namespace, instance.Name)
+	pcb := pretty.NewInstanceContextBuilder(instance)
 	glog.V(4).Info(pcb.Messagef("Error during polling: %v", err))
 	return c.continuePollingServiceInstance(instance)
 }

--- a/pkg/pretty/context_builder_test.go
+++ b/pkg/pretty/context_builder_test.go
@@ -93,7 +93,7 @@ func TestPrettyContextBuilderKindNamespaceName(t *testing.T) {
 }
 
 func TestPrettyContextBuilderKindNamespaceNameNew(t *testing.T) {
-	pcb := NewContextBuilder(ServiceInstance, "Namespace", "Name")
+	pcb := NewContextBuilder(ServiceInstance, "Namespace", "Name", "")
 
 	e := `ServiceInstance "Namespace/Name"`
 	g := pcb.String()


### PR DESCRIPTION
The controller is often working on a stale version of an object, but that
fact isn't very visible when looking at the controller's logs. Logging
the version next to the resource name will allow us to see what's really
going on faster.

(also includes a few other minor log improvements)