### PR TITLE
Class default provision params

### DIFF
--- a/docsite/_data/service-plan-defaults.yml
+++ b/docsite/_data/service-plan-defaults.yml
@@ -6,6 +6,11 @@ toc:
 - title: Enable Service Plan Defaults
   path: "#enable-service-plan-defaults"
 - title: Define Default Provision Parameters
-  path: "#define-default-provision-parameters"
+  landing_page: "#define-default-provision-parameters"
+  section:
+    - title: Create and modify a copy of an existing plan
+      path: "#create-and-modify-a-copy-of-an-existing-plan"
+    - title: Create and modify a copy of an existing class
+      path: "#create-and-modify-a-copy-of-an-existing-class"
 - title: Provision a service instance with default parameters
   path: "#provision-a-service-instance-with-default-parameters"

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -471,6 +471,13 @@ type CommonServiceClassSpec struct {
 	// Foundry.  These 'permissions' have no meaning within Kubernetes and an
 	// ServiceInstance provisioned from this ServiceClass will not work correctly.
 	Requires []string
+
+	// DefaultProvisionParameters are default parameters passed to the broker
+	// when an instance of this class is provisioned. Any parameters defined on
+	// the plan and instance are merged with these defaults, with
+	// plan and then instance-defined parameters taking precedence the class
+	// defaults.
+	DefaultProvisionParameters *runtime.RawExtension
 }
 
 // ClusterServiceClassSpec represents the details about a ClusterServiceClass.

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -475,7 +475,7 @@ type CommonServiceClassSpec struct {
 	// DefaultProvisionParameters are default parameters passed to the broker
 	// when an instance of this class is provisioned. Any parameters defined on
 	// the plan and instance are merged with these defaults, with
-	// plan and then instance-defined parameters taking precedence the class
+	// plan and then instance-defined parameters taking precedence over the class
 	// defaults.
 	DefaultProvisionParameters *runtime.RawExtension
 }

--- a/pkg/apis/servicecatalog/unstructured_test.go
+++ b/pkg/apis/servicecatalog/unstructured_test.go
@@ -78,6 +78,11 @@ func doUnstructuredRoundTrip(t *testing.T, group testapi.TestGroup, kind string)
 			is.ServiceInstanceCreateParameterSchema = nil
 			is.ServiceInstanceUpdateParameterSchema = nil
 		},
+		func(cs *servicecatalog.CommonServiceClassSpec, c fuzz.Continue) {
+			c.FuzzNoCustom(cs)
+			cs.DefaultProvisionParameters = nil
+			cs.ExternalMetadata = nil
+		},
 		func(bs *servicecatalog.ServiceBindingSpec, c fuzz.Continue) {
 			c.FuzzNoCustom(bs)
 			bs.ExternalID = string(uuid.NewUUID())

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -514,6 +514,13 @@ type CommonServiceClassSpec struct {
 	// ServiceInstance provisioned from this ServiceClass will not
 	// work correctly.
 	Requires []string `json:"requires,omitempty"`
+
+	// DefaultProvisionParameters are default parameters passed to the broker
+	// when an instance of this class is provisioned. Any parameters defined on
+	// the plan and instance are merged with these defaults, with
+	// plan and then instance-defined parameters taking precedence the class
+	// defaults.
+	DefaultProvisionParameters *runtime.RawExtension `json:"defaultProvisionParameters,omitempty"`
 }
 
 // ClusterServiceClassSpec represents the details about a ClusterServiceClass

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -518,7 +518,7 @@ type CommonServiceClassSpec struct {
 	// DefaultProvisionParameters are default parameters passed to the broker
 	// when an instance of this class is provisioned. Any parameters defined on
 	// the plan and instance are merged with these defaults, with
-	// plan and then instance-defined parameters taking precedence the class
+	// plan and then instance-defined parameters taking precedence over the class
 	// defaults.
 	DefaultProvisionParameters *runtime.RawExtension `json:"defaultProvisionParameters,omitempty"`
 }

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
@@ -740,6 +740,7 @@ func autoConvert_v1beta1_CommonServiceClassSpec_To_servicecatalog_CommonServiceC
 	out.ExternalMetadata = (*runtime.RawExtension)(unsafe.Pointer(in.ExternalMetadata))
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	out.Requires = *(*[]string)(unsafe.Pointer(&in.Requires))
+	out.DefaultProvisionParameters = (*runtime.RawExtension)(unsafe.Pointer(in.DefaultProvisionParameters))
 	return nil
 }
 
@@ -758,6 +759,7 @@ func autoConvert_servicecatalog_CommonServiceClassSpec_To_v1beta1_CommonServiceC
 	out.ExternalMetadata = (*runtime.RawExtension)(unsafe.Pointer(in.ExternalMetadata))
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	out.Requires = *(*[]string)(unsafe.Pointer(&in.Requires))
+	out.DefaultProvisionParameters = (*runtime.RawExtension)(unsafe.Pointer(in.DefaultProvisionParameters))
 	return nil
 }
 

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.deepcopy.go
@@ -660,6 +660,15 @@ func (in *CommonServiceClassSpec) DeepCopyInto(out *CommonServiceClassSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.DefaultProvisionParameters != nil {
+		in, out := &in.DefaultProvisionParameters, &out.DefaultProvisionParameters
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(runtime.RawExtension)
+			(*in).DeepCopyInto(*out)
+		}
+	}
 	return
 }
 

--- a/pkg/apis/servicecatalog/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/zz_generated.deepcopy.go
@@ -660,6 +660,15 @@ func (in *CommonServiceClassSpec) DeepCopyInto(out *CommonServiceClassSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.DefaultProvisionParameters != nil {
+		in, out := &in.DefaultProvisionParameters, &out.DefaultProvisionParameters
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(runtime.RawExtension)
+			(*in).DeepCopyInto(*out)
+		}
+	}
 	return
 }
 

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -783,9 +783,11 @@ func TestReconcileServiceInstanceAppliesDefaultProvisioningParams(t *testing.T) 
 	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(sc)
 	sp := getTestClusterServicePlan()
 
-	// Setup default parameters on the plan
-	defaultProvParams := `{"secure": true}`
-	sp.Spec.DefaultProvisionParameters = &runtime.RawExtension{Raw: []byte(defaultProvParams)}
+	// Setup default parameters on the class and plan
+	classParams := `{"secure": false, "class-default": 1}`
+	sc.Spec.DefaultProvisionParameters = &runtime.RawExtension{Raw: []byte(classParams)}
+	planParams := `{"secure": true, "plan-default": 2}`
+	sp.Spec.DefaultProvisionParameters = &runtime.RawExtension{Raw: []byte(planParams)}
 
 	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(sp)
 
@@ -817,10 +819,11 @@ func TestReconcileServiceInstanceAppliesDefaultProvisioningParams(t *testing.T) 
 	if !ok {
 		t.Fatalf("couldn't convert to *v1beta1.ServiceInstance")
 	}
+	wantParams := `{"class-default":1,"plan-default":2,"secure":true}`
 	gotParams := string(updateObject.Spec.Parameters.Raw)
-	if gotParams != defaultProvParams {
+	if gotParams != wantParams {
 		t.Fatalf("DefaultProvisioningParameters was not applied to the service instance during reconcile.\n\nWANT: %v\nGOT: %v",
-			defaultProvParams, gotParams)
+			wantParams, gotParams)
 	}
 
 	// Check that the default parameters were saved on the status
@@ -830,9 +833,9 @@ func TestReconcileServiceInstanceAppliesDefaultProvisioningParams(t *testing.T) 
 		t.Fatalf("couldn't convert to *v1beta1.ServiceInstance")
 	}
 	gotParams = string(updateObject.Status.DefaultProvisionParameters.Raw)
-	if gotParams != defaultProvParams {
+	if gotParams != wantParams {
 		t.Fatalf("DefaultProvisioningParameters was not persisted to the service instance status during reconcile.\n\nWANT: %v\nGOT: %v",
-			defaultProvParams, gotParams)
+			wantParams, gotParams)
 	}
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -954,6 +954,12 @@ func schema_pkg_apis_servicecatalog_v1beta1_ClusterServiceClassSpec(ref common.R
 							},
 						},
 					},
+					"defaultProvisionParameters": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DefaultProvisionParameters are default parameters passed to the broker when an instance of this class is provisioned. Any parameters defined on the plan and instance are merged with these defaults, with plan and then instance-defined parameters taking precedence the class defaults.",
+							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
+						},
+					},
 					"clusterServiceBrokerName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ClusterServiceBrokerName is the reference to the Broker that provides this ClusterServiceClass.\n\nImmutable.",
@@ -1396,6 +1402,12 @@ func schema_pkg_apis_servicecatalog_v1beta1_CommonServiceClassSpec(ref common.Re
 									},
 								},
 							},
+						},
+					},
+					"defaultProvisionParameters": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DefaultProvisionParameters are default parameters passed to the broker when an instance of this class is provisioned. Any parameters defined on the plan and instance are merged with these defaults, with plan and then instance-defined parameters taking precedence the class defaults.",
+							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
 				},
@@ -2611,6 +2623,12 @@ func schema_pkg_apis_servicecatalog_v1beta1_ServiceClassSpec(ref common.Referenc
 									},
 								},
 							},
+						},
+					},
+					"defaultProvisionParameters": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DefaultProvisionParameters are default parameters passed to the broker when an instance of this class is provisioned. Any parameters defined on the plan and instance are merged with these defaults, with plan and then instance-defined parameters taking precedence the class defaults.",
+							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
 					"serviceBrokerName": {

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -956,7 +956,7 @@ func schema_pkg_apis_servicecatalog_v1beta1_ClusterServiceClassSpec(ref common.R
 					},
 					"defaultProvisionParameters": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DefaultProvisionParameters are default parameters passed to the broker when an instance of this class is provisioned. Any parameters defined on the plan and instance are merged with these defaults, with plan and then instance-defined parameters taking precedence the class defaults.",
+							Description: "DefaultProvisionParameters are default parameters passed to the broker when an instance of this class is provisioned. Any parameters defined on the plan and instance are merged with these defaults, with plan and then instance-defined parameters taking precedence over the class defaults.",
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
@@ -1406,7 +1406,7 @@ func schema_pkg_apis_servicecatalog_v1beta1_CommonServiceClassSpec(ref common.Re
 					},
 					"defaultProvisionParameters": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DefaultProvisionParameters are default parameters passed to the broker when an instance of this class is provisioned. Any parameters defined on the plan and instance are merged with these defaults, with plan and then instance-defined parameters taking precedence the class defaults.",
+							Description: "DefaultProvisionParameters are default parameters passed to the broker when an instance of this class is provisioned. Any parameters defined on the plan and instance are merged with these defaults, with plan and then instance-defined parameters taking precedence over the class defaults.",
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
@@ -2627,7 +2627,7 @@ func schema_pkg_apis_servicecatalog_v1beta1_ServiceClassSpec(ref common.Referenc
 					},
 					"defaultProvisionParameters": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DefaultProvisionParameters are default parameters passed to the broker when an instance of this class is provisioned. Any parameters defined on the plan and instance are merged with these defaults, with plan and then instance-defined parameters taking precedence the class defaults.",
+							Description: "DefaultProvisionParameters are default parameters passed to the broker when an instance of this class is provisioned. Any parameters defined on the plan and instance are merged with these defaults, with plan and then instance-defined parameters taking precedence over the class defaults.",
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
This allows operators to define default provision parameters on the class, in addition to a plan. The defaults are merged onto the instance, where the order of precedence is INSTANCE, PLAN, and lastly CLASS.

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Closes #2341 

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [x] New feature 
   - [x] Tests
   - [x] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
