### PR TITLE
Link to charter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Also see the [developer's guide](./docs/devguide.md) for information on how to
 build and test the code.
 
 We have weekly meetings - see
-[Kubernetes SIGs](https://github.com/kubernetes/community/blob/master/sig-list.md)
-(search for "Service Catalog") for the exact date and time. For meeting agendas
+[our SIG Readme](https://github.com/kubernetes/community/blob/master/sig-service-catalog/README.md#meetings)
+for details. For meeting agendas
 and notes, see [Kubernetes SIG Service Catalog Agenda](https://docs.google.com/document/d/17xlpkoEbPR5M6P5VDzNx17q6-IPFxKyebEekCGYiIKM/edit).
 
 Previous meeting notes are also available:
@@ -84,4 +84,3 @@ check out the [community site](https://github.com/kubernetes/community/tree/mast
 
 Participation in the Kubernetes community is governed by the
 [Kubernetes Code of Conduct](./code-of-conduct.md).
-

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The project was established 2016-Sept-12. The incubator team for the project is:
 - Sponsor: Brian Grant ([@bgrant0607](https://github.com/bgrant0607))
 - Champion: Paul Morie ([@pmorie](https://github.com/pmorie))
 - SIG: [sig-service-catalog](https://github.com/kubernetes/community/tree/master/sig-service-catalog)
+- See our "working" [SIG Charter](https://github.com/carolynvs/community/blob/sig-service-catalog-charter/sig-service-catalog/charter.md), which should be ratified by the Kubernetes Steering Committee soon.
 
 For more information about sig-service-catalog, such as meeting times and agenda,
 check out the [community site](https://github.com/kubernetes/community/tree/master/sig-service-catalog).


### PR DESCRIPTION
This links to our working charter. Once it is merged, I'll update this to point to the the permanent location.