### PR TITLE
Add coverage for switch stmt case in parameters_test.go

### DIFF
--- a/cmd/svcat/parameters/parameters_test.go
+++ b/cmd/svcat/parameters/parameters_test.go
@@ -61,8 +61,8 @@ func TestParseVariableAssignments_MissingVariableName(t *testing.T) {
 	}
 }
 
-func TestParseVariableAssignments_OneVariableTwoValues(t *testing.T) {
-	params := []string{"a=banana", "a=pineapple"}
+func TestParseVariableAssignments_OneVariableThreeValues(t *testing.T) {
+	params := []string{"a=banana", "a=pineapple", "a=coconut"}
 
 	got, err := ParseVariableAssignments(params)
 	if err != nil {
@@ -70,11 +70,11 @@ func TestParseVariableAssignments_OneVariableTwoValues(t *testing.T) {
 	}
 
 	want := map[string]interface{}{
-		"a": []string{"banana", "pineapple"},
+		"a": []string{"banana", "pineapple", "coconut"},
 	}
 
 	if !reflect.DeepEqual(want, got) {
-		t.Fatalf("%s\nexpected:\n\t%v\ngot:\n\t%v\n", "one var two values", want, got)
+		t.Fatalf("%s\nexpected:\n\t%v\ngot:\n\t%v\n", "one var three values", want, got)
 	}
 }
 


### PR DESCRIPTION
Updating test in parameters_test.go to cover the second case of switch statement line 70 ParseVariableAssignments():  []string exists and new value is to be appended:

`
case []string:
variables[variable] = append(storedValType, value)
`

Link to relevant spot in parameters.go: https://github.com/kubernetes-incubator/service-catalog/blob/0d6f93aaa86d4903cf93c54ee617c75c0bcf49c9/cmd/svcat/parameters/parameters.go#L70-L71
