### PR TITLE
Improve kubectl get experience for service catalog resources

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -831,6 +831,7 @@
     "pkg/api/equality",
     "pkg/api/errors",
     "pkg/api/meta",
+    "pkg/api/meta/table",
     "pkg/api/resource",
     "pkg/api/testing",
     "pkg/api/testing/fuzzer",
@@ -860,6 +861,7 @@
     "pkg/util/cache",
     "pkg/util/clock",
     "pkg/util/diff",
+    "pkg/util/duration",
     "pkg/util/errors",
     "pkg/util/framer",
     "pkg/util/intstr",
@@ -1219,6 +1221,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1cf27edf2c8dd4bad7c5aa80f4bd5c7bec2652e61bfee5f4bd0f5a8eb9aba030"
+  inputs-digest = "18c14a2444b3d1edffdea1eba30f21a69343dd8331a58ce2b8899ccd7b25aa5c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,8 +13,7 @@
 # Force dep to vendor the code generators, which aren't imported just used at dev time.
 # Picking a subpackage with Go code won't be necessary once https://github.com/golang/dep/pull/1545 is merged.
 required = [
-  "github.com/jteeuwen/go-bindata/go-bindata",
-  "k8s.io/code-generator/cmd/defaulter-gen",
+  "github.com/jteeuwen/go-bindata/go-bindata","k8s.io/code-generator/cmd/defaulter-gen",
   "k8s.io/code-generator/cmd/deepcopy-gen",
   "k8s.io/code-generator/cmd/conversion-gen",
   "k8s.io/code-generator/cmd/client-gen",

--- a/pkg/registry/servicecatalog/binding/storage.go
+++ b/pkg/registry/servicecatalog/binding/storage.go
@@ -143,8 +143,8 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage, error) {
 		TableConvertor: tableconvertor.NewTableConvertor(
 			[]metav1beta1.TableColumnDefinition{
 				{Name: "Name", Type: "string", Format: "name"},
-				{Name: "Instance", Type: "string"},
-				{Name: "Secret", Type: "string"},
+				{Name: "Service-Instance", Type: "string"},
+				{Name: "Secret-Name", Type: "string"},
 				{Name: "Status", Type: "string"},
 				{Name: "Age", Type: "string"},
 			},

--- a/pkg/registry/servicecatalog/binding/storage.go
+++ b/pkg/registry/servicecatalog/binding/storage.go
@@ -24,7 +24,9 @@ import (
 	scmeta "github.com/kubernetes-incubator/service-catalog/pkg/api/meta"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/tableconvertor"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -137,6 +139,38 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage, error) {
 		UpdateStrategy:          bindingRESTStrategies,
 		DeleteStrategy:          bindingRESTStrategies,
 		EnableGarbageCollection: true,
+
+		TableConvertor: tableconvertor.NewTableConvertor(
+			[]metav1beta1.TableColumnDefinition{
+				{Name: "Name", Type: "string", Format: "name"},
+				{Name: "Instance", Type: "string"},
+				{Name: "Secret", Type: "string"},
+				{Name: "Status", Type: "string"},
+				{Name: "Age", Type: "string"},
+			},
+			func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
+				getStatus := func(status servicecatalog.ServiceBindingStatus) string {
+					if len(status.Conditions) > 0 {
+						condition := status.Conditions[len(status.Conditions)-1]
+						if condition.Status == servicecatalog.ConditionTrue {
+							return string(condition.Type)
+						}
+						return condition.Reason
+					}
+					return ""
+				}
+
+				binding := obj.(*servicecatalog.ServiceBinding)
+				cells := []interface{}{
+					name,
+					binding.Spec.ServiceInstanceRef.Name,
+					binding.Spec.SecretName,
+					getStatus(binding.Status),
+					age,
+				}
+				return cells, nil
+			},
+		),
 
 		Storage:     storageInterface,
 		DestroyFunc: dFunc,

--- a/pkg/registry/servicecatalog/clusterservicebroker/storage.go
+++ b/pkg/registry/servicecatalog/clusterservicebroker/storage.go
@@ -24,8 +24,10 @@ import (
 	scmeta "github.com/kubernetes-incubator/service-catalog/pkg/api/meta"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/tableconvertor"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -133,6 +135,35 @@ func NewStorage(opts server.Options) (clusterServiceBrokers, clusterServiceBroke
 		UpdateStrategy:          clusterServiceBrokerRESTStrategies,
 		DeleteStrategy:          clusterServiceBrokerRESTStrategies,
 		EnableGarbageCollection: true,
+
+		TableConvertor: tableconvertor.NewTableConvertor(
+			[]metav1beta1.TableColumnDefinition{
+				{Name: "Name", Type: "string", Format: "name"},
+				{Name: "URL", Type: "string"},
+				{Name: "Status", Type: "string"},
+				{Name: "Age", Type: "string"},
+			},
+			func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
+				getStatus := func(status servicecatalog.CommonServiceBrokerStatus) string {
+					if len(status.Conditions) > 0 {
+						condition := status.Conditions[len(status.Conditions)-1]
+						if condition.Status == servicecatalog.ConditionTrue {
+							return string(condition.Type)
+						}
+						return condition.Reason
+					}
+					return ""
+				}
+				broker := obj.(*servicecatalog.ClusterServiceBroker)
+				cells := []interface{}{
+					name,
+					broker.Spec.URL,
+					getStatus(broker.Status.CommonServiceBrokerStatus),
+					age,
+				}
+				return cells, nil
+			},
+		),
 
 		Storage:     storageInterface,
 		DestroyFunc: dFunc,

--- a/pkg/registry/servicecatalog/clusterserviceclass/storage.go
+++ b/pkg/registry/servicecatalog/clusterserviceclass/storage.go
@@ -152,8 +152,6 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 				{Name: "Name", Type: "string", Format: "name"},
 				{Name: "External-Name", Type: "string"},
 				{Name: "Broker", Type: "string"},
-				{Name: "Bindable", Type: "bool"},
-				{Name: "Plan-Updatable", Type: "bool"},
 				{Name: "Age", Type: "string"},
 			},
 			func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
@@ -162,8 +160,6 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 					name,
 					class.Spec.ExternalName,
 					class.Spec.ClusterServiceBrokerName,
-					class.Spec.Bindable,
-					class.Spec.PlanUpdatable,
 					age,
 				}
 				return cells, nil

--- a/pkg/registry/servicecatalog/clusterserviceclass/storage.go
+++ b/pkg/registry/servicecatalog/clusterserviceclass/storage.go
@@ -24,7 +24,9 @@ import (
 	scmeta "github.com/kubernetes-incubator/service-catalog/pkg/api/meta"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/tableconvertor"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -144,8 +146,32 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 		CreateStrategy: clusterServiceClassRESTStrategies,
 		UpdateStrategy: clusterServiceClassRESTStrategies,
 		DeleteStrategy: clusterServiceClassRESTStrategies,
-		Storage:        storageInterface,
-		DestroyFunc:    dFunc,
+
+		TableConvertor: tableconvertor.NewTableConvertor(
+			[]metav1beta1.TableColumnDefinition{
+				{Name: "Name", Type: "string", Format: "name"},
+				{Name: "External name", Type: "string"},
+				{Name: "Broker", Type: "string"},
+				{Name: "Bindable", Type: "bool"},
+				{Name: "Plan updatable", Type: "bool"},
+				{Name: "Age", Type: "string"},
+			},
+			func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
+				class := obj.(*servicecatalog.ClusterServiceClass)
+				cells := []interface{}{
+					name,
+					class.Spec.ExternalName,
+					class.Spec.ClusterServiceBrokerName,
+					class.Spec.Bindable,
+					class.Spec.PlanUpdatable,
+					age,
+				}
+				return cells, nil
+			},
+		),
+
+		Storage:     storageInterface,
+		DestroyFunc: dFunc,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: opts.EtcdOptions.RESTOptions, AttrFunc: GetAttrs}

--- a/pkg/registry/servicecatalog/clusterserviceclass/storage.go
+++ b/pkg/registry/servicecatalog/clusterserviceclass/storage.go
@@ -150,10 +150,10 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 		TableConvertor: tableconvertor.NewTableConvertor(
 			[]metav1beta1.TableColumnDefinition{
 				{Name: "Name", Type: "string", Format: "name"},
-				{Name: "External name", Type: "string"},
+				{Name: "External-Name", Type: "string"},
 				{Name: "Broker", Type: "string"},
 				{Name: "Bindable", Type: "bool"},
-				{Name: "Plan updatable", Type: "bool"},
+				{Name: "Plan-Updatable", Type: "bool"},
 				{Name: "Age", Type: "string"},
 			},
 			func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {

--- a/pkg/registry/servicecatalog/clusterserviceplan/storage.go
+++ b/pkg/registry/servicecatalog/clusterserviceplan/storage.go
@@ -148,7 +148,7 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 		TableConvertor: tableconvertor.NewTableConvertor(
 			[]metav1beta1.TableColumnDefinition{
 				{Name: "Name", Type: "string", Format: "name"},
-				{Name: "External name", Type: "string"},
+				{Name: "External-Name", Type: "string"},
 				{Name: "Broker", Type: "string"},
 				{Name: "Class", Type: "string"},
 				{Name: "Age", Type: "string"},

--- a/pkg/registry/servicecatalog/clusterserviceplan/storage.go
+++ b/pkg/registry/servicecatalog/clusterserviceplan/storage.go
@@ -24,7 +24,9 @@ import (
 	scmeta "github.com/kubernetes-incubator/service-catalog/pkg/api/meta"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/tableconvertor"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -142,8 +144,30 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 		CreateStrategy: clusterServicePlanRESTStrategies,
 		UpdateStrategy: clusterServicePlanRESTStrategies,
 		DeleteStrategy: clusterServicePlanRESTStrategies,
-		Storage:        storageInterface,
-		DestroyFunc:    dFunc,
+
+		TableConvertor: tableconvertor.NewTableConvertor(
+			[]metav1beta1.TableColumnDefinition{
+				{Name: "Name", Type: "string", Format: "name"},
+				{Name: "External name", Type: "string"},
+				{Name: "Broker", Type: "string"},
+				{Name: "Class", Type: "string"},
+				{Name: "Age", Type: "string"},
+			},
+			func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
+				plan := obj.(*servicecatalog.ClusterServicePlan)
+				cells := []interface{}{
+					name,
+					plan.Spec.ExternalName,
+					plan.Spec.ClusterServiceBrokerName,
+					plan.Spec.ClusterServiceClassRef.Name,
+					age,
+				}
+				return cells, nil
+			},
+		),
+
+		Storage:     storageInterface,
+		DestroyFunc: dFunc,
 	}
 
 	statusStore := store

--- a/pkg/registry/servicecatalog/instance/storage.go
+++ b/pkg/registry/servicecatalog/instance/storage.go
@@ -170,10 +170,10 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage, rest.Storage) 
 				var class, plan string
 				if instance.Spec.ClusterServiceClassSpecified() && instance.Spec.ClusterServicePlanSpecified() {
 					class = fmt.Sprintf("ClusterServiceClass/%s", instance.Spec.GetSpecifiedClusterServiceClass())
-					plan = fmt.Sprintf("ClusterServicePlan/%s", instance.Spec.GetSpecifiedClusterServicePlan())
+					plan = instance.Spec.GetSpecifiedClusterServicePlan()
 				} else {
 					class = fmt.Sprintf("ServiceClass/%s", instance.Spec.GetSpecifiedServiceClass())
-					plan = fmt.Sprintf("ServicePlan/%s", instance.Spec.GetSpecifiedServicePlan())
+					plan = instance.Spec.GetSpecifiedServicePlan()
 				}
 
 				cells := []interface{}{

--- a/pkg/registry/servicecatalog/instance/storage.go
+++ b/pkg/registry/servicecatalog/instance/storage.go
@@ -168,8 +168,8 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage, rest.Storage) 
 				instance := obj.(*servicecatalog.ServiceInstance)
 				cells := []interface{}{
 					name,
-					instance.Spec.ClusterServiceClassExternalName,
-					instance.Spec.ClusterServicePlanExternalName,
+					instance.Spec.GetSpecifiedServiceClass(),
+					instance.Spec.GetSpecifiedServicePlan(),
 					getStatus(instance.Status),
 					age,
 				}

--- a/pkg/registry/servicecatalog/instance/storage.go
+++ b/pkg/registry/servicecatalog/instance/storage.go
@@ -166,10 +166,20 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage, rest.Storage) 
 				}
 
 				instance := obj.(*servicecatalog.ServiceInstance)
+
+				var class, plan string
+				if instance.Spec.ClusterServiceClassSpecified() && instance.Spec.ClusterServicePlanSpecified() {
+					class = fmt.Sprintf("ClusterServiceClass/%s", instance.Spec.GetSpecifiedClusterServiceClass())
+					plan = fmt.Sprintf("ClusterServicePlan/%s", instance.Spec.GetSpecifiedClusterServicePlan())
+				} else {
+					class = fmt.Sprintf("ServiceClass/%s", instance.Spec.GetSpecifiedServiceClass())
+					plan = fmt.Sprintf("ServicePlan/%s", instance.Spec.GetSpecifiedServicePlan())
+				}
+
 				cells := []interface{}{
 					name,
-					instance.Spec.GetSpecifiedServiceClass(),
-					instance.Spec.GetSpecifiedServicePlan(),
+					class,
+					plan,
 					getStatus(instance.Status),
 					age,
 				}

--- a/pkg/registry/servicecatalog/servicebroker/storage.go
+++ b/pkg/registry/servicecatalog/servicebroker/storage.go
@@ -24,8 +24,10 @@ import (
 	scmeta "github.com/kubernetes-incubator/service-catalog/pkg/api/meta"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/tableconvertor"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -133,6 +135,35 @@ func NewStorage(opts server.Options) (serviceBrokers, serviceBrokerStatus rest.S
 		UpdateStrategy:          serviceBrokerRESTStrategies,
 		DeleteStrategy:          serviceBrokerRESTStrategies,
 		EnableGarbageCollection: true,
+
+		TableConvertor: tableconvertor.NewTableConvertor(
+			[]metav1beta1.TableColumnDefinition{
+				{Name: "Name", Type: "string", Format: "name"},
+				{Name: "URL", Type: "string"},
+				{Name: "Status", Type: "string"},
+				{Name: "Age", Type: "string"},
+			},
+			func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
+				getStatus := func(status servicecatalog.CommonServiceBrokerStatus) string {
+					if len(status.Conditions) > 0 {
+						condition := status.Conditions[len(status.Conditions)-1]
+						if condition.Status == servicecatalog.ConditionTrue {
+							return string(condition.Type)
+						}
+						return condition.Reason
+					}
+					return ""
+				}
+				broker := obj.(*servicecatalog.ServiceBroker)
+				cells := []interface{}{
+					name,
+					broker.Spec.URL,
+					getStatus(broker.Status.CommonServiceBrokerStatus),
+					age,
+				}
+				return cells, nil
+			},
+		),
 
 		Storage:     storageInterface,
 		DestroyFunc: dFunc,

--- a/pkg/registry/servicecatalog/serviceclass/storage.go
+++ b/pkg/registry/servicecatalog/serviceclass/storage.go
@@ -152,8 +152,6 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 				{Name: "Name", Type: "string", Format: "name"},
 				{Name: "External-Name", Type: "string"},
 				{Name: "Broker", Type: "string"},
-				{Name: "Bindable", Type: "bool"},
-				{Name: "Plan-Updatable", Type: "bool"},
 				{Name: "Age", Type: "string"},
 			},
 			func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
@@ -162,8 +160,6 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 					name,
 					class.Spec.ExternalName,
 					class.Spec.ServiceBrokerName,
-					class.Spec.Bindable,
-					class.Spec.PlanUpdatable,
 					age,
 				}
 				return cells, nil

--- a/pkg/registry/servicecatalog/serviceclass/storage.go
+++ b/pkg/registry/servicecatalog/serviceclass/storage.go
@@ -24,7 +24,9 @@ import (
 	scmeta "github.com/kubernetes-incubator/service-catalog/pkg/api/meta"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/tableconvertor"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -144,8 +146,32 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 		CreateStrategy: serviceClassRESTStrategies,
 		UpdateStrategy: serviceClassRESTStrategies,
 		DeleteStrategy: serviceClassRESTStrategies,
-		Storage:        storageInterface,
-		DestroyFunc:    dFunc,
+
+		TableConvertor: tableconvertor.NewTableConvertor(
+			[]metav1beta1.TableColumnDefinition{
+				{Name: "Name", Type: "string", Format: "name"},
+				{Name: "External name", Type: "string"},
+				{Name: "Broker", Type: "string"},
+				{Name: "Bindable", Type: "bool"},
+				{Name: "Plan updatable", Type: "bool"},
+				{Name: "Age", Type: "string"},
+			},
+			func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
+				class := obj.(*servicecatalog.ServiceClass)
+				cells := []interface{}{
+					name,
+					class.Spec.ExternalName,
+					class.Spec.ServiceBrokerName,
+					class.Spec.Bindable,
+					class.Spec.PlanUpdatable,
+					age,
+				}
+				return cells, nil
+			},
+		),
+
+		Storage:     storageInterface,
+		DestroyFunc: dFunc,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: opts.EtcdOptions.RESTOptions, AttrFunc: GetAttrs}

--- a/pkg/registry/servicecatalog/serviceclass/storage.go
+++ b/pkg/registry/servicecatalog/serviceclass/storage.go
@@ -150,10 +150,10 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 		TableConvertor: tableconvertor.NewTableConvertor(
 			[]metav1beta1.TableColumnDefinition{
 				{Name: "Name", Type: "string", Format: "name"},
-				{Name: "External name", Type: "string"},
+				{Name: "External-Name", Type: "string"},
 				{Name: "Broker", Type: "string"},
 				{Name: "Bindable", Type: "bool"},
-				{Name: "Plan updatable", Type: "bool"},
+				{Name: "Plan-Updatable", Type: "bool"},
 				{Name: "Age", Type: "string"},
 			},
 			func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {

--- a/pkg/registry/servicecatalog/serviceplan/storage.go
+++ b/pkg/registry/servicecatalog/serviceplan/storage.go
@@ -148,7 +148,7 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 		TableConvertor: tableconvertor.NewTableConvertor(
 			[]metav1beta1.TableColumnDefinition{
 				{Name: "Name", Type: "string", Format: "name"},
-				{Name: "External name", Type: "string"},
+				{Name: "External-Name", Type: "string"},
 				{Name: "Broker", Type: "string"},
 				{Name: "Class", Type: "string"},
 				{Name: "Age", Type: "string"},

--- a/pkg/registry/servicecatalog/serviceplan/storage.go
+++ b/pkg/registry/servicecatalog/serviceplan/storage.go
@@ -24,7 +24,9 @@ import (
 	scmeta "github.com/kubernetes-incubator/service-catalog/pkg/api/meta"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/tableconvertor"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -142,8 +144,30 @@ func NewStorage(opts server.Options) (rest.Storage, rest.Storage) {
 		CreateStrategy: servicePlanRESTStrategies,
 		UpdateStrategy: servicePlanRESTStrategies,
 		DeleteStrategy: servicePlanRESTStrategies,
-		Storage:        storageInterface,
-		DestroyFunc:    dFunc,
+
+		TableConvertor: tableconvertor.NewTableConvertor(
+			[]metav1beta1.TableColumnDefinition{
+				{Name: "Name", Type: "string", Format: "name"},
+				{Name: "External name", Type: "string"},
+				{Name: "Broker", Type: "string"},
+				{Name: "Class", Type: "string"},
+				{Name: "Age", Type: "string"},
+			},
+			func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
+				plan := obj.(*servicecatalog.ServicePlan)
+				cells := []interface{}{
+					name,
+					plan.Spec.ExternalName,
+					plan.Spec.ServiceBrokerName,
+					plan.Spec.ServiceClassRef.Name,
+					age,
+				}
+				return cells, nil
+			},
+		),
+
+		Storage:     storageInterface,
+		DestroyFunc: dFunc,
 	}
 
 	statusStore := store

--- a/pkg/registry/servicecatalog/tableconvertor/tableconvertor.go
+++ b/pkg/registry/servicecatalog/tableconvertor/tableconvertor.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tableconvertor
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metatable "k8s.io/apimachinery/pkg/api/meta/table"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+)
+
+// RowFunction is a function that maps an object (e.g. ServiceInstance)
+// to an array of values that get printed in columnar form when a user
+// runs kubectl get.
+type RowFunction func(obj runtime.Object, meta metav1.Object, name, age string) ([]interface{}, error)
+
+// NewTableConvertor creates a TableConvertor with the specified columns
+// and RowFunction, which is used to map an object to those columns.
+func NewTableConvertor(columnDefinitions []metav1beta1.TableColumnDefinition, rowFunction RowFunction) rest.TableConvertor {
+	return &convertor{columnDefinitions, rowFunction}
+}
+
+type convertor struct {
+	columnDefinitions []metav1beta1.TableColumnDefinition
+	rowFunction       RowFunction
+}
+
+func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+	table := &metav1beta1.Table{
+		ColumnDefinitions: c.columnDefinitions,
+	}
+	if m, err := meta.ListAccessor(obj); err == nil {
+		table.ResourceVersion = m.GetResourceVersion()
+		table.SelfLink = m.GetSelfLink()
+		table.Continue = m.GetContinue()
+	} else {
+		if m, err := meta.CommonAccessor(obj); err == nil {
+			table.ResourceVersion = m.GetResourceVersion()
+			table.SelfLink = m.GetSelfLink()
+		}
+	}
+
+	var err error
+	table.Rows, err = metatable.MetaToTableRow(obj, c.rowFunction)
+	return table, err
+}

--- a/vendor/k8s.io/apimachinery/pkg/api/meta/table/table.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/meta/table/table.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package table
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/duration"
+)
+
+// MetaToTableRow converts a list or object into one or more table rows. The provided rowFn is invoked for
+// each accessed item, with name and age being passed to each.
+func MetaToTableRow(obj runtime.Object, rowFn func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error)) ([]metav1beta1.TableRow, error) {
+	if meta.IsListType(obj) {
+		rows := make([]metav1beta1.TableRow, 0, 16)
+		err := meta.EachListItem(obj, func(obj runtime.Object) error {
+			nestedRows, err := MetaToTableRow(obj, rowFn)
+			if err != nil {
+				return err
+			}
+			rows = append(rows, nestedRows...)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return rows, nil
+	}
+
+	rows := make([]metav1beta1.TableRow, 0, 1)
+	m, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	row := metav1beta1.TableRow{
+		Object: runtime.RawExtension{Object: obj},
+	}
+	row.Cells, err = rowFn(obj, m, m.GetName(), ConvertToHumanReadableDateType(m.GetCreationTimestamp()))
+	if err != nil {
+		return nil, err
+	}
+	rows = append(rows, row)
+	return rows, nil
+}
+
+// ConvertToHumanReadableDateType returns the elapsed time since timestamp in
+// human-readable approximation.
+func ConvertToHumanReadableDateType(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+	return duration.ShortHumanDuration(time.Now().Sub(timestamp.Time))
+}

--- a/vendor/k8s.io/apimachinery/pkg/util/duration/duration.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/duration/duration.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duration
+
+import (
+	"fmt"
+	"time"
+)
+
+// ShortHumanDuration returns a succint representation of the provided duration
+// with limited precision for consumption by humans.
+func ShortHumanDuration(d time.Duration) string {
+	// Allow deviation no more than 2 seconds(excluded) to tolerate machine time
+	// inconsistence, it can be considered as almost now.
+	if seconds := int(d.Seconds()); seconds < -1 {
+		return fmt.Sprintf("<invalid>")
+	} else if seconds < 0 {
+		return fmt.Sprintf("0s")
+	} else if seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	} else if minutes := int(d.Minutes()); minutes < 60 {
+		return fmt.Sprintf("%dm", minutes)
+	} else if hours := int(d.Hours()); hours < 24 {
+		return fmt.Sprintf("%dh", hours)
+	} else if hours < 24*365 {
+		return fmt.Sprintf("%dd", hours/24)
+	}
+	return fmt.Sprintf("%dy", int(d.Hours()/24/365))
+}


### PR DESCRIPTION
Instead of using custom-columns in OpenAPI schema, this commit adds
server-side column printing by registering TableConvertors.