### PR TITLE
Owners file updates

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@ approvers:
 - arschles
 - duglin
 - jpeeler
-- krancour
 - mhbauer
 - pmorie
 - vaikas-google

--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,5 @@
 approvers:
 - arschles
-- bmelville
 - duglin
 - jpeeler
 - krancour

--- a/charts/healthcheck/OWNERS
+++ b/charts/healthcheck/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- jboyd01

--- a/cmd/healthcheck/OWNERS
+++ b/cmd/healthcheck/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- jboyd01

--- a/cmd/svcat/OWNERS
+++ b/cmd/svcat/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- carolynvs
+reviewers:
+- eriknelson
+- jeremyrickard
+- kikisdeliveryservice
+- luksa
+- n3wscott

--- a/pkg/registry/OWNERS
+++ b/pkg/registry/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+- eriknelson
+- jpeeler
+- MHBauer
+- nilebox
+- staebler

--- a/pkg/svcat/OWNERS
+++ b/pkg/svcat/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- carolynvs
+reviewers:
+- jberkhahn
+- jeremyricard
+- n3wscott


### PR DESCRIPTION
These are my opinion. Some positive changes. They would not have necessarily changed much recently besides the one removal.

My view is that @jboyd01 obviously owns the healthcheck. 

My view is that @carolynvs obviously owns svcat contents.
 - There have been many contributions so I added everyone who had 2+ contributions to the directory, not looking too hard. We can drill down to more specific sub-directories if that is unacceptable.

I need to go read the actual documents again, but I view approvers as having some responsibility and ownership role, and reviewers less of an obligation, while still being important.

/assign @jboyd01 @carolynvs 