### PR TITLE
support for headless services for API server

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -48,9 +48,9 @@ chart and their default values.
 | `apiserver.aggregator.groupPriorityMinimum` | The minimum priority the group should have. | `10000` |
 | `apiserver.aggregator.versionPriority` | The ordering of this API inside of the group | `20` |
 | `apiserver.tls.requestHeaderCA` | Base64-encoded CA used to validate request-header authentication, when receiving delegated authentication from an aggregator. If not set, the service catalog API server will inherit this CA from the `extension-apiserver-authentication` ConfigMap if available. | `nil` |
-| `apiserver.service.type` | Type of service; valid values are `LoadBalancer` and `NodePort` and `ClusterIP` | `NodePort` |
+| `apiserver.service.type` | Type of service; valid values are `LoadBalancer` , `NodePort` and `ClusterIP` | `NodePort` |
 | `apiserver.service.nodePort.securePort` | If service type is `NodePort`, specifies a port in allowable range (e.g. 30000 - 32767 on minikube); The TLS-enabled endpoint will be exposed here | `30443` |
-| `apiserver.service.clusterIp` | If service type is ClusterIP, specify clusterIP as `None` for `headless services` OR specify your own specific IP OR leave blank to let Kubernetes assign a cluster IP |  |
+| `apiserver.service.clusterIP` | If service type is ClusterIP, specify clusterIP as `None` for `headless services` OR specify your own specific IP OR leave blank to let Kubernetes assign a cluster IP |  |
 | `apiserver.storage.type` | The storage backend to use; the only valid value is `etcd`, left for other storages support in future, e.g. `crd` | `etcd` |
 | `apiserver.storage.etcd.useEmbedded` | If storage type is `etcd`: Whether to embed an etcd container in the apiserver pod; THIS IS INADEQUATE FOR PRODUCTION USE! | `true` |
 | `apiserver.storage.etcd.servers` | If storage type is `etcd`: etcd URL(s); override this if NOT using embedded etcd. Only etcd v3 is supported. | `http://localhost:2379` |

--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -1,7 +1,7 @@
 # Service Catalog
 
 Service Catalog is a Kubernetes Incubator project that provides a
-Kubernetes-native workflow for integrating with 
+Kubernetes-native workflow for integrating with
 [Open Service Brokers](https://www.openservicebrokerapi.org/)
 to provision and bind to application dependencies like databases, object
 storage, message-oriented middleware, and more.
@@ -48,8 +48,9 @@ chart and their default values.
 | `apiserver.aggregator.groupPriorityMinimum` | The minimum priority the group should have. | `10000` |
 | `apiserver.aggregator.versionPriority` | The ordering of this API inside of the group | `20` |
 | `apiserver.tls.requestHeaderCA` | Base64-encoded CA used to validate request-header authentication, when receiving delegated authentication from an aggregator. If not set, the service catalog API server will inherit this CA from the `extension-apiserver-authentication` ConfigMap if available. | `nil` |
-| `apiserver.service.type` | Type of service; valid values are `LoadBalancer` and `NodePort` | `NodePort` |
+| `apiserver.service.type` | Type of service; valid values are `LoadBalancer` and `NodePort` and `ClusterIP` | `NodePort` |
 | `apiserver.service.nodePort.securePort` | If service type is `NodePort`, specifies a port in allowable range (e.g. 30000 - 32767 on minikube); The TLS-enabled endpoint will be exposed here | `30443` |
+| `apiserver.service.clusterIp` | If service type is ClusterIP, specify clusterIP as `None` for `headless services` OR specify your own specific IP OR leave blank to let Kubernetes assign a cluster IP |  |
 | `apiserver.storage.type` | The storage backend to use; the only valid value is `etcd`, left for other storages support in future, e.g. `crd` | `etcd` |
 | `apiserver.storage.etcd.useEmbedded` | If storage type is `etcd`: Whether to embed an etcd container in the apiserver pod; THIS IS INADEQUATE FOR PRODUCTION USE! | `true` |
 | `apiserver.storage.etcd.servers` | If storage type is `etcd`: etcd URL(s); override this if NOT using embedded etcd. Only etcd v3 is supported. | `http://localhost:2379` |

--- a/charts/catalog/templates/apiserver-service.yaml
+++ b/charts/catalog/templates/apiserver-service.yaml
@@ -9,6 +9,11 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   type: {{ .Values.apiserver.service.type }}
+  {{- if eq .Values.apiserver.service.type "ClusterIP" }}
+  {{- if .Values.apiserver.service.clusterIp }}
+  clusterIP: {{ .Values.apiserver.service.clusterIp }}
+  {{- end }}
+  {{- end }}
   selector:
     app: {{ template "fullname" . }}-apiserver
   ports:

--- a/charts/catalog/templates/apiserver-service.yaml
+++ b/charts/catalog/templates/apiserver-service.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   type: {{ .Values.apiserver.service.type }}
   {{- if eq .Values.apiserver.service.type "ClusterIP" }}
-  {{- if .Values.apiserver.service.clusterIp }}
-  clusterIP: {{ .Values.apiserver.service.clusterIp }}
+  {{- if .Values.apiserver.service.clusterIP }}
+  clusterIP: {{ .Values.apiserver.service.clusterIP }}
   {{- end }}
   {{- end }}
   selector:


### PR DESCRIPTION
support for headless services for API server (Type:clusterIP;clusterIP:None). In additon this feature also allow to use userdefined clusterIp type service, where user can specify the IP or let Kubernetes choose an IP.

In some scenarios API server can work with headless services.