### PR TITLE
Adds annotations to catalog chart

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -42,6 +42,7 @@ chart and their default values.
 |-----------|-------------|---------|
 | `image` | apiserver image to use | `quay.io/kubernetes-service-catalog/service-catalog:v0.1.21` |
 | `imagePullPolicy` | `imagePullPolicy` for the service catalog | `Always` |
+| `apiserver.annotations` | Annotations for apiserver pods | `{}` |
 | `apiserver.aggregator.priority` | Priority of the APIService. | `100` |
 | `apiserver.aggregator.groupPriorityMinimum` | The minimum priority the group should have. | `10000` |
 | `apiserver.aggregator.versionPriority` | The ordering of this API inside of the group | `20` |
@@ -61,6 +62,7 @@ chart and their default values.
 | `apiserver.audit.logPath` | If specified, audit log goes to specified path. | `"/tmp/service-catalog-apiserver-audit.log"` |
 | `apiserver.serviceAccount` | Service account. | `service-catalog-apiserver` |
 | `apiserver.serveOpenAPISpec` | If true, makes the API server serve the OpenAPI schema | `false` |
+| `controllerManager.annotations` | Annotations for controllerManager pods | `{}` |
 | `controllerManager.verbosity` | Log level; valid values are in the range 0 - 10 | `10` |
 | `controllerManager.resyncInterval` | How often the controller should resync informers; duration format (`20m`, `1h`, etc) | `5m` |
 | `controllerManager.brokerRelistInterval` | How often the controller should relist the catalogs of ready brokers; duration format (`20m`, `1h`, etc) | `24h` |

--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -20,6 +20,10 @@ spec:
         release: "{{ .Release.Name }}"
         releaseRevision: "{{ .Release.Revision }}"
         heritage: "{{ .Release.Service }}"
+      {{ if .Values.apiserver.annotations }}
+      annotations:
+{{ toYaml .Values.apiserver.annotations | indent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: "{{ .Values.apiserver.serviceAccount }}"
       containers:

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -16,6 +16,9 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: "{{ .Values.controllerManager.enablePrometheusScrape }}"
+      {{ if .Values.controllerManager.annotations }}
+{{ toYaml .Values.controllerManager.annotations | indent 8 }}
+      {{- end }}
       labels:
         app: {{ template "fullname" . }}-controller-manager
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -10,6 +10,8 @@ useAggregator: true
 ##
 rbacEnable: true
 apiserver:
+  # annotations is a collection of annotations to add to the apiserver pods.
+  annotations: {}
   # PodPreset is an optional feature and can be enabled by uncommenting the line below
   # featureGates: "PodPreset=true"
   aggregator:
@@ -84,6 +86,8 @@ apiserver:
   # if true, makes the API server serve the OpenAPI schema (which is problematic with older versions of kubectl)
   serveOpenAPISpec: false
 controllerManager:
+  # annotations is a collection of annotations to add to the controllerManager pod.
+  annotations: {}
   # Log level; valid values are in the range 0 - 10
   verbosity: 10
   # Resync interval; format is a duration (`20m`, `1h`, etc)


### PR DESCRIPTION
Hiya,

This PR lets users specify custom annotations for the apiserver and controllerManager pods.

The use case im going to give is from an AWS perspective, but im sure this is useful for other cloud providers too.

This is so it can integrate easily with services like kube2iam, and we dont require broad CF policies to be attached directly to the metadata of the nodes.

Thanks!