### PR TITLE
Enable setting tls communication with etcd in helm chart

### DIFF
--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -67,12 +67,22 @@ spec:
         {{- if .Values.apiserver.serveOpenAPISpec }}
         - --serve-openapi-spec
         {{- end }}
+        {{- if .Values.apiserver.storage.etcd.tls.enabled }}
+        - --etcd-cafile=/var/run/etcd-client/etcd-client-ca.crt
+        - --etcd-certfile=/var/run/etcd-client/etcd-client.crt
+        - --etcd-keyfile=/var/run/etcd-client/etcd-client.key
+        {{- end }}
         ports:
         - containerPort: 8443
         volumeMounts:
         - name: apiserver-cert
           mountPath: /var/run/kubernetes-service-catalog
           readOnly: true
+        {{- if .Values.apiserver.storage.etcd.tls.enabled }}
+        - name: etcd-client-cert
+          mountPath: /var/run/etcd-client
+          readOnly: true
+        {{- end }}
         {{- if .Values.apiserver.healthcheck.enabled }}
         readinessProbe:
           httpGet:
@@ -159,4 +169,9 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end }}
+      {{- end }}
+      {{- if .Values.apiserver.storage.etcd.tls.enabled }}
+      - name: etcd-client-cert
+        secret:
+          secretName: {{ .Values.apiserver.storage.etcd.tls.clientCertSecretName }}
       {{- end }}

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -58,6 +58,14 @@ apiserver:
     type: etcd
     # Further configuration for the etcd-based backend
     etcd:
+      # Whether to enable TLS communitation with etcd
+      tls:
+        enabled: false
+        ## If etcd tls is enabled you need to provide name of secret which stores 3 keys:
+        ## etcd-client-ca.crt - SSL Certificate Authority file used to secure etcd communication
+        ## etcd-client.crt - SSL certification file used to secure etcd communication.
+        ## etcd-client.key - SSL key file used to secure etcd communication.
+        clientCertSecretName: 
       # Whether to embed an etcd container in the apiserver pod
       # THIS IS INADEQUATE FOR PRODUCTION USE!
       useEmbedded: true


### PR DESCRIPTION
This PR make it possible to set TLS communication between apiserver and etcd in helm chart values