### PR TITLE
Add a nodeSelector to the chart

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -42,6 +42,7 @@ chart and their default values.
 |-----------|-------------|---------|
 | `image` | apiserver image to use | `quay.io/kubernetes-service-catalog/service-catalog:v0.1.22` |
 | `imagePullPolicy` | `imagePullPolicy` for the service catalog | `Always` |
+| `nodeSelector` | A nodeSelector value to apply to the api server and controller manager deployments. If not specified, no nodeSelector will be applied | |
 | `apiserver.annotations` | Annotations for apiserver pods | `{}` |
 | `apiserver.aggregator.priority` | Priority of the APIService. | `100` |
 | `apiserver.aggregator.groupPriorityMinimum` | The minimum priority the group should have. | `10000` |

--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -42,8 +42,8 @@ chart and their default values.
 |-----------|-------------|---------|
 | `image` | apiserver image to use | `quay.io/kubernetes-service-catalog/service-catalog:v0.1.22` |
 | `imagePullPolicy` | `imagePullPolicy` for the service catalog | `Always` |
-| `nodeSelector` | A nodeSelector value to apply to the api server and controller manager deployments. If not specified, no nodeSelector will be applied | |
 | `apiserver.annotations` | Annotations for apiserver pods | `{}` |
+| `apiserver.nodeSelector` | A nodeSelector value to apply to the apiserver pods. If not specified, no nodeSelector will be applied | |
 | `apiserver.aggregator.priority` | Priority of the APIService. | `100` |
 | `apiserver.aggregator.groupPriorityMinimum` | The minimum priority the group should have. | `10000` |
 | `apiserver.aggregator.versionPriority` | The ordering of this API inside of the group | `20` |
@@ -65,6 +65,7 @@ chart and their default values.
 | `apiserver.serviceAccount` | Service account. | `service-catalog-apiserver` |
 | `apiserver.serveOpenAPISpec` | If true, makes the API server serve the OpenAPI schema | `false` |
 | `controllerManager.annotations` | Annotations for controllerManager pods | `{}` |
+| `controllerManager.nodeSelector` | A nodeSelector value to apply to the controllerManager pods. If not specified, no nodeSelector will be applied | |
 | `controllerManager.healthcheck.enabled` | Enable readiness and liveliness probes | `true` |
 | `controllerManager.verbosity` | Log level; valid values are in the range 0 - 10 | `10` |
 | `controllerManager.resyncInterval` | How often the controller should resync informers; duration format (`20m`, `1h`, etc) | `5m` |

--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -144,9 +144,9 @@ spec:
           successThreshold: 1
           timeoutSeconds: 2
       {{- end }}
-      {{ if .Values.nodeSelector }}
+      {{ if .Values.apiserver.nodeSelector }}
       nodeSelector:
-         {{ .Values.nodeSelector }}
+         {{ .Values.apiserver.nodeSelector }}
       {{ end }}
       volumes:
       - name: apiserver-cert

--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -144,6 +144,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 2
       {{- end }}
+      {{ if .Values.nodeSelector }}
+      nodeSelector:
+         {{ .Values.nodeSelector }}
+      {{ end }}
       volumes:
       - name: apiserver-cert
         secret:

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -118,9 +118,9 @@ spec:
           successThreshold: 1
           timeoutSeconds: 2
         {{- end }}
-      {{ if .Values.nodeSelector }}
+      {{ if .Values.controllerManager.nodeSelector }}
       nodeSelector:
-         {{ .Values.nodeSelector }}
+         {{ .Values.controllerManager.nodeSelector }}
       {{ end }}
       volumes:
       - name: service-catalog-cert

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -118,6 +118,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 2
         {{- end }}
+      {{ if .Values.nodeSelector }}
+      nodeSelector:
+         {{ .Values.nodeSelector }}
+      {{ end }}
       volumes:
       - name: service-catalog-cert
         secret:

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -4,8 +4,6 @@ image: quay.io/kubernetes-service-catalog/service-catalog:v0.1.22
 # imagePullPolicy for the service-catalog; valid values are "IfNotPresent",
 # "Never", and "Always"
 imagePullPolicy: Always
-# nodeSelector to apply to the api server and controller manager pods
-nodeSelector: 
 # determines whether the API server should be registered with the kube-aggregator
 useAggregator: true
 ## If true, create & use RBAC resources
@@ -14,6 +12,8 @@ rbacEnable: true
 apiserver:
   # annotations is a collection of annotations to add to the apiserver pods.
   annotations: {}
+  # nodeSelector to apply to the apiserver pods
+  nodeSelector: 
   # PodPreset is an optional feature and can be enabled by uncommenting the line below
   # featureGates: "PodPreset=true"
   aggregator:
@@ -93,6 +93,8 @@ apiserver:
 controllerManager:
   # annotations is a collection of annotations to add to the controllerManager pod.
   annotations: {}
+  # nodeSelector to apply to the controllerManager pods
+  nodeSelector: 
   # healthcheck configures the readiness and liveliness probes for the controllerManager pod.
   healthcheck:
     enabled: true

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -4,6 +4,8 @@ image: quay.io/kubernetes-service-catalog/service-catalog:v0.1.22
 # imagePullPolicy for the service-catalog; valid values are "IfNotPresent",
 # "Never", and "Always"
 imagePullPolicy: Always
+# nodeSelector to apply to the api server and controller manager pods
+nodeSelector: 
 # determines whether the API server should be registered with the kube-aggregator
 useAggregator: true
 ## If true, create & use RBAC resources


### PR DESCRIPTION
This adds a nodeSelector to the api and controller manager deployments.
With this, you can specify a node selector for the api and controller manager
deployments. Currently, deployments will use the same nodeSelector. Should we separate them?

This is useful in the case of a mixed cluster with linux and windows nodes. Currently you can run
into issues where the two are scheduled on the windows nodes and that doesn't work.

Closes: #1769