### PR TITLE
Adding ServicePlan Control Loops

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -160,11 +160,11 @@ func NewController(
 			DeleteFunc: controller.serviceClassDelete,
 		})
 		controller.servicePlanLister = servicePlanInformer.Lister()
-		//servicePlanInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		//AddFunc:    controller.servicePlanAdd,
-		//UpdateFunc: controller.servicePlanUpdate,
-		//DeleteFunc: controller.servicePlanDelete,
-		//})
+		servicePlanInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc:    controller.servicePlanAdd,
+			UpdateFunc: controller.servicePlanUpdate,
+			DeleteFunc: controller.servicePlanDelete,
+		})
 	}
 
 	return controller, nil
@@ -242,6 +242,7 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 		if utilfeature.DefaultFeatureGate.Enabled(scfeatures.NamespacedServiceBroker) {
 			createWorker(c.serviceBrokerQueue, "ServiceBroker", maxRetries, true, c.reconcileServiceBrokerKey, stopCh, &waitGroup)
 			createWorker(c.serviceClassQueue, "ServiceClass", maxRetries, true, c.reconcileServiceClassKey, stopCh, &waitGroup)
+			createWorker(c.servicePlanQueue, "ServicePlan", maxRetries, true, c.reconcileServicePlanKey, stopCh, &waitGroup)
 		}
 
 		if utilfeature.DefaultFeatureGate.Enabled(scfeatures.AsyncBindingOperations) {
@@ -269,6 +270,7 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.NamespacedServiceBroker) {
 		c.serviceBrokerQueue.ShutDown()
 		c.serviceClassQueue.ShutDown()
+		c.servicePlanQueue.ShutDown()
 	}
 
 	waitGroup.Wait()

--- a/pkg/controller/controller_serviceplan.go
+++ b/pkg/controller/controller_serviceplan.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/golang/glog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/pretty"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/tools/cache"
+)
+
+// Service plan handlers and control-loop
+
+func (c *controller) servicePlanAdd(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		glog.Errorf("ServicePlan: Couldn't get key for object %+v: %v", obj, err)
+		return
+	}
+	c.servicePlanQueue.Add(key)
+}
+
+func (c *controller) servicePlanUpdate(oldObj, newObj interface{}) {
+	c.servicePlanAdd(newObj)
+}
+
+func (c *controller) servicePlanDelete(obj interface{}) {
+	servicePlan, ok := obj.(*v1beta1.ServicePlan)
+	if servicePlan == nil || !ok {
+		return
+	}
+
+	glog.V(4).Infof("ServicePlan: Received delete event for %v; no further processing will occur", servicePlan.Name)
+}
+
+// reconcileServicePlanKey reconciles a ServicePlan due to resync
+// or an event on the ServicePlan.  Note that this is NOT the main
+// reconciliation loop for ServicePlans. ServicePlans are primarily
+//  reconciled in a separate flow when a ServiceBroker is reconciled.
+func (c *controller) reconcileServicePlanKey(key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+	pcb := pretty.NewContextBuilder(pretty.ServicePlan, namespace, name, "")
+	plan, err := c.servicePlanLister.ServicePlans(namespace).Get(key)
+	if errors.IsNotFound(err) {
+		glog.Infof(pcb.Message("not doing work because plan has been deleted"))
+		return nil
+	}
+	if err != nil {
+		glog.Infof(pcb.Message("unable to retrieve object from store: %v"))
+		return err
+	}
+
+	return c.reconcileServicePlan(plan)
+}
+
+func (c *controller) reconcileServicePlan(servicePlan *v1beta1.ServicePlan) error {
+	pcb := pretty.NewContextBuilder(pretty.ServicePlan, servicePlan.Namespace, servicePlan.Name, "")
+	glog.Infof("ServicePlan %q (ExternalName: %q): processing", servicePlan.Name, servicePlan.Spec.ExternalName)
+
+	if !servicePlan.Status.RemovedFromBrokerCatalog {
+		return nil
+	}
+
+	glog.Infof(pcb.Message("removed from broker catalog; determining whether there are instances remaining"))
+
+	serviceInstances, err := c.findServiceInstancesOnServicePlan(servicePlan)
+	if err != nil {
+		return err
+	}
+
+	if len(serviceInstances.Items) != 0 {
+		return nil
+	}
+
+	glog.Infof(pcb.Message("removed from broker catalog and has zero instances remaining; deleting"))
+	return c.serviceCatalogClient.ServicePlans(servicePlan.Namespace).Delete(servicePlan.Name, &metav1.DeleteOptions{})
+}
+
+func (c *controller) findServiceInstancesOnServicePlan(servicePlan *v1beta1.ServicePlan) (*v1beta1.ServiceInstanceList, error) {
+	fieldSet := fields.Set{
+		"spec.servicePlanRef.name": servicePlan.Name,
+	}
+	fieldSelector := fields.SelectorFromSet(fieldSet).String()
+	listOpts := metav1.ListOptions{FieldSelector: fieldSelector}
+
+	return c.serviceCatalogClient.ServiceInstances(metav1.NamespaceAll).List(listOpts)
+}

--- a/pkg/controller/controller_serviceplan_test.go
+++ b/pkg/controller/controller_serviceplan_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/test/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	clientgotesting "k8s.io/client-go/testing"
+	"reflect"
+)
+
+func TestReconcileServicePlanRemovedFromCatalog(t *testing.T) {
+	getRemovedPlan := func() *v1beta1.ServicePlan {
+		p := getTestServicePlan()
+		p.Status.RemovedFromBrokerCatalog = true
+		return p
+	}
+
+	cases := []struct {
+		name                    string
+		plan                    *v1beta1.ServicePlan
+		instances               []v1beta1.ServiceInstance
+		catalogClientPrepFunc   func(*fake.Clientset)
+		shouldError             bool
+		errText                 *string
+		catalogActionsCheckFunc func(t *testing.T, name string, actions []clientgotesting.Action)
+	}{
+		{
+			name:        "not removed from catalog",
+			plan:        getTestServicePlan(),
+			shouldError: false,
+		},
+		{
+			name:        "removed from catalog, instances left",
+			plan:        getRemovedPlan(),
+			instances:   []v1beta1.ServiceInstance{*getTestServiceInstance()},
+			shouldError: false,
+			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+				listRestrictions := clientgotesting.ListRestrictions{
+					Labels: labels.Everything(),
+					Fields: fields.OneTermEqualSelector("spec.servicePlanRef.name", "SPGUID"),
+				}
+
+				expectNumberOfActions(t, name, actions, 1)
+				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
+			},
+		},
+		{
+			name:        "removed from catalog, no instances left",
+			plan:        getRemovedPlan(),
+			instances:   nil,
+			shouldError: false,
+			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+				listRestrictions := clientgotesting.ListRestrictions{
+					Labels: labels.Everything(),
+					Fields: fields.OneTermEqualSelector("spec.servicePlanRef.name", "SPGUID"),
+				}
+
+				expectNumberOfActions(t, name, actions, 2)
+				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
+				assertDelete(t, actions[1], getRemovedPlan())
+			},
+		},
+		{
+			name:        "removed from catalog, no instances left, delete fails",
+			plan:        getRemovedPlan(),
+			instances:   nil,
+			shouldError: true,
+			catalogClientPrepFunc: func(client *fake.Clientset) {
+				client.AddReactor("delete", "serviceplans", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("oops")
+				})
+			},
+			errText: strPtr("oops"),
+			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+				listRestrictions := clientgotesting.ListRestrictions{
+					Labels: labels.Everything(),
+					Fields: fields.OneTermEqualSelector("spec.servicePlanRef.name", "SPGUID"),
+				}
+
+				expectNumberOfActions(t, name, actions, 2)
+				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
+				assertDelete(t, actions[1], getRemovedPlan())
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		_, fakeCatalogClient, _, testController, _ := newTestController(t, noFakeActions())
+
+		fakeCatalogClient.AddReactor("list", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			return true, &v1beta1.ServiceInstanceList{Items: tc.instances}, nil
+		})
+
+		if tc.catalogClientPrepFunc != nil {
+			tc.catalogClientPrepFunc(fakeCatalogClient)
+		}
+
+		err := reconcileServicePlan(t, testController, tc.plan)
+		if err != nil {
+			if !tc.shouldError {
+				t.Errorf("%v: unexpected error from method under test: %v", tc.name, err)
+				continue
+			} else if tc.errText != nil && *tc.errText != err.Error() {
+				t.Errorf("%v: unexpected error text from method under test; expected %v, got %v", tc.name, tc.errText, err.Error())
+				continue
+			}
+		}
+
+		actions := fakeCatalogClient.Actions()
+
+		if tc.catalogActionsCheckFunc != nil {
+			tc.catalogActionsCheckFunc(t, tc.name, actions)
+		} else {
+			expectNumberOfActions(t, tc.name, actions, 0)
+		}
+	}
+}
+
+func reconcileServicePlan(t *testing.T, testController *controller, servicePlan *v1beta1.ServicePlan) error {
+	clone := servicePlan.DeepCopy()
+	err := testController.reconcileServicePlan(servicePlan)
+	if !reflect.DeepEqual(servicePlan, clone) {
+		t.Errorf("reconcileServicePlan shouldn't mutate input, but it does: %s", expectedGot(clone, servicePlan))
+	}
+	return err
+}


### PR DESCRIPTION
For namespaced brokers, adding ServicePlan reconciliation control loops.