### PR TITLE
Fix validation error's bad value (ServicePlan instead of ServiceClass)

### DIFF
--- a/pkg/apis/servicecatalog/validation/broker.go
+++ b/pkg/apis/servicecatalog/validation/broker.go
@@ -222,7 +222,7 @@ func validateCommonServiceBrokerSpec(spec *sc.CommonServiceBrokerSpec, fldPath *
 		if err != nil {
 			commonErrs = append(commonErrs,
 				field.Invalid(fldPath.Child("catalogRestrictions", "servicePlan"),
-					spec.CatalogRestrictions.ServiceClass, err.Error()))
+					spec.CatalogRestrictions.ServicePlan, err.Error()))
 		}
 	}
 


### PR DESCRIPTION
When validation of Broker.Spec.CatalogRestrictions.ServicePlan failed,
spec.CatalogRestrictions.ServiceClass was passed as the bad value in
the validation error. It should be spec.CatalogRestrictions.ServicePlan.