### PR TITLE
svcat : Allow dot syntax in --params

### DIFF
--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -92,7 +92,8 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 			case []string:
 				variables[variable] = append(storedValType, value)
 			case map[string]interface{}:
-				return nil, fmt.Errorf("(%s) already exists as an exploding param", variable)
+				return nil, fmt.Errorf(`(%s) was already used as an object path with the dot syntax
+				 							and cannot be mixed with other formats`, variable)
 			}
 		}
 	}

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -63,7 +63,7 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 			if r.MatchString(variable) == true {
 				dotKeys = strings.Split(variable, ".")
 				variable = dotKeys[0]
-			}else {
+			} else {
 				return nil, fmt.Errorf("invalid parameter (%s), must be in x.x format", variable)
 			}
 		}

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -73,7 +73,7 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 			if len(subKey) == 0 {
 				variables[variable] = value // if there is no key, add key&value as string
 			} else {
-				variables[variable] = map[string]string{subKey: value,}
+				variables[variable] = map[string]string{subKey: value}
 			}
 		} else {
 			switch storedValType := storedValue.(type) {

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -89,6 +89,9 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 				variables[variable] = []string{storedValType, value}
 			case []string:
 				variables[variable] = append(storedValType, value)
+			case map[string]interface{}:
+				return nil, fmt.Errorf("(%s) already exists as an exploding param", variable)
+			}
 		}
 	}
 

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -77,8 +77,8 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 				// last element in dot params will have value "value", the rest of map nested
 				// using remaining elements
 				// Ex: A.B.C = Z --> map[A:map[B:map[C:Z]]]
-				variables[variable] = map[string]interface{}{dotKeys[len(dotKeys[1:])]: value}
-				for i := len(dotKeys[1:]) - 1; i > 0; i-- {
+				variables[variable] = map[string]interface{}{dotKeys[len(dotKeys)-1]: value}
+				for i := len(dotKeys) - 2; i > 0; i-- {
 					variables[variable] = map[string]interface{}{dotKeys[i]: variables[variable]}
 				}
 			}

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -44,7 +44,7 @@ func ParseVariableJSON(params string) (map[string]interface{}, error) {
 func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 	variables := make(map[string]interface{})
 	for _, p := range params {
-		var newKeys []string
+		var dotKeys []string
 
 		parts := strings.SplitN(p, "=", 2)
 		if len(parts) < 2 {
@@ -59,8 +59,8 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 
 		if strings.ContainsAny(variable, ".") {
 			//check if params form is -p xxx.xx
-			newKeys = strings.Split(variable, ".")
-			variable = newKeys[0]
+			dotKeys = strings.Split(variable, ".")
+			variable = dotKeys[0]
 		}
 
 		storedValue, ok := variables[variable]
@@ -70,17 +70,16 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 		// Logic to add value to variables where variable already exists in variables:
 		// if variable:value -> variable:[old value, newvalue]
 		// if variable:[value1, value2] -> variable:[value1, value2, newvalue]
-		// if variable:map[somekey:somevalue] -> variable:map[somekey:somevalue newkey:newvalue]
-		// more logic/combinations TBD
+
 		if !ok {
-			if len(newKeys) == 0 {
+			if len(dotKeys) == 0 {
 				variables[variable] = value
 			} else {
-				for i := len(newKeys[1:]); i > 0; i-- {
-					if i == len(newKeys[1:]) {
-						variables[variable] = map[string]interface{}{newKeys[i]: value}
+				for i := len(dotKeys[1:]); i > 0; i-- {
+					if i == len(dotKeys[1:]) {
+						variables[variable] = map[string]interface{}{dotKeys[i]: value}
 					} else {
-						variables[variable] = map[string]interface{}{newKeys[i]: variables[variable]}
+						variables[variable] = map[string]interface{}{dotKeys[i]: variables[variable]}
 					}
 				}
 			}
@@ -90,11 +89,6 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 				variables[variable] = []string{storedValType, value}
 			case []string:
 				variables[variable] = append(storedValType, value)
-				// case map[string]string:
-				// 	if len(subKey) > 0 {
-				// 		storedValType[subKey] = value
-				// 	}
-			}
 		}
 	}
 

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -19,7 +19,6 @@ package parameters
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"regexp"
 	"strings"
 )
@@ -87,10 +86,7 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 				variables[variable] = append(storedValType, value)
 			case map[string]string:
 				if len(subKey) > 0 {
-					varsv, submapv := reflect.ValueOf(variables[variable]), reflect.ValueOf(subMap)
-					for _, k := range submapv.MapKeys() {
-						varsv.SetMapIndex(k, submapv.MapIndex(k))
-					}
+					storedValType[subKey] = value
 				}
 			}
 		}

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -80,12 +80,9 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 			if len(dotKeys) == 0 {
 				variables[variable] = value
 			} else {
-				for i := len(dotKeys[1:]); i > 0; i-- {
-					if i == len(dotKeys[1:]) {
-						variables[variable] = map[string]interface{}{dotKeys[i]: value}
-					} else {
-						variables[variable] = map[string]interface{}{dotKeys[i]: variables[variable]}
-					}
+				variables[variable] = map[string]interface{}{dotKeys[len(dotKeys[1:])]: value}
+				for i := len(dotKeys[1:]) - 1; i > 0; i-- {
+					variables[variable] = map[string]interface{}{dotKeys[i]: variables[variable]}
 				}
 			}
 		} else {

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -59,8 +59,13 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 
 		if strings.ContainsAny(variable, ".") {
 			//check if params form is -p xxx.xx
-			dotKeys = strings.Split(variable, ".")
-			variable = dotKeys[0]
+			r, _ := regexp.Compile(`[^\s\.]+\.[^\s\.]+(\.[^\s\.]+)*`)
+			if r.MatchString(variable) == true {
+				dotKeys = strings.Split(variable, ".")
+				variable = dotKeys[0]
+			}else {
+				return nil, fmt.Errorf("invalid parameter (%s), must be in x.x format", variable)
+			}
 		}
 
 		storedValue, ok := variables[variable]

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -59,6 +59,7 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 		value := strings.TrimSpace(parts[1])
 
 		if strings.ContainsAny(variable, ".") {
+			//check if params form is -p xxx.xx
 			newKeys = strings.Split(variable, ".")
 			variable = newKeys[0]
 			subKey = newKeys[1]
@@ -66,12 +67,16 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 
 		storedValue, ok := variables[variable]
 		// Logic to add new value to map variables:
-		// if variable DNE: add pair to variables as variable:value
-		// if variable exists in form of variable:value, create array to hold old value&new value
-		// if variable exists in form variable:[some values], append new value to existing array
+		// if variable DNE and not exploding params -> variable:value
+		// if variable DNE and exploding params -> variable: map[somekey:somevalue]
+		// Logic to add value to variables where variable already exists in variables:
+		// if variable:value -> variable:[old value, newvalue]
+		// if variable:[value1, value2] -> variable:[value1, value2, newvalue]
+		// if variable:map[somekey:somevalue] -> variable:map[somekey:somevalue newkey:newvalue]
+		// more logic/combinations TBD
 		if !ok {
 			if len(subKey) == 0 {
-				variables[variable] = value // if there is no key, add key&value as string
+				variables[variable] = value
 			} else {
 				variables[variable] = map[string]string{subKey: value}
 			}

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -46,7 +46,6 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 	for _, p := range params {
 		var newKeys []string
 		var subKey = ""
-		var subMap = make(map[string]string)
 
 		parts := strings.SplitN(p, "=", 2)
 		if len(parts) < 2 {
@@ -63,7 +62,6 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 			newKeys = strings.Split(variable, ".")
 			variable = newKeys[0]
 			subKey = newKeys[1]
-			subMap[subKey] = value
 		}
 
 		storedValue, ok := variables[variable]
@@ -75,8 +73,7 @@ func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 			if len(subKey) == 0 {
 				variables[variable] = value // if there is no key, add key&value as string
 			} else {
-				variables[variable] = make(map[string]string)
-				variables[variable] = subMap
+				variables[variable] = map[string]string{subKey: value,}
 			}
 		} else {
 			switch storedValType := storedValue.(type) {

--- a/cmd/svcat/parameters/parameters.go
+++ b/cmd/svcat/parameters/parameters.go
@@ -38,9 +38,9 @@ func ParseVariableJSON(params string) (map[string]interface{}, error) {
 }
 
 // ParseVariableAssignments converts a string array of variable assignments
-// into a map of keys and values
-// Example:
-// [a=b c=abc1232=== d=banana d=pineapple] becomes map[a:b c:abc1232=== d:[banana pineapple]]
+// into a map of keys and values.
+// Examples:
+// [a=b c=abc1232=== d=X d=Y e.f.g=Z] --> map[a:b c:abc1232=== d:[X Y] e:map[f:map[g:Z]]]
 func ParseVariableAssignments(params []string) (map[string]interface{}, error) {
 	variables := make(map[string]interface{})
 	for _, p := range params {

--- a/cmd/svcat/parameters/parameters_test.go
+++ b/cmd/svcat/parameters/parameters_test.go
@@ -77,11 +77,25 @@ func TestParseVariableAssignments_OneVariableThreeValues(t *testing.T) {
 		t.Fatalf("%s\nexpected:\n\t%v\ngot:\n\t%v\n", "one var three values", want, got)
 	}
 }
+
 func TestParseVariableAssignments_InvalidDotParams(t *testing.T) {
-	params := []string{"a.=e"}
-	_, err := ParseVariableAssignments(params)
-	if err == nil {
-		t.Fatal("should have failed due to invalid dot string")
+	testcases := []struct {
+		Name, Raw string
+	}{
+		{"missing right param", "a.=e"},
+		{"missing left param", ".a=e"},
+		{"double dots", "a..b=e"},
+		{"no params", ".="},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			params := []string{tc.Raw}
+
+			result, err := ParseVariableAssignments(params)
+			if err == nil {
+				t.Fatalf("expected parse to fail for %s but got %v", tc.Raw, result)
+			}
+		})
 	}
 }
 

--- a/cmd/svcat/parameters/parameters_test.go
+++ b/cmd/svcat/parameters/parameters_test.go
@@ -88,9 +88,9 @@ func TestParseVariableAssignments_DotParams(t *testing.T) {
 
 	want := map[string]interface{}{
 		"a": map[string]interface{}{
-			"b":map[string]interface{}{
-				"c":map[string]interface{}{
-					"d":"e"}}},
+			"b": map[string]interface{}{
+				"c": map[string]interface{}{
+					"d": "e"}}},
 	}
 
 	if !reflect.DeepEqual(want, got) {

--- a/cmd/svcat/parameters/parameters_test.go
+++ b/cmd/svcat/parameters/parameters_test.go
@@ -85,9 +85,8 @@ func TestParseVariableAssignments_InvalidDotParams(t *testing.T) {
 	}
 }
 
-func TestParseVariableAssignments_DotParams(t *testing.T) {
+func TestParseVariableAssignments_ValidDotParams(t *testing.T) {
 	params := []string{"a.b.c.d=e"}
-	 
 	got, err := ParseVariableAssignments(params)
 	if err != nil {
 		t.Fatal(err)
@@ -105,9 +104,8 @@ func TestParseVariableAssignments_DotParams(t *testing.T) {
 	}
 }
 
-func TestParseVariableAssignments_DotParamsErr(t *testing.T) {
+func TestParseVariableAssignments_DotParamsTypeErr(t *testing.T) {
 	params := []string{"a.b.c.d=e", "a=x"}
-
 	_, err := ParseVariableAssignments(params)
 	if err == nil {
 		t.Fatal("should have failed due to map and string for same variable")

--- a/cmd/svcat/parameters/parameters_test.go
+++ b/cmd/svcat/parameters/parameters_test.go
@@ -77,10 +77,17 @@ func TestParseVariableAssignments_OneVariableThreeValues(t *testing.T) {
 		t.Fatalf("%s\nexpected:\n\t%v\ngot:\n\t%v\n", "one var three values", want, got)
 	}
 }
+func TestParseVariableAssignments_InvalidDotParams(t *testing.T) {
+	params := []string{"a.=e"}
+	_, err := ParseVariableAssignments(params)
+	if err == nil {
+		t.Fatal("should have failed due to invalid dot string")
+	}
+}
 
 func TestParseVariableAssignments_DotParams(t *testing.T) {
 	params := []string{"a.b.c.d=e"}
-
+	 
 	got, err := ParseVariableAssignments(params)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/svcat/parameters/parameters_test.go
+++ b/cmd/svcat/parameters/parameters_test.go
@@ -98,6 +98,15 @@ func TestParseVariableAssignments_DotParams(t *testing.T) {
 	}
 }
 
+func TestParseVariableAssignments_DotParamsErr(t *testing.T) {
+	params := []string{"a.b.c.d=e", "a=x"}
+
+	_, err := ParseVariableAssignments(params)
+	if err == nil {
+		t.Fatal("should have failed due to map and string for same variable")
+	}
+}
+
 func TestParseKeyMaps(t *testing.T) {
 	testcases := []struct {
 		Name, Raw, MapName, Key string

--- a/cmd/svcat/parameters/parameters_test.go
+++ b/cmd/svcat/parameters/parameters_test.go
@@ -78,6 +78,26 @@ func TestParseVariableAssignments_OneVariableThreeValues(t *testing.T) {
 	}
 }
 
+func TestParseVariableAssignments_DotParams(t *testing.T) {
+	params := []string{"a.b.c.d=e"}
+
+	got, err := ParseVariableAssignments(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]interface{}{
+		"a": map[string]interface{}{
+			"b":map[string]interface{}{
+				"c":map[string]interface{}{
+					"d":"e"}}},
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("%s\nexpected:\n\t%v\ngot:\n\t%v\n", "dotparams", want, got)
+	}
+}
+
 func TestParseKeyMaps(t *testing.T) {
 	testcases := []struct {
 		Name, Raw, MapName, Key string


### PR DESCRIPTION
Closes #1853 

Add parsing of params to allow a param to hold value of map so that 
--param foo.bar.baz=boop -- > map{foo: map{bar: map{"baz":"boop"}
