### PR TITLE
Define common interfaces for cluster and namespaced classes and plans

### DIFF
--- a/pkg/apis/servicecatalog/v1beta1/class.go
+++ b/pkg/apis/servicecatalog/v1beta1/class.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+// GetName returns the class's name.
+func (c *ClusterServiceClass) GetName() string {
+	return c.Name
+}
+
+// GetName returns the class's name.
+func (c *ServiceClass) GetName() string {
+	return c.Name
+}
+
+// GetExternalName returns the class's external name.
+func (c *ClusterServiceClass) GetExternalName() string {
+	return c.Spec.ExternalName
+}
+
+// GetExternalName returns the class's external name.
+func (c *ServiceClass) GetExternalName() string {
+	return c.Spec.ExternalName
+}
+
+// GetDescription returns the class description.
+func (c *ClusterServiceClass) GetDescription() string {
+	return c.Spec.Description
+}
+
+// GetDescription returns the class description.
+func (c *ServiceClass) GetDescription() string {
+	return c.Spec.Description
+}

--- a/pkg/apis/servicecatalog/v1beta1/plan.go
+++ b/pkg/apis/servicecatalog/v1beta1/plan.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+// GetName returns the plan's name.
+func (p *ClusterServicePlan) GetName() string {
+	return p.Name
+}
+
+// GetName returns the plan's name.
+func (p *ServicePlan) GetName() string {
+	return p.Name
+}
+
+// GetExternalName returns the plan's external name.
+func (p *ClusterServicePlan) GetExternalName() string {
+	return p.Spec.ExternalName
+}
+
+// GetExternalName returns the plan's external name.
+func (p *ServicePlan) GetExternalName() string {
+	return p.Spec.ExternalName
+}
+
+// GetDescription returns the plan description.
+func (p *ClusterServicePlan) GetDescription() string {
+	return p.Spec.Description
+}
+
+// GetDescription returns the plan description.
+func (p *ServicePlan) GetDescription() string {
+	return p.Spec.Description
+}

--- a/pkg/svcat/service-catalog/class.go
+++ b/pkg/svcat/service-catalog/class.go
@@ -29,6 +29,19 @@ const (
 	FieldExternalClassName = "spec.externalName"
 )
 
+// Class provides a unifying layer of cluster and namespace scoped class resources.
+type Class interface {
+
+	// GetName returns the class's name.
+	GetName() string
+
+	// GetExternalName returns the class's external name.
+	GetExternalName() string
+
+	// GetDescription returns the class description.
+	GetDescription() string
+}
+
 // RetrieveClasses lists all classes defined in the cluster.
 func (sdk *SDK) RetrieveClasses() ([]v1beta1.ClusterServiceClass, error) {
 	classes, err := sdk.ServiceCatalog().ClusterServiceClasses().List(v1.ListOptions{})

--- a/pkg/svcat/service-catalog/plan.go
+++ b/pkg/svcat/service-catalog/plan.go
@@ -32,6 +32,19 @@ const (
 	FieldServiceClassRef = "spec.clusterServiceClassRef.name"
 )
 
+// Plan provides a unifying layer of cluster and namespace scoped plan resources.
+type Plan interface {
+
+	// GetName returns the plan's name.
+	GetName() string
+
+	// GetExternalName returns the plan's external name.
+	GetExternalName() string
+
+	// GetDescription returns the plan description.
+	GetDescription() string
+}
+
 // RetrievePlans lists all plans defined in the cluster.
 func (sdk *SDK) RetrievePlans(opts *FilterOptions) ([]v1beta1.ClusterServicePlan, error) {
 	plans, err := sdk.ServiceCatalog().ClusterServicePlans().List(v1.ListOptions{})


### PR DESCRIPTION
This is necessary groundwork for the svcat cli to deal with both `ClusterServiceBrokers` and `ServiceBrokers`. I expect that interface may expand to add more values from the common specs but for now I just wanted to get it defined so that the many issues for supporting namespaced brokers aren't blocked by a larger PR (#2116).