### PR TITLE
Add homebrew install docs for svcat

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -189,6 +189,12 @@ our canary (master) builds, and tags using the following prefixes:
 * Previous canary builds: https://download.svcat.sh/cli/VERSION-GITDESCRIBE 
   where `GITDESCRIBE` is the result of calling `git describe --tags`, for example `v0.1.20-1-g203c8ad`.
 
+## MacOS with Homebrew
+
+```
+brew update
+brew install kubernetes-service-catalog-client
+```
 
 ## MacOS
 


### PR DESCRIPTION
Thanks to @ageekymonk we have a [homebrew formulae](https://github.com/Homebrew/homebrew-core/pull/29646) for svcat!

Preview available at: https://deploy-preview-2273--svc-cat.netlify.com/docs/install/#macos-with-homebrew