### PR TITLE
repo-sync script fix

### DIFF
--- a/test/repo-sync.sh
+++ b/test/repo-sync.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
-HELM_TARBALL=helm-v2.6.2-linux-amd64.tar.gz
+HELM_TARBALL=helm-v2.9.1-linux-amd64.tar.gz
 SVC_CATALOG_BUCKET=svc-catalog-charts
 SVC_CATALOG_REPO_URL=https://$SVC_CATALOG_BUCKET.storage.googleapis.com/
 
@@ -26,13 +26,12 @@ helm init --client-only
 
 # Install and configure gcloud
 sudo apt-get install -y python
-export PATH=$PATH:/google-cloud-sdk/bin:$PATH
 export CLOUD_SDK_VERSION=204.0.0
 curl -LO "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz"
 tar xzf "google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz"
 rm "google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz"
-ln -s /lib /lib64
 rm -rf /google-cloud-sdk/.install/.backup
+export PATH="$(pwd)/google-cloud-sdk/bin:$PATH"
 gcloud version
 gcloud config set core/disable_usage_reporting true
 gcloud config set component_manager/disable_update_check true


### PR DESCRIPTION
 - don't link to nonexistent directories. Static binaries shouldn't need lib
 - add the exact binary location to PATH
 - update helm 2.6.3 -> 2.9.1