### PR TITLE
Refactor formatted interface to be consistent with the others

### DIFF
--- a/cmd/svcat/binding/get_cmd.go
+++ b/cmd/svcat/binding/get_cmd.go
@@ -24,17 +24,16 @@ import (
 
 type getCmd struct {
 	*command.Namespaced
-	name         string
-	outputFormat string
-}
-
-func (c *getCmd) SetFormat(format string) {
-	c.outputFormat = format
+	*command.Formatted
+	name string
 }
 
 // NewGetCmd builds a "svcat get bindings" command
 func NewGetCmd(cxt *command.Context) *cobra.Command {
-	getCmd := &getCmd{Namespaced: command.NewNamespaced(cxt)}
+	getCmd := &getCmd{
+		Namespaced: command.NewNamespaced(cxt),
+		Formatted:  command.NewFormatted(),
+	}
 	cmd := &cobra.Command{
 		Use:     "bindings [NAME]",
 		Aliases: []string{"binding", "bnd"},
@@ -50,7 +49,7 @@ func NewGetCmd(cxt *command.Context) *cobra.Command {
 	}
 
 	getCmd.AddNamespaceFlags(cmd.Flags(), true)
-	command.AddOutputFlags(cmd.Flags())
+	getCmd.AddOutputFlags(cmd.Flags())
 	return cmd
 }
 
@@ -76,7 +75,7 @@ func (c *getCmd) getAll() error {
 		return err
 	}
 
-	output.WriteBindingList(c.Output, c.outputFormat, bindings)
+	output.WriteBindingList(c.Output, c.OutputFormat, bindings)
 	return nil
 }
 
@@ -86,6 +85,6 @@ func (c *getCmd) get() error {
 		return err
 	}
 
-	output.WriteBinding(c.Output, c.outputFormat, *binding)
+	output.WriteBinding(c.Output, c.OutputFormat, *binding)
 	return nil
 }

--- a/cmd/svcat/binding/get_cmd_test.go
+++ b/cmd/svcat/binding/get_cmd_test.go
@@ -132,10 +132,11 @@ func TestGetCommand(t *testing.T) {
 			// Initialize the command arguments
 			cmd := &getCmd{
 				Namespaced: command.NewNamespaced(cxt),
+				Formatted:  command.NewFormatted(),
 			}
 			cmd.Namespace = namespace
 			cmd.name = tc.bindingName
-			cmd.outputFormat = tc.outputFormat
+			cmd.OutputFormat = tc.outputFormat
 
 			err := cmd.Run()
 

--- a/cmd/svcat/binding/get_cmd_test.go
+++ b/cmd/svcat/binding/get_cmd_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
+	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/output"
 	_ "github.com/kubernetes-incubator/service-catalog/internal/test"
 )
 
@@ -61,21 +62,21 @@ func TestGetCommand(t *testing.T) {
 			name:         "get all existing bindings with json output format",
 			fakeBindings: []string{"myfirstbinding", "mysecondbinding"},
 			bindingName:  "",
-			outputFormat: "json",
+			outputFormat: output.FormatJSON,
 			wantError:    false,
 		},
 		{
 			name:         "get all existing bindings with yaml output format",
 			fakeBindings: []string{"myfirstbinding", "mysecondbinding"},
 			bindingName:  "",
-			outputFormat: "yaml",
+			outputFormat: output.FormatYAML,
 			wantError:    false,
 		},
 		{
 			name:         "get all existing bindings with table output format",
 			fakeBindings: []string{"myfirstbinding", "mysecondbinding"},
 			bindingName:  "",
-			outputFormat: "table",
+			outputFormat: output.FormatTable,
 			wantError:    false,
 		},
 		{
@@ -89,21 +90,21 @@ func TestGetCommand(t *testing.T) {
 			name:         "get existing binding with json output format",
 			fakeBindings: []string{"mybinding"},
 			bindingName:  "mybinding",
-			outputFormat: "json",
+			outputFormat: output.FormatJSON,
 			wantError:    false,
 		},
 		{
 			name:         "get existing binding with yaml output format",
 			fakeBindings: []string{"mybinding"},
 			bindingName:  "mybinding",
-			outputFormat: "yaml",
+			outputFormat: output.FormatYAML,
 			wantError:    false,
 		},
 		{
 			name:         "get existing binding with table output format",
 			fakeBindings: []string{"mybinding"},
 			bindingName:  "mybinding",
-			outputFormat: "table",
+			outputFormat: output.FormatTable,
 			wantError:    false,
 		},
 	}

--- a/cmd/svcat/broker/describe_cmd_test.go
+++ b/cmd/svcat/broker/describe_cmd_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
+	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
 	_ "github.com/kubernetes-incubator/service-catalog/internal/test"
 )
 
@@ -77,7 +78,10 @@ func TestDescribeCommand(t *testing.T) {
 			cxt := svcattest.NewContext(output, fakeApp)
 
 			// Initialize the command arguments
-			cmd := &getCmd{Context: cxt}
+			cmd := &getCmd{
+				Context:   cxt,
+				Formatted: command.NewFormatted(),
+			}
 			cmd.name = tc.brokerName
 
 			err := cmd.Run()

--- a/cmd/svcat/broker/get_cmd.go
+++ b/cmd/svcat/broker/get_cmd.go
@@ -24,17 +24,16 @@ import (
 
 type getCmd struct {
 	*command.Context
-	name         string
-	outputFormat string
-}
-
-func (c *getCmd) SetFormat(format string) {
-	c.outputFormat = format
+	*command.Formatted
+	name string
 }
 
 // NewGetCmd builds a "svcat get brokers" command
 func NewGetCmd(cxt *command.Context) *cobra.Command {
-	getCmd := &getCmd{Context: cxt}
+	getCmd := &getCmd{
+		Context:   cxt,
+		Formatted: command.NewFormatted(),
+	}
 	cmd := &cobra.Command{
 		Use:     "brokers [NAME]",
 		Aliases: []string{"broker", "brk"},
@@ -46,7 +45,7 @@ func NewGetCmd(cxt *command.Context) *cobra.Command {
 		PreRunE: command.PreRunE(getCmd),
 		RunE:    command.RunE(getCmd),
 	}
-	command.AddOutputFlags(cmd.Flags())
+	getCmd.AddOutputFlags(cmd.Flags())
 	return cmd
 }
 
@@ -72,7 +71,7 @@ func (c *getCmd) getAll() error {
 		return err
 	}
 
-	output.WriteBrokerList(c.Output, c.outputFormat, brokers...)
+	output.WriteBrokerList(c.Output, c.OutputFormat, brokers...)
 	return nil
 }
 
@@ -82,6 +81,6 @@ func (c *getCmd) get() error {
 		return err
 	}
 
-	output.WriteBroker(c.Output, c.outputFormat, *broker)
+	output.WriteBroker(c.Output, c.OutputFormat, *broker)
 	return nil
 }

--- a/cmd/svcat/class/get_cmd.go
+++ b/cmd/svcat/class/get_cmd.go
@@ -27,14 +27,10 @@ import (
 type getCmd struct {
 	*command.Namespaced
 	*command.Scoped
+	*command.Formatted
 	lookupByUUID bool
 	uuid         string
 	name         string
-	outputFormat string
-}
-
-func (c *getCmd) SetFormat(format string) {
-	c.outputFormat = format
 }
 
 // NewGetCmd builds a "svcat get classes" command
@@ -42,6 +38,7 @@ func NewGetCmd(cxt *command.Context) *cobra.Command {
 	getCmd := &getCmd{
 		Namespaced: command.NewNamespaced(cxt),
 		Scoped:     command.NewScoped(),
+		Formatted:  command.NewFormatted(),
 	}
 	cmd := &cobra.Command{
 		Use:     "classes [NAME]",
@@ -62,7 +59,7 @@ func NewGetCmd(cxt *command.Context) *cobra.Command {
 		false,
 		"Whether or not to get the class by UUID (the default is by name)",
 	)
-	command.AddOutputFlags(cmd.Flags())
+	getCmd.AddOutputFlags(cmd.Flags())
 	getCmd.AddNamespaceFlags(cmd.Flags(), true)
 	getCmd.AddScopedFlags(cmd.Flags(), true)
 	return cmd
@@ -98,7 +95,7 @@ func (c *getCmd) getAll() error {
 		return err
 	}
 
-	output.WriteClassList(c.Output, c.outputFormat, classes...)
+	output.WriteClassList(c.Output, c.OutputFormat, classes...)
 	return nil
 }
 
@@ -115,6 +112,6 @@ func (c *getCmd) get() error {
 		return err
 	}
 
-	output.WriteClass(c.Output, c.outputFormat, *class)
+	output.WriteClass(c.Output, c.OutputFormat, *class)
 	return nil
 }

--- a/cmd/svcat/class/get_cmd_test.go
+++ b/cmd/svcat/class/get_cmd_test.go
@@ -148,9 +148,9 @@ func TestListClasses(t *testing.T) {
 
 			// Initialize the command arguments
 			cmd := &getCmd{
-				Namespaced:   command.NewNamespaced(cxt),
-				Scoped:       command.NewScoped(),
-				outputFormat: "table",
+				Namespaced: command.NewNamespaced(cxt),
+				Scoped:     command.NewScoped(),
+				Formatted:  command.NewFormatted(),
 			}
 			cmd.Namespace = ns
 			cmd.Scope = tc.scope

--- a/cmd/svcat/command/command.go
+++ b/cmd/svcat/command/command.go
@@ -17,12 +17,10 @@ limitations under the License.
 package command
 
 import (
-	"fmt"
 	"strings"
 	"unicode"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 // Command represents an svcat command.
@@ -32,13 +30,6 @@ type Command interface {
 
 	// Run a validated svcat command.
 	Run() error
-}
-
-// FormattedCommand represents a command that can have it's output
-// formatted
-type FormattedCommand interface {
-	// SetFormat sets the commands output format
-	SetFormat(format string)
 }
 
 // PreRunE validates os args, and then saves them on the svcat command.
@@ -89,32 +80,6 @@ func PreRunE(cmd Command) func(*cobra.Command, []string) error {
 func RunE(cmd Command) func(*cobra.Command, []string) error {
 	return func(_ *cobra.Command, args []string) error {
 		return cmd.Run()
-	}
-}
-
-// AddOutputFlags adds common output flags to a command that can have variable output formats.
-func AddOutputFlags(flags *pflag.FlagSet) {
-	flags.StringP(
-		"output",
-		"o",
-		"",
-		"The output format to use. Valid options are table, json or yaml. If not present, defaults to table",
-	)
-}
-
-func determineOutputFormat(flags *pflag.FlagSet) (string, error) {
-	format, _ := flags.GetString("output")
-	format = strings.ToLower(format)
-
-	switch format {
-	case "", "table":
-		return "table", nil
-	case "json":
-		return "json", nil
-	case "yaml":
-		return "yaml", nil
-	default:
-		return "", fmt.Errorf("invalid --output format %q, allowed values are table, json and yaml", format)
 	}
 }
 

--- a/cmd/svcat/command/command.go
+++ b/cmd/svcat/command/command.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"unicode"
 
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -68,8 +70,8 @@ func PreRunE(cmd Command) func(*cobra.Command, []string) error {
 		// validate the args and print help info if needed.
 		err := cmd.Validate(args)
 		if err != nil {
-			fmt.Println(err)
-			fmt.Println(c.UsageString())
+			fmt.Fprintln(c.OutOrStderr(), err)
+			fmt.Fprintln(c.OutOrStdout(), c.UsageString())
 		}
 		return err
 	}

--- a/cmd/svcat/command/command.go
+++ b/cmd/svcat/command/command.go
@@ -41,12 +41,11 @@ func PreRunE(cmd Command) func(*cobra.Command, []string) error {
 		if scopedCmd, ok := cmd.(HasScopedFlags); ok {
 			scopedCmd.ApplyScopedFlags(c.Flags())
 		}
-		if fmtCmd, ok := cmd.(FormattedCommand); ok {
-			fmtString, err := determineOutputFormat(c.Flags())
+		if fmtCmd, ok := cmd.(HasFormatFlags); ok {
+			err := fmtCmd.ApplyFormatFlags(c.Flags())
 			if err != nil {
 				return err
 			}
-			fmtCmd.SetFormat(fmtString)
 		}
 		if classFilteredCmd, ok := cmd.(HasClassFlag); ok {
 			err := classFilteredCmd.ApplyClassFlag(c)

--- a/cmd/svcat/command/formatted.go
+++ b/cmd/svcat/command/formatted.go
@@ -23,35 +23,39 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// FormattedCommand represents a command that can have it's output
-// formatted
-type FormattedCommand interface {
-	// SetFormat sets the commands output format
-	SetFormat(format string)
+// HasFormatFlags represents a command that can have its output formatted.
+type HasFormatFlags interface {
+	// ApplyFormatFlags persists the format-related flags:
+	// * --output
+	ApplyFormatFlags(lags *pflag.FlagSet) error
+}
+
+// Formatted is the base command of all svcat commands that support customizable output formats.
+type Formatted struct {
+	OutputFormat string
+}
+
+// NewFormatted command.
+func NewFormatted() *Formatted {
+	return &Formatted{}
 }
 
 // AddOutputFlags adds common output flags to a command that can have variable output formats.
-func AddOutputFlags(flags *pflag.FlagSet) {
-	flags.StringP(
-		"output",
-		"o",
-		"",
+func (c *Formatted) AddOutputFlags(flags *pflag.FlagSet) {
+	flags.StringVarP(&c.OutputFormat, "output", "o", "table",
 		"The output format to use. Valid options are table, json or yaml. If not present, defaults to table",
 	)
 }
 
-func determineOutputFormat(flags *pflag.FlagSet) (string, error) {
-	format, _ := flags.GetString("output")
-	format = strings.ToLower(format)
+// ApplyFormatFlags persists the format-related flags:
+// * --output
+func (c *Formatted) ApplyFormatFlags(flags *pflag.FlagSet) error {
+	c.OutputFormat = strings.ToLower(c.OutputFormat)
 
-	switch format {
-	case "", "table":
-		return "table", nil
-	case "json":
-		return "json", nil
-	case "yaml":
-		return "yaml", nil
+	switch c.OutputFormat {
+	case "table", "json", "yaml":
+		return nil
 	default:
-		return "", fmt.Errorf("invalid --output format %q, allowed values are table, json and yaml", format)
+		return fmt.Errorf("invalid --output format %q, allowed values are: table, json and yaml", c.OutputFormat)
 	}
 }

--- a/cmd/svcat/command/formatted.go
+++ b/cmd/svcat/command/formatted.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// FormattedCommand represents a command that can have it's output
+// formatted
+type FormattedCommand interface {
+	// SetFormat sets the commands output format
+	SetFormat(format string)
+}
+
+// AddOutputFlags adds common output flags to a command that can have variable output formats.
+func AddOutputFlags(flags *pflag.FlagSet) {
+	flags.StringP(
+		"output",
+		"o",
+		"",
+		"The output format to use. Valid options are table, json or yaml. If not present, defaults to table",
+	)
+}
+
+func determineOutputFormat(flags *pflag.FlagSet) (string, error) {
+	format, _ := flags.GetString("output")
+	format = strings.ToLower(format)
+
+	switch format {
+	case "", "table":
+		return "table", nil
+	case "json":
+		return "json", nil
+	case "yaml":
+		return "yaml", nil
+	default:
+		return "", fmt.Errorf("invalid --output format %q, allowed values are table, json and yaml", format)
+	}
+}

--- a/cmd/svcat/command/formatted.go
+++ b/cmd/svcat/command/formatted.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/output"
 	"github.com/spf13/pflag"
 )
 
@@ -37,12 +38,14 @@ type Formatted struct {
 
 // NewFormatted command.
 func NewFormatted() *Formatted {
-	return &Formatted{}
+	return &Formatted{
+		OutputFormat: output.FormatTable,
+	}
 }
 
 // AddOutputFlags adds common output flags to a command that can have variable output formats.
 func (c *Formatted) AddOutputFlags(flags *pflag.FlagSet) {
-	flags.StringVarP(&c.OutputFormat, "output", "o", "table",
+	flags.StringVarP(&c.OutputFormat, "output", "o", output.FormatTable,
 		"The output format to use. Valid options are table, json or yaml. If not present, defaults to table",
 	)
 }
@@ -53,7 +56,7 @@ func (c *Formatted) ApplyFormatFlags(flags *pflag.FlagSet) error {
 	c.OutputFormat = strings.ToLower(c.OutputFormat)
 
 	switch c.OutputFormat {
-	case "table", "json", "yaml":
+	case output.FormatTable, output.FormatJSON, output.FormatYAML:
 		return nil
 	default:
 		return fmt.Errorf("invalid --output format %q, allowed values are: table, json and yaml", c.OutputFormat)

--- a/cmd/svcat/instance/get_cmd.go
+++ b/cmd/svcat/instance/get_cmd.go
@@ -26,20 +26,17 @@ import (
 
 type getCmd struct {
 	*command.Namespaced
+	*command.Formatted
 	*command.PlanFiltered
 	*command.ClassFiltered
-	name         string
-	outputFormat string
-}
-
-func (c *getCmd) SetFormat(format string) {
-	c.outputFormat = format
+	name string
 }
 
 // NewGetCmd builds a "svcat get instances" command
 func NewGetCmd(cxt *command.Context) *cobra.Command {
 	getCmd := &getCmd{
 		Namespaced:    command.NewNamespaced(cxt),
+		Formatted:     command.NewFormatted(),
 		ClassFiltered: command.NewClassFiltered(),
 		PlanFiltered:  command.NewPlanFiltered(),
 	}
@@ -59,7 +56,7 @@ func NewGetCmd(cxt *command.Context) *cobra.Command {
 		RunE:    command.RunE(getCmd),
 	}
 	getCmd.AddNamespaceFlags(cmd.Flags(), true)
-	command.AddOutputFlags(cmd.Flags())
+	getCmd.AddOutputFlags(cmd.Flags())
 	getCmd.AddClassFlag(cmd)
 	getCmd.AddPlanFlag(cmd)
 
@@ -96,7 +93,7 @@ func (c *getCmd) getAll() error {
 		return err
 	}
 
-	output.WriteInstanceList(c.Output, c.outputFormat, instances)
+	output.WriteInstanceList(c.Output, c.OutputFormat, instances)
 	return nil
 }
 
@@ -106,7 +103,7 @@ func (c *getCmd) get() error {
 		return err
 	}
 
-	output.WriteInstance(c.Output, c.outputFormat, *instance)
+	output.WriteInstance(c.Output, c.OutputFormat, *instance)
 
 	return nil
 }

--- a/cmd/svcat/output/binding.go
+++ b/cmd/svcat/output/binding.go
@@ -59,11 +59,11 @@ func writeBindingListTable(w io.Writer, bindingList *v1beta1.ServiceBindingList)
 // WriteBindingList prints a list of bindings in the specified output format.
 func WriteBindingList(w io.Writer, outputFormat string, bindingList *v1beta1.ServiceBindingList) {
 	switch outputFormat {
-	case formatJSON:
+	case FormatJSON:
 		writeJSON(w, bindingList)
-	case formatYAML:
+	case FormatYAML:
 		writeYAML(w, bindingList, 0)
-	case formatTable:
+	case FormatTable:
 		writeBindingListTable(w, bindingList)
 	}
 }
@@ -71,11 +71,11 @@ func WriteBindingList(w io.Writer, outputFormat string, bindingList *v1beta1.Ser
 // WriteBinding prints a single bindings in the specified output format.
 func WriteBinding(w io.Writer, outputFormat string, binding v1beta1.ServiceBinding) {
 	switch outputFormat {
-	case formatJSON:
+	case FormatJSON:
 		writeJSON(w, binding)
-	case formatYAML:
+	case FormatYAML:
 		writeYAML(w, binding, 0)
-	case formatTable:
+	case FormatTable:
 		l := v1beta1.ServiceBindingList{
 			Items: []v1beta1.ServiceBinding{binding},
 		}

--- a/cmd/svcat/output/broker.go
+++ b/cmd/svcat/output/broker.go
@@ -63,11 +63,11 @@ func WriteBrokerList(w io.Writer, outputFormat string, brokers ...v1beta1.Cluste
 		Items: brokers,
 	}
 	switch outputFormat {
-	case formatJSON:
+	case FormatJSON:
 		writeJSON(w, l)
-	case formatYAML:
+	case FormatYAML:
 		writeYAML(w, l, 0)
-	case formatTable:
+	case FormatTable:
 		writeBrokerListTable(w, brokers)
 	}
 }
@@ -75,11 +75,11 @@ func WriteBrokerList(w io.Writer, outputFormat string, brokers ...v1beta1.Cluste
 // WriteBroker prints a broker in the specified output format.
 func WriteBroker(w io.Writer, outputFormat string, broker v1beta1.ClusterServiceBroker) {
 	switch outputFormat {
-	case formatJSON:
+	case FormatJSON:
 		writeJSON(w, broker)
-	case formatYAML:
+	case FormatYAML:
 		writeYAML(w, broker, 0)
-	case formatTable:
+	case FormatTable:
 		writeBrokerListTable(w, []v1beta1.ClusterServiceBroker{broker})
 	}
 }

--- a/cmd/svcat/output/class.go
+++ b/cmd/svcat/output/class.go
@@ -51,11 +51,11 @@ func writeClassListTable(w io.Writer, classes []servicecatalog.Class) {
 // WriteClassList prints a list of classes in the specified output format.
 func WriteClassList(w io.Writer, outputFormat string, classes ...servicecatalog.Class) {
 	switch outputFormat {
-	case formatJSON:
+	case FormatJSON:
 		writeJSON(w, classes)
-	case formatYAML:
+	case FormatYAML:
 		writeYAML(w, classes, 0)
-	case formatTable:
+	case FormatTable:
 		writeClassListTable(w, classes)
 	}
 }
@@ -63,11 +63,11 @@ func WriteClassList(w io.Writer, outputFormat string, classes ...servicecatalog.
 // WriteClass prints a single class in the specified output format.
 func WriteClass(w io.Writer, outputFormat string, class v1beta1.ClusterServiceClass) {
 	switch outputFormat {
-	case formatJSON:
+	case FormatJSON:
 		writeJSON(w, class)
-	case formatYAML:
+	case FormatYAML:
 		writeYAML(w, class, 0)
-	case formatTable:
+	case FormatTable:
 		writeClassListTable(w, []servicecatalog.Class{&class})
 	}
 }

--- a/cmd/svcat/output/instance.go
+++ b/cmd/svcat/output/instance.go
@@ -66,11 +66,11 @@ func writeInstanceListTable(w io.Writer, instanceList *v1beta1.ServiceInstanceLi
 // WriteInstanceList prints a list of instances.
 func WriteInstanceList(w io.Writer, outputFormat string, instanceList *v1beta1.ServiceInstanceList) {
 	switch outputFormat {
-	case formatJSON:
+	case FormatJSON:
 		writeJSON(w, instanceList)
-	case formatYAML:
+	case FormatYAML:
 		writeYAML(w, instanceList, 0)
-	case formatTable:
+	case FormatTable:
 		writeInstanceListTable(w, instanceList)
 	}
 }
@@ -78,11 +78,11 @@ func WriteInstanceList(w io.Writer, outputFormat string, instanceList *v1beta1.S
 // WriteInstance prints a single instance
 func WriteInstance(w io.Writer, outputFormat string, instance v1beta1.ServiceInstance) {
 	switch outputFormat {
-	case "json":
+	case FormatJSON:
 		writeJSON(w, instance)
-	case "yaml":
+	case FormatYAML:
 		writeYAML(w, instance, 0)
-	case "table":
+	case FormatTable:
 		p := v1beta1.ServiceInstanceList{
 			Items: []v1beta1.ServiceInstance{instance},
 		}

--- a/cmd/svcat/output/output.go
+++ b/cmd/svcat/output/output.go
@@ -31,9 +31,14 @@ const (
 )
 
 const (
-	formatJSON  = "json"
-	formatTable = "table"
-	formatYAML  = "yaml"
+	// FormatJSON is the --output flag value for json output.
+	FormatJSON = "json"
+
+	// FormatTable is the --output flag value for tablular output.
+	FormatTable = "table"
+
+	// FormatYAML is the --output flag value for yaml output.
+	FormatYAML = "yaml"
 )
 
 func formatStatusShort(condition string, conditionStatus v1beta1.ConditionStatus, reason string) string {

--- a/cmd/svcat/output/plan.go
+++ b/cmd/svcat/output/plan.go
@@ -77,11 +77,11 @@ func WritePlanList(w io.Writer, outputFormat string, plans []v1beta1.ClusterServ
 		Items: plans,
 	}
 	switch outputFormat {
-	case formatJSON:
+	case FormatJSON:
 		writeJSON(w, list)
-	case formatYAML:
+	case FormatYAML:
 		writeYAML(w, list, 0)
-	case formatTable:
+	case FormatTable:
 		writePlanListTable(w, plans, classNames)
 	}
 }
@@ -90,11 +90,11 @@ func WritePlanList(w io.Writer, outputFormat string, plans []v1beta1.ClusterServ
 func WritePlan(w io.Writer, outputFormat string, plan v1beta1.ClusterServicePlan, class v1beta1.ClusterServiceClass) {
 
 	switch outputFormat {
-	case formatJSON:
+	case FormatJSON:
 		writeJSON(w, plan)
-	case formatYAML:
+	case FormatYAML:
 		writeYAML(w, plan, 0)
-	case formatTable:
+	case FormatTable:
 		classNames := map[string]string{}
 		classNames[class.Name] = class.Spec.ExternalName
 		writePlanListTable(w, []v1beta1.ClusterServicePlan{plan}, classNames)

--- a/cmd/svcat/plan/get_cmd.go
+++ b/cmd/svcat/plan/get_cmd.go
@@ -29,23 +29,22 @@ import (
 
 type getCmd struct {
 	*command.Context
+	*command.Formatted
 	lookupByUUID bool
 	uuid         string
 	name         string
 
-	classFilter  string
-	classUUID    string
-	className    string
-	outputFormat string
-}
-
-func (c *getCmd) SetFormat(format string) {
-	c.outputFormat = format
+	classFilter string
+	classUUID   string
+	className   string
 }
 
 // NewGetCmd builds a "svcat get plans" command
 func NewGetCmd(cxt *command.Context) *cobra.Command {
-	getCmd := &getCmd{Context: cxt}
+	getCmd := &getCmd{
+		Context:   cxt,
+		Formatted: command.NewFormatted(),
+	}
 	cmd := &cobra.Command{
 		Use:     "plans [NAME]",
 		Aliases: []string{"plan", "pl"},
@@ -77,7 +76,7 @@ func NewGetCmd(cxt *command.Context) *cobra.Command {
 		"",
 		"Filter plans based on class. When --uuid is specified, the class name is interpreted as a uuid.",
 	)
-	command.AddOutputFlags(cmd.Flags())
+	getCmd.AddOutputFlags(cmd.Flags())
 	return cmd
 }
 
@@ -148,7 +147,7 @@ func (c *getCmd) getAll() error {
 		return fmt.Errorf("unable to list plans (%s)", err)
 	}
 
-	output.WritePlanList(c.Output, c.outputFormat, plans, classes)
+	output.WritePlanList(c.Output, c.OutputFormat, plans, classes)
 	return nil
 }
 
@@ -175,7 +174,7 @@ func (c *getCmd) get() error {
 		return err
 	}
 
-	output.WritePlan(c.Output, c.outputFormat, *plan, *class)
+	output.WritePlan(c.Output, c.OutputFormat, *plan, *class)
 
 	return nil
 }


### PR DESCRIPTION
I refactored the formatted interface (which is applied to svcat commands that support `-o json|yaml`) so that it matches the nicer interface that we came up with a while back for namespaced commands.

FYI, if you review commit by commit, it may be easier to see that most of this is just moving this into it's own file and base struct, without changing the functionality much.