### PR TITLE
disable unit tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
           make verify-docs
         else
           echo "Running full build"
-          make verify build svcat build-integration build-e2e test
+          make verify build svcat build-integration build-e2e test-integration
         fi
       env: GO_VERSION=1.10
     # Cross Build Check


### PR DESCRIPTION
The pull-service-catalog-unit runs this now.

We don't have to do this, but it's an interesting thought. Probably only saves a few seconds at most.

Belt and suspenders if we leave it on.