### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+# Bug Report 
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Kubernetes version (use `kubectl version`):
+- service-catalog version:
+- Cloud provider or hardware configuration:
+- Do you have api aggregation enabled? 
+  - Do you see the configmap in kube-system? 
+  - Does it have all the necessary fields?
+    - `kubectl get cm -n kube-system extension-apiserver-authentication -o yaml` and look for `requestheader-XXX` fields
+- Install tools:
+  - Did you use helm? What were the helm arguments? Did you `--set` any extra values?
+- Are you trying to use ALPHA features? Did you enable them?


### PR DESCRIPTION
 - copied from upstream k/k template with service-catalog additions

Trying to get more information from bug-reports by default. We have a devguide, do we have a TROUBLESHOOTING doc?