### PR TITLE
Make Originating Identity feature gate on by default

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -84,7 +84,7 @@ chart and their default values.
 | `controllerManager.resources` | Resources allocation (Requests and Limits) | `{requests: {cpu: 100m, memory: 20Mi}, limits: {cpu: 100m, memory: 30Mi}}` |
 | `useAggregator` | whether or not to set up the controller-manager to go through the main Kubernetes API server's API aggregator | `true` |
 | `rbacEnable` | If true, create & use RBAC resources | `true` |
-| `originatingIdentityEnabled` | Whether the OriginatingIdentity alpha feature should be enabled | `false` |
+| `originatingIdentityEnabled` | Whether the OriginatingIdentity feature should be enabled | `true` |
 | `asyncBindingOperationsEnabled` | Whether or not alpha support for async binding operations is enabled | `false` |
 | `namespacedServiceBrokerDisabled` | Whether or not alpha support for namespace scoped brokers is disabled | `false` |
 

--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -56,9 +56,9 @@ spec:
         {{- if not .Values.apiserver.auth.enabled }}
         - --disable-auth
         {{- end }}
-        {{- if .Values.originatingIdentityEnabled }}
+        {{- if not .Values.originatingIdentityEnabled }}
         - --feature-gates
-        - OriginatingIdentity=true
+        - OriginatingIdentity=false
         {{- end }}
         {{- if .Values.namespacedServiceBrokerDisabled }}
         - --feature-gates

--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -56,10 +56,8 @@ spec:
         {{- if not .Values.apiserver.auth.enabled }}
         - --disable-auth
         {{- end }}
-        {{- if not .Values.originatingIdentityEnabled }}
         - --feature-gates
-        - OriginatingIdentity=false
-        {{- end }}
+        - OriginatingIdentity={{.Values.originatingIdentityEnabled}}
         {{- if .Values.namespacedServiceBrokerDisabled }}
         - --feature-gates
         - NamespacedServiceBroker=false

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -69,10 +69,8 @@ spec:
         - --broker-relist-interval
         - {{ .Values.controllerManager.brokerRelistInterval }}
         {{- end }}
-        {{- if not .Values.originatingIdentityEnabled }}
         - --feature-gates
-        - OriginatingIdentity=false
-        {{- end }}
+        - OriginatingIdentity={{.Values.originatingIdentityEnabled}}
         {{- if .Values.asyncBindingOperationsEnabled }}
         - --feature-gates
         - AsyncBindingOperations=true

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -69,9 +69,9 @@ spec:
         - --broker-relist-interval
         - {{ .Values.controllerManager.brokerRelistInterval }}
         {{- end }}
-        {{- if .Values.originatingIdentityEnabled }}
+        {{- if not .Values.originatingIdentityEnabled }}
         - --feature-gates
-        - OriginatingIdentity=true
+        - OriginatingIdentity=false
         {{- end }}
         {{- if .Values.asyncBindingOperationsEnabled }}
         - --feature-gates

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -162,7 +162,7 @@ controllerManager:
       cpu: 100m
       memory: 30Mi
 # Whether the OriginatingIdentity feature should be enabled
-originatingIdentityEnabled: false
+originatingIdentityEnabled: true
 # Whether the AsyncBindingOperations alpha feature should be enabled
 asyncBindingOperationsEnabled: false
 # Whether the NamespacedServiceBroker alpha feature should be disabled

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -161,7 +161,7 @@ controllerManager:
     limits:
       cpu: 100m
       memory: 30Mi
-# Whether the OriginatingIdentity alpha feature should be enabled
+# Whether the OriginatingIdentity feature should be enabled
 originatingIdentityEnabled: false
 # Whether the AsyncBindingOperations alpha feature should be enabled
 asyncBindingOperationsEnabled: false

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -317,13 +317,40 @@ Counterfeiter by running `go get github.com/maxbrunsfeld/counterfeiter`.
 Then regenerate the fake with `counterfeiter ./pkg/svcat/service-catalog SvcatClient` and manually paste the boilerplate
 copyright comment into the the generated file.
 
-### FeatureGates
+## FeatureGates
 Feature gates are a set of key=value pairs that describe experimental features
 and can be turned on or off by specifying the value when launching the Service
 Catalog executable (typically done in the Helm chart).  A new feature gate
 should be created when introducing new features that may break existing
 functionality or introduce instability.  See [FeatureGates](feature-gates.md)
 for more details.
+
+When adding a FeatureGate to Helm charts, define the variable
+`fooEnabled` with a value of `false`.  In the API Server and Controller
+templates, add logic that enables the feature gate:
+{% raw %}
+```yaml
+    {{- if .Values.fooEnabled }}
+    - --feature-gates
+    - Foo=true
+    {{- end }}
+```
+{% endraw %}
+
+When the feature has had enough testing and the community agrees to change the
+default to true, update `features.go` to set the default to true, update the
+`values.yaml` changing the default for feature foo to `true` and change the
+template logic like this:
+{% raw %}
+```yaml
+    {{- if not .Values.fooEnabled }}
+    - --feature-gates
+    - Foo=false
+    {{- end }}
+```
+{% endraw %}
+
+and update the [FeatureGates doc](feature-gates.md).
 
 ## Documentation
 

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -326,31 +326,19 @@ functionality or introduce instability.  See [FeatureGates](feature-gates.md)
 for more details.
 
 When adding a FeatureGate to Helm charts, define the variable
-`fooEnabled` with a value of `false`.  In the API Server and Controller
-templates, add logic that enables the feature gate:
+`fooEnabled` with a value of `false` in [values.yaml](https://github.com/kubernetes-incubator/service-catalog/blob/master/charts/catalog/values.yaml).  In the [API Server](https://github.com/kubernetes-incubator/service-catalog/blob/master/charts/catalog/templates/apiserver-deployment.yaml) and [Controller](https://github.com/kubernetes-incubator/service-catalog/blob/master/charts/catalog/templates/controller-manager-deployment.yaml)
+templates, add the new FeatureGate:
 {% raw %}
 ```yaml
-    {{- if .Values.fooEnabled }}
     - --feature-gates
-    - Foo=true
-    {{- end }}
+    - Foo={{.Values.fooEnabled}}
 ```
 {% endraw %}
 
 When the feature has had enough testing and the community agrees to change the
-default to true, update `features.go` to set the default to true, update the
-`values.yaml` changing the default for feature foo to `true` and change the
-template logic like this:
-{% raw %}
-```yaml
-    {{- if not .Values.fooEnabled }}
-    - --feature-gates
-    - Foo=false
-    {{- end }}
-```
-{% endraw %}
-
-and update the [FeatureGates doc](feature-gates.md).
+default to true, update [features.go](https://github.com/kubernetes-incubator/service-catalog/blob/master/pkg/features/features.go) and `values.yaml` changing the default for
+feature foo to `true`. And lastly update the appropriate information in the
+[FeatureGates doc](feature-gates.md).
 
 ## Documentation
 

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -317,6 +317,14 @@ Counterfeiter by running `go get github.com/maxbrunsfeld/counterfeiter`.
 Then regenerate the fake with `counterfeiter ./pkg/svcat/service-catalog SvcatClient` and manually paste the boilerplate
 copyright comment into the the generated file.
 
+### FeatureGates
+Feature gates are a set of key=value pairs that describe experimental features
+and can be turned on or off by specifying the value when launching the Service
+Catalog executable (typically done in the Helm chart).  A new feature gate
+should be created when introducing new features that may break existing
+functionality or introduce instability.  See [FeatureGates](feature-gates.md)
+for more details.
+
 ## Documentation
 
 Our documentation site is located at [svc-cat.io](https://svc-cat.io). The content files are located

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -1,0 +1,97 @@
+---
+title: Feature Gates
+layout: docwithnav
+---
+
+## Overview
+
+Feature gates are a set of key=value pairs that describe alpha or experimental
+features and can be turned on or off by specifying the key=value pair in the
+arguments list when launching the Service Catalog executable.  A new geature
+gate should be created when introducing new features that may break existing
+functionality or introduce instability.
+
+The following table is a summary of the feature gates that you can set on
+different Service Catalog.
+
+- The "Since" column contains the Service Catalog release when a feature is
+  introduced or its release stage is changed.
+- The "Until" column, if not empty, contains the last Service Catalog release in
+  which you can still use a feature gate.
+
+| Feature | Default | Stage | Since | Until |
+|---------|---------|-------|-------|-------|
+| `AsyncBindingOperations` | `false` | Alpha | v0.1.7 | |
+| `NamespacedServiceBroker` | `false` | Alpha | v0.1.10 | v0.1.28 |
+| `NamespacedServiceBroker` | `true` | GA | v0.1.29 | |
+| `OriginatingIdentity` | `false` | Alpha | v0.1.7 | v0.1.29 |
+| `OriginatingIdentity` | `true` | GA | v0.1.30 | |
+| `OriginatingIdentityLocking` | `true` | Alpha | v0.1.14 | |
+| `PodPreset` | `false` | Alpha | v0.1.6 | |
+| `ResponseSchema` | `false` | Alpha | v0.1.12 | |
+| `UpdateDashboardURL` | `false` | Alpha | v0.1.13 | |
+
+
+## Using a Feature
+
+### Feature Stages
+
+A feature can be in *Alpha*, *Beta* or *GA* stage.
+An *Alpha* feature means:
+
+* Disabled by default.
+* Might be buggy. Enabling the feature may expose bugs.
+* Support for feature may be dropped at any time without notice.
+* The API may change in incompatible ways in a later software release without
+  notice.
+* Recommended for use only in short-lived testing clusters, due to increased
+  risk of bugs and lack of long-term support.
+
+A *Beta* feature means:
+
+* Enabled by default.
+* The feature is well tested. Enabling the feature is considered safe.
+* Support for the overall feature will not be dropped, though details may change.
+* The schema and/or semantics of objects may change in incompatible ways in a
+  subsequent beta or stable release. When this happens, we will provide
+  instructions for migrating to the next version. This may require deleting,
+  editing, and re-creating API objects. The editing process may require some
+  thought. This may require downtime for applications that rely on the feature.
+* Recommended for only non-business-critical uses because of potential for
+  incompatible changes in subsequent releases. If you have multiple clusters
+  that can be upgraded independently, you may be able to relax this restriction.
+
+**Note:** Please do try *Beta* features and give feedback on them!
+After they exit beta, it may not be practical for us to make more changes.
+
+A *GA* feature is also referred to as a *stable* feature. It means:
+
+* The corresponding feature gate is no longer needed.
+* Stable versions of features will appear in released software for many
+  subsequent versions.
+
+### Feature Gates
+
+Each feature gate is designed for enabling/disabling a specific feature:
+
+- `AsyncBindingOperations`: Controls whether the controller should attempt
+ asynchronous binding operations
+
+- `NamespacedServiceBroker`: Enables namespaced variants of ServiceBrokers,
+ServiceClasses, and ServicePlans.
+
+- `OriginatingIdentity`: Controls whether the controller should include
+originating identity in the header of requests sent to brokers
+
+- `OriginatingIdentityLocking`:  Controls whether we lock OSB API resources
+for updating while we are still processing the current spec.
+
+ - `PodPreset`: Controls whether PodPreset resource is enabled or not in the
+ API server.
+
+- `ResponseSchema`:  Enables the storage of the binding response schema in
+ServicePlans
+
+- `UpdateDashboardURL`:  Enables the update of DashboardURL in response to
+update service instance requests to brokers.
+

--- a/docsite/_data/devguide.yaml
+++ b/docsite/_data/devguide.yaml
@@ -15,6 +15,8 @@ toc:
   path: /docs/devguide/#building
 - title: Testing
   path: /docs/devguide/#testing
+- title: FeatureGates
+  path: "#featuregates"
 - title: Documentation
   path: "#documentation"
 - title: Making a Contribution

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -29,6 +29,7 @@ import (
 	scmeta "github.com/kubernetes-incubator/service-catalog/pkg/api/meta"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	v1beta1informers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/externalversions/servicecatalog/v1beta1"
+	sctestutil "github.com/kubernetes-incubator/service-catalog/test/util"
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
 	fakeosb "github.com/pmorie/go-open-service-broker-client/v2/fake"
 	corev1 "k8s.io/api/core/v1"
@@ -2026,10 +2027,8 @@ func TestReconcileUnbindingWithClusterServiceBrokerHTTPError(t *testing.T) {
 func TestReconcileBindingUsingOriginatingIdentity(t *testing.T) {
 	for _, tc := range originatingIdentityTestCases {
 		func() {
-			if tc.enableOriginatingIdentity {
-				utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.OriginatingIdentity))
-				defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.OriginatingIdentity))
-			}
+			prevOrigIDEnablement := sctestutil.EnableOriginatingIdentity(t, tc.enableOriginatingIdentity)
+			defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=%v", scfeatures.OriginatingIdentity, prevOrigIDEnablement))
 
 			fakeKubeClient, fakeCatalogClient, fakeBrokerClient, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
 				BindReaction: &fakeosb.BindReaction{
@@ -2085,13 +2084,8 @@ func TestReconcileBindingUsingOriginatingIdentity(t *testing.T) {
 func TestReconcileBindingDeleteUsingOriginatingIdentity(t *testing.T) {
 	for _, tc := range originatingIdentityTestCases {
 		func() {
-			if tc.enableOriginatingIdentity {
-				err := utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.OriginatingIdentity))
-				if err != nil {
-					t.Fatalf("Failed to enable originating identity feature: %v", err)
-				}
-				defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.OriginatingIdentity))
-			}
+			prevOrigIDEnablement := sctestutil.EnableOriginatingIdentity(t, tc.enableOriginatingIdentity)
+			defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=%v", scfeatures.OriginatingIdentity, prevOrigIDEnablement))
 
 			fakeKubeClient, fakeCatalogClient, fakeBrokerClient, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
 				UnbindReaction: &fakeosb.UnbindReaction{

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -42,6 +42,7 @@ import (
 
 	scfeatures "github.com/kubernetes-incubator/service-catalog/pkg/features"
 	"github.com/kubernetes-incubator/service-catalog/test/fake"
+	sctestutil "github.com/kubernetes-incubator/service-catalog/test/util"
 	corev1 "k8s.io/api/core/v1"
 	clientgotesting "k8s.io/client-go/testing"
 )
@@ -3632,13 +3633,8 @@ func TestUpdateServiceInstanceCondition(t *testing.T) {
 func TestReconcileInstanceUsingOriginatingIdentity(t *testing.T) {
 	for _, tc := range originatingIdentityTestCases {
 		func() {
-			if tc.enableOriginatingIdentity {
-				err := utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.OriginatingIdentity))
-				if err != nil {
-					t.Fatalf("Failed to enable originating identity feature: %v", err)
-				}
-				defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.OriginatingIdentity))
-			}
+			prevOrigIDEnablement := sctestutil.EnableOriginatingIdentity(t, tc.enableOriginatingIdentity)
+			defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=%v", scfeatures.OriginatingIdentity, prevOrigIDEnablement))
 
 			fakeKubeClient, fakeCatalogClient, fakeBrokerClient, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
 				ProvisionReaction: &fakeosb.ProvisionReaction{
@@ -3692,10 +3688,9 @@ func TestReconcileInstanceUsingOriginatingIdentity(t *testing.T) {
 func TestReconcileInstanceDeleteUsingOriginatingIdentity(t *testing.T) {
 	for _, tc := range originatingIdentityTestCases {
 		func() {
-			if tc.enableOriginatingIdentity {
-				utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.OriginatingIdentity))
-				defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.OriginatingIdentity))
-			}
+
+			prevOrigIDEnablement := sctestutil.EnableOriginatingIdentity(t, tc.enableOriginatingIdentity)
+			defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=%v", scfeatures.OriginatingIdentity, prevOrigIDEnablement))
 
 			_, fakeCatalogClient, fakeBrokerClient, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
 				DeprovisionReaction: &fakeosb.DeprovisionReaction{
@@ -3760,10 +3755,8 @@ func TestReconcileInstanceDeleteUsingOriginatingIdentity(t *testing.T) {
 func TestPollInstanceUsingOriginatingIdentity(t *testing.T) {
 	for _, tc := range originatingIdentityTestCases {
 		func() {
-			if tc.enableOriginatingIdentity {
-				utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.OriginatingIdentity))
-				defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.OriginatingIdentity))
-			}
+			prevOrigIDEnablement := sctestutil.EnableOriginatingIdentity(t, tc.enableOriginatingIdentity)
+			defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=%v", scfeatures.OriginatingIdentity, prevOrigIDEnablement))
 
 			_, _, fakeBrokerClient, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
 				PollLastOperationReaction: &fakeosb.PollLastOperationReaction{

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -82,7 +82,7 @@ func init() {
 // available throughout service catalog binaries.
 var defaultServiceCatalogFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
 	PodPreset:                  {Default: false, PreRelease: utilfeature.Alpha},
-	OriginatingIdentity:        {Default: false, PreRelease: utilfeature.Alpha},
+	OriginatingIdentity:        {Default: true, PreRelease: utilfeature.GA},
 	AsyncBindingOperations:     {Default: false, PreRelease: utilfeature.Alpha},
 	NamespacedServiceBroker:    {Default: true, PreRelease: utilfeature.Alpha},
 	ResponseSchema:             {Default: false, PreRelease: utilfeature.Alpha},

--- a/pkg/registry/servicecatalog/clusterservicebroker/strategy_test.go
+++ b/pkg/registry/servicecatalog/clusterservicebroker/strategy_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	sctestutil "github.com/kubernetes-incubator/service-catalog/test/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -82,8 +83,10 @@ func TestClusterServiceBroker(t *testing.T) {
 		},
 	}
 
+	creatorUserName := "creator"
+	createContext := sctestutil.ContextWithUserName(creatorUserName)
 	// Canonicalize the broker
-	clusterServiceBrokerRESTStrategies.PrepareForCreate(nil, broker)
+	clusterServiceBrokerRESTStrategies.PrepareForCreate(createContext, broker)
 
 	if broker.Status.Conditions == nil {
 		t.Fatalf("Fresh clusterservicebroker should have empty status")
@@ -115,9 +118,10 @@ func TestClusterServiceBrokerUpdate(t *testing.T) {
 			shouldGenerationIncrement: true,
 		},
 	}
-
+	creatorUserName := "creator"
+	createContext := sctestutil.ContextWithUserName(creatorUserName)
 	for i := range cases {
-		clusterServiceBrokerRESTStrategies.PrepareForUpdate(nil, cases[i].newer, cases[i].older)
+		clusterServiceBrokerRESTStrategies.PrepareForUpdate(createContext, cases[i].newer, cases[i].older)
 
 		if cases[i].shouldGenerationIncrement {
 			if e, a := cases[i].older.Generation+1, cases[i].newer.Generation; e != a {
@@ -171,8 +175,9 @@ func TestClusterServiceBrokerUpdateForRelistRequests(t *testing.T) {
 
 		newClusterServiceBroker := clusterServiceBrokerWithOldSpec()
 		newClusterServiceBroker.Spec.RelistRequests = tc.newValue
-
-		clusterServiceBrokerRESTStrategies.PrepareForUpdate(nil, newClusterServiceBroker, oldBroker)
+		creatorUserName := "creator"
+		createContext := sctestutil.ContextWithUserName(creatorUserName)
+		clusterServiceBrokerRESTStrategies.PrepareForUpdate(createContext, newClusterServiceBroker, oldBroker)
 
 		if e, a := tc.expectedValue, newClusterServiceBroker.Spec.RelistRequests; e != a {
 			t.Errorf("%s: got unexpected RelistRequests: expected %v, got %v", tc.name, e, a)

--- a/pkg/registry/servicecatalog/instance/strategy_test.go
+++ b/pkg/registry/servicecatalog/instance/strategy_test.go
@@ -17,17 +17,15 @@ limitations under the License.
 package instance
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	scfeatures "github.com/kubernetes-incubator/service-catalog/pkg/features"
+	sctestutil "github.com/kubernetes-incubator/service-catalog/test/util"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apiserver/pkg/authentication/user"
-	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 func getTestInstance() *servicecatalog.ServiceInstance {
@@ -55,14 +53,6 @@ func getTestInstance() *servicecatalog.ServiceInstance {
 			},
 		},
 	}
-}
-
-func contextWithUserName(userName string) context.Context {
-	ctx := genericapirequest.NewContext()
-	userInfo := &user.DefaultInfo{
-		Name: userName,
-	}
-	return genericapirequest.WithUser(ctx, userInfo)
 }
 
 // TestInstanceUpdate tests that updates to the spec of an Instance.
@@ -147,9 +137,10 @@ func TestInstanceUpdate(t *testing.T) {
 			shouldPlanRefClear:        true,
 		},
 	}
-
+	creatorUserName := "creator"
+	createContext := sctestutil.ContextWithUserName(creatorUserName)
 	for _, tc := range cases {
-		instanceRESTStrategies.PrepareForUpdate(nil, tc.newer, tc.older)
+		instanceRESTStrategies.PrepareForUpdate(createContext, tc.newer, tc.older)
 
 		expectedGeneration := tc.older.Generation
 		if tc.shouldGenerationIncrement {
@@ -175,12 +166,12 @@ func TestInstanceUpdate(t *testing.T) {
 // as the user changes for different modifications of the instance.
 func TestInstanceUserInfo(t *testing.T) {
 	// Enable the OriginatingIdentity feature
-	utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.OriginatingIdentity))
-	defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.OriginatingIdentity))
+	prevOrigIDEnablement := sctestutil.EnableOriginatingIdentity(t, true)
+	defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=%v", scfeatures.OriginatingIdentity, prevOrigIDEnablement))
 
 	creatorUserName := "creator"
 	createdInstance := getTestInstance()
-	createContext := contextWithUserName(creatorUserName)
+	createContext := sctestutil.ContextWithUserName(creatorUserName)
 	instanceRESTStrategies.PrepareForCreate(createContext, createdInstance)
 
 	if e, a := creatorUserName, createdInstance.Spec.UserInfo.Username; e != a {
@@ -190,7 +181,7 @@ func TestInstanceUserInfo(t *testing.T) {
 	updaterUserName := "updater"
 	updatedInstance := getTestInstance()
 	updatedInstance.Spec.UpdateRequests = updatedInstance.Spec.UpdateRequests + 1
-	updateContext := contextWithUserName(updaterUserName)
+	updateContext := sctestutil.ContextWithUserName(updaterUserName)
 	instanceRESTStrategies.PrepareForUpdate(updateContext, updatedInstance, createdInstance)
 
 	if e, a := updaterUserName, updatedInstance.Spec.UserInfo.Username; e != a {
@@ -199,7 +190,7 @@ func TestInstanceUserInfo(t *testing.T) {
 
 	deleterUserName := "deleter"
 	deletedInstance := getTestInstance()
-	deleteContext := contextWithUserName(deleterUserName)
+	deleteContext := sctestutil.ContextWithUserName(deleterUserName)
 	instanceRESTStrategies.CheckGracefulDelete(deleteContext, deletedInstance, nil)
 
 	if e, a := deleterUserName, deletedInstance.Spec.UserInfo.Username; e != a {
@@ -241,6 +232,8 @@ func TestInstanceUpdateForUpdateRequests(t *testing.T) {
 			expectedValue: 2,
 		},
 	}
+	creatorUserName := "creator"
+	createContext := sctestutil.ContextWithUserName(creatorUserName)
 	for _, tc := range cases {
 		oldInstance := getTestInstance()
 		oldInstance.Spec.UpdateRequests = tc.oldValue
@@ -248,7 +241,7 @@ func TestInstanceUpdateForUpdateRequests(t *testing.T) {
 		newInstance := getTestInstance()
 		newInstance.Spec.UpdateRequests = tc.newValue
 
-		instanceRESTStrategies.PrepareForUpdate(nil, newInstance, oldInstance)
+		instanceRESTStrategies.PrepareForUpdate(createContext, newInstance, oldInstance)
 
 		if e, a := tc.expectedValue, newInstance.Spec.UpdateRequests; e != a {
 			t.Errorf("%s: got unexpected UpdateRequests: expected %v, got %v", tc.name, e, a)
@@ -259,7 +252,9 @@ func TestInstanceUpdateForUpdateRequests(t *testing.T) {
 // TestExternalIDSet checks that we set the ExternalID if the user doesn't provide it.
 func TestExternalIDSet(t *testing.T) {
 	createdInstanceCredential := getTestInstance()
-	instanceRESTStrategies.PrepareForCreate(nil, createdInstanceCredential)
+	creatorUserName := "creator"
+	createContext := sctestutil.ContextWithUserName(creatorUserName)
+	instanceRESTStrategies.PrepareForCreate(createContext, createdInstanceCredential)
 
 	if createdInstanceCredential.Spec.ExternalID == "" {
 		t.Error("Expected an ExternalID to be set, but got none")
@@ -271,7 +266,9 @@ func TestExternalIDUserProvided(t *testing.T) {
 	userExternalID := "my-id"
 	createdInstanceCredential := getTestInstance()
 	createdInstanceCredential.Spec.ExternalID = userExternalID
-	instanceRESTStrategies.PrepareForCreate(nil, createdInstanceCredential)
+	creatorUserName := "creator"
+	createContext := sctestutil.ContextWithUserName(creatorUserName)
+	instanceRESTStrategies.PrepareForCreate(createContext, createdInstanceCredential)
 
 	if createdInstanceCredential.Spec.ExternalID != userExternalID {
 		t.Errorf("Modified user provided ExternalID to %q", createdInstanceCredential.Spec.ExternalID)

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	sctestutil "github.com/kubernetes-incubator/service-catalog/test/util"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -230,8 +231,8 @@ func verifyUsernameInLastBrokerAction(t *testing.T, osbClient *fakeosb.FakeClien
 // as part of originating identity included in broker requests.
 func TestBasicFlowsWithOriginatingIdentity(t *testing.T) {
 	// Enable the OriginatingIdentity feature
-	utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.OriginatingIdentity))
-	defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.OriginatingIdentity))
+	prevOrigIDEnablement := sctestutil.EnableOriginatingIdentity(t, true)
+	defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=%v", scfeatures.OriginatingIdentity, prevOrigIDEnablement))
 
 	createChangeUsernameFunc := func(username string) func(*controllerTest) {
 		return func(ct *controllerTest) {


### PR DESCRIPTION
Enable Originating Identity Feature Gate by default.

Also add Feature Gate doc, using [K8s FG doc](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) as a template

doc preview available here:  https://deploy-preview-2277--svc-cat.netlify.com/docs/devguide/#featuregates