### PR TITLE
Remove regex validation of service class external IDs

### DIFF
--- a/pkg/apis/servicecatalog/validation/serviceclass.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass.go
@@ -31,12 +31,7 @@ const commonServiceClassNameMaxLength int = 63
 
 var commonServiceClassNameRegexp = regexp.MustCompile("^" + commonServiceClassNameFmt + "$")
 
-const guidFmt string = "[a-zA-Z0-9]([-a-zA-Z0-9.]*[a-zA-Z0-9])?"
 const guidMaxLength int = 63
-
-// guidRegexp is a loosened validation for
-// DNS1123 labels that allows uppercase characters.
-var guidRegexp = regexp.MustCompile("^" + guidFmt + "$")
 
 // validateCommonServiceClassName is the common validation function for
 // service class types.
@@ -64,8 +59,8 @@ func validateExternalID(value string) []string {
 	if len(value) > guidMaxLength {
 		errs = append(errs, utilvalidation.MaxLenError(guidMaxLength))
 	}
-	if !guidRegexp.MatchString(value) {
-		errs = append(errs, utilvalidation.RegexError(guidFmt, "my-name", "123-abc", "456-DEF"))
+	if len(value) == 0 {
+		errs = append(errs, utilvalidation.EmptyError())
 	}
 	return errs
 }

--- a/pkg/apis/servicecatalog/validation/serviceclass_test.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass_test.go
@@ -53,7 +53,7 @@ func TestValidateClusterServiceClass(t *testing.T) {
 			valid:        true,
 		},
 		{
-			name: "valid serviceClass - uppercase in GUID",
+			name: "valid serviceClass - uppercase in externalID",
 			serviceClass: func() *servicecatalog.ClusterServiceClass {
 				s := validClusterServiceClass()
 				s.Spec.ExternalID = "40D-0983-1b89"
@@ -62,10 +62,19 @@ func TestValidateClusterServiceClass(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "valid serviceClass - period in GUID",
+			name: "valid serviceClass - period in externalID",
 			serviceClass: func() *servicecatalog.ClusterServiceClass {
 				s := validClusterServiceClass()
 				s.Spec.ExternalID = "4315f5e1-0139-4ecf-9706-9df0aff33e5a.plan-name"
+				return s
+			}(),
+			valid: true,
+		},
+		{
+			name: "valid serviceClass - underscore in ExternalID",
+			serviceClass: func() *servicecatalog.ClusterServiceClass {
+				s := validClusterServiceClass()
+				s.Spec.ExternalID = "4315f5e1-0139-4ecf-9706-9df0aff33e5a_plan-name"
 				return s
 			}(),
 			valid: true,
@@ -89,19 +98,10 @@ func TestValidateClusterServiceClass(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "invalid serviceClass - missing guid",
+			name: "invalid serviceClass - empty externalID",
 			serviceClass: func() *servicecatalog.ClusterServiceClass {
 				s := validClusterServiceClass()
 				s.Spec.ExternalID = ""
-				return s
-			}(),
-			valid: false,
-		},
-		{
-			name: "invalid serviceClass - invalid guid",
-			serviceClass: func() *servicecatalog.ClusterServiceClass {
-				s := validClusterServiceClass()
-				s.Spec.ExternalID = "1234-4354a\\%-49b"
 				return s
 			}(),
 			valid: false,
@@ -203,7 +203,7 @@ func TestValidateServiceClass(t *testing.T) {
 			valid:        true,
 		},
 		{
-			name: "valid serviceClass - uppercase in GUID",
+			name: "valid serviceClass - uppercase in externalID",
 			serviceClass: func() *servicecatalog.ServiceClass {
 				s := validServiceClass()
 				s.Spec.ExternalID = "40D-0983-1b89"
@@ -212,7 +212,7 @@ func TestValidateServiceClass(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "valid serviceClass - period in GUID",
+			name: "valid serviceClass - period in externalID",
 			serviceClass: func() *servicecatalog.ServiceClass {
 				s := validServiceClass()
 				s.Spec.ExternalID = "4315f5e1-0139-4ecf-9706-9df0aff33e5a.plan-name"
@@ -230,6 +230,15 @@ func TestValidateServiceClass(t *testing.T) {
 			valid: true,
 		},
 		{
+			name: "valid serviceClass - underscore in ExternalID",
+			serviceClass: func() *servicecatalog.ServiceClass {
+				s := validServiceClass()
+				s.Spec.ExternalID = "4315f5e1-0139-4ecf-9706-9df0aff33e5a_plan-name"
+				return s
+			}(),
+			valid: true,
+		},
+		{
 			name: "invalid serviceClass - has no namespace",
 			serviceClass: func() *servicecatalog.ServiceClass {
 				s := validServiceClass()
@@ -239,19 +248,10 @@ func TestValidateServiceClass(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "invalid serviceClass - missing guid",
+			name: "invalid serviceClass - empty externalID",
 			serviceClass: func() *servicecatalog.ServiceClass {
 				s := validServiceClass()
 				s.Spec.ExternalID = ""
-				return s
-			}(),
-			valid: false,
-		},
-		{
-			name: "invalid serviceClass - invalid guid",
-			serviceClass: func() *servicecatalog.ServiceClass {
-				s := validServiceClass()
-				s.Spec.ExternalID = "1234-4354a\\%-49b"
 				return s
 			}(),
 			valid: false,


### PR DESCRIPTION
Per the OSB API spec, although external ID is recommended to be a GUID, it can be any non-empty string. So, remove the regex validation, and add a validation to assert it's non-empty.