### PR TITLE
Share OSB client for ServiceBroker

### DIFF
--- a/pkg/controller/broker_client_manager.go
+++ b/pkg/controller/broker_client_manager.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+	"reflect"
+	"sync"
+)
+
+// BrokerKey defines a key which points to a broker (cluster wide or namespaced)
+type BrokerKey struct {
+	name      string
+	namespace string
+}
+
+// IsClusterScoped whether this broker key points to cluster scoped service broker.
+func (bk *BrokerKey) IsClusterScoped() bool {
+	return bk.namespace == ""
+}
+
+// String returns string representation of the broker key
+func (bk *BrokerKey) String() string {
+	if bk.IsClusterScoped() {
+		return bk.name
+	}
+	return fmt.Sprintf("%s/%s", bk.namespace, bk.name)
+}
+
+// NewServiceBrokerKey creates a BrokerKey instance which points to namespaced broker
+func NewServiceBrokerKey(namespace, name string) BrokerKey {
+	return BrokerKey{
+		namespace: namespace,
+		name:      name,
+	}
+}
+
+// NewClusterServiceBrokerKey creates a BrokerKey instance which points to cluster wide broker
+func NewClusterServiceBrokerKey(name string) BrokerKey {
+	return BrokerKey{
+		namespace: "",
+		name:      name,
+	}
+}
+
+// BrokerClientManager stores OSB client instances per broker
+type BrokerClientManager struct {
+	mu      sync.RWMutex
+	clients map[BrokerKey]clientWithConfig
+
+	brokerClientCreateFunc osb.CreateFunc
+}
+
+// NewBrokerClientManager creates BrokerClientManager instance
+func NewBrokerClientManager(brokerClientCreateFunc osb.CreateFunc) *BrokerClientManager {
+	return &BrokerClientManager{
+		clients:                map[BrokerKey]clientWithConfig{},
+		brokerClientCreateFunc: brokerClientCreateFunc,
+	}
+}
+
+// UpdateBrokerClient creates new broker client if necessary (the ClientConfig has changed or there is no client for the broker),
+// the method returns created or stored osb.Client instance.
+func (m *BrokerClientManager) UpdateBrokerClient(brokerKey BrokerKey, clientConfig *osb.ClientConfiguration) (osb.Client, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	existing, found := m.clients[brokerKey]
+
+	if !found || configHasChanged(existing.clientConfig, clientConfig) {
+		glog.V(4).Infof("Updating OSB client for broker %s, URL: %s", brokerKey.String(), clientConfig.URL)
+		return m.createClient(brokerKey, clientConfig)
+	}
+
+	return existing.OSBClient, nil
+}
+
+// RemoveBrokerClient removes broker client broker
+func (m *BrokerClientManager) RemoveBrokerClient(brokerKey BrokerKey) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	glog.V(4).Info("Removing OSB client for broker %s", brokerKey.String())
+	delete(m.clients, brokerKey)
+}
+
+// BrokerClient returns broker client for a broker specified by the brokerKey
+func (m *BrokerClientManager) BrokerClient(brokerKey BrokerKey) (osb.Client, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	existing, found := m.clients[brokerKey]
+	return existing.OSBClient, found
+}
+
+func (m *BrokerClientManager) createClient(brokerKey BrokerKey, clientConfig *osb.ClientConfiguration) (osb.Client, error) {
+	client, err := m.brokerClientCreateFunc(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	m.clients[brokerKey] = clientWithConfig{
+		OSBClient:    client,
+		clientConfig: clientConfig,
+	}
+	return client, nil
+}
+
+func configHasChanged(cfg1 *osb.ClientConfiguration, cfg2 *osb.ClientConfiguration) bool {
+	return !reflect.DeepEqual(cfg1, cfg2)
+}
+
+type clientWithConfig struct {
+	OSBClient    osb.Client
+	clientConfig *osb.ClientConfiguration
+}

--- a/pkg/controller/broker_client_manager_test.go
+++ b/pkg/controller/broker_client_manager_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"github.com/kubernetes-incubator/service-catalog/pkg/controller"
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+	"testing"
+)
+
+func TestBrokerClientManager_CreateBrokerClient(t *testing.T) {
+	// GIVEN
+	osbCl1, _ := osb.NewClient(testOsbConfig("osb-1"))
+	osbCl2, _ := osb.NewClient(testOsbConfig("osb-2"))
+	brokerClientFunc := clientFunc(osbCl1, osbCl2)
+	manager := controller.NewBrokerClientManager(brokerClientFunc)
+
+	// WHEN
+	createdClient1, _ := manager.UpdateBrokerClient(controller.NewClusterServiceBrokerKey("broker1"), testOsbConfig("osb-1"))
+	createdClient2, _ := manager.UpdateBrokerClient(controller.NewServiceBrokerKey("prod", "broker1"), testOsbConfig("osb-2"))
+	gotClient1, exists1 := manager.BrokerClient(controller.NewClusterServiceBrokerKey("broker1"))
+	gotClient2, exists2 := manager.BrokerClient(controller.NewServiceBrokerKey("prod", "broker1"))
+	_, exists3 := manager.BrokerClient(controller.NewServiceBrokerKey("stage", "broker1"))
+
+	// THEN
+	if !exists1 {
+		t.Fatal("Broker client osb-1 does not exists")
+	}
+	if !exists2 {
+		t.Fatal("Broker client osb-2 does not exists")
+	}
+	if exists3 {
+		t.Fatal("Broker client for namespace 'stage' must not exists")
+	}
+
+	if osbCl1 != createdClient1 {
+		t.Fatalf("Wrong client from broker1")
+	}
+	if osbCl2 != createdClient2 {
+		t.Fatalf("Wrong client from broker2")
+	}
+
+	if osbCl1 != gotClient1 {
+		t.Fatalf("Wrong client from broker1")
+	}
+	if osbCl2 != gotClient2 {
+		t.Fatalf("Wrong client from broker2")
+	}
+}
+
+func TestBrokerClientManager_RemoveBrokerClient(t *testing.T) {
+	// GIVEN
+	osbCl1, _ := osb.NewClient(testOsbConfig("osb-1"))
+	osbCl2, _ := osb.NewClient(testOsbConfig("osb-2"))
+	brokerClientFunc := clientFunc(osbCl1, osbCl2)
+	manager := controller.NewBrokerClientManager(brokerClientFunc)
+
+	// WHEN
+	manager.UpdateBrokerClient(controller.NewClusterServiceBrokerKey("broker1"), testOsbConfig("osb-1"))
+	manager.UpdateBrokerClient(controller.NewServiceBrokerKey("prod", "broker1"), testOsbConfig("osb-2"))
+	manager.RemoveBrokerClient(controller.NewClusterServiceBrokerKey("broker1"))
+	_, exists1 := manager.BrokerClient(controller.NewClusterServiceBrokerKey("broker1"))
+	_, exists2 := manager.BrokerClient(controller.NewServiceBrokerKey("prod", "broker1"))
+
+	// THEN
+	if exists1 {
+		t.Fatal("Broker client for 'broker1' must not exists")
+	}
+	if !exists2 {
+		t.Fatal("Broker client osb-2 does not exists")
+	}
+}
+
+func TestBrokerClientManager_UpdateBrokerClient(t *testing.T) {
+	// GIVEN
+	osbCl1, _ := osb.NewClient(testOsbConfig("osb-1"))
+	osbCl2, _ := osb.NewClient(testOsbConfig("osb-2"))
+	osbCl3, _ := osb.NewClient(testOsbConfig("osb-3"))
+	brokerClientFunc := clientFunc(osbCl1, osbCl2, osbCl3)
+	manager := controller.NewBrokerClientManager(brokerClientFunc)
+
+	osbCfg := testOsbConfig("osb-1")
+	osbCfg.AuthConfig = &osb.AuthConfig{
+		BasicAuthConfig: &osb.BasicAuthConfig{
+			Username: "user-1",
+			Password: "password-1",
+		},
+	}
+	osbCfgWithPasswordChange := testOsbConfig("osb-1")
+	osbCfgWithPasswordChange.AuthConfig = &osb.AuthConfig{
+		BasicAuthConfig: &osb.BasicAuthConfig{
+			Username: "user-1",
+			Password: "password-changed",
+		},
+	}
+	manager.UpdateBrokerClient(controller.NewClusterServiceBrokerKey("broker1"), osbCfg)
+	manager.UpdateBrokerClient(controller.NewServiceBrokerKey("prod", "broker1"), testOsbConfig("osb-2"))
+
+	// WHEN
+	manager.UpdateBrokerClient(controller.NewClusterServiceBrokerKey("broker1"), osbCfgWithPasswordChange)
+
+	// THEN
+	gotClient, exists := manager.BrokerClient(controller.NewClusterServiceBrokerKey("broker1"))
+	if !exists {
+		t.Fatal("Broker client osb-2 does not exists")
+	}
+	if gotClient != osbCl3 {
+		t.Fatalf("Broker client must have updated auth config")
+	}
+}
+
+func clientFunc(clients ...osb.Client) osb.CreateFunc {
+	var i = 0
+	return func(_ *osb.ClientConfiguration) (osb.Client, error) {
+		client := clients[i]
+		i++
+		return client, nil
+	}
+}
+
+func testOsbConfig(name string) *osb.ClientConfiguration {
+	return &osb.ClientConfiguration{
+		Name: name,
+	}
+}

--- a/pkg/controller/controller_clusterservicebroker.go
+++ b/pkg/controller/controller_clusterservicebroker.go
@@ -109,7 +109,7 @@ func (c *controller) reconcileClusterServiceBrokerKey(key string) error {
 	broker, err := c.clusterServiceBrokerLister.Get(key)
 	pcb := pretty.NewContextBuilder(pretty.ClusterServiceBroker, "", key, "")
 
-	glog.V(4).Info(pcb.Message(fmt.Sprintf("Processing service broker %s", key)))
+	glog.V(4).Info(pcb.Message("Processing service broker"))
 
 	if errors.IsNotFound(err) {
 		glog.Info(pcb.Message("Not doing work because it has been deleted"))

--- a/pkg/controller/controller_clusterservicebroker.go
+++ b/pkg/controller/controller_clusterservicebroker.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/metrics"
 	"github.com/kubernetes-incubator/service-catalog/pkg/pretty"
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
 )
 
 // the Message strings have a terminating period and space so they can
@@ -107,8 +108,12 @@ func shouldReconcileClusterServiceBroker(broker *v1beta1.ClusterServiceBroker, n
 func (c *controller) reconcileClusterServiceBrokerKey(key string) error {
 	broker, err := c.clusterServiceBrokerLister.Get(key)
 	pcb := pretty.NewContextBuilder(pretty.ClusterServiceBroker, "", key, "")
+
+	glog.V(4).Info(pcb.Message(fmt.Sprintf("Processing service broker %s", key)))
+
 	if errors.IsNotFound(err) {
 		glog.Info(pcb.Message("Not doing work because it has been deleted"))
+		c.brokerClientManager.RemoveBrokerClient(NewClusterServiceBrokerKey(key))
 		return nil
 	}
 	if err != nil {
@@ -119,12 +124,44 @@ func (c *controller) reconcileClusterServiceBrokerKey(key string) error {
 	return c.reconcileClusterServiceBroker(broker)
 }
 
+func (c *controller) updateClusterServiceBrokerClient(broker *v1beta1.ClusterServiceBroker) (osb.Client, error) {
+	pcb := pretty.NewClusterServiceBrokerContextBuilder(broker)
+	glog.V(4).Info(pcb.Message("Updating broker client"))
+	authConfig, err := getAuthCredentialsFromClusterServiceBroker(c.kubeClient, broker)
+	if err != nil {
+		s := fmt.Sprintf("Error getting broker auth credentials: %s", err)
+		glog.Info(pcb.Message(s))
+		c.recorder.Event(broker, corev1.EventTypeWarning, errorAuthCredentialsReason, s)
+		if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorFetchingCatalogReason, errorFetchingCatalogMessage+s); err != nil {
+			return nil, err
+		}
+		return nil, err
+	}
+	clientConfig := NewClientConfigurationForBroker(broker.ObjectMeta, &broker.Spec.CommonServiceBrokerSpec, authConfig)
+	brokerClient, err := c.brokerClientManager.UpdateBrokerClient(NewClusterServiceBrokerKey(broker.Name), clientConfig)
+	if err != nil {
+		s := fmt.Sprintf("Error creating client for broker %q: %s", broker.Name, err)
+		glog.Info(pcb.Message(s))
+		c.recorder.Event(broker, corev1.EventTypeWarning, errorAuthCredentialsReason, s)
+		if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorFetchingCatalogReason, errorFetchingCatalogMessage+s); err != nil {
+			return nil, err
+		}
+		return nil, err
+	}
+	return brokerClient, nil
+}
+
 // reconcileClusterServiceBroker is the control-loop that reconciles a Broker. An
 // error is returned to indicate that the binding has not been fully
 // processed and should be resubmitted at a later time.
 func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServiceBroker) error {
 	pcb := pretty.NewClusterServiceBrokerContextBuilder(broker)
 	glog.V(4).Infof(pcb.Message("Processing"))
+
+	brokerClient, err := c.updateClusterServiceBrokerClient(broker)
+	if err != nil {
+		return err
+	}
 
 	// * If the broker's ready condition is true and the RelistBehavior has been
 	// set to Manual, do not reconcile it.
@@ -135,31 +172,6 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 	}
 
 	if broker.DeletionTimestamp == nil { // Add or update
-		authConfig, err := getAuthCredentialsFromClusterServiceBroker(c.kubeClient, broker)
-		if err != nil {
-			s := fmt.Sprintf("Error getting broker auth credentials: %s", err)
-			glog.Info(pcb.Message(s))
-			c.recorder.Event(broker, corev1.EventTypeWarning, errorAuthCredentialsReason, s)
-			if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorFetchingCatalogReason, errorFetchingCatalogMessage+s); err != nil {
-				return err
-			}
-			return err
-		}
-
-		clientConfig := NewClientConfigurationForBroker(broker.ObjectMeta, &broker.Spec.CommonServiceBrokerSpec, authConfig)
-
-		glog.V(4).Info(pcb.Messagef("Creating client, URL: %v", broker.Spec.URL))
-		brokerClient, err := c.brokerClientCreateFunc(clientConfig)
-		if err != nil {
-			s := fmt.Sprintf("Error creating client for broker %q: %s", broker.Name, err)
-			glog.Info(pcb.Message(s))
-			c.recorder.Event(broker, corev1.EventTypeWarning, errorAuthCredentialsReason, s)
-			if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorFetchingCatalogReason, errorFetchingCatalogMessage+s); err != nil {
-				return err
-			}
-			return err
-		}
-
 		glog.V(4).Info(pcb.Message("Processing adding/update event"))
 
 		// get the broker's catalog

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -179,21 +179,14 @@ func TestReconcileServiceInstanceNonExistentClusterServiceBroker(t *testing.T) {
 	}
 }
 
-// TestReconcileServiceInstanceWithAuthError tests reconcileInstance when Kube Client
-// fails to locate the broker authentication secret.
-func TestReconcileServiceInstanceWithAuthError(t *testing.T) {
+// TestReconcileServiceInstanceWithNotExistingBroker tests reconcileInstance
+// when the BrokerClientManager instance does not contain client for the broker.
+func TestReconcileServiceInstanceWithNotExistingBroker(t *testing.T) {
 	fakeKubeClient, fakeCatalogClient, fakeClusterServiceBrokerClient, testController, sharedInformers := newTestController(t, noFakeActions())
 
-	broker := getTestClusterServiceBroker()
-	broker.Spec.AuthInfo = &v1beta1.ClusterServiceBrokerAuthInfo{
-		Basic: &v1beta1.ClusterBasicAuthConfig{
-			SecretRef: &v1beta1.ObjectReference{
-				Namespace: "does_not_exist",
-				Name:      "auth-name",
-			},
-		},
-	}
-	sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(broker)
+	// the broker does not exists
+	testController.brokerClientManager.RemoveBrokerClient(NewClusterServiceBrokerKey(getTestClusterServiceBroker().Name))
+
 	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(getTestClusterServiceClass())
 	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
 
@@ -217,22 +210,14 @@ func TestReconcileServiceInstanceWithAuthError(t *testing.T) {
 
 	// There should only be one action that says it failed fetching auth credentials.
 	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceErrorBeforeRequest(t, updatedServiceInstance, errorAuthCredentialsReason, instance)
-
-	// verify one kube action occurred
-	kubeActions := fakeKubeClient.Actions()
-	if err := checkKubeClientActions(kubeActions, []kubeClientAction{
-		{verb: "get", resourceName: "secrets", checkType: checkGetActionType},
-	}); err != nil {
-		t.Fatal(err)
-	}
+	assertServiceInstanceErrorBeforeRequest(t, updatedServiceInstance, errorNonexistentClusterServiceBrokerReason, instance)
 
 	// verify that one event was emitted
 	events := getRecordedEvents(testController)
-	expectedEvent := warningEventBuilder(errorAuthCredentialsReason).msgf(
-		"Error getting broker auth credentials for broker %q:",
+	expectedEvent := warningEventBuilder(errorNonexistentClusterServiceBrokerReason).msgf(
+		"The instance references a non-existent broker %q",
 		"test-clusterservicebroker",
-	).msg("no secret defined")
+	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/controller_servicebroker.go
+++ b/pkg/controller/controller_servicebroker.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/metrics"
 	"github.com/kubernetes-incubator/service-catalog/pkg/pretty"
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
 )
 
 // the Message strings have a terminating period and space so they can
@@ -102,6 +103,7 @@ func (c *controller) reconcileServiceBrokerKey(key string) error {
 	broker, err := c.serviceBrokerLister.ServiceBrokers(namespace).Get(name)
 	if errors.IsNotFound(err) {
 		glog.Info(pcb.Message("Not doing work because the ServiceBroker has been deleted"))
+		c.brokerClientManager.RemoveBrokerClient(NewServiceBrokerKey(namespace, name))
 		return nil
 	}
 	if err != nil {
@@ -112,12 +114,47 @@ func (c *controller) reconcileServiceBrokerKey(key string) error {
 	return c.reconcileServiceBroker(broker)
 }
 
+func (c *controller) updateServiceBrokerClient(broker *v1beta1.ServiceBroker) (osb.Client, error) {
+	pcb := pretty.NewServiceBrokerContextBuilder(broker)
+	authConfig, err := getAuthCredentialsFromServiceBroker(c.kubeClient, broker)
+	if err != nil {
+		s := fmt.Sprintf("Error getting broker auth credentials: %s", err)
+		glog.Info(pcb.Message(s))
+		c.recorder.Event(broker, corev1.EventTypeWarning, errorAuthCredentialsReason, s)
+		if err := c.updateServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorFetchingCatalogReason, errorFetchingCatalogMessage+s); err != nil {
+			return nil, err
+		}
+		return nil, err
+	}
+
+	// clientConfig := NewClientConfigurationForBroker(broker, authConfig)
+	clientConfig := NewClientConfigurationForBroker(broker.ObjectMeta, &broker.Spec.CommonServiceBrokerSpec, authConfig)
+
+	brokerClient, err := c.brokerClientManager.UpdateBrokerClient(NewClusterServiceBrokerKey(broker.Name), clientConfig)
+	if err != nil {
+		s := fmt.Sprintf("Error creating client for broker %q: %s", broker.Name, err)
+		glog.Info(pcb.Message(s))
+		c.recorder.Event(broker, corev1.EventTypeWarning, errorAuthCredentialsReason, s)
+		if err := c.updateServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorFetchingCatalogReason, errorFetchingCatalogMessage+s); err != nil {
+			return nil, err
+		}
+		return nil, err
+	}
+
+	return brokerClient, nil
+}
+
 // reconcileServiceBroker is the control-loop that reconciles a ServiceBroker. An
 // error is returned to indicate that the binding has not been fully
 // processed and should be resubmitted at a later time.
 func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error {
 	pcb := pretty.NewServiceBrokerContextBuilder(broker)
 	glog.V(4).Infof(pcb.Message("Processing"))
+
+	brokerClient, err := c.updateServiceBrokerClient(broker)
+	if err != nil {
+		return err
+	}
 
 	// * If the broker's ready condition is true and the RelistBehavior has been
 	// set to Manual, do not reconcile it.
@@ -128,32 +165,6 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 	}
 
 	if broker.DeletionTimestamp == nil { // Add or update
-		authConfig, err := getAuthCredentialsFromServiceBroker(c.kubeClient, broker)
-		if err != nil {
-			s := fmt.Sprintf("Error getting broker auth credentials: %s", err)
-			glog.Info(pcb.Message(s))
-			c.recorder.Event(broker, corev1.EventTypeWarning, errorAuthCredentialsReason, s)
-			if err := c.updateServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorFetchingCatalogReason, errorFetchingCatalogMessage+s); err != nil {
-				return err
-			}
-			return err
-		}
-
-		// clientConfig := NewClientConfigurationForBroker(broker, authConfig)
-		clientConfig := NewClientConfigurationForBroker(broker.ObjectMeta, &broker.Spec.CommonServiceBrokerSpec, authConfig)
-
-		glog.V(4).Info(pcb.Messagef("Creating client, URL: %v", broker.Spec.URL))
-		brokerClient, err := c.brokerClientCreateFunc(clientConfig)
-		if err != nil {
-			s := fmt.Sprintf("Error creating client for broker %q: %s", broker.Name, err)
-			glog.Info(pcb.Message(s))
-			c.recorder.Event(broker, corev1.EventTypeWarning, errorAuthCredentialsReason, s)
-			if err := c.updateServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorFetchingCatalogReason, errorFetchingCatalogMessage+s); err != nil {
-				return err
-			}
-			return err
-		}
-
 		glog.V(4).Info(pcb.Message("Processing adding/update event"))
 
 		// get the broker's catalog

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2006,6 +2006,12 @@ func newTestController(t *testing.T, config fakeosb.FakeClientConfiguration) (
 
 	if c, ok := testController.(*controller); ok {
 		c.setClusterID(testClusterID)
+		c.brokerClientManager.clients[NewClusterServiceBrokerKey(getTestClusterServiceBroker().Name)] = clientWithConfig{
+			OSBClient: fakeOSBClient,
+		}
+		c.brokerClientManager.clients[NewServiceBrokerKey(getTestServiceBroker().Namespace, getTestServiceBroker().Name)] = clientWithConfig{
+			OSBClient: fakeOSBClient,
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

This PR introduces BrokerClientManager which stores OSB clients - one client per broker. It allows to share one OSB client instance for all calls to the broker. It prevents the controller from creating OSB clients for every operation and it follows the description of the Golang HTTP client: "The Client's Transport typically has internal state (cached TCP connections), so Clients should be reused instead of created as needed. Clients are safe for concurrent use by multiple goroutines."

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #2276 

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [x] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
