### PR TITLE
Docker 17.05+ is required for dev builds

### DIFF
--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -65,7 +65,7 @@ document.
 
 At a minimum you will need:
 
-* [Docker](https://www.docker.com) installed locally
+* [Docker](https://www.docker.com) 17.05+ installed locally
 * GNU Make
 * [git](https://git-scm.com)
 


### PR DESCRIPTION
See https://github.com/moby/moby/issues/19197#issuecomment-329974121 for context

Fixes #2157