### PR TITLE
Fix goldenfile ouput

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,8 @@ verify: .init verify-generated verify-client-gen verify-docs verify-vendor
 	@$(DOCKER_CMD) build/verify-errexit.sh
 	@echo Running tag verification:
 	@$(DOCKER_CMD) build/verify-tags.sh
+	@echo Validating golden file flag is defined:
+	@$(DOCKER_CMD) go test -run DRYRUN ./cmd/svcat/... -update || printf "\n\nmake test-update-goldenfiles is broken. For each failed package above, add the following empty import to one of the test files to define the -update flag:\n_ \"github.com/kubernetes-incubator/service-catalog/internal/test\""
 
 verify-docs: .init
 	@echo Running href checker$(SKIP_COMMENT):

--- a/cmd/svcat/class/get_cmd_test.go
+++ b/cmd/svcat/class/get_cmd_test.go
@@ -35,6 +35,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+
+	_ "github.com/kubernetes-incubator/service-catalog/internal/test"
 )
 
 func TestListClasses(t *testing.T) {

--- a/cmd/svcat/plan/get_cmd_test.go
+++ b/cmd/svcat/plan/get_cmd_test.go
@@ -35,6 +35,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+
+	_ "github.com/kubernetes-incubator/service-catalog/internal/test"
 )
 
 func TestListPlans(t *testing.T) {


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
This fixes the `make test-update-golden-files` target and ensures that it doesn't get broken again during CI.

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #2319 

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update

You can see from the Travis build log that we are now checking that -update is defined in every package in ./cmd/svcat

```console
Validating golden file flag is defined:
ok  	github.com/kubernetes-incubator/service-catalog/cmd/svcat	0.015s [no tests to run]
ok  	github.com/kubernetes-incubator/service-catalog/cmd/svcat/binding	0.016s [no tests to run]
ok  	github.com/kubernetes-incubator/service-catalog/cmd/svcat/broker	0.025s [no tests to run]
ok  	github.com/kubernetes-incubator/service-catalog/cmd/svcat/class	0.021s [no tests to run]
?   	github.com/kubernetes-incubator/service-catalog/cmd/svcat/command	[no test files]
?   	github.com/kubernetes-incubator/service-catalog/cmd/svcat/completion	[no test files]
?   	github.com/kubernetes-incubator/service-catalog/cmd/svcat/instance	[no test files]
ok  	github.com/kubernetes-incubator/service-catalog/cmd/svcat/output	0.012s [no tests to run]
ok  	github.com/kubernetes-incubator/service-catalog/cmd/svcat/parameters	0.009s [no tests to run]
ok  	github.com/kubernetes-incubator/service-catalog/cmd/svcat/plan	0.018s [no tests to run]
?   	github.com/kubernetes-incubator/service-catalog/cmd/svcat/plugin	[no test files]
?   	github.com/kubernetes-incubator/service-catalog/cmd/svcat/test	[no test files]
ok  	github.com/kubernetes-incubator/service-catalog/cmd/svcat/versions	0.012s [no tests to run]
```

If it fails, it prints a message at the bottom explaining how to fix a package.