### PR TITLE
Replace expectXxx functions with asserts and wrap code with t.Run()

### DIFF
--- a/pkg/controller/controller_clusterserviceplan_test.go
+++ b/pkg/controller/controller_clusterserviceplan_test.go
@@ -44,7 +44,7 @@ func TestReconcileClusterServicePlanRemovedFromCatalog(t *testing.T) {
 		catalogClientPrepFunc   func(*fake.Clientset)
 		shouldError             bool
 		errText                 *string
-		catalogActionsCheckFunc func(t *testing.T, name string, actions []clientgotesting.Action)
+		catalogActionsCheckFunc func(t *testing.T, actions []clientgotesting.Action)
 	}{
 		{
 			name:        "not removed from catalog",
@@ -56,13 +56,13 @@ func TestReconcileClusterServicePlanRemovedFromCatalog(t *testing.T) {
 			plan:        getRemovedPlan(),
 			instances:   []v1beta1.ServiceInstance{*getTestServiceInstance()},
 			shouldError: false,
-			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
 					Fields: fields.OneTermEqualSelector("spec.clusterServicePlanRef.name", "CSPGUID"),
 				}
 
-				expectNumberOfActions(t, name, actions, 1)
+				assertNumberOfActions(t, actions, 1)
 				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
 			},
 		},
@@ -71,13 +71,13 @@ func TestReconcileClusterServicePlanRemovedFromCatalog(t *testing.T) {
 			plan:        getRemovedPlan(),
 			instances:   nil,
 			shouldError: false,
-			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
 					Fields: fields.OneTermEqualSelector("spec.clusterServicePlanRef.name", "CSPGUID"),
 				}
 
-				expectNumberOfActions(t, name, actions, 2)
+				assertNumberOfActions(t, actions, 2)
 				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
 				assertDelete(t, actions[1], getRemovedPlan())
 			},
@@ -93,13 +93,13 @@ func TestReconcileClusterServicePlanRemovedFromCatalog(t *testing.T) {
 				})
 			},
 			errText: strPtr("oops"),
-			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
 					Fields: fields.OneTermEqualSelector("spec.clusterServicePlanRef.name", "CSPGUID"),
 				}
 
-				expectNumberOfActions(t, name, actions, 2)
+				assertNumberOfActions(t, actions, 2)
 				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
 				assertDelete(t, actions[1], getRemovedPlan())
 			},
@@ -107,34 +107,35 @@ func TestReconcileClusterServicePlanRemovedFromCatalog(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, fakeCatalogClient, _, testController, _ := newTestController(t, noFakeActions())
+		t.Run(tc.name, func(t *testing.T) {
 
-		fakeCatalogClient.AddReactor("list", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
-			return true, &v1beta1.ServiceInstanceList{Items: tc.instances}, nil
-		})
+			_, fakeCatalogClient, _, testController, _ := newTestController(t, noFakeActions())
 
-		if tc.catalogClientPrepFunc != nil {
-			tc.catalogClientPrepFunc(fakeCatalogClient)
-		}
+			fakeCatalogClient.AddReactor("list", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+				return true, &v1beta1.ServiceInstanceList{Items: tc.instances}, nil
+			})
 
-		err := reconcileClusterServicePlan(t, testController, tc.plan)
-		if err != nil {
-			if !tc.shouldError {
-				t.Errorf("%v: unexpected error from method under test: %v", tc.name, err)
-				continue
-			} else if tc.errText != nil && *tc.errText != err.Error() {
-				t.Errorf("%v: unexpected error text from method under test; expected %v, got %v", tc.name, tc.errText, err.Error())
-				continue
+			if tc.catalogClientPrepFunc != nil {
+				tc.catalogClientPrepFunc(fakeCatalogClient)
 			}
-		}
 
-		actions := fakeCatalogClient.Actions()
+			err := reconcileClusterServicePlan(t, testController, tc.plan)
+			if err != nil {
+				if !tc.shouldError {
+					t.Fatalf("unexpected error from method under test: %v", err)
+				} else if tc.errText != nil && *tc.errText != err.Error() {
+					t.Fatalf("unexpected error text from method under test; expected %v, got %v", tc.errText, err.Error())
+				}
+			}
 
-		if tc.catalogActionsCheckFunc != nil {
-			tc.catalogActionsCheckFunc(t, tc.name, actions)
-		} else {
-			expectNumberOfActions(t, tc.name, actions, 0)
-		}
+			actions := fakeCatalogClient.Actions()
+
+			if tc.catalogActionsCheckFunc != nil {
+				tc.catalogActionsCheckFunc(t, actions)
+			} else {
+				assertNumberOfActions(t, actions, 0)
+			}
+		})
 	}
 }
 

--- a/pkg/controller/controller_servicebroker_test.go
+++ b/pkg/controller/controller_servicebroker_test.go
@@ -71,15 +71,15 @@ func TestReconcileServiceClassFromServiceBrokerCatalog(t *testing.T) {
 		shouldError             bool
 		errText                 *string
 		catalogClientPrepFunc   func(*fake.Clientset)
-		catalogActionsCheckFunc func(t *testing.T, name string, actions []clientgotesting.Action)
+		catalogActionsCheckFunc func(t *testing.T, actions []clientgotesting.Action)
 	}{
 		{
 			name:            "new class",
 			newServiceClass: getTestServiceClass(),
 			shouldError:     false,
-			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
-				expectNumberOfActions(t, name, actions, 1)
-				expectCreate(t, name, actions[0], getTestServiceClass())
+			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
+				assertNumberOfActions(t, actions, 1)
+				assertCreate(t, actions[0], getTestServiceClass())
 			},
 		},
 		{
@@ -99,9 +99,9 @@ func TestReconcileServiceClassFromServiceBrokerCatalog(t *testing.T) {
 			newServiceClass:      updatedClass(),
 			existingServiceClass: getTestServiceClass(),
 			shouldError:          false,
-			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
-				expectNumberOfActions(t, name, actions, 1)
-				expectUpdate(t, name, actions[0], updatedClass())
+			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
+				assertNumberOfActions(t, actions, 1)
+				assertUpdate(t, actions[0], updatedClass())
 			},
 		},
 		{
@@ -121,36 +121,36 @@ func TestReconcileServiceClassFromServiceBrokerCatalog(t *testing.T) {
 	broker := getTestServiceBroker()
 
 	for _, tc := range cases {
-		err := utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.NamespacedServiceBroker))
-		if err != nil {
-			t.Fatalf("Failed to enable namespaced service broker feature: %v", err)
-		}
-		defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.NamespacedServiceBroker))
-
-		_, fakeCatalogClient, _, testController, sharedInformers := newTestController(t, noFakeActions())
-		if tc.catalogClientPrepFunc != nil {
-			tc.catalogClientPrepFunc(fakeCatalogClient)
-		}
-
-		if tc.listerServiceClass != nil {
-			sharedInformers.ServiceClasses().Informer().GetStore().Add(tc.listerServiceClass)
-		}
-
-		err = testController.reconcileServiceClassFromServiceBrokerCatalog(broker, tc.newServiceClass, tc.existingServiceClass)
-		if err != nil {
-			if !tc.shouldError {
-				t.Errorf("%v: unexpected error from method under test: %v", tc.name, err)
-				continue
-			} else if tc.errText != nil && *tc.errText != err.Error() {
-				t.Errorf("%v: unexpected error text from method under test; %s", tc.name, expectedGot(tc.errText, err.Error()))
-				continue
+		t.Run(tc.name, func(t *testing.T) {
+			err := utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.NamespacedServiceBroker))
+			if err != nil {
+				t.Fatalf("Failed to enable namespaced service broker feature: %v", err)
 			}
-		}
+			defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.NamespacedServiceBroker))
 
-		if tc.catalogActionsCheckFunc != nil {
-			actions := fakeCatalogClient.Actions()
-			tc.catalogActionsCheckFunc(t, tc.name, actions)
-		}
+			_, fakeCatalogClient, _, testController, sharedInformers := newTestController(t, noFakeActions())
+			if tc.catalogClientPrepFunc != nil {
+				tc.catalogClientPrepFunc(fakeCatalogClient)
+			}
+
+			if tc.listerServiceClass != nil {
+				sharedInformers.ServiceClasses().Informer().GetStore().Add(tc.listerServiceClass)
+			}
+
+			err = testController.reconcileServiceClassFromServiceBrokerCatalog(broker, tc.newServiceClass, tc.existingServiceClass)
+			if err != nil {
+				if !tc.shouldError {
+					t.Fatalf("unexpected error from method under test: %v", err)
+				} else if tc.errText != nil && *tc.errText != err.Error() {
+					t.Fatalf("unexpected error text from method under test; %s", expectedGot(tc.errText, err.Error()))
+				}
+			}
+
+			if tc.catalogActionsCheckFunc != nil {
+				actions := fakeCatalogClient.Actions()
+				tc.catalogActionsCheckFunc(t, actions)
+			}
+		})
 	}
 }
 
@@ -176,15 +176,15 @@ func TestReconcileServicePlanFromServiceBrokerCatalog(t *testing.T) {
 		shouldError             bool
 		errText                 *string
 		catalogClientPrepFunc   func(*fake.Clientset)
-		catalogActionsCheckFunc func(t *testing.T, name string, actions []clientgotesting.Action)
+		catalogActionsCheckFunc func(t *testing.T, actions []clientgotesting.Action)
 	}{
 		{
 			name:           "new plan",
 			newServicePlan: getTestServicePlan(),
 			shouldError:    false,
-			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
-				expectNumberOfActions(t, name, actions, 1)
-				expectCreate(t, name, actions[0], getTestServicePlan())
+			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
+				assertNumberOfActions(t, actions, 1)
+				assertCreate(t, actions[0], getTestServicePlan())
 			},
 		},
 		{
@@ -204,9 +204,9 @@ func TestReconcileServicePlanFromServiceBrokerCatalog(t *testing.T) {
 			newServicePlan:      updatedPlan(),
 			existingServicePlan: getTestServicePlan(),
 			shouldError:         false,
-			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
-				expectNumberOfActions(t, name, actions, 1)
-				expectUpdate(t, name, actions[0], updatedPlan())
+			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
+				assertNumberOfActions(t, actions, 1)
+				assertUpdate(t, actions[0], updatedPlan())
 			},
 		},
 		{
@@ -226,35 +226,35 @@ func TestReconcileServicePlanFromServiceBrokerCatalog(t *testing.T) {
 	broker := getTestServiceBroker()
 
 	for _, tc := range cases {
-		err := utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.NamespacedServiceBroker))
-		if err != nil {
-			t.Fatalf("Failed to enable namespaced service broker feature: %v", err)
-		}
-		defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.NamespacedServiceBroker))
-
-		_, fakeCatalogClient, _, testController, sharedInformers := newTestController(t, noFakeActions())
-		if tc.catalogClientPrepFunc != nil {
-			tc.catalogClientPrepFunc(fakeCatalogClient)
-		}
-
-		if tc.listerServicePlan != nil {
-			sharedInformers.ServicePlans().Informer().GetStore().Add(tc.listerServicePlan)
-		}
-
-		err = testController.reconcileServicePlanFromServiceBrokerCatalog(broker, tc.newServicePlan, tc.existingServicePlan)
-		if err != nil {
-			if !tc.shouldError {
-				t.Errorf("%v: unexpected error from method under test: %v", tc.name, err)
-				continue
-			} else if tc.errText != nil && *tc.errText != err.Error() {
-				t.Errorf("%v: unexpected error text from method under test; %s", tc.name, expectedGot(tc.errText, err.Error()))
-				continue
+		t.Run(tc.name, func(t *testing.T) {
+			err := utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.NamespacedServiceBroker))
+			if err != nil {
+				t.Fatalf("Failed to enable namespaced service broker feature: %v", err)
 			}
-		}
+			defer utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.NamespacedServiceBroker))
 
-		if tc.catalogActionsCheckFunc != nil {
-			actions := fakeCatalogClient.Actions()
-			tc.catalogActionsCheckFunc(t, tc.name, actions)
-		}
+			_, fakeCatalogClient, _, testController, sharedInformers := newTestController(t, noFakeActions())
+			if tc.catalogClientPrepFunc != nil {
+				tc.catalogClientPrepFunc(fakeCatalogClient)
+			}
+
+			if tc.listerServicePlan != nil {
+				sharedInformers.ServicePlans().Informer().GetStore().Add(tc.listerServicePlan)
+			}
+
+			err = testController.reconcileServicePlanFromServiceBrokerCatalog(broker, tc.newServicePlan, tc.existingServicePlan)
+			if err != nil {
+				if !tc.shouldError {
+					t.Fatalf("unexpected error from method under test: %v", err)
+				} else if tc.errText != nil && *tc.errText != err.Error() {
+					t.Fatalf("unexpected error text from method under test; %s", expectedGot(tc.errText, err.Error()))
+				}
+			}
+
+			if tc.catalogActionsCheckFunc != nil {
+				actions := fakeCatalogClient.Actions()
+				tc.catalogActionsCheckFunc(t, actions)
+			}
+		})
 	}
 }

--- a/pkg/controller/controller_serviceclass_test.go
+++ b/pkg/controller/controller_serviceclass_test.go
@@ -44,7 +44,7 @@ func TestReconcileServiceClassRemovedFromCatalog(t *testing.T) {
 		catalogClientPrepFunc   func(*fake.Clientset)
 		shouldError             bool
 		errText                 *string
-		catalogActionsCheckFunc func(t *testing.T, name string, actions []clientgotesting.Action)
+		catalogActionsCheckFunc func(t *testing.T, actions []clientgotesting.Action)
 	}{
 		{
 			name:         "not removed from catalog",
@@ -56,13 +56,13 @@ func TestReconcileServiceClassRemovedFromCatalog(t *testing.T) {
 			serviceClass: getRemovedServiceClass(),
 			instances:    []v1beta1.ServiceInstance{*getTestServiceInstance()},
 			shouldError:  false,
-			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
 					Fields: fields.OneTermEqualSelector("spec.serviceClassRef.name", "SCGUID"),
 				}
 
-				expectNumberOfActions(t, name, actions, 1)
+				assertNumberOfActions(t, actions, 1)
 				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
 			},
 		},
@@ -71,13 +71,13 @@ func TestReconcileServiceClassRemovedFromCatalog(t *testing.T) {
 			serviceClass: getRemovedServiceClass(),
 			instances:    nil,
 			shouldError:  false,
-			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
 					Fields: fields.OneTermEqualSelector("spec.serviceClassRef.name", "SCGUID"),
 				}
 
-				expectNumberOfActions(t, name, actions, 2)
+				assertNumberOfActions(t, actions, 2)
 				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
 				assertDelete(t, actions[1], getRemovedServiceClass())
 			},
@@ -93,13 +93,13 @@ func TestReconcileServiceClassRemovedFromCatalog(t *testing.T) {
 				})
 			},
 			errText: strPtr("oops"),
-			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
 					Fields: fields.OneTermEqualSelector("spec.serviceClassRef.name", "SCGUID"),
 				}
 
-				expectNumberOfActions(t, name, actions, 2)
+				assertNumberOfActions(t, actions, 2)
 				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
 				assertDelete(t, actions[1], getRemovedServiceClass())
 			},
@@ -107,34 +107,34 @@ func TestReconcileServiceClassRemovedFromCatalog(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, fakeCatalogClient, _, testController, _ := newTestController(t, noFakeActions())
+		t.Run(tc.name, func(t *testing.T) {
+			_, fakeCatalogClient, _, testController, _ := newTestController(t, noFakeActions())
 
-		fakeCatalogClient.AddReactor("list", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
-			return true, &v1beta1.ServiceInstanceList{Items: tc.instances}, nil
-		})
+			fakeCatalogClient.AddReactor("list", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+				return true, &v1beta1.ServiceInstanceList{Items: tc.instances}, nil
+			})
 
-		if tc.catalogClientPrepFunc != nil {
-			tc.catalogClientPrepFunc(fakeCatalogClient)
-		}
-
-		err := reconcileServiceClass(t, testController, tc.serviceClass)
-		if err != nil {
-			if !tc.shouldError {
-				t.Errorf("%v: unexpected error from method under test: %v", tc.name, err)
-				continue
-			} else if tc.errText != nil && *tc.errText != err.Error() {
-				t.Errorf("%v: unexpected error text from method under test; expected %v, got %v", tc.name, tc.errText, err.Error())
-				continue
+			if tc.catalogClientPrepFunc != nil {
+				tc.catalogClientPrepFunc(fakeCatalogClient)
 			}
-		}
 
-		actions := fakeCatalogClient.Actions()
+			err := reconcileServiceClass(t, testController, tc.serviceClass)
+			if err != nil {
+				if !tc.shouldError {
+					t.Fatalf("unexpected error from method under test: %v", err)
+				} else if tc.errText != nil && *tc.errText != err.Error() {
+					t.Fatalf("unexpected error text from method under test; expected %v, got %v", tc.errText, err.Error())
+				}
+			}
 
-		if tc.catalogActionsCheckFunc != nil {
-			tc.catalogActionsCheckFunc(t, tc.name, actions)
-		} else {
-			expectNumberOfActions(t, tc.name, actions, 0)
-		}
+			actions := fakeCatalogClient.Actions()
+
+			if tc.catalogActionsCheckFunc != nil {
+				tc.catalogActionsCheckFunc(t, actions)
+			} else {
+				assertNumberOfActions(t, actions, 0)
+			}
+		})
 	}
 }
 

--- a/pkg/controller/controller_serviceplan_test.go
+++ b/pkg/controller/controller_serviceplan_test.go
@@ -44,7 +44,7 @@ func TestReconcileServicePlanRemovedFromCatalog(t *testing.T) {
 		catalogClientPrepFunc   func(*fake.Clientset)
 		shouldError             bool
 		errText                 *string
-		catalogActionsCheckFunc func(t *testing.T, name string, actions []clientgotesting.Action)
+		catalogActionsCheckFunc func(t *testing.T, actions []clientgotesting.Action)
 	}{
 		{
 			name:        "not removed from catalog",
@@ -56,13 +56,13 @@ func TestReconcileServicePlanRemovedFromCatalog(t *testing.T) {
 			plan:        getRemovedPlan(),
 			instances:   []v1beta1.ServiceInstance{*getTestServiceInstance()},
 			shouldError: false,
-			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
 					Fields: fields.OneTermEqualSelector("spec.servicePlanRef.name", "SPGUID"),
 				}
 
-				expectNumberOfActions(t, name, actions, 1)
+				assertNumberOfActions(t, actions, 1)
 				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
 			},
 		},
@@ -71,13 +71,13 @@ func TestReconcileServicePlanRemovedFromCatalog(t *testing.T) {
 			plan:        getRemovedPlan(),
 			instances:   nil,
 			shouldError: false,
-			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
 					Fields: fields.OneTermEqualSelector("spec.servicePlanRef.name", "SPGUID"),
 				}
 
-				expectNumberOfActions(t, name, actions, 2)
+				assertNumberOfActions(t, actions, 2)
 				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
 				assertDelete(t, actions[1], getRemovedPlan())
 			},
@@ -93,13 +93,13 @@ func TestReconcileServicePlanRemovedFromCatalog(t *testing.T) {
 				})
 			},
 			errText: strPtr("oops"),
-			catalogActionsCheckFunc: func(t *testing.T, name string, actions []clientgotesting.Action) {
+			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
 					Fields: fields.OneTermEqualSelector("spec.servicePlanRef.name", "SPGUID"),
 				}
 
-				expectNumberOfActions(t, name, actions, 2)
+				assertNumberOfActions(t, actions, 2)
 				assertList(t, actions[0], &v1beta1.ServiceInstance{}, listRestrictions)
 				assertDelete(t, actions[1], getRemovedPlan())
 			},
@@ -107,34 +107,34 @@ func TestReconcileServicePlanRemovedFromCatalog(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, fakeCatalogClient, _, testController, _ := newTestController(t, noFakeActions())
+		t.Run(tc.name, func(t *testing.T) {
+			_, fakeCatalogClient, _, testController, _ := newTestController(t, noFakeActions())
 
-		fakeCatalogClient.AddReactor("list", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
-			return true, &v1beta1.ServiceInstanceList{Items: tc.instances}, nil
-		})
+			fakeCatalogClient.AddReactor("list", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+				return true, &v1beta1.ServiceInstanceList{Items: tc.instances}, nil
+			})
 
-		if tc.catalogClientPrepFunc != nil {
-			tc.catalogClientPrepFunc(fakeCatalogClient)
-		}
-
-		err := reconcileServicePlan(t, testController, tc.plan)
-		if err != nil {
-			if !tc.shouldError {
-				t.Errorf("%v: unexpected error from method under test: %v", tc.name, err)
-				continue
-			} else if tc.errText != nil && *tc.errText != err.Error() {
-				t.Errorf("%v: unexpected error text from method under test; expected %v, got %v", tc.name, tc.errText, err.Error())
-				continue
+			if tc.catalogClientPrepFunc != nil {
+				tc.catalogClientPrepFunc(fakeCatalogClient)
 			}
-		}
 
-		actions := fakeCatalogClient.Actions()
+			err := reconcileServicePlan(t, testController, tc.plan)
+			if err != nil {
+				if !tc.shouldError {
+					t.Fatalf("unexpected error from method under test: %v", err)
+				} else if tc.errText != nil && *tc.errText != err.Error() {
+					t.Fatalf("unexpected error text from method under test; expected %v, got %v", tc.errText, err.Error())
+				}
+			}
 
-		if tc.catalogActionsCheckFunc != nil {
-			tc.catalogActionsCheckFunc(t, tc.name, actions)
-		} else {
-			expectNumberOfActions(t, tc.name, actions, 0)
-		}
+			actions := fakeCatalogClient.Actions()
+
+			if tc.catalogActionsCheckFunc != nil {
+				tc.catalogActionsCheckFunc(t, actions)
+			} else {
+				assertNumberOfActions(t, actions, 0)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
If we use `testing.Run()`, we can simplify the test code by using asserts instead of using `expectXxx()` and `continue`.