### PR TITLE
Allow filtering of ServiceInstances on serviceClassRef/servicePlanRef.name

### DIFF
--- a/pkg/apis/servicecatalog/v1beta1/conversion.go
+++ b/pkg/apis/servicecatalog/v1beta1/conversion.go
@@ -93,7 +93,9 @@ func ServiceInstanceFieldLabelConversionFunc(label, value string) (string, strin
 		"metadata.namespace",
 		"spec.externalID",
 		"spec.clusterServiceClassRef.name",
-		"spec.clusterServicePlanRef.name":
+		"spec.clusterServicePlanRef.name",
+		"spec.serviceClassRef.name",
+		"spec.servicePlanRef.name":
 		return label, value, nil
 	default:
 		return "", "", fmt.Errorf("field label not supported: %s", label)

--- a/pkg/apis/servicecatalog/v1beta1/conversion_test.go
+++ b/pkg/apis/servicecatalog/v1beta1/conversion_test.go
@@ -197,6 +197,22 @@ func TestServiceInstanceFieldLabelConversionFunc(t *testing.T) {
 			success:  true,
 		},
 		{
+			name:     "spec.serviceClassRef.name works",
+			inLabel:  "spec.serviceClassRef.name",
+			inValue:  "someref",
+			outLabel: "spec.serviceClassRef.name",
+			outValue: "someref",
+			success:  true,
+		},
+		{
+			name:     "spec.servicePlanRef.name works",
+			inLabel:  "spec.servicePlanRef.name",
+			inValue:  "someref",
+			outLabel: "spec.servicePlanRef.name",
+			outValue: "someref",
+			success:  true,
+		},
+		{
 			name:     "spec.externalID works",
 			inLabel:  "spec.externalID",
 			inValue:  "externalid",


### PR DESCRIPTION
This is needed by the controller to find ServiceInstances whose
referenced class/plan is about to be removed from the catalog.

Fixes #2335 

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
