### PR TITLE
Adding docs for namespaced broker resources

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,9 @@ cid: docs-home
 permalink: /docs/
 ---
 
-Welcome to the documentation for Service Catalog. This page is an index for
-the articles in here. We recommend you start by reading the 
+# Service Catalog Documentation
+
+This page is an index for the articles in here. We recommend you start by reading the 
 [introduction](./concepts/index.md#introduction), and then move on to the 
 [installation instructions](./install.md). After you install, see our
 [walkthrough](./walkthrough.md) document to get started using Service Catalog.
@@ -27,6 +28,10 @@ Afterward, see the topics below.
 - [Developer guide](./devguide.md)
 - [Design](./design.md)
 - [Notes on authentication](./auth.md)
+
+## Topics for operators:
+
+- [Using Namespaced Broker Resources](./namespaced-broker-resources.md)
 
 ## Request for Comments
 

--- a/docs/namespaced-broker-resources.md
+++ b/docs/namespaced-broker-resources.md
@@ -5,29 +5,80 @@ layout: docwithnav
 
 # Cluster-Scoped vs Namespace-Scoped Broker Resources
 
-Service Catalog enables service brokers to be registered in two manners: as a cluster-scoped resource or as a namespace-scoped resource. As a user of service catalog, you might use these approaches to accomplish different goals, like providing a common set of service broker resources to all users or extending your existing role based access control (RBAC) policies to the lifecycle of service broker resources. This document will explain some use cases for namespace-scoped resources and how to accomplish them using Service Catalog.
+Service Catalog enables service brokers to be registered in two manners: as a 
+cluster-scoped resource or as a namespace-scoped resource. As a user of service
+ catalog, you might use these approaches to accomplish different goals such as 
+ providing a common set of service broker resources to all users or utilizing 
+ role based access (RBAC) policies to control service provisioning. This 
+ document will explain some use cases for namespace-scoped resources and how to
+  accomplish them using Service Catalog.
 
 ## Possible Use Cases
 
-When using `ClusterServiceBroker` and associated `ClusterServiceClass` and `ClusterServicePlan` resources, service broker resources existing within the cluster as cluster-scoped resources. This means that you are limited in how you can apply RBAC and you can only have a single instance of that resource for a given identifier. As an example, if the service broker you are registering has fixed class and plan identifiers, you will be limited to one instance of the broker. With namespace-scoped brokers, however, the `ServiceBroker`, along with the `ServiceClass` and `ServicePlan` resources are scoped to a particular namespace. This allows for some more complicated use cases that were not possible with the cluster-scoped broker resources. 
+When using `ClusterServiceBroker` and associated `ClusterServiceClass` and 
+`ClusterServicePlan` resources, service broker resources, such as classes and 
+plans, are created as cluster-scoped resources. This means that you are limited
+ in how you can apply RBAC and you can only have a single instance of that 
+ resource for a given identifier. As an example, if the service broker you are 
+ registering has fixed class and plan identifiers, you will be limited to one 
+ instance of the broker. With namespace-scoped brokers, however, the 
+ `ServiceBroker`, along with the `ServiceClass` and `ServicePlan` resources are
+  scoped to a particular namespace. This allows for some more advanced use 
+  cases that were not possible with the cluster-scoped broker resources. 
 
 ### Registering Brokers Per Namespace
 
-A service broker that provisions services in a cloud provider usually needs credentials in order to complete the request on behalf of Service Catalog. Some organizations may provide different access credentials to different teams in order to separate billing usage or to isolate control of resources. In these cases, the cluster operator might want to register two copies of the broker using different credentials for each team. When using `ClusterServiceBroker` and the associated `ClusterServiceClass` and `ClusterServicePlan` resources, it was not possible to register two instances of a service broker unless each registration could provide unique identifiers for service c lasses and service plans.
+A service broker that provisions services in a cloud provider usually needs 
+credentials in order to complete the request on behalf of Service Catalog. 
+Some organizations may provide different access credentials to different teams 
+in order to separate billing usage or to isolate control of resources. In these 
+cases, the cluster operator might want to register two copies of the broker 
+using different credentials for each team. When using `ClusterServiceBroker` 
+and the associated `ClusterServiceClass` and `ClusterServicePlan` resources, it
+ was not possible to register two instances of a service broker unless each 
+ registration could provide unique identifiers for service c lasses and service
+  plans.
 
-Using namespace-scoped brokers, however, enables the broker to be installed in each namespace without conflicting at the class and plan level. When creating a service instance, you specify either the external class or plan name, or provide the class or plan identifier. Service Catalog then resolves these in order to determine which broker it should issue the provision command to. When using namespace-scoped brokers and their associated resources, this resolution occurs within the namespace. That means that users in namespace `backend-team` and namespace `front-end-team` can have the their own broker registrations and provision requests will be issued to the correct broker.
+Using namespace-scoped brokers, however, enables the broker to be installed in
+ each namespace without conflicting at the class and plan level. When creating
+  a service instance, you specify either the external class or plan name, or 
+  provide the class or plan identifier. Service Catalog then resolves these in 
+  order to determine which broker it should issue the provision command to. 
+  When using namespace-scoped brokers and their associated resources, this 
+  resolution occurs within the namespace. That means that users in namespace 
+  `backend-team` and namespace `frontend-team` can have the their own broker 
+  registrations and provision requests will be issued to the correct broker.
 
 ### Limiting Access to Plans
 
-There are often situations when not all services and plans should be available to all users. A cluster administrator may wish to only provide free plans to certain users or restrict the ability to provision very expensive services. Additionally, when developers are creating new services that are exposed by brokers, they want to be able to iterate on those services without exposing them to all users in a cluster.
+There are often situations when not all services and plans should be available 
+to all users. A cluster administrator may wish to only provide free plans to 
+certain users or restrict the ability to provision very expensive services. 
+Additionally, when developers are creating new services that are exposed by 
+brokers, they want to be able to iterate on those services without exposing 
+them to all users in a cluster.
 
-Service Catalog's cluster-scoped resources for brokers, services, and plans are not sufficient to implement access control to ensure that users have access only to the service and plans that they should. For these resources, application of RBAC is really centered around what is visible to them, but is not enforced when a provision request is issued. For example, a `CLusterRole` could be created to prohibit a given user or group to view classes and plans, but this can not be used at provisioning time to ensure that the user cannot create the resource. Namespace-scoped brokers, services and plans, however, can be effectively combined with Kubernetes role based access control and Service Catalog Catalog Restrictions in order to provide more granular control over service instance provisioning.
+Service Catalog's cluster-scoped resources for brokers, services, and plans are
+ not sufficient to implement access control to ensure that users have access 
+ only to the service and plans that they should. For these resources, 
+ application of RBAC is really centered around what is visible to them, but is 
+ not enforced when a provision request is issued. For example, a `ClusterRole` 
+ could be created to prohibit a given user or group to view classes and plans, 
+ but cannot at provisioning time to ensure that the user cannot create the 
+ resource. Namespace-scoped brokers, services and plans, however, can be 
+ effectively combined with Kubernetes role based access control and Service 
+ Catalog Catalog Restrictions in order to provide more granular control over 
+ service instance provisioning.
 
 ## Enabling Namespace Scoped Broker Resources
 
-Currently, namespace-scoped broker resources are an alpha-feature of Service Catalog behind a feature flag. To start using these resources, you will need to pass an argument to the API Server when you install Service Catalog: `--feature-gates NamespacedServiceBroker=true`.
+Currently, namespace-scoped broker resources are an alpha-feature of Service 
+Catalog behind a feature flag. To start using these resources, you will need 
+to pass an argument to the API Server when you install Service Catalog:
+ `--feature-gates NamespacedServiceBroker=true`.
 
-If you are using Helm, this flag has been surfaced as a chart parameter:
+If you are using Helm, you can use the `namespacedServiceBrokerEnabled` setting
+ to control that flag:
 
 ```console
 helm install svc-cat/catalog \
@@ -36,13 +87,15 @@ helm install svc-cat/catalog \
    --set namespacedServiceBrokerEnabled=true
 ```
 
-If you are also using RBAC, providing this option to the Helm install command will also create the needed RBAC resources.
-
 ## Using Namespace Scoped Broker Resources
 
-Once Service Catalog has been installed with this feature gate enabled, you should see three new resource types: `ServiceBroker`, `ServiceClass`, and `ServicePlan`.
+Once Service Catalog has been installed with this feature gate enabled, you 
+should see three new resource types: `ServiceBroker`, `ServiceClass`, 
+and `ServicePlan`.
 
-In order to register a `ServiceBroker` resource, you create a YAML definition that looks similar to a `ClusterServiceBroker`. This resource will use a different resource kind, however, and requires a namespace. An example might look like:
+In order to register a `ServiceBroker` resource, you create a YAML definition 
+that looks similar to a `ClusterServiceBroker`. This resource will use resource
+ kind `ServiceBroker` and requires a namespace. An example might look like:
 
 ```yaml
 apiVersion: servicecatalog.k8s.io/v1beta1
@@ -59,7 +112,9 @@ spec:
   url: http://my-service-broker.broker.svc.cluster.local
 ```
 
-Once this resource is created, Service Catalog will query the Service Broker for the list of available Services and create corresponding `ServiceClass` and `ServicePlan` resources. These resources might look like this:
+Once this resource is created, Service Catalog will query the Service Broker 
+for the list of available Services and create corresponding `ServiceClass` 
+and `ServicePlan` resources. These resources might look like this:
 
 ```yaml
 apiVersion: servicecatalog.k8s.io/v1beta1
@@ -79,8 +134,6 @@ spec:
   externalName: mysql-5-7
   planUpdatable: false
   serviceBrokerName: example-ns-broker
-status:
-  removedFromBrokerCatalog: false
 ```
 
 ```yaml
@@ -98,12 +151,15 @@ spec:
   externalID: 4c6932e8-30ec-4af9-83d2-6e27286dbab3
 serviceBrokerName: example-ns-broker
   serviceClassRef:
-    name: 25434f16-d762-41c7-bbdd-8045d7f74ca6
-status:
-  removedFromBrokerCatalog: false
+    name: 25434f16-d762-41c7-bbdd-8045d7f74ca6e
 ```
 
-The `ServiceInstance` resource has also been updated to allow you to use these resources just as you would the existing `ClusterServiceBroker`, `ClusterServiceClass` and `ClusterServicePlan` resources, except you will use them in the context of a namespace. For example, a `ServiceInstance` YAML that references a `ClusterServiceClass` and a `ClusterServicePlan` resource might look like this:
+The `ServiceInstance` resource has also been updated to allow you to use these 
+resources just as you would the existing `ClusterServiceBroker`, 
+`ClusterServiceClass` and `ClusterServicePlan` resources, except you will use 
+them in the context of a namespace. For example, a `ServiceInstance` YAML that
+ references a `ClusterServiceClass` and a `ClusterServicePlan` resource might 
+ look like this:
 
 ```yaml
 apiVersion: servicecatalog.k8s.io/v1beta1
@@ -116,7 +172,8 @@ spec:
   clusterServicePlanExternalName: basic
 ```
 
-If you instead want to use the `ServiceClass` and `ServicePlan` namespace-scoped resources, the yaml might look like this:
+If you instead want to use the `ServiceClass` and `ServicePlan`
+ namespace-scoped resources, the yaml might look like this:
 
 ```yaml
 apiVersion: servicecatalog.k8s.io/v1beta1
@@ -129,14 +186,35 @@ spec:
   servicePlanExternalName: basic
 ```
 
-In order to successfully create the resource using the namespace-scoped `ServiceClass` and `ServicePlan`, those resources must exist 
-in the same namespace as the `ServiceInstance` that you are creating. If a user attempts to create a `ServiceInstance` in a namespace 
-using a `ServiceClass` and `ServicePlan` that are contained in a different namespace, they request will fail.
+For comparison, using the cluster-scoped `ClusterServiceClass` or 
+`ClusterServicePlan`, the yaml would look like:
+
+```yaml
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
+metadata:
+  name: example-mysql-instance
+  namespace: default
+spec:
+  clusterServiceClassExternalName: mysql-5-7
+  clusterServicePlanExternalName: basic
+```
+
+Instances can reference cluster-scoped `ClusterServiceClass` or 
+`ClusterServicePlan` resources or to the namespace scope `ServiceClass` and 
+`ServicePlan` resources in the same namespace. They cannot reference 
+`ServiceClass` and `ServicePlan` resources in another namespace.
 
 ## Further Restricting Plan Access
 
-The use of namespace-scoped resources enables you to register brokers within a given namespace and leverage RBAC in order to control who can 
-provision services in that namespace. By default, all service classes and plans from that broker will be available to users of the namespace. When registering a broker, catalog restrictions can be specified in order to restrict what plans are available within a given namespace. This allows you to specify that in the `developer` namespace, only plans named `basic` can be created. The YAML to accomplish this might look like:
+The use of namespace-scoped resources enables you to register brokers within a
+ given namespace and leverage RBAC in order to control who can 
+provision services in that namespace. By default, all service classes and plans 
+from that broker will be available to users of the namespace. When registering 
+a broker, catalog restrictions can be specified in order to restrict what plans
+ are available within a given namespace. This allows you to specify that in 
+ the `developer` namespace, only plans named `basic` can be created. The YAML 
+ to accomplish this might look like:
 
 ```yaml
 apiVersion: servicecatalog.k8s.io/v1beta1
@@ -156,4 +234,7 @@ spec:
     - "spec.externalName==basic"
 ```
 
-When you combine the two capabilities, you can effectively restrict provisioning of service classes or plans to very specific namespaces. Production grade instances, for example, could be heavily restricted to a small subset of users. Other namespaces could be given access to other plans.
+When you combine the two capabilities, you can effectively restrict 
+provisioning of service classes or plans to very specific namespaces. 
+Production grade instances, for example, could be heavily restricted to a small
+ subset of users. Other namespaces could be given access to other plans.

--- a/docs/namespaced-broker-resources.md
+++ b/docs/namespaced-broker-resources.md
@@ -63,12 +63,13 @@ Service Catalog's cluster-scoped resources for brokers, services, and plans are
  only to the service and plans that they should. For these resources, 
  application of RBAC is really centered around what is visible to them, but is 
  not enforced when a provision request is issued. For example, a `ClusterRole` 
- could be created to prohibit a given user or group to view classes and plans, 
- but cannot at provisioning time to ensure that the user cannot create the 
- resource. Namespace-scoped brokers, services and plans, however, can be 
- effectively combined with Kubernetes role based access control and Service 
- Catalog Catalog Restrictions in order to provide more granular control over 
- service instance provisioning.
+ could be created to prohibit a given user or group from viewing 
+ `ClusterServiceClass` and `ClusterServicePlan` resources, but this role cannot
+be used to prevent a user from creating a `ServiceInstance` using that 
+`ClusterServiceClass` and `ClusterServicePlan`. Namespace-scoped brokers, 
+services and plans, however, can be effectively combined with Kubernetes RBAC
+and Service Catalog Catalog Restrictions in order to provide more granular 
+control over service instance provisioning.
 
 ## Enabling Namespace Scoped Broker Resources
 

--- a/docs/namespaced-broker-resources.md
+++ b/docs/namespaced-broker-resources.md
@@ -1,9 +1,9 @@
 ---
-title: Namespaced Broker Resources
+title: Using Namespaced Broker Resources
 layout: docwithnav
 ---
 
-# Namespaced Broker Resources
+# Cluster-Scoped vs Namespace-Scoped Broker Resources
 
 Service Catalog enables service brokers to be registered in two manners: as a cluster-scoped resource or as a namespace-scoped resource. As a user of service catalog, you might use these approaches to accomplish different goals, like providing a common set of service broker resources to all users or extending your existing role based access control (RBAC) policies to the lifecycle of service broker resources. This document will explain some use cases for namespace-scoped resources and how to accomplish them using Service Catalog.
 

--- a/docs/namespaced-broker-resources.md
+++ b/docs/namespaced-broker-resources.md
@@ -1,0 +1,159 @@
+---
+title: Namespaced Broker Resources
+layout: docwithnav
+---
+
+# Namespaced Broker Resources
+
+Service Catalog enables service brokers to be registered in two manners: as a cluster-scoped resource or as a namespace-scoped resource. As a user of service catalog, you might use these approaches to accomplish different goals, like providing a common set of service broker resources to all users or extending your existing role based access control (RBAC) policies to the lifecycle of service broker resources. This document will explain some use cases for namespace-scoped resources and how to accomplish them using Service Catalog.
+
+## Possible Use Cases
+
+When using `ClusterServiceBroker` and associated `ClusterServiceClass` and `ClusterServicePlan` resources, service broker resources existing within the cluster as cluster-scoped resources. This means that you are limited in how you can apply RBAC and you can only have a single instance of that resource for a given identifier. As an example, if the service broker you are registering has fixed class and plan identifiers, you will be limited to one instance of the broker. With namespace-scoped brokers, however, the `ServiceBroker`, along with the `ServiceClass` and `ServicePlan` resources are scoped to a particular namespace. This allows for some more complicated use cases that were not possible with the cluster-scoped broker resources. 
+
+### Registering Brokers Per Namespace
+
+A service broker that provisions services in a cloud provider usually needs credentials in order to complete the request on behalf of Service Catalog. Some organizations may provide different access credentials to different teams in order to separate billing usage or to isolate control of resources. In these cases, the cluster operator might want to register two copies of the broker using different credentials for each team. When using `ClusterServiceBroker` and the associated `ClusterServiceClass` and `ClusterServicePlan` resources, it was not possible to register two instances of a service broker unless each registration could provide unique identifiers for service c lasses and service plans.
+
+Using namespace-scoped brokers, however, enables the broker to be installed in each namespace without conflicting at the class and plan level. When creating a service instance, you specify either the external class or plan name, or provide the class or plan identifier. Service Catalog then resolves these in order to determine which broker it should issue the provision command to. When using namespace-scoped brokers and their associated resources, this resolution occurs within the namespace. That means that users in namespace `backend-team` and namespace `front-end-team` can have the their own broker registrations and provision requests will be issued to the correct broker.
+
+### Limiting Access to Plans
+
+There are often situations when not all services and plans should be available to all users. A cluster administrator may wish to only provide free plans to certain users or restrict the ability to provision very expensive services. Additionally, when developers are creating new services that are exposed by brokers, they want to be able to iterate on those services without exposing them to all users in a cluster.
+
+Service Catalog's cluster-scoped resources for brokers, services, and plans are not sufficient to implement access control to ensure that users have access only to the service and plans that they should. For these resources, application of RBAC is really centered around what is visible to them, but is not enforced when a provision request is issued. For example, a `CLusterRole` could be created to prohibit a given user or group to view classes and plans, but this can not be used at provisioning time to ensure that the user cannot create the resource. Namespace-scoped brokers, services and plans, however, can be effectively combined with Kubernetes role based access control and Service Catalog Catalog Restrictions in order to provide more granular control over service instance provisioning.
+
+## Enabling Namespace Scoped Broker Resources
+
+Currently, namespace-scoped broker resources are an alpha-feature of Service Catalog behind a feature flag. To start using these resources, you will need to pass an argument to the API Server when you install Service Catalog: `--feature-gates NamespacedServiceBroker=true`.
+
+If you are using Helm, this flag has been surfaced as a chart parameter:
+
+```console
+helm install svc-cat/catalog \
+   --name catalog \
+   --namespace catalog \
+   --set namespacedServiceBrokerEnabled=true
+```
+
+If you are also using RBAC, providing this option to the Helm install command will also create the needed RBAC resources.
+
+## Using Namespace Scoped Broker Resources
+
+Once Service Catalog has been installed with this feature gate enabled, you should see three new resource types: `ServiceBroker`, `ServiceClass`, and `ServicePlan`.
+
+In order to register a `ServiceBroker` resource, you create a YAML definition that looks similar to a `ClusterServiceBroker`. This resource will use a different resource kind, however, and requires a namespace. An example might look like:
+
+```yaml
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBroker
+metadata:
+  name: example-ns-broker
+  namespace: ns-broker
+spec:
+  authInfo:
+    basic:
+      secretRef:
+        name: my-service-broker-auth
+        namespace: broker
+  url: http://my-service-broker.broker.svc.cluster.local
+```
+
+Once this resource is created, Service Catalog will query the Service Broker for the list of available Services and create corresponding `ServiceClass` and `ServicePlan` resources. These resources might look like this:
+
+```yaml
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceClass
+metadata:
+  creationTimestamp: 2018-07-12T13:30:01Z
+  name: 25434f16-d762-41c7-bbdd-8045d7f74ca6
+  namespace: ns-broker
+  resourceVersion: "13"
+  selfLink: /apis/servicecatalog.k8s.io/v1beta1/namespaces/ns-broker/serviceclasses/25434f16-d762-41c7-bbdd-8045d7f74ca6
+  uid: adfa2d9a-85d7-11e8-a4f3-2ae408f4a9e4
+spec:
+  bindable: true
+  bindingRetrievable: false
+  description: MySQL
+  externalID: 25434f16-d762-41c7-bbdd-8045d7f74ca6
+  externalName: mysql-5-7
+  planUpdatable: false
+  serviceBrokerName: example-ns-broker
+status:
+  removedFromBrokerCatalog: false
+```
+
+```yaml
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServicePlan
+metadata:
+  creationTimestamp: 2018-07-12T13:30:02Z
+  name: 4c6932e8-30ec-4af9-83d2-6e27286dbab3
+  namespace: ns-broker
+  resourceVersion: "24"
+  selfLink: /apis/servicecatalog.k8s.io/v1beta1/namespaces/ns-broker/serviceplans/4c6932e8-30ec-4af9-83d2-6e27286dbab3
+  uid: ae8e23ac-85d7-11e8-a4f3-2ae408f4a9e4
+spec:
+  description: basic plan
+  externalID: 4c6932e8-30ec-4af9-83d2-6e27286dbab3
+serviceBrokerName: example-ns-broker
+  serviceClassRef:
+    name: 25434f16-d762-41c7-bbdd-8045d7f74ca6
+status:
+  removedFromBrokerCatalog: false
+```
+
+The `ServiceInstance` resource has also been updated to allow you to use these resources just as you would the existing `ClusterServiceBroker`, `ClusterServiceClass` and `ClusterServicePlan` resources, except you will use them in the context of a namespace. For example, a `ServiceInstance` YAML that references a `ClusterServiceClass` and a `ClusterServicePlan` resource might look like this:
+
+```yaml
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
+metadata:
+  name: example-mysql-instance
+  namespace: default
+spec:
+  clusterServiceClassExternalName: mysql-5-7
+  clusterServicePlanExternalName: basic
+```
+
+If you instead want to use the `ServiceClass` and `ServicePlan` namespace-scoped resources, the yaml might look like this:
+
+```yaml
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
+metadata:
+  name: example-mysql-instance
+  namespace: default
+spec:
+  serviceClassExternalName: mysql-5-7
+  servicePlanExternalName: basic
+```
+
+In order to successfully create the resource using the namespace-scoped `ServiceClass` and `ServicePlan`, those resources must exist 
+in the same namespace as the `ServiceInstance` that you are creating. If a user attempts to create a `ServiceInstance` in a namespace 
+using a `ServiceClass` and `ServicePlan` that are contained in a different namespace, they request will fail.
+
+## Further Restricting Plan Access
+
+The use of namespace-scoped resources enables you to register brokers within a given namespace and leverage RBAC in order to control who can 
+provision services in that namespace. By default, all service classes and plans from that broker will be available to users of the namespace. When registering a broker, catalog restrictions can be specified in order to restrict what plans are available within a given namespace. This allows you to specify that in the `developer` namespace, only plans named `basic` can be created. The YAML to accomplish this might look like:
+
+```yaml
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBroker
+metadata:
+  name: example-ns-broker
+  namespace: ns-broker
+spec:
+  authInfo:
+    basic:
+      secretRef:
+        name: my-service-broker-auth
+        namespace: broker
+  url: http://my-service-broker.broker.svc.cluster.local
+  catalogRestrictions:
+    servicePlan:
+    - "spec.externalName==basic"
+```
+
+When you combine the two capabilities, you can effectively restrict provisioning of service classes or plans to very specific namespaces. Production grade instances, for example, could be heavily restricted to a small subset of users. Other namespaces could be given access to other plans.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -99,7 +99,7 @@ apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ServiceClass
 metadata:
   name: 4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
-  namesspace: default
+  namespace: default
 spec:
   bindable: true
   serviceBrokerName: ups-broker

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -3,18 +3,28 @@ title: Resources
 layout: docwithnav
 ---
 
+# Service Catalog Resources
+
 The Service Catalog resource model specifies all the behaviors that 
 Service Catalog supports. This document details each resource.
 
 All of these resources are also defined in Go code at
 [`pkg/apis/servicecatalog/v1beta1/types.go`](https://github.com/kubernetes-incubator/service-catalog/blob/master/pkg/apis/servicecatalog/v1beta1/types.go).
 
-# ClusterServiceBroker
+
+## Service Brokers
 
 Before a Service can be used by an Application it must first be registered
 with the Kubernetes platform. Since Services are managed by Service Brokers
 we must first register the Service Broker by creating an instance of a
-`ClusterServiceBroker`:
+`ClusterServiceBroker` or a `ServiceBroker`. These resources are similar, 
+however one is cluster-scoped and one is namespace-scoped.
+
+### ClusterServiceBroker
+
+If you would like to make a service broker available cluster wide, you register 
+the broker using a `ClusterServiceBroker` resource. This will result in Service Class 
+and Service Plan objects being created with a cluster-scope as well. 
 
 ```console
 kubectl create -f broker.yaml
@@ -31,15 +41,39 @@ kind: ClusterServiceBroker
     url: http://broker-url.com
 ```
 
-**Note:** The `ClusterServiceBroker` resource is  cluster-scoped, and doesn't 
-have a namespace.
+### ServiceBroker
 
-# ClusterServiceClass
+If you would like to make a service broker available to only a single namespace, you register 
+the broker using a `ServiceBroker` resource. This will result in Service Class 
+and Service Plan objects being created with a namespace-scope as well.
 
-After a `ClusterServiceBroker` resource is created, the Service Catalog 
-will query the Service Broker (at the `url` specified) for the list
+```console
+kubectl create -f broker.yaml
+```
+
+The `broker.yaml` looks similar to this:
+
+```yaml
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBroker
+  metadata:
+    name: broker-name
+    namespace: default
+  spec:
+    url: http://broker-url.com
+```
+
+## Service Classes
+
+After a Service Broker has been registered by creating either a `ClusterServiceBroker` or 
+`ServiceBroker`, the Service Catalog  will query the Service Broker (at the `url` specified) for the list
 of available Services (the catalog). Each Service will then have a corresponding
-`ClusterServiceClass` resource created:
+`ClusterServiceClass` or `ServiceClass` resource created.
+
+### ClusterServiceClass
+
+After a `ClusterServiceBroker` resource is created, each service provided by the broker will then have a corresponding
+`ClusterServiceClass` resource created. These resources will also be cluster-scoped. A `ClusterServiceClass` looks similar to this example:
 
 ```yaml
 apiVersion: servicecatalog.k8s.io/v1beta1
@@ -55,26 +89,47 @@ spec:
   planUpdatable: false
 ```
 
-**Note:** The `ClusterServiceClass` resource is  cluster-scoped, and doesn't 
-have a namespace.
+## ServiceClass
 
-# ClusterServicePlan
+After a `ServiceBroker` resource is created, each service provided by the broker will then have a corresponding
+`ServiceClass` resource created. These resources will also be namespaced-scoped. A `ServiceClass` looks similar to this example:
 
-Each `ClusterServiceClass` has one or more Plans associated with it. Each
-`{ClusterServiceClass, ClusterServicePlan}` pair is the broker's service that 
-we can provision. Plans generally indicate details like cost, performance, or 
+```yaml
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceClass
+metadata:
+  name: 4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
+  namesspace: default
+spec:
+  bindable: true
+  serviceBrokerName: ups-broker
+  description: A user provided service
+  externalID: 4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468
+  externalName: user-provided-service
+  planUpdatable: false
+```
+
+## Service Plans
+
+Each Service Class has one or more Plans associated with it. Each
+`{ClusterServiceClass, ClusterServicePlan}` or `{ServiceClass, ServicePlan}` pair is the broker's 
+service that we can provision. Plans generally indicate details like cost, performance, or 
 quality-of-service.
+
+### ClusterServicePlan
 
 For each plan of each `ClusterServiceClass`, a `ClusterServicePlan` will be created.
 
-**Note:** The `ClusterServicePlan` resource is  cluster-scoped, and doesn't 
-have a namespace.
+### ServicePlan
 
-# ServiceInstance
+For each plan of each `ServiceClass`, a `ServicePlan` will be created.
+
+## ServiceInstance
 
 Use a `ServiceInstance` to tell the broker to provision a new service. The 
-`ServiceInstance` indicates the `ClusterServiceClass` and `ClusterServicePlan`
-name to be provisioned.
+`ServiceInstance` can use either cluster-scoped or namespace-scoped Service Class 
+and Service Plan resources. When using `ServiceClass` and `ServicePlan`, the `ServiceInstance`
+must be in the same namespace.
 
 Create the `ServiceInstance`:
 
@@ -95,7 +150,20 @@ spec:
   clusterServicePlanExternalName: free
  ```
 
-## Service Instance Parameters
+or
+
+```yaml
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
+metadata:
+  namespace: default
+  name: test-database
+spec:
+  serviceClassExternalName: small-db
+  servicePlanExternalName: free
+ ```
+
+### Service Instance Parameters
 
 Each `ServiceInstance` has a `paramters` field that you can add 
 metadata to. Service Catalog passes this metadata directly through to the
@@ -123,7 +191,7 @@ you have to manually increment the `UpdateRequests` field in the
 
 For more information, see the documentation on [parameters](parameters.md).
 
-# ServiceBinding
+## ServiceBinding
 
 `ServiceBinding` is the final resource that will be created in most
 workflows. This resource indicates that an application wants to connect

--- a/docsite/_config.yml
+++ b/docsite/_config.yml
@@ -57,4 +57,5 @@ tocs:
   - cli
   - concepts
   - resources
+  - namespaced-broker-resources
   - docs-home # fallthrough, leave this last

--- a/docsite/_data/namespaced-broker-resources.yml
+++ b/docsite/_data/namespaced-broker-resources.yml
@@ -6,10 +6,10 @@ toc:
 - title: Cluster-Scoped vs Namespace-scoped Broker
   path: "#cluster-scopedvsmamespace-scopedbrokerresources"
 - title: Possible Use Cases
-  path: "#possibleusecases"
+  path: "#possible-use-cases"
 - title: Enabling Namespace Scoped Broker Resources
-  path: "#enablingnamespacescopedbrokerresources"
+  path: "#enabling-namespace-scoped-broker-resources"
 - title: Using Namespace Scoped Broker Resources
-  path: "#usingnamespacescopedbrokerresources"
+  path: "#using-namespace-scoped-broker-resources"
 - title: Further Restricting Plan Access
-  path: "#furtherrestrictingplanaccess"
+  path: "#further-restricting-plan-access"

--- a/docsite/_data/namespaced-broker-resources.yml
+++ b/docsite/_data/namespaced-broker-resources.yml
@@ -4,7 +4,7 @@ landing_page: /docs/namespaced-broker-resources
 toc:
 - docs/namespaced-broker-resources.md
 - title: Cluster-Scoped vs Namespace-scoped Broker
-  path: "#cluster-scopedvsmamespace-scopedbroker-resources"
+  path: "#cluster-scoped-vs-namespace-scoped-broker-resources"
 - title: Possible Use Cases
   path: "#possible-use-cases"
 - title: Enabling Namespace Scoped Broker Resources

--- a/docsite/_data/namespaced-broker-resources.yml
+++ b/docsite/_data/namespaced-broker-resources.yml
@@ -4,7 +4,7 @@ landing_page: /docs/namespaced-broker-resources
 toc:
 - docs/namespaced-broker-resources.md
 - title: Cluster-Scoped vs Namespace-scoped Broker
-  path: "#cluster-scopedvsmamespace-scopedbrokerresources"
+  path: "#cluster-scopedvsmamespace-scopedbroker-resources"
 - title: Possible Use Cases
   path: "#possible-use-cases"
 - title: Enabling Namespace Scoped Broker Resources

--- a/docsite/_data/namespaced-broker-resources.yml
+++ b/docsite/_data/namespaced-broker-resources.yml
@@ -1,0 +1,15 @@
+bigheader: "Namespaces"
+abstract: "Namespaced Broker Resources"
+landing_page: /docs/namespaced-broker-resources
+toc:
+- docs/namespaced-broker-resources.md
+- title: Cluster-Scoped vs Namespace-scoped Broker
+  path: "#cluster-scopedvsmamespace-scopedbrokerresources"
+- title: Possible Use Cases
+  path: "#possibleusecases"
+- title: Enabling Namespace Scoped Broker Resources
+  path: "#enablingnamespacescopedbrokerresources"
+- title: Using Namespace Scoped Broker Resources
+  path: "#usingnamespacescopedbrokerresources"
+- title: Further Restricting Plan Access
+  path: "#furtherrestrictingplanaccess"

--- a/docsite/_data/resources.yml
+++ b/docsite/_data/resources.yml
@@ -3,10 +3,12 @@ abstract: "Service Catalog Resources"
 landing_page: /docs/resources
 toc:
 - docs/resources.md
-- title: Broker
-  path: "#clusterservicebroker"
-- title: Class
-  path: "#clusterserviceclass"
+- title: Service Broker
+  path: "#servicebrokers"
+- title: Service Class
+  path: "#serviceclasses"
+- title: Service Plans
+  path: "#serviceplans"
 - title: Instance
   path: "#serviceinstance"
 - title: Instance Parameters

--- a/docsite/_data/resources.yml
+++ b/docsite/_data/resources.yml
@@ -4,11 +4,11 @@ landing_page: /docs/resources
 toc:
 - docs/resources.md
 - title: Service Broker
-  path: "#servicebrokers"
+  path: "#service-brokers"
 - title: Service Class
-  path: "#serviceclasses"
+  path: "#service-classes"
 - title: Service Plans
-  path: "#serviceplans"
+  path: "#service-plans"
 - title: Instance
   path: "#serviceinstance"
 - title: Instance Parameters

--- a/docsite/index.html
+++ b/docsite/index.html
@@ -105,7 +105,7 @@ cid: home
             </div>
             <div>
                 <h4><a href="/docs/cli">Operator Friendly</a></h4>
-                <p>Install a broker at the cluster or in a single names, control
+                <p>Install a broker at the cluster or in a single namespace, control
                 which services you'd like to make available, and provide sensible
                 defaults for provisioning cloud services.</p>
             </div>

--- a/docsite/index.html
+++ b/docsite/index.html
@@ -105,7 +105,7 @@ cid: home
             </div>
             <div>
                 <h4><a href="/docs/cli">Operator Friendly</a></h4>
-                <p>Install a broker at the cluster or in a single namespace, control
+                <p>Install a broker at the cluster level or in a single namespace, control
                 which services you'd like to make available, and provide sensible
                 defaults for provisioning cloud services.</p>
             </div>


### PR DESCRIPTION
This PR adds relevant wording to the docs/resources.md file to introduce the namespaced resources. 

It also introduces a new section to docs/README.md called 'Topics for operators' and introduces a page dedicated to namespaced brokers. 

docs/namespaced-broker-resources.md provides:
* Example use cases
* How to enable the feature flag
* How to create namespaced resources and use them from Service Instances
* How to combine with catalog restrictions (need to link to this later) to make tight control of what can be provisioned

Closes: #2202