### PR TITLE
Make the building of our build image smarter per issue 2329

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,12 +181,15 @@ $(BINDIR)/e2e.test: .init
 $(BINDIR):
 	mkdir -p $@
 
-.scBuildImage: build/build-image/Dockerfile
+.scBuildImage: build/build-image/Dockerfile $$(shell sh -c "docker inspect scbuildimage" > /dev/null 2>&1 || echo .forceIt)
 	mkdir -p .cache
 	mkdir -p .pkg
 	sed "s/GO_VERSION/$(GO_VERSION)/g" < build/build-image/Dockerfile | \
 	  docker build -t scbuildimage -f - .
 	touch $@
+
+# Just a dummy target that will force anything dependent on it to rebuild
+.forceIt:
 
 # Util targets
 ##############


### PR DESCRIPTION
Checks to see if the image is in our docker cache too, instead of just
looking for .scBuildImage

Closes: #2329

Signed-off-by: Doug Davis <dug@us.ibm.com>