### PR TITLE
Repaire make build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,8 +184,8 @@ $(BINDIR):
 .scBuildImage: build/build-image/Dockerfile $$(shell sh -c "docker inspect scbuildimage" > /dev/null 2>&1 || echo .forceIt)
 	mkdir -p .cache
 	mkdir -p .pkg
-	sed "s/GO_VERSION/$(GO_VERSION)/g" < build/build-image/Dockerfile | \
-	  docker build -t scbuildimage -f - .
+	sed -i "s/GO_VERSION/$(GO_VERSION)/g" build/build-image/Dockerfile
+	docker build -t scbuildimage -f build/build-image/Dockerfile .
 	touch $@
 
 # Just a dummy target that will force anything dependent on it to rebuild


### PR DESCRIPTION
When do the action "make" in the service catalog, errors like the
following:
"sed "s/GO_VERSION/1.10/g" < build/build-image/Dockerfile | \
  docker build -t scbuildimage -f - .
unable to prepare context: unable to evaluate symlinks in
Dockerfile path: lstat /root/service-catalog/-: no such file
or directory". We need repaire it.

 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
