### PR TITLE
Re-work TestCreateServiceInstanceWithProvisionFailure to mitigate its flake

### DIFF
--- a/test/util/util.go
+++ b/test/util/util.go
@@ -345,9 +345,7 @@ func AssertServiceInstanceCondition(t *testing.T, instance *v1beta1.ServiceInsta
 	}
 
 	if !foundCondition {
-		if status != v1beta1.ConditionFalse || len(reason) != 0 {
-			t.Fatalf("%v condition not found", conditionType)
-		}
+		t.Fatalf("%v condition not found", conditionType)
 	}
 }
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -345,7 +345,9 @@ func AssertServiceInstanceCondition(t *testing.T, instance *v1beta1.ServiceInsta
 	}
 
 	if !foundCondition {
-		t.Fatalf("%v condition not found", conditionType)
+		if status != v1beta1.ConditionFalse || len(reason) != 0 {
+			t.Fatalf("%v condition not found", conditionType)
+		}
 	}
 }
 
@@ -367,5 +369,18 @@ func AssertServiceBindingCondition(t *testing.T, binding *v1beta1.ServiceBinding
 
 	if !foundCondition {
 		t.Fatalf("%v condition not found", conditionType)
+	}
+}
+
+// AssertServiceInstanceConditionFalseOrAbsent asserts that the instance's status
+// either contains the given condition type with a status of False or does not
+// contain the given condition.
+func AssertServiceInstanceConditionFalseOrAbsent(t *testing.T, instance *v1beta1.ServiceInstance, conditionType v1beta1.ServiceInstanceConditionType) {
+	for _, condition := range instance.Status.Conditions {
+		if condition.Type == conditionType {
+			if e, a := v1beta1.ConditionFalse, condition.Status; e != a {
+				t.Fatalf("%v condition had unexpected status; expected %v, got %v", conditionType, e, a)
+			}
+		}
 	}
 }


### PR DESCRIPTION
I have thought about this flake a lot many different times and have not been able to rationalize either (1) why the test would produce failures if the code being tested is correct or (2) why the code being tested is incorrect. I have never been able to reproduce this flake locally, so I am not sure whether this re-work will do anything to fix the flake. However, if it doesn't, then I will be very concerned about what is going on in the code being tested.

I will kick this PR repeatedly to try to provoke a flake in the unit tests.