### PR TITLE
Notify mailing list of master and release failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: generic
+notifications:
+  email:
+    recipients:
+      - kubernetes-sig-service-catalog-alerts@googlegroups.com
 env:
   - GO_VERSION=1.9
   - GO_VERSION=rc

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -9,6 +9,7 @@ PRs may only be merged after the following criteria are met:
 
 1. It has been 'LGTM'-ed by 2 different reviewers
 1. It has all appropriate corresponding documentation and testcases
+1. The master build is passing. Do not merge a PR unless it is fixing the broken build.
 
 ## LGTMs
 
@@ -28,3 +29,8 @@ is a fundamental problem with the PR. The reviewer should summarize that problem
 in the PR comments and a longer discussion may be required.
 
 We expect this label to be used infrequently.
+
+# Alerts
+
+You can join the [SIG Service Catalog Alerts](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog-alerts)
+mailing list to receive notifications when there are problems with master or release builds.


### PR DESCRIPTION
If you would like to receive alerts for master build failures, or release failures, join this group:

https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog-alerts

This is in response to https://github.com/kubernetes-incubator/service-catalog/issues/2093 where we didn't realize for a couple days that the release build had failed. It will also help reviewers avoid merging when master is red.