### PR TITLE
Fix indent so minReadySeconds is under spec

### DIFF
--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -11,7 +11,7 @@ spec:
   replicas: {{ .Values.apiserver.replicas }}
   strategy:
     type: {{ .Values.apiserver.updateStrategy }}
-    minReadySeconds: {{ .Values.apiserver.minReadySeconds }}
+  minReadySeconds: {{ .Values.apiserver.minReadySeconds }}
   selector:
     matchLabels:
       app: {{ template "fullname" . }}-apiserver

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -11,7 +11,7 @@ spec:
   replicas: {{ .Values.controllerManager.replicas }}
   strategy:
     type: {{ .Values.controllerManager.updateStrategy }}
-    minReadySeconds: {{ .Values.apiserver.minReadySeconds }}
+  minReadySeconds: {{ .Values.apiserver.minReadySeconds }}
   selector:
     matchLabels:
       app: {{ template "fullname" . }}-controller-manager


### PR DESCRIPTION
The indentation for `minReadySeconds` introduced in #2381 was off. My kubectl and helm both ignore it and the configured value isn't used.  For for some, this is also causing a hard validation error as well, though I can't reproduce the validation error.

This fixes the indent to put `minReadySeconds` directly under `spec`.

Fixes #2390 