### PR TITLE
Show hover link for all headers

### DIFF
--- a/docsite/_includes/footer-scripts.html
+++ b/docsite/_includes/footer-scripts.html
@@ -56,7 +56,7 @@ ga('send', 'pageview');
                 'use strict';
 
                 /* selector */
-                var postHeader = 'h1';
+                var postHeader = 'h1,h2,h3,h4';
 
                 $(postHeader).filter('[id]').each(function () {
                     var header      = $(this),


### PR DESCRIPTION
This enables the hover anchor link (which makes it easy to copy a bookmark to a particular heading) for all headings.

![screen shot 2018-09-17 at 9 38 00 am](https://user-images.githubusercontent.com/1368985/45630051-76a43d00-ba5d-11e8-9cd4-b901aba21c4c.png)

Preview available at: https://deploy-preview-2340--svc-cat.netlify.com/docs/catalog-restrictions/#allow-all-service-class-resources-except-those-with-specific-external-name