### PR TITLE
Refactor Namespaced svcat commands

### DIFF
--- a/cmd/svcat/binding/bind_cmd.go
+++ b/cmd/svcat/binding/bind_cmd.go
@@ -26,7 +26,7 @@ import (
 )
 
 type bindCmd struct {
-	*command.NamespacedCommand
+	*command.Namespaced
 	*command.Waitable
 
 	instanceName string
@@ -43,8 +43,8 @@ type bindCmd struct {
 // NewBindCmd builds a "svcat bind" command
 func NewBindCmd(cxt *command.Context) *cobra.Command {
 	bindCmd := &bindCmd{
-		NamespacedCommand: command.NewNamespacedCommand(cxt),
-		Waitable:          command.NewWaitable(),
+		Namespaced: command.NewNamespaced(cxt),
+		Waitable:   command.NewWaitable(),
 	}
 	cmd := &cobra.Command{
 		Use:   "bind INSTANCE_NAME",

--- a/cmd/svcat/binding/bind_cmd.go
+++ b/cmd/svcat/binding/bind_cmd.go
@@ -27,7 +27,7 @@ import (
 
 type bindCmd struct {
 	*command.NamespacedCommand
-	*command.WaitableCommand
+	*command.Waitable
 
 	instanceName string
 	bindingName  string
@@ -44,7 +44,7 @@ type bindCmd struct {
 func NewBindCmd(cxt *command.Context) *cobra.Command {
 	bindCmd := &bindCmd{
 		NamespacedCommand: command.NewNamespacedCommand(cxt),
-		WaitableCommand:   command.NewWaitableCommand(),
+		Waitable:          command.NewWaitable(),
 	}
 	cmd := &cobra.Command{
 		Use:   "bind INSTANCE_NAME",

--- a/cmd/svcat/binding/bind_cmd.go
+++ b/cmd/svcat/binding/bind_cmd.go
@@ -66,7 +66,7 @@ func NewBindCmd(cxt *command.Context) *cobra.Command {
 		PreRunE: command.PreRunE(bindCmd),
 		RunE:    command.RunE(bindCmd),
 	}
-	command.AddNamespaceFlags(cmd.Flags(), false)
+	bindCmd.AddNamespaceFlags(cmd.Flags(), false)
 	cmd.Flags().StringVarP(
 		&bindCmd.bindingName,
 		"name",

--- a/cmd/svcat/binding/bind_cmd.go
+++ b/cmd/svcat/binding/bind_cmd.go
@@ -26,7 +26,7 @@ import (
 )
 
 type bindCmd struct {
-	*command.Namespaced
+	*command.NamespacedCommand
 	*command.WaitableCommand
 
 	instanceName string
@@ -43,8 +43,8 @@ type bindCmd struct {
 // NewBindCmd builds a "svcat bind" command
 func NewBindCmd(cxt *command.Context) *cobra.Command {
 	bindCmd := &bindCmd{
-		Namespaced:      command.NewNamespacedCommand(cxt),
-		WaitableCommand: command.NewWaitableCommand(),
+		NamespacedCommand: command.NewNamespacedCommand(cxt),
+		WaitableCommand:   command.NewWaitableCommand(),
 	}
 	cmd := &cobra.Command{
 		Use:   "bind INSTANCE_NAME",

--- a/cmd/svcat/binding/describe_cmd.go
+++ b/cmd/svcat/binding/describe_cmd.go
@@ -41,7 +41,7 @@ func NewDescribeCmd(cxt *command.Context) *cobra.Command {
 		PreRunE: command.PreRunE(describeCmd),
 		RunE:    command.RunE(describeCmd),
 	}
-	command.AddNamespaceFlags(cmd.Flags(), false)
+	describeCmd.AddNamespaceFlags(cmd.Flags(), false)
 	cmd.Flags().BoolVar(
 		&describeCmd.showSecrets,
 		"show-secrets",

--- a/cmd/svcat/binding/describe_cmd.go
+++ b/cmd/svcat/binding/describe_cmd.go
@@ -25,14 +25,14 @@ import (
 )
 
 type describeCmd struct {
-	*command.NamespacedCommand
+	*command.Namespaced
 	name        string
 	showSecrets bool
 }
 
 // NewDescribeCmd builds a "svcat describe binding" command
 func NewDescribeCmd(cxt *command.Context) *cobra.Command {
-	describeCmd := &describeCmd{NamespacedCommand: command.NewNamespacedCommand(cxt)}
+	describeCmd := &describeCmd{Namespaced: command.NewNamespaced(cxt)}
 	cmd := &cobra.Command{
 		Use:     "binding NAME",
 		Aliases: []string{"bindings", "bnd"},

--- a/cmd/svcat/binding/describe_cmd.go
+++ b/cmd/svcat/binding/describe_cmd.go
@@ -25,14 +25,14 @@ import (
 )
 
 type describeCmd struct {
-	*command.Namespaced
+	*command.NamespacedCommand
 	name        string
 	showSecrets bool
 }
 
 // NewDescribeCmd builds a "svcat describe binding" command
 func NewDescribeCmd(cxt *command.Context) *cobra.Command {
-	describeCmd := &describeCmd{Namespaced: command.NewNamespacedCommand(cxt)}
+	describeCmd := &describeCmd{NamespacedCommand: command.NewNamespacedCommand(cxt)}
 	cmd := &cobra.Command{
 		Use:     "binding NAME",
 		Aliases: []string{"bindings", "bnd"},

--- a/cmd/svcat/binding/get_cmd.go
+++ b/cmd/svcat/binding/get_cmd.go
@@ -23,7 +23,7 @@ import (
 )
 
 type getCmd struct {
-	*command.NamespacedCommand
+	*command.Namespaced
 	name         string
 	outputFormat string
 }
@@ -34,7 +34,7 @@ func (c *getCmd) SetFormat(format string) {
 
 // NewGetCmd builds a "svcat get bindings" command
 func NewGetCmd(cxt *command.Context) *cobra.Command {
-	getCmd := &getCmd{NamespacedCommand: command.NewNamespacedCommand(cxt)}
+	getCmd := &getCmd{Namespaced: command.NewNamespaced(cxt)}
 	cmd := &cobra.Command{
 		Use:     "bindings [NAME]",
 		Aliases: []string{"binding", "bnd"},

--- a/cmd/svcat/binding/get_cmd.go
+++ b/cmd/svcat/binding/get_cmd.go
@@ -23,7 +23,7 @@ import (
 )
 
 type getCmd struct {
-	*command.Namespaced
+	*command.NamespacedCommand
 	name         string
 	outputFormat string
 }
@@ -34,7 +34,7 @@ func (c *getCmd) SetFormat(format string) {
 
 // NewGetCmd builds a "svcat get bindings" command
 func NewGetCmd(cxt *command.Context) *cobra.Command {
-	getCmd := &getCmd{Namespaced: command.NewNamespacedCommand(cxt)}
+	getCmd := &getCmd{NamespacedCommand: command.NewNamespacedCommand(cxt)}
 	cmd := &cobra.Command{
 		Use:     "bindings [NAME]",
 		Aliases: []string{"binding", "bnd"},

--- a/cmd/svcat/binding/get_cmd.go
+++ b/cmd/svcat/binding/get_cmd.go
@@ -49,7 +49,7 @@ func NewGetCmd(cxt *command.Context) *cobra.Command {
 		RunE:    command.RunE(getCmd),
 	}
 
-	command.AddNamespaceFlags(cmd.Flags(), true)
+	getCmd.AddNamespaceFlags(cmd.Flags(), true)
 	command.AddOutputFlags(cmd.Flags())
 	return cmd
 }

--- a/cmd/svcat/binding/unbind_cmd.go
+++ b/cmd/svcat/binding/unbind_cmd.go
@@ -32,7 +32,7 @@ import (
 
 type unbindCmd struct {
 	*command.NamespacedCommand
-	*command.WaitableCommand
+	*command.Waitable
 
 	instanceName string
 	bindingName  string
@@ -42,7 +42,7 @@ type unbindCmd struct {
 func NewUnbindCmd(cxt *command.Context) *cobra.Command {
 	unbindCmd := &unbindCmd{
 		NamespacedCommand: command.NewNamespacedCommand(cxt),
-		WaitableCommand:   command.NewWaitableCommand(),
+		Waitable:          command.NewWaitable(),
 	}
 	cmd := &cobra.Command{
 		Use:   "unbind INSTANCE_NAME",

--- a/cmd/svcat/binding/unbind_cmd.go
+++ b/cmd/svcat/binding/unbind_cmd.go
@@ -31,7 +31,7 @@ import (
 )
 
 type unbindCmd struct {
-	*command.NamespacedCommand
+	*command.Namespaced
 	*command.Waitable
 
 	instanceName string
@@ -41,8 +41,8 @@ type unbindCmd struct {
 // NewUnbindCmd builds a "svcat unbind" command
 func NewUnbindCmd(cxt *command.Context) *cobra.Command {
 	unbindCmd := &unbindCmd{
-		NamespacedCommand: command.NewNamespacedCommand(cxt),
-		Waitable:          command.NewWaitable(),
+		Namespaced: command.NewNamespaced(cxt),
+		Waitable:   command.NewWaitable(),
 	}
 	cmd := &cobra.Command{
 		Use:   "unbind INSTANCE_NAME",

--- a/cmd/svcat/binding/unbind_cmd.go
+++ b/cmd/svcat/binding/unbind_cmd.go
@@ -54,7 +54,7 @@ func NewUnbindCmd(cxt *command.Context) *cobra.Command {
 		PreRunE: command.PreRunE(unbindCmd),
 		RunE:    command.RunE(unbindCmd),
 	}
-	command.AddNamespaceFlags(cmd.Flags(), false)
+	unbindCmd.AddNamespaceFlags(cmd.Flags(), false)
 	cmd.Flags().StringVar(
 		&unbindCmd.bindingName,
 		"name",

--- a/cmd/svcat/binding/unbind_cmd.go
+++ b/cmd/svcat/binding/unbind_cmd.go
@@ -31,7 +31,7 @@ import (
 )
 
 type unbindCmd struct {
-	*command.Namespaced
+	*command.NamespacedCommand
 	*command.WaitableCommand
 
 	instanceName string
@@ -41,8 +41,8 @@ type unbindCmd struct {
 // NewUnbindCmd builds a "svcat unbind" command
 func NewUnbindCmd(cxt *command.Context) *cobra.Command {
 	unbindCmd := &unbindCmd{
-		Namespaced:      command.NewNamespacedCommand(cxt),
-		WaitableCommand: command.NewWaitableCommand(),
+		NamespacedCommand: command.NewNamespacedCommand(cxt),
+		WaitableCommand:   command.NewWaitableCommand(),
 	}
 	cmd := &cobra.Command{
 		Use:   "unbind INSTANCE_NAME",

--- a/cmd/svcat/binding/unbind_cmd_test.go
+++ b/cmd/svcat/binding/unbind_cmd_test.go
@@ -157,8 +157,8 @@ func TestUnbindCommand(t *testing.T) {
 
 			// Initialize the command arguments
 			cmd := &unbindCmd{
-				NamespacedCommand: command.NewNamespacedCommand(cxt),
-				Waitable:          command.NewWaitable(),
+				Namespaced: command.NewNamespaced(cxt),
+				Waitable:   command.NewWaitable(),
 			}
 			cmd.Namespace = ns
 			cmd.bindingName = tc.bindingName

--- a/cmd/svcat/binding/unbind_cmd_test.go
+++ b/cmd/svcat/binding/unbind_cmd_test.go
@@ -157,8 +157,8 @@ func TestUnbindCommand(t *testing.T) {
 
 			// Initialize the command arguments
 			cmd := &unbindCmd{
-				Namespaced:      command.NewNamespacedCommand(cxt),
-				WaitableCommand: command.NewWaitableCommand(),
+				NamespacedCommand: command.NewNamespacedCommand(cxt),
+				WaitableCommand:   command.NewWaitableCommand(),
 			}
 			cmd.Namespace = ns
 			cmd.bindingName = tc.bindingName

--- a/cmd/svcat/binding/unbind_cmd_test.go
+++ b/cmd/svcat/binding/unbind_cmd_test.go
@@ -158,7 +158,7 @@ func TestUnbindCommand(t *testing.T) {
 			// Initialize the command arguments
 			cmd := &unbindCmd{
 				NamespacedCommand: command.NewNamespacedCommand(cxt),
-				WaitableCommand:   command.NewWaitableCommand(),
+				Waitable:          command.NewWaitable(),
 			}
 			cmd.Namespace = ns
 			cmd.bindingName = tc.bindingName

--- a/cmd/svcat/command/command.go
+++ b/cmd/svcat/command/command.go
@@ -34,8 +34,8 @@ type Command interface {
 	Run() error
 }
 
-// NamespacedCommand represents a command that can be scoped to a namespace.
-type NamespacedCommand interface {
+// HasNamespaceFlags represents a command that can be scoped to a namespace.
+type HasNamespaceFlags interface {
 	Command
 
 	// GetContext retrieves the command's context.
@@ -55,7 +55,7 @@ type FormattedCommand interface {
 // PreRunE validates os args, and then saves them on the svcat command.
 func PreRunE(cmd Command) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, args []string) error {
-		if nsCmd, ok := cmd.(NamespacedCommand); ok {
+		if nsCmd, ok := cmd.(HasNamespaceFlags); ok {
 			namespace := DetermineNamespace(c.Flags(), nsCmd.GetContext().App.CurrentNamespace)
 			nsCmd.SetNamespace(namespace)
 		}

--- a/cmd/svcat/command/command.go
+++ b/cmd/svcat/command/command.go
@@ -71,25 +71,6 @@ func RunE(cmd Command) func(*cobra.Command, []string) error {
 	}
 }
 
-// AddNamespaceFlags applies the --namespace and --all-namespaces flags to a command.
-// This is intended to be used in conjunction with the NamespacedCommand interface.
-func AddNamespaceFlags(flags *pflag.FlagSet, allowAll bool) {
-	flags.StringP(
-		"namespace",
-		"n",
-		"",
-		"If present, the namespace scope for this request",
-	)
-
-	if allowAll {
-		flags.Bool(
-			"all-namespaces",
-			false,
-			"If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace",
-		)
-	}
-}
-
 // AddOutputFlags adds common output flags to a command that can have variable output formats.
 func AddOutputFlags(flags *pflag.FlagSet) {
 	flags.StringP(

--- a/cmd/svcat/command/namespaced.go
+++ b/cmd/svcat/command/namespaced.go
@@ -17,22 +17,22 @@ limitations under the License.
 package command
 
 // Namespaced is the base command of all svcat commands that are namespace scoped.
-type Namespaced struct {
+type NamespacedCommand struct {
 	*Context
 	Namespace string
 }
 
 // NewNamespacedCommand from context.
-func NewNamespacedCommand(cxt *Context) *Namespaced {
-	return &Namespaced{Context: cxt}
+func NewNamespacedCommand(cxt *Context) *NamespacedCommand {
+	return &NamespacedCommand{Context: cxt}
 }
 
 // GetContext retrieves the command's context.
-func (c *Namespaced) GetContext() *Context {
+func (c *NamespacedCommand) GetContext() *Context {
 	return c.Context
 }
 
 // SetNamespace sets the effective namespace for the command.
-func (c *Namespaced) SetNamespace(namespace string) {
+func (c *NamespacedCommand) SetNamespace(namespace string) {
 	c.Namespace = namespace
 }

--- a/cmd/svcat/command/namespaced.go
+++ b/cmd/svcat/command/namespaced.go
@@ -28,7 +28,7 @@ type HasNamespaceFlags interface {
 	ApplyNamespaceFlags(flags *pflag.FlagSet)
 }
 
-// Namespaced is the base command of all svcat commands that are namespace scoped.
+// NamespacedCommand is the base command of all svcat commands that are namespace scoped.
 type NamespacedCommand struct {
 	*Context
 	Namespace string

--- a/cmd/svcat/command/namespaced.go
+++ b/cmd/svcat/command/namespaced.go
@@ -39,6 +39,24 @@ func NewNamespacedCommand(cxt *Context) *NamespacedCommand {
 	return &NamespacedCommand{Context: cxt}
 }
 
+// AddNamespaceFlags adds the namespace-related flags:
+// * --namespace
+// * --all-namespaces
+func (c *NamespacedCommand) AddNamespaceFlags(flags *pflag.FlagSet, allowAll bool) {
+	flags.StringP(
+		"namespace",
+		"n",
+		"",
+		"If present, the namespace scope for this request",
+	)
+
+	if allowAll {
+		flags.Bool(
+			"all-namespaces",
+			false,
+			"If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace",
+		)
+	}
 }
 
 // ApplyNamespaceFlags persists the namespace-related flags:

--- a/cmd/svcat/command/namespaced.go
+++ b/cmd/svcat/command/namespaced.go
@@ -28,21 +28,21 @@ type HasNamespaceFlags interface {
 	ApplyNamespaceFlags(flags *pflag.FlagSet)
 }
 
-// NamespacedCommand is the base command of all svcat commands that are namespace scoped.
-type NamespacedCommand struct {
+// Namespaced is the base command of all svcat commands that are namespace scoped.
+type Namespaced struct {
 	*Context
 	Namespace string
 }
 
-// NewNamespacedCommand from context.
-func NewNamespacedCommand(cxt *Context) *NamespacedCommand {
-	return &NamespacedCommand{Context: cxt}
+// NewNamespaced from context.
+func NewNamespaced(cxt *Context) *Namespaced {
+	return &Namespaced{Context: cxt}
 }
 
 // AddNamespaceFlags adds the namespace-related flags:
 // * --namespace
 // * --all-namespaces
-func (c *NamespacedCommand) AddNamespaceFlags(flags *pflag.FlagSet, allowAll bool) {
+func (c *Namespaced) AddNamespaceFlags(flags *pflag.FlagSet, allowAll bool) {
 	flags.StringP(
 		"namespace",
 		"n",
@@ -62,12 +62,12 @@ func (c *NamespacedCommand) AddNamespaceFlags(flags *pflag.FlagSet, allowAll boo
 // ApplyNamespaceFlags persists the namespace-related flags:
 // * --namespace
 // * --all-namespaces
-func (c *NamespacedCommand) ApplyNamespaceFlags(flags *pflag.FlagSet) {
+func (c *Namespaced) ApplyNamespaceFlags(flags *pflag.FlagSet) {
 	c.Namespace = c.determineNamespace(flags)
 }
 
 // determineNamespace using the current context's namespace, and the user-requested namespace.
-func (c *NamespacedCommand) determineNamespace(flags *pflag.FlagSet) string {
+func (c *Namespaced) determineNamespace(flags *pflag.FlagSet) string {
 	currentNamespace := c.Context.App.CurrentNamespace
 
 	namespace, _ := flags.GetString("namespace")

--- a/cmd/svcat/command/waitable.go
+++ b/cmd/svcat/command/waitable.go
@@ -32,8 +32,8 @@ type HasWaitFlags interface {
 	ApplyWaitFlags() error
 }
 
-// WaitableCommand adds support to a command for the --wait flags.
-type WaitableCommand struct {
+// Waitable adds support to a command for the --wait flags.
+type Waitable struct {
 	Wait        bool
 	rawTimeout  string
 	Timeout     *time.Duration
@@ -41,16 +41,16 @@ type WaitableCommand struct {
 	Interval    time.Duration
 }
 
-// NewWaitableCommand initializes a new waitable command.
-func NewWaitableCommand() *WaitableCommand {
-	return &WaitableCommand{}
+// NewWaitable initializes a new waitable command.
+func NewWaitable() *Waitable {
+	return &Waitable{}
 }
 
 // AddWaitFlags adds the wait related flags.
 //   --wait
 //   --timeout
 //   --interval
-func (c *WaitableCommand) AddWaitFlags(cmd *cobra.Command) {
+func (c *Waitable) AddWaitFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&c.Wait, "wait", false,
 		"Wait until the operation completes.")
 	cmd.Flags().StringVar(&c.rawTimeout, "timeout", "5m",
@@ -63,7 +63,7 @@ func (c *WaitableCommand) AddWaitFlags(cmd *cobra.Command) {
 //   --wait
 //   --timeout
 //   --interval
-func (c *WaitableCommand) ApplyWaitFlags() error {
+func (c *Waitable) ApplyWaitFlags() error {
 	if !c.Wait {
 		return nil
 	}

--- a/cmd/svcat/instance/deprovision_cmd.go
+++ b/cmd/svcat/instance/deprovision_cmd.go
@@ -27,7 +27,7 @@ import (
 )
 
 type deprovisonCmd struct {
-	*command.Namespaced
+	*command.NamespacedCommand
 	*command.WaitableCommand
 
 	instanceName string
@@ -36,8 +36,8 @@ type deprovisonCmd struct {
 // NewDeprovisionCmd builds a "svcat deprovision" command
 func NewDeprovisionCmd(cxt *command.Context) *cobra.Command {
 	deprovisonCmd := &deprovisonCmd{
-		Namespaced:      command.NewNamespacedCommand(cxt),
-		WaitableCommand: command.NewWaitableCommand(),
+		NamespacedCommand: command.NewNamespacedCommand(cxt),
+		WaitableCommand:   command.NewWaitableCommand(),
 	}
 	cmd := &cobra.Command{
 		Use:   "deprovision NAME",

--- a/cmd/svcat/instance/deprovision_cmd.go
+++ b/cmd/svcat/instance/deprovision_cmd.go
@@ -27,7 +27,7 @@ import (
 )
 
 type deprovisonCmd struct {
-	*command.NamespacedCommand
+	*command.Namespaced
 	*command.Waitable
 
 	instanceName string
@@ -36,8 +36,8 @@ type deprovisonCmd struct {
 // NewDeprovisionCmd builds a "svcat deprovision" command
 func NewDeprovisionCmd(cxt *command.Context) *cobra.Command {
 	deprovisonCmd := &deprovisonCmd{
-		NamespacedCommand: command.NewNamespacedCommand(cxt),
-		Waitable:          command.NewWaitable(),
+		Namespaced: command.NewNamespaced(cxt),
+		Waitable:   command.NewWaitable(),
 	}
 	cmd := &cobra.Command{
 		Use:   "deprovision NAME",

--- a/cmd/svcat/instance/deprovision_cmd.go
+++ b/cmd/svcat/instance/deprovision_cmd.go
@@ -28,7 +28,7 @@ import (
 
 type deprovisonCmd struct {
 	*command.NamespacedCommand
-	*command.WaitableCommand
+	*command.Waitable
 
 	instanceName string
 }
@@ -37,7 +37,7 @@ type deprovisonCmd struct {
 func NewDeprovisionCmd(cxt *command.Context) *cobra.Command {
 	deprovisonCmd := &deprovisonCmd{
 		NamespacedCommand: command.NewNamespacedCommand(cxt),
-		WaitableCommand:   command.NewWaitableCommand(),
+		Waitable:          command.NewWaitable(),
 	}
 	cmd := &cobra.Command{
 		Use:   "deprovision NAME",

--- a/cmd/svcat/instance/deprovision_cmd.go
+++ b/cmd/svcat/instance/deprovision_cmd.go
@@ -48,7 +48,7 @@ func NewDeprovisionCmd(cxt *command.Context) *cobra.Command {
 		PreRunE: command.PreRunE(deprovisonCmd),
 		RunE:    command.RunE(deprovisonCmd),
 	}
-	command.AddNamespaceFlags(cmd.Flags(), false)
+	deprovisonCmd.AddNamespaceFlags(cmd.Flags(), false)
 	deprovisonCmd.AddWaitFlags(cmd)
 
 	return cmd

--- a/cmd/svcat/instance/describe_cmd.go
+++ b/cmd/svcat/instance/describe_cmd.go
@@ -42,7 +42,7 @@ func NewDescribeCmd(cxt *command.Context) *cobra.Command {
 		PreRunE: command.PreRunE(describeCmd),
 		RunE:    command.RunE(describeCmd),
 	}
-	command.AddNamespaceFlags(cmd.Flags(), false)
+	describeCmd.AddNamespaceFlags(cmd.Flags(), false)
 	return cmd
 }
 

--- a/cmd/svcat/instance/describe_cmd.go
+++ b/cmd/svcat/instance/describe_cmd.go
@@ -25,13 +25,13 @@ import (
 )
 
 type describeCmd struct {
-	*command.NamespacedCommand
+	*command.Namespaced
 	name string
 }
 
 // NewDescribeCmd builds a "svcat describe instance" command
 func NewDescribeCmd(cxt *command.Context) *cobra.Command {
-	describeCmd := &describeCmd{NamespacedCommand: command.NewNamespacedCommand(cxt)}
+	describeCmd := &describeCmd{Namespaced: command.NewNamespaced(cxt)}
 	cmd := &cobra.Command{
 		Use:     "instance NAME",
 		Aliases: []string{"instances", "inst"},

--- a/cmd/svcat/instance/describe_cmd.go
+++ b/cmd/svcat/instance/describe_cmd.go
@@ -25,13 +25,13 @@ import (
 )
 
 type describeCmd struct {
-	*command.Namespaced
+	*command.NamespacedCommand
 	name string
 }
 
 // NewDescribeCmd builds a "svcat describe instance" command
 func NewDescribeCmd(cxt *command.Context) *cobra.Command {
-	describeCmd := &describeCmd{Namespaced: command.NewNamespacedCommand(cxt)}
+	describeCmd := &describeCmd{NamespacedCommand: command.NewNamespacedCommand(cxt)}
 	cmd := &cobra.Command{
 		Use:     "instance NAME",
 		Aliases: []string{"instances", "inst"},

--- a/cmd/svcat/instance/get_cmd.go
+++ b/cmd/svcat/instance/get_cmd.go
@@ -23,7 +23,7 @@ import (
 )
 
 type getCmd struct {
-	*command.NamespacedCommand
+	*command.Namespaced
 	name         string
 	outputFormat string
 }
@@ -34,7 +34,7 @@ func (c *getCmd) SetFormat(format string) {
 
 // NewGetCmd builds a "svcat get instances" command
 func NewGetCmd(cxt *command.Context) *cobra.Command {
-	getCmd := &getCmd{NamespacedCommand: command.NewNamespacedCommand(cxt)}
+	getCmd := &getCmd{Namespaced: command.NewNamespaced(cxt)}
 	cmd := &cobra.Command{
 		Use:     "instances [NAME]",
 		Aliases: []string{"instance", "inst"},

--- a/cmd/svcat/instance/get_cmd.go
+++ b/cmd/svcat/instance/get_cmd.go
@@ -23,7 +23,7 @@ import (
 )
 
 type getCmd struct {
-	*command.Namespaced
+	*command.NamespacedCommand
 	name         string
 	outputFormat string
 }
@@ -34,7 +34,7 @@ func (c *getCmd) SetFormat(format string) {
 
 // NewGetCmd builds a "svcat get instances" command
 func NewGetCmd(cxt *command.Context) *cobra.Command {
-	getCmd := &getCmd{Namespaced: command.NewNamespacedCommand(cxt)}
+	getCmd := &getCmd{NamespacedCommand: command.NewNamespacedCommand(cxt)}
 	cmd := &cobra.Command{
 		Use:     "instances [NAME]",
 		Aliases: []string{"instance", "inst"},

--- a/cmd/svcat/instance/get_cmd.go
+++ b/cmd/svcat/instance/get_cmd.go
@@ -48,7 +48,7 @@ func NewGetCmd(cxt *command.Context) *cobra.Command {
 		PreRunE: command.PreRunE(getCmd),
 		RunE:    command.RunE(getCmd),
 	}
-	command.AddNamespaceFlags(cmd.Flags(), true)
+	getCmd.AddNamespaceFlags(cmd.Flags(), true)
 	command.AddOutputFlags(cmd.Flags())
 	return cmd
 }

--- a/cmd/svcat/instance/provision_cmd.go
+++ b/cmd/svcat/instance/provision_cmd.go
@@ -27,7 +27,7 @@ import (
 
 type provisonCmd struct {
 	*command.NamespacedCommand
-	*command.WaitableCommand
+	*command.Waitable
 
 	instanceName string
 	externalID   string
@@ -44,7 +44,7 @@ type provisonCmd struct {
 func NewProvisionCmd(cxt *command.Context) *cobra.Command {
 	provisionCmd := &provisonCmd{
 		NamespacedCommand: command.NewNamespacedCommand(cxt),
-		WaitableCommand:   command.NewWaitableCommand(),
+		Waitable:          command.NewWaitable(),
 	}
 	cmd := &cobra.Command{
 		Use:   "provision NAME --plan PLAN --class CLASS",

--- a/cmd/svcat/instance/provision_cmd.go
+++ b/cmd/svcat/instance/provision_cmd.go
@@ -26,7 +26,7 @@ import (
 )
 
 type provisonCmd struct {
-	*command.NamespacedCommand
+	*command.Namespaced
 	*command.Waitable
 
 	instanceName string
@@ -43,8 +43,8 @@ type provisonCmd struct {
 // NewProvisionCmd builds a "svcat provision" command
 func NewProvisionCmd(cxt *command.Context) *cobra.Command {
 	provisionCmd := &provisonCmd{
-		NamespacedCommand: command.NewNamespacedCommand(cxt),
-		Waitable:          command.NewWaitable(),
+		Namespaced: command.NewNamespaced(cxt),
+		Waitable:   command.NewWaitable(),
 	}
 	cmd := &cobra.Command{
 		Use:   "provision NAME --plan PLAN --class CLASS",

--- a/cmd/svcat/instance/provision_cmd.go
+++ b/cmd/svcat/instance/provision_cmd.go
@@ -26,7 +26,7 @@ import (
 )
 
 type provisonCmd struct {
-	*command.Namespaced
+	*command.NamespacedCommand
 	*command.WaitableCommand
 
 	instanceName string
@@ -43,8 +43,8 @@ type provisonCmd struct {
 // NewProvisionCmd builds a "svcat provision" command
 func NewProvisionCmd(cxt *command.Context) *cobra.Command {
 	provisionCmd := &provisonCmd{
-		Namespaced:      command.NewNamespacedCommand(cxt),
-		WaitableCommand: command.NewWaitableCommand(),
+		NamespacedCommand: command.NewNamespacedCommand(cxt),
+		WaitableCommand:   command.NewWaitableCommand(),
 	}
 	cmd := &cobra.Command{
 		Use:   "provision NAME --plan PLAN --class CLASS",

--- a/cmd/svcat/instance/provision_cmd.go
+++ b/cmd/svcat/instance/provision_cmd.go
@@ -67,7 +67,7 @@ func NewProvisionCmd(cxt *command.Context) *cobra.Command {
 		PreRunE: command.PreRunE(provisionCmd),
 		RunE:    command.RunE(provisionCmd),
 	}
-	command.AddNamespaceFlags(cmd.Flags(), false)
+	provisionCmd.AddNamespaceFlags(cmd.Flags(), false)
 	cmd.Flags().StringVar(&provisionCmd.externalID, "external-id", "",
 		"The ID of the instance for use with the OSB SB API (Optional)")
 	cmd.Flags().StringVar(&provisionCmd.className, "class", "",

--- a/cmd/svcat/instance/touch_cmd.go
+++ b/cmd/svcat/instance/touch_cmd.go
@@ -24,13 +24,13 @@ import (
 )
 
 type touchInstanceCmd struct {
-	*command.NamespacedCommand
+	*command.Namespaced
 	name string
 }
 
 // NewTouchCommand builds a "svcat touch instance" command.
 func NewTouchCommand(cxt *command.Context) *cobra.Command {
-	touchInstanceCmd := &touchInstanceCmd{NamespacedCommand: command.NewNamespacedCommand(cxt)}
+	touchInstanceCmd := &touchInstanceCmd{Namespaced: command.NewNamespaced(cxt)}
 	cmd := &cobra.Command{
 		Use:   "instance",
 		Short: "Touch an instance to make service-catalog try to process the spec again",

--- a/cmd/svcat/instance/touch_cmd.go
+++ b/cmd/svcat/instance/touch_cmd.go
@@ -24,13 +24,13 @@ import (
 )
 
 type touchInstanceCmd struct {
-	*command.Namespaced
+	*command.NamespacedCommand
 	name string
 }
 
 // NewTouchCommand builds a "svcat touch instance" command.
 func NewTouchCommand(cxt *command.Context) *cobra.Command {
-	touchInstanceCmd := &touchInstanceCmd{Namespaced: command.NewNamespacedCommand(cxt)}
+	touchInstanceCmd := &touchInstanceCmd{NamespacedCommand: command.NewNamespacedCommand(cxt)}
 	cmd := &cobra.Command{
 		Use:   "instance",
 		Short: "Touch an instance to make service-catalog try to process the spec again",

--- a/cmd/svcat/instance/touch_cmd.go
+++ b/cmd/svcat/instance/touch_cmd.go
@@ -41,7 +41,7 @@ nothing.`,
 		PreRunE: command.PreRunE(touchInstanceCmd),
 		RunE:    command.RunE(touchInstanceCmd),
 	}
-	command.AddNamespaceFlags(cmd.Flags(), false)
+	touchInstanceCmd.AddNamespaceFlags(cmd.Flags(), false)
 
 	return cmd
 }


### PR DESCRIPTION
Before I add support for --all-namespaces to `svcat get classes` for namespace scoped broker resources, I wanted to apply this nice refactoring that we figured out for waitable commands to the --namespace flags.

I recommend walking through this by commit so that the renames are easier to review.

Follow-up from https://github.com/kubernetes-incubator/service-catalog/pull/1991#issuecomment-385031545.