### PR TITLE
Fix image tagging when releases use a lightweight tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ SRC_DIRS       = $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*.go \
 TEST_DIRS     ?= $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go \
                    -exec dirname {} \\; | sort | uniq")
 # Either the tag name, e.g. v1.2.3 or the commit hash for untagged commits, e.g. abc123
-VERSION       ?= $(shell git describe --always --abbrev=7 --dirty)
+VERSION       ?= $(shell git describe --tags --always --abbrev=7 --dirty)
 # Either the tag name, e.g. v1.2.3 or a combination of the closest tag combined with the commit hash, e.g. v1.2.3-2-gabc123
 TAG_VERSION   ?= $(shell git describe --tags --abbrev=7 --dirty)
 BUILD_LDFLAGS  = $(shell build/version.sh $(ROOT) $(SC_PKG))


### PR DESCRIPTION
This fixes our tag identification logic in the Makefile to recognize lightweight tags (i.e. tags created like this `git tag foo` vs `git tag foo -a -m""`.

Right now depending on the preferences of the person doing the release process, we are aren't identifying the tag properly. You can see for yourself by checking out our quay images:

https://quay.io/repository/kubernetes-service-catalog/service-catalog?tag=latest&tab=tags

Notice that very recently we are still pushing images tagged with v0.1.28* because that was the last non-lightweight tag pushed.