### PR TITLE
Make readiness and liveliness probes optional

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -60,9 +60,11 @@ chart and their default values.
 | `apiserver.auth.enabled` | Enable authentication and authorization | `true` |
 | `apiserver.audit.activated` | If true, enables the use of audit features via this chart. | `false` |
 | `apiserver.audit.logPath` | If specified, audit log goes to specified path. | `"/tmp/service-catalog-apiserver-audit.log"` |
+| `apiserver.healthcheck.enabled` | Enable readiness and liveliness probes | `true` |
 | `apiserver.serviceAccount` | Service account. | `service-catalog-apiserver` |
 | `apiserver.serveOpenAPISpec` | If true, makes the API server serve the OpenAPI schema | `false` |
 | `controllerManager.annotations` | Annotations for controllerManager pods | `{}` |
+| `controllerManager.healthcheck.enabled` | Enable readiness and liveliness probes | `true` |
 | `controllerManager.verbosity` | Log level; valid values are in the range 0 - 10 | `10` |
 | `controllerManager.resyncInterval` | How often the controller should resync informers; duration format (`20m`, `1h`, etc) | `5m` |
 | `controllerManager.brokerRelistInterval` | How often the controller should relist the catalogs of ready brokers; duration format (`20m`, `1h`, etc) | `24h` |

--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -78,6 +78,7 @@ spec:
         - name: apiserver-cert
           mountPath: /var/run/kubernetes-service-catalog
           readOnly: true
+        {{- if .Values.apiserver.healthcheck.enabled }}
         readinessProbe:
           httpGet:
             port: 8443
@@ -98,6 +99,7 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 2
+        {{- end }}
       {{- if and (eq .Values.apiserver.storage.type "etcd") .Values.apiserver.storage.etcd.useEmbedded }}
       - name: etcd
         image: quay.io/coreos/etcd:latest

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -96,6 +96,7 @@ spec:
         - name: service-catalog-cert
           mountPath: /var/run/kubernetes-service-catalog
           readOnly: true
+        {{- if .Values.controllerManager.healthcheck.enabled }}
         readinessProbe:
           httpGet:
             port: 8444
@@ -116,6 +117,7 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 2
+        {{- end }}
       volumes:
       - name: service-catalog-cert
         secret:

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -30,6 +30,9 @@ apiserver:
     # https://github.com/kubernetes/kubernetes/blob/v1.7.0/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/types.go#L56-L61
     # for more information on proper values of this field
     versionPriority: 20
+  # healthcheck configures the readiness and liveliness probes for the apiserver pod.
+  healthcheck:
+    enabled: true
   tls:
     # Base64-encoded CA used to validate request-header authentication, when
     # receiving delegated authentication from an aggregator. If not set, the
@@ -88,6 +91,9 @@ apiserver:
 controllerManager:
   # annotations is a collection of annotations to add to the controllerManager pod.
   annotations: {}
+  # healthcheck configures the readiness and liveliness probes for the controllerManager pod.
+  healthcheck:
+    enabled: true
   # Log level; valid values are in the range 0 - 10
   verbosity: 10
   # Resync interval; format is a duration (`20m`, `1h`, etc)


### PR DESCRIPTION
Due to reported problems with unreliable readiness and liveliness probes on installations where the apiserver and controller-manager are not on the same node (working theory), on non-dev clusters, a number of users are reporting that the controller-manager pod spends most of its
time in a self-induced crashloopbackoff.

As a workaround, we have been having people manually edit the deployment ot remove the checks. Long term we want to make these more configurable anyway (i.e. bumping the timeouts), but for now an "enabled" flag will make it easier for people on AKS, EKS and GKE workaround the issue more
easily while we investigate further.

Related to #2100 and https://github.com/Azure/AKS/issues/417. 