### PR TITLE
Enable ginkgo cmd/svcat unit tests to run and fix existing ones

### DIFF
--- a/cmd/svcat/class/class_suite_test.go
+++ b/cmd/svcat/class/class_suite_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package class_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+
+	_ "github.com/kubernetes-incubator/service-catalog/internal/test"
+)
+
+func TestClass(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Class Suite")
+}

--- a/cmd/svcat/class/create_cmd_test.go
+++ b/cmd/svcat/class/create_cmd_test.go
@@ -72,8 +72,10 @@ var _ = Describe("Create Command", func() {
 			existingClassName := "existingclass"
 
 			classToReturn := &v1beta1.ClusterServiceClass{
-				ObjectMeta: v1.ObjectMeta{
-					Name: className,
+				Spec: v1beta1.ClusterServiceClassSpec{
+					CommonServiceClassSpec: v1beta1.CommonServiceClassSpec{
+						ExternalName: className,
+					},
 				},
 			}
 
@@ -107,8 +109,12 @@ var _ = Describe("Create Command", func() {
 
 			classToReturn := &v1beta1.ServiceClass{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      className,
 					Namespace: classNamespace,
+				},
+				Spec: v1beta1.ServiceClassSpec{
+					CommonServiceClassSpec: v1beta1.CommonServiceClassSpec{
+						ExternalName: className,
+					},
 				},
 			}
 

--- a/cmd/svcat/class/get_cmd_test.go
+++ b/cmd/svcat/class/get_cmd_test.go
@@ -28,7 +28,7 @@ import (
 	svcatfake "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/fake"
 	"github.com/kubernetes-incubator/service-catalog/pkg/svcat"
 	"github.com/kubernetes-incubator/service-catalog/pkg/svcat/service-catalog"
-	"github.com/kubernetes-incubator/service-catalog/pkg/svcat/service-catalog/service-catalogfakes"
+	servicecatalogfakes "github.com/kubernetes-incubator/service-catalog/pkg/svcat/service-catalog/service-catalogfakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -209,27 +209,39 @@ var _ = Describe("Get Classes Command", func() {
 	})
 	Describe("Run", func() {
 		It("Calls the pkg/svcat libs RetrieveClasses with namespace scope and current namespace", func() {
+			className := "mysqldb"
+			classNamespace := "default"
+
+			classToReturn := &v1beta1.ServiceClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: classNamespace,
+				},
+				Spec: v1beta1.ServiceClassSpec{
+					CommonServiceClassSpec: v1beta1.CommonServiceClassSpec{
+						ExternalName: className,
+					},
+				},
+			}
+
 			outputBuffer := &bytes.Buffer{}
 
 			fakeApp, _ := svcat.NewApp(nil, nil, "default")
 			fakeSDK := new(servicecatalogfakes.FakeSvcatClient)
-			fakeSDK.RetrieveClassesReturns(
-				[]servicecatalog.Class{&v1beta1.ServiceClass{ObjectMeta: metav1.ObjectMeta{Name: "mysqldb", Namespace: "default"}}},
-				nil)
+			fakeSDK.RetrieveClassesReturns([]servicecatalog.Class{classToReturn}, nil)
 			fakeApp.SvcatClient = fakeSDK
 			cmd := getCmd{
 				Namespaced: &command.Namespaced{Context: svcattest.NewContext(outputBuffer, fakeApp)},
 				Scoped:     command.NewScoped(),
+				Formatted:  command.NewFormatted(),
 			}
-			cmd.Namespace = "default"
 			cmd.Scope = servicecatalog.NamespaceScope
-
+			cmd.Namespace = classNamespace
 			err := cmd.Run()
 
 			Expect(err).NotTo(HaveOccurred())
 			scopeArg := fakeSDK.RetrieveClassesArgsForCall(0)
 			Expect(scopeArg).To(Equal(servicecatalog.ScopeOptions{
-				Namespace: "default",
+				Namespace: classNamespace,
 				Scope:     servicecatalog.NamespaceScope,
 			}))
 
@@ -237,24 +249,47 @@ var _ = Describe("Get Classes Command", func() {
 			Expect(output).To(ContainSubstring("mysqldb"))
 		})
 		It("Calls the pkg/svcat libs RetrieveClasses with namespace scope and all namespaces", func() {
+			classOneName := "mysqldb"
+			classOneNamespace := "default"
+
+			classTwoName := "postgresdb"
+			classTwoNamespace := "test-ns"
+
+			classOneToReturn := &v1beta1.ServiceClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: classOneNamespace,
+				},
+				Spec: v1beta1.ServiceClassSpec{
+					CommonServiceClassSpec: v1beta1.CommonServiceClassSpec{
+						ExternalName: classOneName,
+					},
+				},
+			}
+
+			classTwoToReturn := &v1beta1.ServiceClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: classTwoNamespace,
+				},
+				Spec: v1beta1.ServiceClassSpec{
+					CommonServiceClassSpec: v1beta1.CommonServiceClassSpec{
+						ExternalName: classTwoName,
+					},
+				},
+			}
+
 			outputBuffer := &bytes.Buffer{}
 
 			fakeApp, _ := svcat.NewApp(nil, nil, "default")
 			fakeSDK := new(servicecatalogfakes.FakeSvcatClient)
-			fakeSDK.RetrieveClassesReturns(
-				[]servicecatalog.Class{
-					&v1beta1.ServiceClass{ObjectMeta: metav1.ObjectMeta{Name: "mysqldb", Namespace: "default"}},
-					&v1beta1.ServiceClass{ObjectMeta: metav1.ObjectMeta{Name: "postgresdb", Namespace: "test-ns"}},
-				},
-				nil)
+			fakeSDK.RetrieveClassesReturns([]servicecatalog.Class{classOneToReturn, classTwoToReturn}, nil)
 			fakeApp.SvcatClient = fakeSDK
 			cmd := getCmd{
 				Namespaced: &command.Namespaced{Context: svcattest.NewContext(outputBuffer, fakeApp)},
 				Scoped:     command.NewScoped(),
+				Formatted:  command.NewFormatted(),
 			}
-			cmd.Namespace = ""
 			cmd.Scope = servicecatalog.NamespaceScope
-
+			cmd.Namespace = ""
 			err := cmd.Run()
 
 			Expect(err).NotTo(HaveOccurred())
@@ -269,30 +304,49 @@ var _ = Describe("Get Classes Command", func() {
 			Expect(output).To(ContainSubstring("postgresdb"))
 		})
 		It("Calls the pkg/svcat libs RetrieveClasses with all scope and current namespaces", func() {
+			classOneName := "mysqldb"
+
+			classTwoName := "postgresdb"
+			classTwoNamespace := "default"
+
+			classOneToReturn := &v1beta1.ClusterServiceClass{
+				Spec: v1beta1.ClusterServiceClassSpec{
+					CommonServiceClassSpec: v1beta1.CommonServiceClassSpec{
+						ExternalName: classOneName,
+					},
+				},
+			}
+
+			classTwoToReturn := &v1beta1.ServiceClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: classTwoNamespace,
+				},
+				Spec: v1beta1.ServiceClassSpec{
+					CommonServiceClassSpec: v1beta1.CommonServiceClassSpec{
+						ExternalName: classTwoName,
+					},
+				},
+			}
+
 			outputBuffer := &bytes.Buffer{}
 
 			fakeApp, _ := svcat.NewApp(nil, nil, "default")
 			fakeSDK := new(servicecatalogfakes.FakeSvcatClient)
-			fakeSDK.RetrieveClassesReturns(
-				[]servicecatalog.Class{
-					&v1beta1.ClusterServiceClass{ObjectMeta: metav1.ObjectMeta{Name: "mysqldb"}},
-					&v1beta1.ServiceClass{ObjectMeta: metav1.ObjectMeta{Name: "postgresdb", Namespace: "default"}},
-				},
-				nil)
+			fakeSDK.RetrieveClassesReturns([]servicecatalog.Class{classOneToReturn, classTwoToReturn}, nil)
 			fakeApp.SvcatClient = fakeSDK
 			cmd := getCmd{
 				Namespaced: &command.Namespaced{Context: svcattest.NewContext(outputBuffer, fakeApp)},
 				Scoped:     command.NewScoped(),
+				Formatted:  command.NewFormatted(),
 			}
-			cmd.Namespace = "default"
 			cmd.Scope = servicecatalog.AllScope
-
+			cmd.Namespace = classTwoNamespace
 			err := cmd.Run()
 
 			Expect(err).NotTo(HaveOccurred())
 			scopeArg := fakeSDK.RetrieveClassesArgsForCall(0)
 			Expect(scopeArg).To(Equal(servicecatalog.ScopeOptions{
-				Namespace: "default",
+				Namespace: classTwoNamespace,
 				Scope:     servicecatalog.AllScope,
 			}))
 

--- a/cmd/svcat/plan/get_cmd_test.go
+++ b/cmd/svcat/plan/get_cmd_test.go
@@ -209,96 +209,153 @@ var _ = Describe("Get Plans Command", func() {
 	})
 	Describe("Run", func() {
 		It("Calls the pkg/svcat libs RetrievePlans with namespace scope and current namespace", func() {
+			planName := "myplan"
+			planNamespace := "default"
+
+			planToReturn := &v1beta1.ServicePlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: planNamespace,
+				},
+				Spec: v1beta1.ServicePlanSpec{
+					CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+						ExternalName: planName,
+					},
+				},
+			}
+
 			outputBuffer := &bytes.Buffer{}
 
 			fakeApp, _ := svcat.NewApp(nil, nil, "default")
 			fakeSDK := new(servicecatalogfakes.FakeSvcatClient)
-			fakeSDK.RetrievePlansReturns(
-				[]servicecatalog.Plan{&v1beta1.ServicePlan{ObjectMeta: metav1.ObjectMeta{Name: "myplan", Namespace: "default"}}},
-				nil)
+			fakeSDK.RetrievePlansReturns([]servicecatalog.Plan{planToReturn}, nil)
 			fakeApp.SvcatClient = fakeSDK
 			cmd := getCmd{
 				Namespaced: &command.Namespaced{Context: svcattest.NewContext(outputBuffer, fakeApp)},
 				Scoped:     command.NewScoped(),
+				Formatted:  command.NewFormatted(),
 			}
-			cmd.Namespace = "default"
 			cmd.Scope = servicecatalog.NamespaceScope
-
+			cmd.Namespace = planNamespace
 			err := cmd.Run()
 
 			Expect(err).NotTo(HaveOccurred())
 			scopeArg := fakeSDK.RetrievePlansArgsForCall(0)
-			Expect(scopeArg).To(Equal(servicecatalog.ScopeOptions{
-				Namespace: "default",
+			Expect(scopeArg).To(Equal(servicecatalog.RetrievePlanOptions{
+				ClassID:   "",
+				Namespace: planNamespace,
 				Scope:     servicecatalog.NamespaceScope,
 			}))
 
 			output := outputBuffer.String()
-			Expect(output).To(ContainSubstring("myplan"))
+			Expect(output).To(ContainSubstring(planName))
 		})
 		It("Calls the pkg/svcat libs RetrievePlans with namespace scope and all namespaces", func() {
+			planOneName := "myplan"
+			planOneNamespace := "default"
+
+			planTwoName := "anotherplan"
+			planTwoNamespace := "test-ns"
+
+			planOneToReturn := &v1beta1.ServicePlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: planOneNamespace,
+				},
+				Spec: v1beta1.ServicePlanSpec{
+					CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+						ExternalName: planOneName,
+					},
+				},
+			}
+
+			planTwoToReturn := &v1beta1.ServicePlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: planTwoNamespace,
+				},
+				Spec: v1beta1.ServicePlanSpec{
+					CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+						ExternalName: planTwoName,
+					},
+				},
+			}
+
 			outputBuffer := &bytes.Buffer{}
 
 			fakeApp, _ := svcat.NewApp(nil, nil, "default")
 			fakeSDK := new(servicecatalogfakes.FakeSvcatClient)
-			fakeSDK.RetrievePlansReturns(
-				[]servicecatalog.Plan{
-					&v1beta1.ServicePlan{ObjectMeta: metav1.ObjectMeta{Name: "myplan", Namespace: "default"}},
-					&v1beta1.ServicePlan{ObjectMeta: metav1.ObjectMeta{Name: "anotherplan", Namespace: "test-ns"}},
-				},
-				nil)
+			fakeSDK.RetrievePlansReturns([]servicecatalog.Plan{planOneToReturn, planTwoToReturn}, nil)
 			fakeApp.SvcatClient = fakeSDK
 			cmd := getCmd{
 				Namespaced: &command.Namespaced{Context: svcattest.NewContext(outputBuffer, fakeApp)},
 				Scoped:     command.NewScoped(),
+				Formatted:  command.NewFormatted(),
 			}
-			cmd.Namespace = ""
 			cmd.Scope = servicecatalog.NamespaceScope
-
+			cmd.Namespace = ""
 			err := cmd.Run()
 
 			Expect(err).NotTo(HaveOccurred())
 			scopeArg := fakeSDK.RetrievePlansArgsForCall(0)
-			Expect(scopeArg).To(Equal(servicecatalog.ScopeOptions{
-				Namespace: "",
+			Expect(scopeArg).To(Equal(servicecatalog.RetrievePlanOptions{
+				ClassID:   "",
 				Scope:     servicecatalog.NamespaceScope,
+				Namespace: "",
 			}))
 
 			output := outputBuffer.String()
-			Expect(output).To(ContainSubstring("myplan"))
-			Expect(output).To(ContainSubstring("anotherplan"))
+			Expect(output).To(ContainSubstring(planOneName))
+			Expect(output).To(ContainSubstring(planTwoName))
 		})
 		It("Calls the pkg/svcat libs RetrievePlans with all scope and current namespaces", func() {
+			planOneName := "myplan"
+
+			planTwoName := "anotherplan"
+			planTwoNamespace := "default"
+
+			planOneToReturn := &v1beta1.ClusterServicePlan{
+				Spec: v1beta1.ClusterServicePlanSpec{
+					CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+						ExternalName: planOneName,
+					},
+				},
+			}
+
+			planTwoToReturn := &v1beta1.ServicePlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: planTwoNamespace,
+				},
+				Spec: v1beta1.ServicePlanSpec{
+					CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+						ExternalName: planTwoName,
+					},
+				},
+			}
+
 			outputBuffer := &bytes.Buffer{}
 
 			fakeApp, _ := svcat.NewApp(nil, nil, "default")
 			fakeSDK := new(servicecatalogfakes.FakeSvcatClient)
-			fakeSDK.RetrievePlansReturns(
-				[]servicecatalog.Plan{
-					&v1beta1.ClusterServicePlan{ObjectMeta: metav1.ObjectMeta{Name: "myplan"}},
-					&v1beta1.ServicePlan{ObjectMeta: metav1.ObjectMeta{Name: "anotherplan", Namespace: "default"}},
-				},
-				nil)
+			fakeSDK.RetrievePlansReturns([]servicecatalog.Plan{planOneToReturn, planTwoToReturn}, nil)
 			fakeApp.SvcatClient = fakeSDK
 			cmd := getCmd{
 				Namespaced: &command.Namespaced{Context: svcattest.NewContext(outputBuffer, fakeApp)},
 				Scoped:     command.NewScoped(),
+				Formatted:  command.NewFormatted(),
 			}
-			cmd.Namespace = "default"
 			cmd.Scope = servicecatalog.AllScope
-
+			cmd.Namespace = planTwoNamespace
 			err := cmd.Run()
 
 			Expect(err).NotTo(HaveOccurred())
 			scopeArg := fakeSDK.RetrievePlansArgsForCall(0)
-			Expect(scopeArg).To(Equal(servicecatalog.ScopeOptions{
-				Namespace: "default",
+			Expect(scopeArg).To(Equal(servicecatalog.RetrievePlanOptions{
+				ClassID:   "",
+				Namespace: planTwoNamespace,
 				Scope:     servicecatalog.AllScope,
 			}))
 
 			output := outputBuffer.String()
-			Expect(output).To(ContainSubstring("myplan"))
-			Expect(output).To(ContainSubstring("anotherplan"))
+			Expect(output).To(ContainSubstring(planOneName))
+			Expect(output).To(ContainSubstring(planTwoName))
 		})
 	})
 })

--- a/cmd/svcat/plan/plan_suite_test.go
+++ b/cmd/svcat/plan/plan_suite_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plan_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+
+	_ "github.com/kubernetes-incubator/service-catalog/internal/test"
+)
+
+func TestPlan(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Plan Suite")
+}


### PR DESCRIPTION
This PR is a 
 - [ ] Feature Implementation
 - [X] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
Enable ginkgo cmd/svcat unit tests to run and fix existing ones

**Which issue(s) this PR fixes** 
Fixes #2375 

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
