### PR TITLE
Add warning about json params

### DIFF
--- a/cmd/svcat/binding/bind_cmd.go
+++ b/cmd/svcat/binding/bind_cmd.go
@@ -86,7 +86,7 @@ func NewBindCmd(cxt *command.Context) *cobra.Command {
 		"The name of the secret. Defaults to the name of the instance.",
 	)
 	cmd.Flags().StringSliceVarP(&bindCmd.rawParams, "param", "p", nil,
-		"Additional parameter to use when binding the instance, format: NAME=VALUE. Cannot be combined with --params-json")
+		"Additional parameter to use when binding the instance, format: NAME=VALUE. Cannot be combined with --params-json, Sensitive information should be placed in a secret and specified with --secret")
 	cmd.Flags().StringSliceVarP(&bindCmd.rawSecrets, "secret", "s", nil,
 		"Additional parameter, whose value is stored in a secret, to use when binding the instance, format: SECRET[KEY]")
 	cmd.Flags().StringVar(&bindCmd.jsonParams, "params-json", "",

--- a/cmd/svcat/instance/provision_cmd.go
+++ b/cmd/svcat/instance/provision_cmd.go
@@ -78,7 +78,7 @@ func NewProvisionCmd(cxt *command.Context) *cobra.Command {
 		"The plan name (Required)")
 	cmd.MarkFlagRequired("plan")
 	cmd.Flags().StringSliceVarP(&provisionCmd.rawParams, "param", "p", nil,
-		"Additional parameter to use when provisioning the service, format: NAME=VALUE. Cannot be combined with --params-json")
+		"Additional parameter to use when provisioning the service, format: NAME=VALUE. Cannot be combined with --params-json, Sensitive information should be placed in a secret and specified with --secret")
 	cmd.Flags().StringSliceVarP(&provisionCmd.rawSecrets, "secret", "s", nil,
 		"Additional parameter, whose value is stored in a secret, to use when provisioning the service, format: SECRET[KEY]")
 	cmd.Flags().StringVar(&provisionCmd.jsonParams, "params-json", "",

--- a/cmd/svcat/testdata/plugin.yaml
+++ b/cmd/svcat/testdata/plugin.yaml
@@ -25,7 +25,8 @@ tree:
   - name: param
     shorthand: p
     desc: 'Additional parameter to use when binding the instance, format: NAME=VALUE.
-      Cannot be combined with --params-json'
+      Cannot be combined with --params-json, Sensitive information should be placed
+      in a secret and specified with --secret'
   - name: params-json
     desc: Additional parameters to use when binding the instance, provided as a JSON
       object. Cannot be combined with --param
@@ -242,7 +243,8 @@ tree:
   - name: param
     shorthand: p
     desc: 'Additional parameter to use when provisioning the service, format: NAME=VALUE.
-      Cannot be combined with --params-json'
+      Cannot be combined with --params-json, Sensitive information should be placed
+      in a secret and specified with --secret'
   - name: params-json
     desc: Additional parameters to use when provisioning the service, provided as
       a JSON object. Cannot be combined with --param


### PR DESCRIPTION
We should have a message to warning people not to use
--param[s-json] for secret information.

Closes #1897