### PR TITLE
Add support for replicas and clarify updateStrategy

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -27,7 +27,7 @@ $ helm install . --name catalog --namespace catalog
 To uninstall/delete the `catalog` deployment:
 
 ```bash
-$ helm delete catalog
+$ helm delete --purge catalog
 ```
 
 The command removes all the Kubernetes components associated with the chart and
@@ -42,7 +42,9 @@ chart and their default values.
 |-----------|-------------|---------|
 | `image` | apiserver image to use | `quay.io/kubernetes-service-catalog/service-catalog:v0.1.33` |
 | `imagePullPolicy` | `imagePullPolicy` for the service catalog | `Always` |
-| `deploymentStrategy` | `deploymentStrategy` for the service catalog deployments | `RollingUpdate` |
+| `apiserver.replicas` | `replicas` for the service catalog apiserver pod count | `2` |
+| `apiserver.updateStrategy` | `updateStrategy` for the service catalog apiserver deployments | `RollingUpdate` |
+| `apiserver.minReadySeconds` | how many seconds an apiServer pod needs to be ready before killing the next, during update | `1` |
 | `apiserver.annotations` | Annotations for apiserver pods | `{}` |
 | `apiserver.nodeSelector` | A nodeSelector value to apply to the apiserver pods. If not specified, no nodeSelector will be applied | |
 | `apiserver.aggregator.priority` | Priority of the APIService. | `100` |
@@ -70,6 +72,9 @@ chart and their default values.
 | `apiserver.serviceAccount` | Service account. | `service-catalog-apiserver` |
 | `apiserver.serveOpenAPISpec` | If true, makes the API server serve the OpenAPI schema | `false` |
 | `apiserver.resources` | Resources allocation (Requests and Limits) | `{requests: {cpu: 100m, memory: 20Mi}, limits: {cpu: 100m, memory: 30Mi}}` |
+| `controllerManager.replicas` | `replicas` for the service catalog controllerManager pod count | `3` |
+| `controllerManager.updateStrategy` | `updateStrategy` for the service catalog controllerManager deployments | `RollingUpdate` |
+| `controllerManager.minReadySeconds` | how many seconds a controllerManager pod needs to be ready before killing the next, during update | `1` |
 | `controllerManager.annotations` | Annotations for controllerManager pods | `{}` |
 | `controllerManager.nodeSelector` | A nodeSelector value to apply to the controllerManager pods. If not specified, no nodeSelector will be applied | |
 | `controllerManager.healthcheck.enabled` | Enable readiness and liveliness probes | `true` |

--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -8,9 +8,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  replicas: 1
+  replicas: {{ .Values.apiserver.replicas }}
   strategy:
-    type: {{ .Values.deploymentStrategy }}
+    type: {{ .Values.apiserver.updateStrategy }}
+    minReadySeconds: {{ .Values.apiserver.minReadySeconds }}
   selector:
     matchLabels:
       app: {{ template "fullname" . }}-apiserver

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -8,9 +8,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  replicas: 1
+  replicas: {{ .Values.controllerManager.replicas }}
   strategy:
-    type: {{ .Values.deploymentStrategy }}
+    type: {{ .Values.controllerManager.updateStrategy }}
+    minReadySeconds: {{ .Values.apiserver.minReadySeconds }}
   selector:
     matchLabels:
       app: {{ template "fullname" . }}-controller-manager

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -11,7 +11,7 @@ useAggregator: true
 rbacEnable: true
 apiserver:
   replicas: 2
-  # deploymentStrategy for service-catalog; value values are "RollingUpdate" and "Recreate"
+  # updateStrategy for service-catalog; value values are "RollingUpdate" and "Recreate"
   updateStrategy: RollingUpdate
   minReadySeconds: 1
   # annotations is a collection of annotations to add to the apiserver pods.
@@ -127,7 +127,7 @@ apiserver:
       memory: 30Mi
 controllerManager:
   replicas: 3
-  # deploymentStrategy for service-catalog; value values are "RollingUpdate" and "Recreate"
+  # updateStrategy for service-catalog; value values are "RollingUpdate" and "Recreate"
   updateStrategy: RollingUpdate
   minReadySeconds: 1
   # annotations is a collection of annotations to add to the controllerManager pod.

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -4,14 +4,16 @@ image: quay.io/kubernetes-service-catalog/service-catalog:v0.1.33
 # imagePullPolicy for the service-catalog; valid values are "IfNotPresent",
 # "Never", and "Always"
 imagePullPolicy: Always
-# deploymentStrategy for service-catalog; value values are "RollingUpdate" and "Recreate"
-deploymentStrategy: RollingUpdate
 # determines whether the API server should be registered with the kube-aggregator
 useAggregator: true
 ## If true, create & use RBAC resources
 ##
 rbacEnable: true
 apiserver:
+  replicas: 2
+  # deploymentStrategy for service-catalog; value values are "RollingUpdate" and "Recreate"
+  updateStrategy: RollingUpdate
+  minReadySeconds: 1
   # annotations is a collection of annotations to add to the apiserver pods.
   annotations: {}
   # nodeSelector to apply to the apiserver pods
@@ -124,6 +126,10 @@ apiserver:
       cpu: 100m
       memory: 30Mi
 controllerManager:
+  replicas: 3
+  # deploymentStrategy for service-catalog; value values are "RollingUpdate" and "Recreate"
+  updateStrategy: RollingUpdate
+  minReadySeconds: 1
   # annotations is a collection of annotations to add to the controllerManager pod.
   annotations: {}
   # nodeSelector to apply to the controllerManager pods


### PR DESCRIPTION
This PR is a 
 - [x ] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
This PR adds in support for:
 - `replicas` per apiServer deployment and controllerManager deployment (useful in prod envs)
 - support for `minReadySeconds` per deployment for pods
 - clarify/change `deploymentStrategy` to `updateStrategy` since the type of "deployment" really only happens during "update"
 - update readme.md to include `helm delete --purge` for full deletion
 - update readme.md to include proposed updates mentioned above

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
