### PR TITLE
Fix documents issue

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -94,7 +94,7 @@ often use client certificate authentication.
 By default, a main Kubernetes API server configured with the
 `--client-ca-file` option automatically creates a ConfigMap called
 `extension-apiserver-authentication` in the `kube-system` namespace,
-populated with the the client CA file.  The service catalog API server use
+populated with the client CA file.  The service catalog API server use
 this CA certificate as the CA used to verify client authentication. This
 way, client certificate users who can authenticate with the main
 Kubernetes system can also authenticate with the service catalog API

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -323,7 +323,7 @@ Certain tests use fakes generated with [Counterfeiter](http://github.com/maxbrun
 to an interface (such as SvcatClient in pkg/svcat/service-catalog) you may need to regenerate the fake. You can install
 Counterfeiter by running `go get github.com/maxbrunsfeld/counterfeiter`.
 Then regenerate the fake with `counterfeiter ./pkg/svcat/service-catalog SvcatClient` and manually paste the boilerplate
-copyright comment into the the generated file.
+copyright comment into the generated file.
 
 ## FeatureGates
 Feature gates are a set of key=value pairs that describe experimental features

--- a/docs/v1/milestones.md
+++ b/docs/v1/milestones.md
@@ -42,7 +42,7 @@ High-level functional requirements:
   6.  Remove broker
   7.  Update broker
   8.  Delete broker
-5.  ServiceBindings manifest as a Secret in the the k8s core; users will be expected
+5.  ServiceBindings manifest as a Secret in the k8s core; users will be expected
     to explicitly reference this secret in their Pod specs
 
 High-level architectural requirements:

--- a/docs/v1/use-cases.md
+++ b/docs/v1/use-cases.md
@@ -79,7 +79,7 @@ whether deleting a broker should:
 
 #### Searching Services
 
-Consumers should be be able to search or filter their catalog by labels. For
+Consumers should be able to search or filter their catalog by labels. For
 example, if I search for all services with 'catalog=database' the catalog
 will return the list of services that match that label. This assumes, of
 course, that producers are able to label their service offerings.
@@ -190,7 +190,7 @@ As an Application Operator, I should be able to accomplish the following sets of
 
 Consuming applications that need specific handling of credentials or
 configuration should be able to use additional Kubernetes facilities to
-adapt/transform the contents of the the credentials/configuration. This
+adapt/transform the contents of the credentials/configuration. This
 includes, but is not limited to, side-car and init containers.
 
 If the user were willing to change the application, then we could


### PR DESCRIPTION
Signed-off-by: mooncake <xcoder@tenxcloud.com>

 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [ -] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
Fix documents issue:

1. docs/auth.md
2. docs/devguide.md
3. docs/v1/milestones.md
4. docs/v1/use-cases.md


**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [- ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
