### PR TITLE
Verify builds on all platforms on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ cache:
     - .pkg
 stages:
   - test
+  - xbuild # Test all of our supported platform builds for master builds
+    if: type != pull_request
   - name: deploy
     if: type != pull_request
 before_install:
@@ -40,6 +42,9 @@ script:
 jobs:
   include:
     # Test is implicit from the build matrix
+    # Cross Build
+    - stage: xbuild
+      script: make images-all
     # Deploy
     - stage: deploy
       script: skip


### PR DESCRIPTION
This is to avoid realizing too late (when we tag a release) that one of the supported architectures has a build problem. I didn't want to slow down all the PR builds, so I'm only doing this for master.