### PR TITLE
Add ginkgo tests for svcat get classes

### DIFF
--- a/cmd/svcat/class/get_cmd.go
+++ b/cmd/svcat/class/get_cmd.go
@@ -46,9 +46,11 @@ func NewGetCmd(cxt *command.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "classes [NAME]",
 		Aliases: []string{"class", "cl"},
-		Short:   "List classes, optionally filtered by name",
+		Short:   "List classes, optionally filtered by name, scope or namespace",
 		Example: command.NormalizeExamples(`
   svcat get classes
+  svcat get classes --scope cluster
+  svcat get classes --scope namespace --namespace dev
   svcat get class mysqldb
   svcat get class --uuid 997b8372-8dac-40ac-ae65-758b4a5075a5
 `),

--- a/cmd/svcat/class/get_cmd_test.go
+++ b/cmd/svcat/class/get_cmd_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Get Classes Command", func() {
 			Expect(cmd.name).To(Equal("mysqldb"))
 		})
 	})
-	Describe("getAll", func() {
+	Describe("Run", func() {
 		It("Calls the pkg/svcat libs RetrieveClasses with namespace scope and current namespace", func() {
 			outputBuffer := &bytes.Buffer{}
 
@@ -222,7 +222,7 @@ var _ = Describe("Get Classes Command", func() {
 			cmd.Namespace = "default"
 			cmd.Scope = servicecatalog.NamespaceScope
 
-			err := cmd.getAll()
+			err := cmd.Run()
 
 			Expect(err).NotTo(HaveOccurred())
 			scopeArg := fakeSDK.RetrieveClassesArgsForCall(0)
@@ -253,7 +253,7 @@ var _ = Describe("Get Classes Command", func() {
 			cmd.Namespace = ""
 			cmd.Scope = servicecatalog.NamespaceScope
 
-			err := cmd.getAll()
+			err := cmd.Run()
 
 			Expect(err).NotTo(HaveOccurred())
 			scopeArg := fakeSDK.RetrieveClassesArgsForCall(0)
@@ -285,7 +285,7 @@ var _ = Describe("Get Classes Command", func() {
 			cmd.Namespace = "default"
 			cmd.Scope = servicecatalog.AllScope
 
-			err := cmd.getAll()
+			err := cmd.Run()
 
 			Expect(err).NotTo(HaveOccurred())
 			scopeArg := fakeSDK.RetrieveClassesArgsForCall(0)

--- a/cmd/svcat/testdata/plugin.yaml
+++ b/cmd/svcat/testdata/plugin.yaml
@@ -158,9 +158,11 @@ tree:
         present, defaults to table
   - name: classes
     use: classes [NAME]
-    shortDesc: List classes, optionally filtered by name
+    shortDesc: List classes, optionally filtered by name, scope or namespace
     example: |2-
         svcat get classes
+        svcat get classes --scope cluster
+        svcat get classes --scope namespace --namespace dev
         svcat get class mysqldb
         svcat get class --uuid 997b8372-8dac-40ac-ae65-758b4a5075a5
     command: ./svcat get classes


### PR DESCRIPTION
This is a follow-up on #2116. I had originally only written tests for error handling cases, this fills that in to use the new pattern that @jberkhahn has set for our command tests.