### PR TITLE
remove from travis integration-tests which are now running in prow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
           make verify-docs
         else
           echo "Running full build"
-          make verify build svcat build-integration build-e2e test-integration
+          make verify build svcat build-integration build-e2e
         fi
       env: GO_VERSION=1.10
     # Doc Site svc-cat.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ jobs:
           make verify-docs
         else
           echo "Running full build"
+          # make sure code quality is good and proper
+          # generate the output binaries for server and client
+          # ensure the tests build
           make verify build svcat build-integration build-e2e
         fi
       env: GO_VERSION=1.10


### PR DESCRIPTION
itests in prow take ~30minutes

We need to make the integration tests create only one set of certificates and reuse them for the whole run.