### PR TITLE
Fix the controller updateServiceBrokerClient  method.

### DIFF
--- a/pkg/controller/controller_servicebroker.go
+++ b/pkg/controller/controller_servicebroker.go
@@ -130,7 +130,7 @@ func (c *controller) updateServiceBrokerClient(broker *v1beta1.ServiceBroker) (o
 	// clientConfig := NewClientConfigurationForBroker(broker, authConfig)
 	clientConfig := NewClientConfigurationForBroker(broker.ObjectMeta, &broker.Spec.CommonServiceBrokerSpec, authConfig)
 
-	brokerClient, err := c.brokerClientManager.UpdateBrokerClient(NewClusterServiceBrokerKey(broker.Name), clientConfig)
+	brokerClient, err := c.brokerClientManager.UpdateBrokerClient(NewServiceBrokerKey(broker.Namespace, broker.Name), clientConfig)
 	if err != nil {
 		s := fmt.Sprintf("Error creating client for broker %q: %s", broker.Name, err)
 		glog.Info(pcb.Message(s))

--- a/pkg/controller/controller_servicebroker_test.go
+++ b/pkg/controller/controller_servicebroker_test.go
@@ -41,6 +41,18 @@ func TestShouldReconcileServiceBroker(t *testing.T) {
 	}
 }
 
+func TestReconcileServiceBrokerUpdatesBrokerClient(t *testing.T) {
+	broker := getTestServiceBroker()
+	broker.Name = broker.Name + "not-predefined"
+	_, _, _, testController, _ := newTestController(t, noFakeActions())
+	testController.reconcileServiceBroker(broker)
+
+	_, found := testController.brokerClientManager.BrokerClient(NewServiceBrokerKey(broker.Namespace, broker.Name))
+	if !found {
+		t.Error("expected predefined OSB client")
+	}
+}
+
 func TestReconcileServiceClassFromServiceBrokerCatalog(t *testing.T) {
 	updatedClass := func() *v1beta1.ServiceClass {
 		p := getTestServiceClass()


### PR DESCRIPTION
  <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
This PR fixes storing OSB clients for namespaced service brokers. The line:
https://github.com/kubernetes-incubator/service-catalog/blob/master/pkg/controller/controller_servicebroker.go#L133
treats the broker like cluster wide, but namespaced broker is being processed. Additionally, a unit test was added, which was failing before the fix.

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update