### PR TITLE
Split docs build into travis stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ jobs:
           make images-all
         fi
       env: XBUILD=true
+    # Doc Site svc-cat.io
+    - stage: test
+      script: make docs
+      env: DOCS=true
     # Deploy
     - stage: deploy
       script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
           # Builds triggered by initial commit of a new branch.
           DOCS_ONLY=0
       else
-          DOCS_REGEX='(OWNERS|LICENSE)|(\.md$)|(^docs/)'
+          DOCS_REGEX='(OWNERS|LICENSE)|(\.md$)|(^docs/)|(^docsite/)'
           [[ -z "$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -vE $DOCS_REGEX)" ]]
           DOCS_ONLY=$?
       fi

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ verify: .init verify-generated verify-client-gen verify-docs verify-vendor
 	@echo Running tag verification:
 	@$(DOCKER_CMD) build/verify-tags.sh
 
-verify-docs: .init docs
+verify-docs: .init
 	@echo Running href checker$(SKIP_COMMENT):
 	@$(DOCKER_CMD) verify-links.sh -s .pkg -s .bundler -s _plugins -s _includes -t $(SKIP_HTTP) .
 


### PR DESCRIPTION
This helps us shave time off of the main build (which is limited to 50min) and
makes it easier to identify when the build failed, vs. weird jekyll stuff.

Closes #2086 