### PR TITLE
Distinguish between user-defined and managed resources

### DIFF
--- a/pkg/controller/controller_clusterservicebroker_test.go
+++ b/pkg/controller/controller_clusterservicebroker_test.go
@@ -1320,3 +1320,264 @@ func reconcileClusterServiceBroker(t *testing.T, testController *controller, bro
 	}
 	return err
 }
+
+// TestReconcileUpdatesManagedClassesAndPlans
+// verifies that when an service classes and plans are updated during relist
+// that they are flagged as service catalog managed.
+func TestReconcileUpdatesManagedClassesAndPlans(t *testing.T) {
+	_, fakeCatalogClient, _, testController, sharedInformers := newTestController(t, getTestCatalogConfig())
+
+	testClusterServiceClass := getTestClusterServiceClass()
+	testClusterServicePlan := getTestClusterServicePlan()
+
+	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(testClusterServiceClass)
+	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(testClusterServicePlan)
+
+	fakeCatalogClient.AddReactor("list", "clusterserviceclasses", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, &v1beta1.ClusterServiceClassList{
+			Items: []v1beta1.ClusterServiceClass{
+				*testClusterServiceClass,
+			},
+		}, nil
+	})
+	fakeCatalogClient.AddReactor("list", "clusterserviceplans", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, &v1beta1.ClusterServicePlanList{
+			Items: []v1beta1.ClusterServicePlan{
+				*testClusterServicePlan,
+			},
+		}, nil
+	})
+
+	if err := reconcileClusterServiceBroker(t, testController, getTestClusterServiceBroker()); err != nil {
+		t.Fatalf("This should not fail: %v", err)
+	}
+
+	actions := fakeCatalogClient.Actions()
+
+	c := assertUpdate(t, actions[2], testClusterServiceClass)
+	updatedClass, ok := c.(metav1.Object)
+	if !ok {
+		t.Fatalf("could not cast %T to metav1.Object", c)
+	}
+	if !isServiceCatalogManagedResource(updatedClass) {
+		t.Error("expected the class to have a service catalog controller reference")
+	}
+
+	p := assertUpdate(t, actions[3], testClusterServicePlan)
+	updatedPlan, ok := p.(metav1.Object)
+	if !ok {
+		t.Fatalf("could not cast %T to metav1.Object", p)
+	}
+	if !isServiceCatalogManagedResource(updatedPlan) {
+		t.Error("expected the plan to have a service catalog controller reference")
+	}
+}
+
+// TestReconcileMarksNewResourcesAsManaged
+// verifies that when new service classes and plans are created during relist
+// that they are flagged as service catalog managed.
+func TestReconcileCreatesManagedClassesAndPlans(t *testing.T) {
+	_, fakeCatalogClient, _, testController, _ := newTestController(t, getTestCatalogConfig())
+
+	testClusterServiceClass := getTestClusterServiceClass()
+	testClusterServicePlan := getTestClusterServicePlan()
+
+	if err := reconcileClusterServiceBroker(t, testController, getTestClusterServiceBroker()); err != nil {
+		t.Fatalf("This should not fail: %v", err)
+	}
+
+	actions := fakeCatalogClient.Actions()
+
+	// Verify that the new class and plan are marked as managed
+	c := assertCreate(t, actions[2], testClusterServiceClass)
+	createdClass, ok := c.(metav1.Object)
+	if !ok {
+		t.Fatalf("could not cast %T to metav1.Object", c)
+	}
+	if !isServiceCatalogManagedResource(createdClass) {
+		t.Error("expected the class to have a service catalog controller reference")
+	}
+
+	p := assertCreate(t, actions[3], testClusterServicePlan)
+	createdPlan, ok := p.(metav1.Object)
+	if !ok {
+		t.Fatalf("could not cast %T to metav1.Object", p)
+	}
+	if !isServiceCatalogManagedResource(createdPlan) {
+		t.Error("expected the plan to have a service catalog controller reference")
+	}
+}
+
+// TestReconcileDoesNotUpdateUserDefinedClassesAndPlans
+// verifies that user-defined classes and plans are not modified
+// during relist.
+func TestReconcileMarksExistingClassesAndPlansAsManaged(t *testing.T) {
+	_, fakeCatalogClient, _, testController, sharedInformers := newTestController(t, getTestCatalogConfig())
+
+	testClusterServiceClass := getTestClusterServiceClass()
+	testClusterServicePlan := getTestClusterServicePlan()
+
+	// Remove the controller ref, but keep the same names as resources returned during broker list
+	testClusterServiceClass.ObjectMeta.OwnerReferences = nil
+	testClusterServicePlan.ObjectMeta.OwnerReferences = nil
+
+	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(testClusterServiceClass)
+	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(testClusterServicePlan)
+
+	fakeCatalogClient.AddReactor("list", "clusterserviceclasses", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, &v1beta1.ClusterServiceClassList{
+			Items: []v1beta1.ClusterServiceClass{
+				*testClusterServiceClass,
+			},
+		}, nil
+	})
+	fakeCatalogClient.AddReactor("list", "clusterserviceplans", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, &v1beta1.ClusterServicePlanList{
+			Items: []v1beta1.ClusterServicePlan{
+				*testClusterServicePlan,
+			},
+		}, nil
+	})
+
+	if err := reconcileClusterServiceBroker(t, testController, getTestClusterServiceBroker()); err != nil {
+		t.Fatalf("This should not fail: %v", err)
+	}
+
+	actions := fakeCatalogClient.Actions()
+
+	// Verify that the existing class and plan are now marked as managed
+	c := assertUpdate(t, actions[2], testClusterServiceClass)
+	updatedClass, ok := c.(metav1.Object)
+	if !ok {
+		t.Fatalf("could not cast %T to metav1.Object", c)
+	}
+	if !isServiceCatalogManagedResource(updatedClass) {
+		t.Error("expected the class to have a service catalog controller reference")
+	}
+
+	p := assertUpdate(t, actions[3], testClusterServicePlan)
+	updatedPlan, ok := p.(metav1.Object)
+	if !ok {
+		t.Fatalf("could not cast %T to metav1.Object", p)
+	}
+	if !isServiceCatalogManagedResource(updatedPlan) {
+		t.Error("expected the plan to have a service catalog controller reference")
+	}
+}
+
+// TestReconcileDoesNotDeleteUserDefinedClassesAndPlans
+// verifies that user-defined plans are not marked with RemovedFromBrokerCatalog during a list.
+func TestReconcileDoesNotUpdateUserDefinedClassesAndPlans(t *testing.T) {
+	_, fakeCatalogClient, _, testController, sharedInformers := newTestController(t, getTestCatalogConfig())
+
+	testClusterServiceClass := getTestClusterServiceClass()
+	testClusterServicePlan := getTestClusterServicePlan()
+
+	// Flag the class and plan as user-defined with unique names not found in the broker catalog
+	testClusterServiceClass.OwnerReferences = nil
+	testClusterServiceClass.Name = "user-defined-class"
+	testClusterServicePlan.OwnerReferences = nil
+	testClusterServicePlan.Name = "user-defined-plan"
+
+	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(testClusterServiceClass)
+	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(testClusterServicePlan)
+
+	fakeCatalogClient.AddReactor("list", "clusterserviceclasses", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, &v1beta1.ClusterServiceClassList{
+			Items: []v1beta1.ClusterServiceClass{
+				*testClusterServiceClass,
+			},
+		}, nil
+	})
+	fakeCatalogClient.AddReactor("list", "clusterserviceplans", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, &v1beta1.ClusterServicePlanList{
+			Items: []v1beta1.ClusterServicePlan{
+				*testClusterServicePlan,
+			},
+		}, nil
+	})
+
+	if err := reconcileClusterServiceBroker(t, testController, getTestClusterServiceBroker()); err != nil {
+		t.Fatalf("This should not fail: %v", err)
+	}
+
+	actions := fakeCatalogClient.Actions()
+
+	// Verify none of the actions affected the user-defined class and plan
+	for _, a := range actions {
+		r := a.GetResource().Resource
+		if a.GetVerb() == "update" &&
+			(r == "clusterserviceclasses" || r == "clusterserviceplans") {
+			t.Errorf("expected user-defined classes and plans to be ignored but found action %+v", a)
+		}
+	}
+}
+
+func TestIsServiceCatalogManagedResource(t *testing.T) {
+	testcases := []struct {
+		name     string
+		resource metav1.Object
+		want     bool
+	}{
+		{"unmanaged service class", &v1beta1.ServiceClass{}, false},
+		{"unmanaged service plan", &v1beta1.ServicePlan{}, false},
+		{"managed service class", &v1beta1.ServiceClass{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{
+			{Controller: truePtr(), APIVersion: v1beta1.SchemeGroupVersion.String()}}}}, true},
+		{"managed service plan", &v1beta1.ServicePlan{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{
+			{Controller: truePtr(), APIVersion: v1beta1.SchemeGroupVersion.String()}}}}, true},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isServiceCatalogManagedResource(tc.resource)
+			if tc.want != got {
+				t.Fatalf("WANT: %v, GOT: %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestMarkAsServiceCatalogManagedResource(t *testing.T) {
+	testcases := []struct {
+		name     string
+		resource metav1.Object
+	}{
+		{"service class", &v1beta1.ServiceClass{}},
+		{"service plan", &v1beta1.ServicePlan{}},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			broker := getTestClusterServiceBroker()
+			markAsServiceCatalogManagedResource(tc.resource, broker)
+
+			numOwners := len(tc.resource.GetOwnerReferences())
+			if numOwners != 1 {
+				t.Fatalf("Expected 1 owner reference, got %v", numOwners)
+			}
+
+			gotOwner := tc.resource.GetOwnerReferences()[0]
+
+			gotIsController := gotOwner.Controller != nil && *gotOwner.Controller == true
+			if !gotIsController {
+				t.Errorf("Expected a controller reference, but Controller is false")
+			}
+
+			gotBlockOwnerDeletion := gotOwner.BlockOwnerDeletion != nil && *gotOwner.BlockOwnerDeletion == true
+			if gotBlockOwnerDeletion {
+				t.Errorf("Expected the controller reference to not modify deletion semantics, but BlockOwnerDeletion is true")
+			}
+
+			wantAPIVersion := v1beta1.SchemeGroupVersion.String()
+			gotAPIVersion := gotOwner.APIVersion
+			if wantAPIVersion != gotAPIVersion {
+				t.Errorf("unexpected APIVersion. WANT: %q, GOT: %q", wantAPIVersion, gotAPIVersion)
+			}
+
+			// Also verify that our pair of functions work together
+			if !isServiceCatalogManagedResource(tc.resource) {
+				t.Fatal("expected isServiceCatalogManagedResource to return true")
+			}
+		})
+	}
+}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -527,7 +527,8 @@ func getTestClusterServiceBrokerWithAuth(authInfo *v1beta1.ClusterServiceBrokerA
 
 // a bindable service class wired to the result of getTestClusterServiceBroker()
 func getTestClusterServiceClass() *v1beta1.ClusterServiceClass {
-	return &v1beta1.ClusterServiceClass{
+	broker := getTestClusterServiceBroker()
+	class := &v1beta1.ClusterServiceClass{
 		ObjectMeta: metav1.ObjectMeta{Name: testClusterServiceClassGUID},
 		Spec: v1beta1.ClusterServiceClassSpec{
 			ClusterServiceBrokerName: testClusterServiceBrokerName,
@@ -539,10 +540,13 @@ func getTestClusterServiceClass() *v1beta1.ClusterServiceClass {
 			},
 		},
 	}
+	markAsServiceCatalogManagedResource(class, broker)
+	return class
 }
 
 func getTestMarkedAsRemovedClusterServiceClass() *v1beta1.ClusterServiceClass {
-	return &v1beta1.ClusterServiceClass{
+	broker := getTestClusterServiceBroker()
+	class := &v1beta1.ClusterServiceClass{
 		ObjectMeta: metav1.ObjectMeta{Name: testRemovedClusterServiceClassGUID},
 		Spec: v1beta1.ClusterServiceClassSpec{
 			ClusterServiceBrokerName: testClusterServiceBrokerName,
@@ -559,10 +563,13 @@ func getTestMarkedAsRemovedClusterServiceClass() *v1beta1.ClusterServiceClass {
 			},
 		},
 	}
+	markAsServiceCatalogManagedResource(class, broker)
+	return class
 }
 
 func getTestRemovedClusterServiceClass() *v1beta1.ClusterServiceClass {
-	return &v1beta1.ClusterServiceClass{
+	broker := getTestClusterServiceBroker()
+	class := &v1beta1.ClusterServiceClass{
 		ObjectMeta: metav1.ObjectMeta{Name: testRemovedClusterServiceClassGUID},
 		Spec: v1beta1.ClusterServiceClassSpec{
 			ClusterServiceBrokerName: testClusterServiceBrokerName,
@@ -574,6 +581,8 @@ func getTestRemovedClusterServiceClass() *v1beta1.ClusterServiceClass {
 			},
 		},
 	}
+	markAsServiceCatalogManagedResource(class, broker)
+	return class
 }
 
 func getTestBindingRetrievableClusterServiceClass() *v1beta1.ClusterServiceClass {
@@ -593,7 +602,8 @@ func getTestBindingRetrievableClusterServiceClass() *v1beta1.ClusterServiceClass
 }
 
 func getTestClusterServicePlan() *v1beta1.ClusterServicePlan {
-	return &v1beta1.ClusterServicePlan{
+	broker := getTestClusterServiceBroker()
+	plan := &v1beta1.ClusterServicePlan{
 		ObjectMeta: metav1.ObjectMeta{Name: testClusterServicePlanGUID},
 		Spec: v1beta1.ClusterServicePlanSpec{
 			ClusterServiceBrokerName: testClusterServiceBrokerName,
@@ -608,10 +618,13 @@ func getTestClusterServicePlan() *v1beta1.ClusterServicePlan {
 		},
 		Status: v1beta1.ClusterServicePlanStatus{},
 	}
+	markAsServiceCatalogManagedResource(plan, broker)
+	return plan
 }
 
 func getTestMarkedAsRemovedClusterServicePlan() *v1beta1.ClusterServicePlan {
-	return &v1beta1.ClusterServicePlan{
+	broker := getTestClusterServiceBroker()
+	plan := &v1beta1.ClusterServicePlan{
 		ObjectMeta: metav1.ObjectMeta{Name: testRemovedClusterServicePlanGUID},
 		Spec: v1beta1.ClusterServicePlanSpec{
 			ClusterServiceBrokerName: testClusterServiceBrokerName,
@@ -630,10 +643,13 @@ func getTestMarkedAsRemovedClusterServicePlan() *v1beta1.ClusterServicePlan {
 			},
 		},
 	}
+	markAsServiceCatalogManagedResource(plan, broker)
+	return plan
 }
 
 func getTestRemovedClusterServicePlan() *v1beta1.ClusterServicePlan {
-	return &v1beta1.ClusterServicePlan{
+	broker := getTestClusterServiceBroker()
+	plan := &v1beta1.ClusterServicePlan{
 		ObjectMeta: metav1.ObjectMeta{Name: testRemovedClusterServicePlanGUID},
 		Spec: v1beta1.ClusterServicePlanSpec{
 			ClusterServiceBrokerName: testClusterServiceBrokerName,
@@ -647,10 +663,13 @@ func getTestRemovedClusterServicePlan() *v1beta1.ClusterServicePlan {
 			},
 		},
 	}
+	markAsServiceCatalogManagedResource(plan, broker)
+	return plan
 }
 
 func getTestClusterServicePlanNonbindable() *v1beta1.ClusterServicePlan {
-	return &v1beta1.ClusterServicePlan{
+	broker := getTestClusterServiceBroker()
+	plan := &v1beta1.ClusterServicePlan{
 		ObjectMeta: metav1.ObjectMeta{Name: testNonbindableClusterServicePlanGUID},
 		Spec: v1beta1.ClusterServicePlanSpec{
 			CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
@@ -663,6 +682,8 @@ func getTestClusterServicePlanNonbindable() *v1beta1.ClusterServicePlan {
 			},
 		},
 	}
+	markAsServiceCatalogManagedResource(plan, broker)
+	return plan
 }
 
 // an unbindable service class wired to the result of getTestClusterServiceBroker()


### PR DESCRIPTION
This is the first step towards supporting [user-defined classes and plans](https://github.com/carolynvs/service-catalog/blob/default-service-plan-proposal/docs/proposals/default-service-plans.md#user-defined-plans) from #1896. Before we can allow users to create them, we need to make sure that our controller doesn't immediately nuke them. 😀 

* Classes and plans that were created by the service catalog controller during a list now have a controller reference set to indicate that they are managed by service catalog.
* User defined classes and plans will not have a controller reference set, and are left alone during a list.

Closes #2060 
