### PR TITLE
Add Context object to Bind requests (OSBAPI)

### DIFF
--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -1217,6 +1217,14 @@ func (c *controller) prepareBindRequest(
 	}
 
 	appGUID := string(ns.UID)
+	clusterID := c.getClusterID()
+
+	requestContext := map[string]interface{}{
+		"platform":           ContextProfilePlatformKubernetes,
+		"namespace":          instance.Namespace,
+		clusterIdentifierKey: clusterID,
+	}
+
 	request := &osb.BindRequest{
 		BindingID:    binding.Spec.ExternalID,
 		InstanceID:   instance.Spec.ExternalID,
@@ -1225,6 +1233,7 @@ func (c *controller) prepareBindRequest(
 		AppGUID:      &appGUID,
 		Parameters:   parameters,
 		BindResource: &osb.BindResource{AppGUID: &appGUID},
+		Context:      requestContext,
 	}
 
 	// Asynchronous binding operations are currently ALPHA and not

--- a/pkg/controller/controller_binding_ns_test.go
+++ b/pkg/controller/controller_binding_ns_test.go
@@ -134,6 +134,7 @@ func TestReconcileServiceBindingWithParametersNamespacedRefs(t *testing.T) {
 		BindResource: &osb.BindResource{
 			AppGUID: strPtr(testNamespaceGUID),
 		},
+		Context: testContext,
 	})
 
 	actions := fakeCatalogClient.Actions()

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -359,6 +359,7 @@ func TestReconcileServiceBindingWithSecretConflict(t *testing.T) {
 		BindResource: &osb.BindResource{
 			AppGUID: strPtr(testNamespaceGUID),
 		},
+		Context: testContext,
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -482,6 +483,7 @@ func TestReconcileServiceBindingWithParameters(t *testing.T) {
 		BindResource: &osb.BindResource{
 			AppGUID: strPtr(testNamespaceGUID),
 		},
+		Context: testContext,
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -617,6 +619,7 @@ func TestReconcileServiceBindingWithSecretTransform(t *testing.T) {
 		BindResource: &osb.BindResource{
 			AppGUID: strPtr(testNamespaceGUID),
 		},
+		Context: testContext,
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -799,6 +802,7 @@ func TestReconcileServiceBindingNonbindableClusterServiceClassBindablePlan(t *te
 		BindResource: &osb.BindResource{
 			AppGUID: strPtr(testNamespaceGUID),
 		},
+		Context: testContext,
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -1654,6 +1658,7 @@ func TestReconcileServiceBindingWithServiceBindingCallFailure(t *testing.T) {
 		BindResource: &osb.BindResource{
 			AppGUID: strPtr(testNamespaceGUID),
 		},
+		Context: testContext,
 	})
 
 	events := getRecordedEvents(testController)
@@ -1728,6 +1733,7 @@ func TestReconcileServiceBindingWithServiceBindingFailure(t *testing.T) {
 		BindResource: &osb.BindResource{
 			AppGUID: strPtr(testNamespaceGUID),
 		},
+		Context: testContext,
 	})
 
 	events := getRecordedEvents(testController)
@@ -2189,6 +2195,7 @@ func TestReconcileBindingSuccessOnFinalRetry(t *testing.T) {
 		BindResource: &osb.BindResource{
 			AppGUID: strPtr(testNamespaceGUID),
 		},
+		Context: testContext,
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -2314,6 +2321,7 @@ func TestReconcileBindingWithSecretConflictFailedAfterFinalRetry(t *testing.T) {
 		BindResource: &osb.BindResource{
 			AppGUID: strPtr(testNamespaceGUID),
 		},
+		Context: testContext,
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -2500,6 +2508,7 @@ func TestReconcileServiceBindingWithSecretParameters(t *testing.T) {
 		BindResource: &osb.BindResource{
 			AppGUID: strPtr(testNamespaceGUID),
 		},
+		Context: testContext,
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -2675,6 +2684,7 @@ func TestReconcileBindingWithSetOrphanMitigation(t *testing.T) {
 				BindResource: &osb.BindResource{
 					AppGUID: strPtr(testNamespaceGUID),
 				},
+				Context: testContext,
 			})
 
 			kubeActions := fakeKubeClient.Actions()
@@ -3102,6 +3112,7 @@ func TestReconcileServiceBindingAsynchronousBind(t *testing.T) {
 			AppGUID: strPtr(testNamespaceGUID),
 		},
 		AcceptsIncomplete: true,
+		Context:           testContext,
 	})
 
 	// Kube actions


### PR DESCRIPTION
# Add Context object to Bind requests

This pull request addresses the issue where a bind operation for a specific service instance does not include the Context object (as specified in the [OSBAPI spec][3]) in the request to the broker.

The change was fairly simple and required to add similar logic like the one in [*controller_instange.go*][1] to [*controller_binding.go*][2].

Old tests have been **fixed**.

Closes: #2283 

[1]: https://github.com/kubernetes-incubator/service-catalog/blob/v0.1.29/pkg/controller/controller_instance.go#L2040-L2047 
[2]: https://github.com/kubernetes-incubator/service-catalog/blob/v0.1.29/pkg/controller/controller_binding.go#L1219-L1228
[3]: https://github.com/openservicebrokerapi/servicebroker/blob/v2.14/spec.md#binding 