### PR TITLE
Define test flags in nested svcat tests

### DIFF
--- a/cmd/svcat/output/yaml_test.go
+++ b/cmd/svcat/output/yaml_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"testing"
 
+	_ "github.com/kubernetes-incubator/service-catalog/internal/test"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 


### PR DESCRIPTION
This allows us to run `go test ./cmd/svcat/... -update` to update the golden files and not get errors about undefined flags. 