### PR TITLE
Reject ServiceBrokers whose catalogRestrictions reference invalid fields

### DIFF
--- a/pkg/apis/servicecatalog/v1beta1/filter.go
+++ b/pkg/apis/servicecatalog/v1beta1/filter.go
@@ -40,6 +40,12 @@ func ConvertServiceClassToProperties(serviceClass *ServiceClass) filter.Properti
 	}
 }
 
+// IsValidServiceClassProperty returns true if the specified property
+// is a valid filterable property of ServiceClasses
+func IsValidServiceClassProperty(p string) bool {
+	return p == FilterName || p == FilterSpecExternalName || p == FilterSpecExternalID
+}
+
 // ConvertServicePlanToProperties takes a Service Plan and pulls out the
 // properties we support for filtering, converting them into a map in the
 // expected format.
@@ -56,6 +62,12 @@ func ConvertServicePlanToProperties(servicePlan *ServicePlan) filter.Properties 
 	}
 }
 
+// IsValidServicePlanProperty returns true if the specified property
+// is a valid filterable property of ServicePlans
+func IsValidServicePlanProperty(p string) bool {
+	return p == FilterName || p == FilterSpecExternalName || p == FilterSpecExternalID || p == FilterSpecServiceClassName || p == FilterSpecFree
+}
+
 // ConvertClusterServiceClassToProperties takes a Service Class and pulls out the
 // properties we support for filtering, converting them into a map in the
 // expected format.
@@ -68,6 +80,12 @@ func ConvertClusterServiceClassToProperties(serviceClass *ClusterServiceClass) f
 		FilterSpecExternalName: serviceClass.Spec.ExternalName,
 		FilterSpecExternalID:   serviceClass.Spec.ExternalID,
 	}
+}
+
+// IsValidClusterServiceClassProperty returns true if the specified property
+// is a valid filterable property of ClusterServiceClasses
+func IsValidClusterServiceClassProperty(p string) bool {
+	return p == FilterName || p == FilterSpecExternalName || p == FilterSpecExternalID
 }
 
 // ConvertClusterServicePlanToProperties takes a Service Plan and pulls out the
@@ -84,4 +102,10 @@ func ConvertClusterServicePlanToProperties(servicePlan *ClusterServicePlan) filt
 		FilterSpecClusterServiceClassName: servicePlan.Spec.ClusterServiceClassRef.Name,
 		FilterSpecFree:                    strconv.FormatBool(servicePlan.Spec.Free),
 	}
+}
+
+// IsValidClusterServicePlanProperty returns true if the specified property
+// is a valid filterable property of ServicePlans
+func IsValidClusterServicePlanProperty(p string) bool {
+	return p == FilterName || p == FilterSpecExternalName || p == FilterSpecExternalID || p == FilterSpecClusterServiceClassName || p == FilterSpecFree
 }

--- a/pkg/apis/servicecatalog/validation/broker.go
+++ b/pkg/apis/servicecatalog/validation/broker.go
@@ -17,11 +17,14 @@ limitations under the License.
 package validation
 
 import (
+	"fmt"
+
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/filter"
 )
 
@@ -88,7 +91,7 @@ func validateClusterServiceBrokerSpec(spec *sc.ClusterServiceBrokerSpec, fldPath
 		}
 	}
 
-	commonErrs := validateCommonServiceBrokerSpec(&spec.CommonServiceBrokerSpec, fldPath)
+	commonErrs := validateCommonServiceBrokerSpec(&spec.CommonServiceBrokerSpec, fldPath, true)
 
 	if len(commonErrs) != 0 {
 		allErrs = append(allErrs, commonErrs...)
@@ -150,7 +153,7 @@ func validateServiceBrokerSpec(spec *sc.ServiceBrokerSpec, fldPath *field.Path) 
 		}
 	}
 
-	commonErrs := validateCommonServiceBrokerSpec(&spec.CommonServiceBrokerSpec, fldPath)
+	commonErrs := validateCommonServiceBrokerSpec(&spec.CommonServiceBrokerSpec, fldPath, false)
 
 	if len(commonErrs) != 0 {
 		allErrs = append(allErrs, commonErrs...)
@@ -159,7 +162,7 @@ func validateServiceBrokerSpec(spec *sc.ServiceBrokerSpec, fldPath *field.Path) 
 	return allErrs
 }
 
-func validateCommonServiceBrokerSpec(spec *sc.CommonServiceBrokerSpec, fldPath *field.Path) field.ErrorList {
+func validateCommonServiceBrokerSpec(spec *sc.CommonServiceBrokerSpec, fldPath *field.Path, isClusterServiceBroker bool) field.ErrorList {
 	commonErrs := field.ErrorList{}
 
 	if "" == spec.URL {
@@ -205,8 +208,6 @@ func validateCommonServiceBrokerSpec(spec *sc.CommonServiceBrokerSpec, fldPath *
 		}
 	}
 
-	// TODO: could validate if the fields being selected are on the approve list, but this will require breaking
-	// apart the label selector.
 	if spec.CatalogRestrictions != nil && len(spec.CatalogRestrictions.ServiceClass) > 0 {
 		// confirm that the restrictions can turn into a predicate.
 		_, err := filter.CreatePredicate(spec.CatalogRestrictions.ServiceClass)
@@ -214,6 +215,16 @@ func validateCommonServiceBrokerSpec(spec *sc.CommonServiceBrokerSpec, fldPath *
 			commonErrs = append(commonErrs,
 				field.Invalid(fldPath.Child("catalogRestrictions", "serviceClass"),
 					spec.CatalogRestrictions.ServiceClass, err.Error()))
+		} else {
+			for _, restriction := range spec.CatalogRestrictions.ServiceClass {
+				p := filter.ExtractProperty(restriction)
+				if !isClusterServiceBroker && !v1beta1.IsValidServiceClassProperty(p) ||
+					isClusterServiceBroker && !v1beta1.IsValidClusterServiceClassProperty(p) {
+					commonErrs = append(commonErrs,
+						field.Invalid(fldPath.Child("catalogRestrictions", "serviceClass"),
+							spec.CatalogRestrictions.ServiceClass, fmt.Sprintf("Invalid property: %s", p)))
+				}
+			}
 		}
 	}
 	if spec.CatalogRestrictions != nil && len(spec.CatalogRestrictions.ServicePlan) > 0 {
@@ -223,6 +234,16 @@ func validateCommonServiceBrokerSpec(spec *sc.CommonServiceBrokerSpec, fldPath *
 			commonErrs = append(commonErrs,
 				field.Invalid(fldPath.Child("catalogRestrictions", "servicePlan"),
 					spec.CatalogRestrictions.ServicePlan, err.Error()))
+		} else {
+			for _, restriction := range spec.CatalogRestrictions.ServicePlan {
+				p := filter.ExtractProperty(restriction)
+				if !isClusterServiceBroker && !v1beta1.IsValidServicePlanProperty(p) ||
+					isClusterServiceBroker && !v1beta1.IsValidClusterServicePlanProperty(p) {
+					commonErrs = append(commonErrs,
+						field.Invalid(fldPath.Child("catalogRestrictions", "servicePlan"),
+							spec.CatalogRestrictions.ServicePlan, fmt.Sprintf("Invalid property: %s", p)))
+				}
+			}
 		}
 	}
 

--- a/pkg/apis/servicecatalog/validation/broker_test.go
+++ b/pkg/apis/servicecatalog/validation/broker_test.go
@@ -402,7 +402,7 @@ func TestValidateClusterServiceBroker(t *testing.T) {
 						CatalogRestrictions: &servicecatalog.CatalogRestrictions{
 							ServiceClass: []string{
 								"name==foobar",
-								"externalName in (foobar, bazboof, wizzbang)",
+								"spec.externalName in (foobar, bazboof, wizzbang)",
 							},
 						},
 					},
@@ -423,6 +423,26 @@ func TestValidateClusterServiceBroker(t *testing.T) {
 						CatalogRestrictions: &servicecatalog.CatalogRestrictions{
 							ServiceClass: []string{
 								"invalid restriction",
+							},
+						},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid clusterservicebroker - catalogRequirements.serviceClass - invalid property",
+			broker: &servicecatalog.ClusterServiceBroker{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-broker",
+				},
+				Spec: servicecatalog.ClusterServiceBrokerSpec{
+					CommonServiceBrokerSpec: servicecatalog.CommonServiceBrokerSpec{
+						URL:            "http://example.com",
+						RelistBehavior: servicecatalog.ServiceBrokerRelistBehaviorManual,
+						CatalogRestrictions: &servicecatalog.CatalogRestrictions{
+							ServiceClass: []string{
+								"spec.invalidProperty==foobar",
 							},
 						},
 					},
@@ -463,7 +483,7 @@ func TestValidateClusterServiceBroker(t *testing.T) {
 						CatalogRestrictions: &servicecatalog.CatalogRestrictions{
 							ServicePlan: []string{
 								"name==foobar",
-								"externalName in (foobar, bazboof, wizzbang)",
+								"spec.externalName in (foobar, bazboof, wizzbang)",
 							},
 						},
 					},
@@ -492,6 +512,26 @@ func TestValidateClusterServiceBroker(t *testing.T) {
 			valid: false,
 		},
 		{
+			name: "invalid clusterservicebroker - catalogRequirements.servicePlan - invalid property",
+			broker: &servicecatalog.ClusterServiceBroker{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-broker",
+				},
+				Spec: servicecatalog.ClusterServiceBrokerSpec{
+					CommonServiceBrokerSpec: servicecatalog.CommonServiceBrokerSpec{
+						URL:            "http://example.com",
+						RelistBehavior: servicecatalog.ServiceBrokerRelistBehaviorManual,
+						CatalogRestrictions: &servicecatalog.CatalogRestrictions{
+							ServicePlan: []string{
+								"spec.invalidProperty notin (foo, bar)",
+							},
+						},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
 			name: "valid clusterservicebroker - catalogRequirements with serviceClass and servicePlan",
 			broker: &servicecatalog.ClusterServiceBroker{
 				ObjectMeta: metav1.ObjectMeta{
@@ -503,12 +543,12 @@ func TestValidateClusterServiceBroker(t *testing.T) {
 						RelistBehavior: servicecatalog.ServiceBrokerRelistBehaviorManual,
 						CatalogRestrictions: &servicecatalog.CatalogRestrictions{
 							ServiceClass: []string{
-								"name==barfoobar",
-								"externalName in (barfoobar, batbazboof, batwizzbang)",
+								"name=barfoobar",
+								"spec.externalName in (barfoobar, batbazboof, batwizzbang)",
 							},
 							ServicePlan: []string{
 								"name==foobar",
-								"externalName in (foobar, bazboof, wizzbang)",
+								"spec.externalName in (foobar, bazboof, wizzbang)",
 							},
 						},
 					},

--- a/pkg/filter/helper.go
+++ b/pkg/filter/helper.go
@@ -18,9 +18,12 @@ package filter
 
 import (
 	"fmt"
+	"regexp"
 
 	"k8s.io/apimachinery/pkg/labels"
 )
+
+var conditionalsRegex = regexp.MustCompile("=|==|!=| in | notin ")
 
 // CreatePredicate creates the Predicate that will be used to
 // test if acceptance is allowed for service classes.
@@ -46,4 +49,11 @@ func CreatePredicate(restrictions []string) (Predicate, error) {
 // ConvertToSelector converts Predicate to a labels.Selector
 func ConvertToSelector(p Predicate) (labels.Selector, error) {
 	return labels.Parse(p.String())
+}
+
+// ExtractProperty extracts the property from the given restriction
+// E.g., for the restriction "spec.externalName=foo", the function
+// returns "spec.externalName"
+func ExtractProperty(restriction string) string {
+	return conditionalsRegex.Split(restriction, 2)[0]
 }


### PR DESCRIPTION
The admission control plugin now validates if the fields being selected 
in broker.spec.catalogRestrictions are on the approved list or not.