### PR TITLE
Remove reduplication in contrib

### DIFF
--- a/contrib/pkg/brokerapi/fake/fake.go
+++ b/contrib/pkg/brokerapi/fake/fake.go
@@ -140,7 +140,7 @@ func (i *InstanceClient) UpdateServiceInstance(
 }
 
 // DeleteServiceInstance returns i.DeleteErr if it was non-nil. Otherwise returns
-// ErrInstanceNotFound if id didn't already exist in i.Instances. If it it did already exist,
+// ErrInstanceNotFound if id didn't already exist in i.Instances. If it did already exist,
 // removes i.Instances[id] from the map and returns nil
 func (i *InstanceClient) DeleteServiceInstance(id string, req *brokerapi.DeleteServiceInstanceRequest) (*brokerapi.DeleteServiceInstanceResponse, int, error) {
 	resp := &brokerapi.DeleteServiceInstanceResponse{}

--- a/contrib/pkg/brokerapi/service_plan.go
+++ b/contrib/pkg/brokerapi/service_plan.go
@@ -17,7 +17,7 @@ limitations under the License.
 package brokerapi
 
 // ServicePlan is the Open Service API compatible struct for service plans.
-// It comes with with JSON struct tags to match the API spec
+// It comes with JSON struct tags to match the API spec
 type ServicePlan struct {
 	Name        string      `json:"name"`
 	ID          string      `json:"id"`


### PR DESCRIPTION
Signed-off-by: mooncake <xcoder@tenxcloud.com>

 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [x] Feature Implementation
 - [-] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
Remove reduplication in contrib:

1. contrib/pkg/brokerapi/fake/fake.go
2. contrib/pkg/brokerapi/service_plan.go

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
