### PR TITLE
Enable namespaced brokers by default

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -84,6 +84,7 @@ chart and their default values.
 | `rbacEnable` | If true, create & use RBAC resources | `true` |
 | `originatingIdentityEnabled` | Whether the OriginatingIdentity alpha feature should be enabled | `false` |
 | `asyncBindingOperationsEnabled` | Whether or not alpha support for async binding operations is enabled | `false` |
+| `namespacedServiceBrokerDisabled` | Whether or not alpha support for namespace scoped brokers is disabled | `false` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -60,9 +60,9 @@ spec:
         - --feature-gates
         - OriginatingIdentity=true
         {{- end }}
-        {{- if .Values.namespacedServiceBrokerEnabled }}
+        {{- if .Values.namespacedServiceBrokerDisabled }}
         - --feature-gates
-        - NamespacedServiceBroker=true
+        - NamespacedServiceBroker=false
         {{- end }}
         {{- if .Values.apiserver.serveOpenAPISpec }}
         - --serve-openapi-spec

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -81,9 +81,9 @@ spec:
         - --feature-gates
         - CatalogRestrictions=true
         {{- end }}
-        {{- if .Values.namespacedServiceBrokerEnabled }}
+        {{- if .Values.namespacedServiceBrokerDisabled }}
         - --feature-gates
-        - NamespacedServiceBroker=true
+        - NamespacedServiceBroker=false
         {{- end }}
         ports:
         - containerPort: 8444

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -152,5 +152,5 @@ controllerManager:
 originatingIdentityEnabled: false
 # Whether the AsyncBindingOperations alpha feature should be enabled
 asyncBindingOperationsEnabled: false
-# Whether the NamespacedServiceBroker alpha feature should be enabled
-namespacedServiceBrokerEnabled: false
+# Whether the NamespacedServiceBroker alpha feature should be disabled
+namespacedServiceBrokerDisabled: false

--- a/docs/namespaced-broker-resources.md
+++ b/docs/namespaced-broker-resources.md
@@ -71,21 +71,21 @@ services and plans, however, can be effectively combined with Kubernetes RBAC
 and Service Catalog [Catalog Restrictions](catalog-restrictions.md) in order to provide more granular 
 control over service instance provisioning.
 
-## Enabling Namespace Scoped Broker Resources
+## Disabling Namespace Scoped Broker Resources
 
 Currently, namespace-scoped broker resources are an alpha-feature of Service 
-Catalog behind a feature flag. To start using these resources, you will need 
+Catalog that is on by default. To disable use of these resources, you will need 
 to pass an argument to the API Server when you install Service Catalog:
- `--feature-gates NamespacedServiceBroker=true`.
+ `--feature-gates NamespacedServiceBroker=false`.
 
-If you are using Helm, you can use the `namespacedServiceBrokerEnabled` setting
+If you are using Helm, you can use the `namespacedServiceBrokerDisabled` setting
  to control that flag:
 
 ```console
 helm install svc-cat/catalog \
    --name catalog \
    --namespace catalog \
-   --set namespacedServiceBrokerEnabled=true
+   --set namespacedServiceBrokerDisabled=true
 ```
 
 ## Using Namespace Scoped Broker Resources

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -84,7 +84,7 @@ var defaultServiceCatalogFeatureGates = map[utilfeature.Feature]utilfeature.Feat
 	PodPreset:                  {Default: false, PreRelease: utilfeature.Alpha},
 	OriginatingIdentity:        {Default: false, PreRelease: utilfeature.Alpha},
 	AsyncBindingOperations:     {Default: false, PreRelease: utilfeature.Alpha},
-	NamespacedServiceBroker:    {Default: false, PreRelease: utilfeature.Alpha},
+	NamespacedServiceBroker:    {Default: true, PreRelease: utilfeature.Alpha},
 	ResponseSchema:             {Default: false, PreRelease: utilfeature.Alpha},
 	UpdateDashboardURL:         {Default: false, PreRelease: utilfeature.Alpha},
 	OriginatingIdentityLocking: {Default: true, PreRelease: utilfeature.Alpha},


### PR DESCRIPTION
This is ready to be turned on per [#2244](https://github.com/kubernetes-incubator/service-catalog/issues/2244).