### PR TITLE
Ensure that ObjectMeta field selectors (e.g. name and namespace) can be used appropriately for all types

### DIFF
--- a/pkg/apis/servicecatalog/v1beta1/conversion.go
+++ b/pkg/apis/servicecatalog/v1beta1/conversion.go
@@ -29,7 +29,8 @@ import (
 // what it's given for the supported fields, and errors for unsupported.
 func ClusterServicePlanFieldLabelConversionFunc(label, value string) (string, string, error) {
 	switch label {
-	case "spec.externalID",
+	case "metadata.name",
+		"spec.externalID",
 		"spec.externalName",
 		"spec.clusterServiceBrokerName",
 		"spec.clusterServiceClassRef.name":
@@ -43,7 +44,9 @@ func ClusterServicePlanFieldLabelConversionFunc(label, value string) (string, st
 // what it's given for the supported fields, and errors for unsupported.
 func ServicePlanFieldLabelConversionFunc(label, value string) (string, string, error) {
 	switch label {
-	case "spec.externalID",
+	case "metadata.name",
+		"metadata.namespace",
+		"spec.externalID",
 		"spec.externalName",
 		"spec.serviceBrokerName",
 		"spec.serviceClassRef.name":
@@ -57,7 +60,9 @@ func ServicePlanFieldLabelConversionFunc(label, value string) (string, string, e
 // what it's given for the supported fields, and errors for unsupported.
 func ServiceClassFieldLabelConversionFunc(label, value string) (string, string, error) {
 	switch label {
-	case "spec.externalID",
+	case "metadata.name",
+		"metadata.namespace",
+		"spec.externalID",
 		"spec.externalName",
 		"spec.serviceBrokerName":
 		return label, value, nil
@@ -70,7 +75,8 @@ func ServiceClassFieldLabelConversionFunc(label, value string) (string, string, 
 // what it's given for the supported fields, and errors for unsupported.
 func ClusterServiceClassFieldLabelConversionFunc(label, value string) (string, string, error) {
 	switch label {
-	case "spec.externalID",
+	case "metadata.name",
+		"spec.externalID",
 		"spec.externalName",
 		"spec.clusterServiceBrokerName":
 		return label, value, nil
@@ -83,7 +89,9 @@ func ClusterServiceClassFieldLabelConversionFunc(label, value string) (string, s
 // what it's given for the supported fields, and errors for unsupported.
 func ServiceInstanceFieldLabelConversionFunc(label, value string) (string, string, error) {
 	switch label {
-	case "spec.externalID",
+	case "metadata.name",
+		"metadata.namespace",
+		"spec.externalID",
 		"spec.clusterServiceClassRef.name",
 		"spec.clusterServicePlanRef.name":
 		return label, value, nil
@@ -96,7 +104,9 @@ func ServiceInstanceFieldLabelConversionFunc(label, value string) (string, strin
 // what it's given for the supported fields, and errors for unsupported.
 func ServiceBindingFieldLabelConversionFunc(label, value string) (string, string, error) {
 	switch label {
-	case "spec.externalID":
+	case "metadata.name",
+		"metadata.namespace",
+		"spec.externalID":
 		return label, value, nil
 	default:
 		return "", "", fmt.Errorf("field label not supported: %s", label)

--- a/pkg/registry/servicecatalog/binding/storage.go
+++ b/pkg/registry/servicecatalog/binding/storage.go
@@ -90,15 +90,9 @@ func Match(label labels.Selector, field fields.Selector) storage.SelectionPredic
 func toSelectableFields(binding *servicecatalog.ServiceBinding) fields.Set {
 	// If you add a new selectable field, you also need to modify
 	// pkg/apis/servicecatalog/v1beta1/conversion[_test].go
-	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(&binding.ObjectMeta, true)
-
 	specFieldSet := make(fields.Set, 1)
-
-	if binding.Spec.ExternalID != "" {
-		specFieldSet["spec.externalID"] = binding.Spec.ExternalID
-	}
-
-	return generic.MergeFieldsSets(objectMetaFieldsSet, specFieldSet)
+	specFieldSet["spec.externalID"] = binding.Spec.ExternalID
+	return generic.AddObjectMetaFieldsSet(specFieldSet, &binding.ObjectMeta, true)
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.

--- a/pkg/registry/servicecatalog/clusterservicebroker/storage.go
+++ b/pkg/registry/servicecatalog/clusterservicebroker/storage.go
@@ -89,8 +89,7 @@ func Match(label labels.Selector, field fields.Selector) storage.SelectionPredic
 
 // toSelectableFields returns a field set that represents the object for matching purposes.
 func toSelectableFields(broker *servicecatalog.ClusterServiceBroker) fields.Set {
-	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(&broker.ObjectMeta, true)
-	return generic.MergeFieldsSets(objectMetaFieldsSet, nil)
+	return generic.ObjectMetaFieldsSet(&broker.ObjectMeta, false)
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.

--- a/pkg/registry/servicecatalog/clusterserviceclass/storage.go
+++ b/pkg/registry/servicecatalog/clusterserviceclass/storage.go
@@ -100,7 +100,7 @@ func toSelectableFields(clusterServiceClass *servicecatalog.ClusterServiceClass)
 	cscSpecificFieldsSet["spec.clusterServiceBrokerName"] = clusterServiceClass.Spec.ClusterServiceBrokerName
 	cscSpecificFieldsSet["spec.externalName"] = clusterServiceClass.Spec.ExternalName
 	cscSpecificFieldsSet["spec.externalID"] = clusterServiceClass.Spec.ExternalID
-	return generic.AddObjectMetaFieldsSet(cscSpecificFieldsSet, &clusterServiceClass.ObjectMeta, true)
+	return generic.AddObjectMetaFieldsSet(cscSpecificFieldsSet, &clusterServiceClass.ObjectMeta, false)
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.

--- a/pkg/registry/servicecatalog/clusterserviceplan/storage.go
+++ b/pkg/registry/servicecatalog/clusterserviceplan/storage.go
@@ -99,7 +99,7 @@ func toSelectableFields(servicePlan *servicecatalog.ClusterServicePlan) fields.S
 	spSpecificFieldsSet["spec.clusterServiceClassRef.name"] = servicePlan.Spec.ClusterServiceClassRef.Name
 	spSpecificFieldsSet["spec.externalName"] = servicePlan.Spec.ExternalName
 	spSpecificFieldsSet["spec.externalID"] = servicePlan.Spec.ExternalID
-	return generic.AddObjectMetaFieldsSet(spSpecificFieldsSet, &servicePlan.ObjectMeta, true)
+	return generic.AddObjectMetaFieldsSet(spSpecificFieldsSet, &servicePlan.ObjectMeta, false)
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.

--- a/pkg/registry/servicecatalog/instance/storage.go
+++ b/pkg/registry/servicecatalog/instance/storage.go
@@ -90,23 +90,15 @@ func Match(label labels.Selector, field fields.Selector) storage.SelectionPredic
 func toSelectableFields(instance *servicecatalog.ServiceInstance) fields.Set {
 	// If you add a new selectable field, you also need to modify
 	// pkg/apis/servicecatalog/v1beta1/conversion[_test].go
-	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(&instance.ObjectMeta, true)
-
 	specFieldSet := make(fields.Set, 3)
-
 	if instance.Spec.ClusterServiceClassRef != nil {
 		specFieldSet["spec.clusterServiceClassRef.name"] = instance.Spec.ClusterServiceClassRef.Name
 	}
-
 	if instance.Spec.ClusterServicePlanRef != nil {
 		specFieldSet["spec.clusterServicePlanRef.name"] = instance.Spec.ClusterServicePlanRef.Name
 	}
-
-	if instance.Spec.ExternalID != "" {
-		specFieldSet["spec.externalID"] = instance.Spec.ExternalID
-	}
-
-	return generic.MergeFieldsSets(objectMetaFieldsSet, specFieldSet)
+	specFieldSet["spec.externalID"] = instance.Spec.ExternalID
+	return generic.AddObjectMetaFieldsSet(specFieldSet, &instance.ObjectMeta, true)
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.

--- a/pkg/registry/servicecatalog/servicebroker/storage.go
+++ b/pkg/registry/servicecatalog/servicebroker/storage.go
@@ -89,8 +89,7 @@ func Match(label labels.Selector, field fields.Selector) storage.SelectionPredic
 
 // toSelectableFields returns a field set that represents the object for matching purposes.
 func toSelectableFields(broker *servicecatalog.ServiceBroker) fields.Set {
-	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(&broker.ObjectMeta, true)
-	return generic.MergeFieldsSets(objectMetaFieldsSet, nil)
+	return generic.ObjectMetaFieldsSet(&broker.ObjectMeta, true)
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.

--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -542,6 +542,15 @@ func testClusterServiceClassClient(sType server.StorageType, client servicecatal
 		return fmt.Errorf("should have two ClusterServiceClasses, had %v ClusterServiceClasses", len(serviceClasses.Items))
 	}
 
+	serviceClasses, err = serviceClassClient.List(metav1.ListOptions{FieldSelector: "metadata.name=" + name})
+	if err != nil {
+		return fmt.Errorf("error listing ClusterServiceClasses: %v", err)
+	}
+
+	if 1 != len(serviceClasses.Items) {
+		return fmt.Errorf("should have exactly one ClusterServiceClass, had %v ClusterServiceClasses", len(serviceClasses.Items))
+	}
+
 	err = serviceClassClient.Delete(name, &metav1.DeleteOptions{})
 	if nil != err {
 		return fmt.Errorf("serviceclass should be deleted (%s)", err)
@@ -757,6 +766,15 @@ func testClusterServicePlanClient(sType server.StorageType, client servicecatalo
 	}
 	if 2 != len(servicePlans.Items) {
 		return fmt.Errorf("should have two ClusterServicePlans, had %v ClusterServicePlans : %+v", len(servicePlans.Items), servicePlans.Items)
+	}
+
+	servicePlans, err = servicePlanClient.List(metav1.ListOptions{FieldSelector: "metadata.name=" + name})
+	if err != nil {
+		return fmt.Errorf("error listing ClusterServicePlans: %v", err)
+	}
+
+	if 1 != len(servicePlans.Items) {
+		return fmt.Errorf("should have exactly one ClusterServicePlan, had %v ClusterServicePlans", len(servicePlans.Items))
 	}
 
 	err = servicePlanClient.Delete(name, &metav1.DeleteOptions{})
@@ -984,6 +1002,15 @@ func testInstanceClient(sType server.StorageType, client servicecatalogclient.In
 	}
 
 	instances, err = instanceClient.List(metav1.ListOptions{FieldSelector: "spec.clusterServicePlanRef.name=service-plan-ref"})
+	if err != nil {
+		return fmt.Errorf("error listing instances: %v", err)
+	}
+
+	if 1 != len(instances.Items) {
+		return fmt.Errorf("should have exactly one instance, had %v instances", len(instances.Items))
+	}
+
+	instances, err = instanceClient.List(metav1.ListOptions{FieldSelector: "metadata.name=" + name})
 	if err != nil {
 		return fmt.Errorf("error listing instances: %v", err)
 	}


### PR DESCRIPTION
Noticed that the ObjectMeta fields `metadata.name` and `metadata.namespace` do not work as they haven't been registered in conversions.

I also took the liberty of tidying up the fields methods in registry to make them consitent in their approach.