### PR TITLE
Allow lists in --param

### DIFF
--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -41,8 +41,8 @@ func ParseVariableJSON(params string) (map[string]interface{}, error) {
 // into a map of keys and values
 // Example:
 // [a=b c=abc1232===] becomes map[a:b c:abc1232===]
-func ParseVariableAssignments(params []string) (map[string]string, error) {
-	variables := map[string]string{}
+func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
+	variables:= make(map[string]interface{})
 	for _, p := range params {
 
 		parts := strings.SplitN(p, "=", 2)

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -40,11 +40,11 @@ func ParseVariableJSON(params string) (map[string]interface{}, error) {
 // ParseVariableAssignments converts a string array of variable assignments
 // into a map of keys and values
 // Example:
-// [a=b c=abc1232===] becomes map[a:b c:abc1232===]
-func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
-	variables := make(map[string]interface{})
-	for _, p := range params {
+// [a=b c=abc123 a=somethingelse] becomes map[a:[b,somethingelse] c=[abc123]]
+func ParseVariableAssignments(params []string) (map[string][]string, error) {
+	variables := make(map[string][]string)
 
+	for _, p := range params {
 		parts := strings.SplitN(p, "=", 2)
 		if len(parts) < 2 {
 			return nil, fmt.Errorf("invalid parameter (%s), must be in name=value format", p)
@@ -56,7 +56,12 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 		}
 		value := strings.TrimSpace(parts[1])
 
-		variables[variable] = value
+		_, ok := variables[variable]
+		if !ok {
+			variables[variable] = make([]string, 0)
+		}
+
+		variables[variable] = append(variables[variable], value)
 	}
 
 	return variables, nil

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -61,14 +61,14 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 		// if variable DNE: add pair to variables as variable:value
 		// if variable exists in form of variable:value, create array to hold old value&new value
 		// if variable exists in form variable:[some values], append new value to existing array
-		if !ok{
-			variables[variable] = value	// if there is no key, add key&value as string
-		}else{
-			switch storedValType:= storedValue.(type){
+		if !ok {
+			variables[variable] = value // if there is no key, add key&value as string
+		} else {
+			switch storedValType := storedValue.(type) {
 			case string:
-				variables[variable] =[]string{storedValType,value}
+				variables[variable] = []string{storedValType, value}
 			case []string:
-				variables[variable]=append(storedValType,value)
+				variables[variable] = append(storedValType, value)
 			}
 		}
 	}

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -40,7 +40,7 @@ func ParseVariableJSON(params string) (map[string]interface{}, error) {
 // ParseVariableAssignments converts a string array of variable assignments
 // into a map of keys and values
 // Example:
-// [a=b c=abc1232===] becomes map[a:b c:abc1232===]
+// [a=b c=abc1232=== d=banana d=pineapple] becomes map[a:b c:abc1232=== d:[banana pineapple]]
 func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 	variables := make(map[string]interface{})
 	for _, p := range params {
@@ -57,7 +57,10 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 		value := strings.TrimSpace(parts[1])
 
 		storedValue, ok := variables[variable]
-
+		// Logic to add new value to map variables:
+		// if variable DNE: add pair to variables as variable:value
+		// if variable exists in form of variable:value, create array to hold old value&new value
+		// if variable exists in form variable:[some values], append new value to existing array
 		if !ok{
 			variables[variable] = value	// if there is no key, add key&value as string
 		}else{

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -42,7 +42,7 @@ func ParseVariableJSON(params string) (map[string]interface{}, error) {
 // Example:
 // [a=b c=abc1232===] becomes map[a:b c:abc1232===]
 func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
-	variables:= make(map[string]interface{})
+	variables := make(map[string]interface{})
 	for _, p := range params {
 
 		parts := strings.SplitN(p, "=", 2)

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -56,11 +56,6 @@ func ParseVariableAssignments(params []string) (map[string][]string, error) {
 		}
 		value := strings.TrimSpace(parts[1])
 
-		_, ok := variables[variable]
-		if !ok {
-			variables[variable] = make([]string, 0)
-		}
-
 		variables[variable] = append(variables[variable], value)
 	}
 

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -40,11 +40,11 @@ func ParseVariableJSON(params string) (map[string]interface{}, error) {
 // ParseVariableAssignments converts a string array of variable assignments
 // into a map of keys and values
 // Example:
-// [a=b c=abc123 a=somethingelse] becomes map[a:[b,somethingelse] c=[abc123]]
-func ParseVariableAssignments(params []string) (map[string][]string, error) {
-	variables := make(map[string][]string)
-
+// [a=b c=abc1232===] becomes map[a:b c:abc1232===]
+func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
+	variables := make(map[string]interface{})
 	for _, p := range params {
+
 		parts := strings.SplitN(p, "=", 2)
 		if len(parts) < 2 {
 			return nil, fmt.Errorf("invalid parameter (%s), must be in name=value format", p)
@@ -56,7 +56,7 @@ func ParseVariableAssignments(params []string) (map[string][]string, error) {
 		}
 		value := strings.TrimSpace(parts[1])
 
-		variables[variable] = append(variables[variable], value)
+		variables[variable] = value
 	}
 
 	return variables, nil

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -56,7 +56,18 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 		}
 		value := strings.TrimSpace(parts[1])
 
-		variables[variable] = value
+		storedValue, ok := variables[variable]
+
+		if !ok{
+			variables[variable] = value	// if there is no key, add key&value as string
+		}else{
+			switch storedValType:= storedValue.(type){
+			case string:
+				variables[variable] =[]string{storedValType,value}
+			case []string:
+				variables[variable]=append(storedValType,value)
+			}
+		}
 	}
 
 	return variables, nil

--- a/cmd/svcat/parameters/parameters_test.go
+++ b/cmd/svcat/parameters/parameters_test.go
@@ -43,7 +43,7 @@ func TestParseVariableAssignments(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			want:= make(map[string]interface{})
+			want := make(map[string]interface{})
 			want[tc.Variable] = tc.Value
 			if !reflect.DeepEqual(want, got) {
 				t.Fatalf("%s\nexpected:\n\t%v\ngot:\n\t%v\n", tc.Raw, want, got)

--- a/cmd/svcat/parameters/parameters_test.go
+++ b/cmd/svcat/parameters/parameters_test.go
@@ -61,6 +61,23 @@ func TestParseVariableAssignments_MissingVariableName(t *testing.T) {
 	}
 }
 
+func TestParseVariableAssignments_OneVariableTwoValues(t *testing.T) {
+	params := []string{"a=banana", "a=pineapple"}
+
+	got, err := ParseVariableAssignments(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]interface{}{
+		"a": []string{"banana", "pineapple"},
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("%s\nexpected:\n\t%v\ngot:\n\t%v\n", "one var two values", want, got)
+	}
+}
+
 func TestParseKeyMaps(t *testing.T) {
 	testcases := []struct {
 		Name, Raw, MapName, Key string

--- a/cmd/svcat/parameters/parameters_test.go
+++ b/cmd/svcat/parameters/parameters_test.go
@@ -43,7 +43,8 @@ func TestParseVariableAssignments(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			want := map[string]string{tc.Variable: tc.Value}
+			want:= make(map[string]interface{})
+			want[tc.Variable] = tc.Value
 			if !reflect.DeepEqual(want, got) {
 				t.Fatalf("%s\nexpected:\n\t%v\ngot:\n\t%v\n", tc.Raw, want, got)
 			}

--- a/cmd/svcat/parameters/parameters_test.go
+++ b/cmd/svcat/parameters/parameters_test.go
@@ -43,8 +43,8 @@ func TestParseVariableAssignments(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			want := make(map[string]interface{})
-			want[tc.Variable] = tc.Value
+			want := make(map[string][]string)
+			want[tc.Variable] = append(want[tc.Variable], tc.Value)
 			if !reflect.DeepEqual(want, got) {
 				t.Fatalf("%s\nexpected:\n\t%v\ngot:\n\t%v\n", tc.Raw, want, got)
 			}

--- a/cmd/svcat/parameters/parameters_test.go
+++ b/cmd/svcat/parameters/parameters_test.go
@@ -43,8 +43,8 @@ func TestParseVariableAssignments(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			want := make(map[string][]string)
-			want[tc.Variable] = append(want[tc.Variable], tc.Value)
+			want := make(map[string]interface{})
+			want[tc.Variable] = tc.Value
 			if !reflect.DeepEqual(want, got) {
 				t.Fatalf("%s\nexpected:\n\t%v\ngot:\n\t%v\n", tc.Raw, want, got)
 			}


### PR DESCRIPTION
closes #1987 

Summary: Change ParseVariableFunction to return map[string]interface{}. 

Function will allow svcat to accept multiple values for a variable and store those values as a list so that:

-p varname = value1 -p varname = value2 --> "varname": ["value1" "value2"]


