### PR TITLE
Add marketplace command to svcat

### DIFF
--- a/cmd/svcat/extra/extra_suite_test.go
+++ b/cmd/svcat/extra/extra_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extra_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestExtra(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Extra Suite")
+}

--- a/cmd/svcat/extra/marketplace_cmd.go
+++ b/cmd/svcat/extra/marketplace_cmd.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extra
+
+import (
+	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
+	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/output"
+	"github.com/kubernetes-incubator/service-catalog/pkg/svcat/service-catalog"
+	"github.com/spf13/cobra"
+)
+
+// MarketplaceCmd contains the information needed to query the marketplace of
+// services available to the user
+type MarketplaceCmd struct {
+	*command.Namespaced
+	*command.Formatted
+}
+
+// NewMarketplaceCmd builds a "svcat marketplace" command
+func NewMarketplaceCmd(cxt *command.Context) *cobra.Command {
+	mpCmd := &MarketplaceCmd{
+		Namespaced: command.NewNamespaced(cxt),
+		Formatted:  command.NewFormatted(),
+	}
+	cmd := &cobra.Command{
+		Use:     "marketplace",
+		Aliases: []string{"marketplace", "mp"},
+		Short:   "List available service offerings",
+		Example: command.NormalizeExamples(`
+  svcat marketplace
+	svcat marketplace --namespace dev
+`),
+		PreRunE: command.PreRunE(mpCmd),
+		RunE:    command.RunE(mpCmd),
+	}
+
+	mpCmd.AddOutputFlags(cmd.Flags())
+	mpCmd.AddNamespaceFlags(cmd.Flags(), true)
+	return cmd
+}
+
+// Validate always returns true, there are no args to validate
+func (c *MarketplaceCmd) Validate(args []string) error {
+	return nil
+}
+
+// Run retrieves all service classes visible in the current namespace,
+// retrieves the plans belonging to those classses, and then displays
+// that to the user
+func (c *MarketplaceCmd) Run() error {
+	opts := servicecatalog.ScopeOptions{
+		Namespace: c.Namespace,
+		Scope:     servicecatalog.AllScope,
+	}
+	classes, err := c.App.RetrieveClasses(opts)
+	if err != nil {
+		return err
+	}
+	plans := make([][]servicecatalog.Plan, len(classes))
+	classPlans, err := c.App.RetrievePlans("", opts)
+	if err != nil {
+		return err
+	}
+	for i, class := range classes {
+		for _, plan := range classPlans {
+			if plan.GetClassID() == class.GetName() {
+				plans[i] = append(plans[i], plan)
+			}
+		}
+	}
+	output.WriteClassAndPlanDetails(c.Output, classes, plans)
+	return nil
+}

--- a/cmd/svcat/extra/marketplace_cmd_test.go
+++ b/cmd/svcat/extra/marketplace_cmd_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extra_test
+
+import (
+	"bytes"
+
+	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
+	. "github.com/kubernetes-incubator/service-catalog/cmd/svcat/extra"
+	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/test"
+	_ "github.com/kubernetes-incubator/service-catalog/internal/test"
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/pkg/svcat"
+	servicecatalog "github.com/kubernetes-incubator/service-catalog/pkg/svcat/service-catalog"
+	servicecatalogfakes "github.com/kubernetes-incubator/service-catalog/pkg/svcat/service-catalog/service-catalogfakes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Register Command", func() {
+	Describe("NewMarketplaceCmd", func() {
+		It("Builds and returns a cobra command with the correct flags", func() {
+			cxt := &command.Context{}
+			cmd := NewMarketplaceCmd(cxt)
+			Expect(*cmd).NotTo(BeNil())
+
+			Expect(cmd.Use).To(Equal("marketplace"))
+			Expect(cmd.Short).To(ContainSubstring("List available service offerings"))
+			Expect(cmd.Example).To(ContainSubstring("svcat marketplace --namespace dev"))
+			Expect(cmd.Aliases).To(ConsistOf("marketplace", "mp"))
+
+			urlFlag := cmd.Flags().Lookup("namespace")
+			Expect(urlFlag).NotTo(BeNil())
+			Expect(urlFlag.Usage).To(ContainSubstring("If present, the namespace scope for this request"))
+		})
+	})
+	Describe("Validate", func() {
+	})
+	Describe("Run", func() {
+		It("Calls the pkg/svcat libs methods to retrieve all classes and plans and prints output to the user", func() {
+			namespace := "banana"
+
+			className := "foobarclass"
+			classDescription := "This class foobars"
+			className2 := "barbazclass"
+			classDescription2 := "This class barbazs"
+			planName := "foobarplan1"
+			planName2 := "foobarplan2"
+			planName3 := "barbazplan"
+			classToReturn := &v1beta1.ClusterServiceClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      className,
+				},
+				Spec: v1beta1.ClusterServiceClassSpec{
+					CommonServiceClassSpec: v1beta1.CommonServiceClassSpec{
+						Description:  classDescription,
+						ExternalName: className,
+					},
+				},
+			}
+			classToReturn2 := &v1beta1.ClusterServiceClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      className2,
+				},
+				Spec: v1beta1.ClusterServiceClassSpec{
+					CommonServiceClassSpec: v1beta1.CommonServiceClassSpec{
+						Description:  classDescription2,
+						ExternalName: className2,
+					},
+				},
+			}
+			planToReturn := &v1beta1.ClusterServicePlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      planName,
+				},
+				Spec: v1beta1.ClusterServicePlanSpec{
+					CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+						ExternalName: planName,
+					},
+					ClusterServiceClassRef: v1beta1.ClusterObjectReference{
+						Name: className,
+					},
+				},
+			}
+			planToReturn2 := &v1beta1.ClusterServicePlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      planName2,
+				},
+				Spec: v1beta1.ClusterServicePlanSpec{
+					CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+						ExternalName: planName2,
+					},
+					ClusterServiceClassRef: v1beta1.ClusterObjectReference{
+						Name: className,
+					},
+				},
+			}
+			planToReturn3 := &v1beta1.ClusterServicePlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      planName3,
+				},
+				Spec: v1beta1.ClusterServicePlanSpec{
+					CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+						ExternalName: planName3,
+					},
+					ClusterServiceClassRef: v1beta1.ClusterObjectReference{
+						Name: className2,
+					},
+				},
+			}
+
+			outputBuffer := &bytes.Buffer{}
+			fakeApp, _ := svcat.NewApp(nil, nil, "default")
+			fakeSDK := new(servicecatalogfakes.FakeSvcatClient)
+			fakeSDK.RetrieveClassesReturns([]servicecatalog.Class{classToReturn, classToReturn2}, nil)
+			fakeSDK.RetrievePlansReturns([]servicecatalog.Plan{planToReturn, planToReturn2, planToReturn3}, nil)
+			fakeApp.SvcatClient = fakeSDK
+			cmd := MarketplaceCmd{
+				Namespaced: &command.Namespaced{Context: svcattest.NewContext(outputBuffer, fakeApp)},
+				Formatted:  command.NewFormatted(),
+			}
+			cmd.Namespace = namespace
+
+			err := cmd.Run()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fakeSDK.RetrieveClassesCallCount()).To(Equal(1))
+			scopeOpts := fakeSDK.RetrieveClassesArgsForCall(0)
+			Expect(scopeOpts).To(Equal(servicecatalog.ScopeOptions{
+				Scope:     servicecatalog.AllScope,
+				Namespace: namespace,
+			}))
+
+			Expect(fakeSDK.RetrievePlansCallCount()).To(Equal(1))
+			class, scopeOpts := fakeSDK.RetrievePlansArgsForCall(0)
+			Expect(class).To(Equal(""))
+			Expect(scopeOpts).To(Equal(servicecatalog.ScopeOptions{
+				Scope:     servicecatalog.AllScope,
+				Namespace: namespace,
+			}))
+
+			output := outputBuffer.String()
+			Expect(output).To(ContainSubstring(className))
+			Expect(output).To(ContainSubstring(planName))
+			Expect(output).To(ContainSubstring(planName2))
+			Expect(output).To(ContainSubstring(classDescription))
+			Expect(output).To(ContainSubstring(className2))
+			Expect(output).To(ContainSubstring(planName3))
+			Expect(output).To(ContainSubstring(classDescription2))
+		})
+	})
+})

--- a/cmd/svcat/main.go
+++ b/cmd/svcat/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/class"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/completion"
+	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/extra"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/instance"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/plan"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/plugin"
@@ -124,6 +125,7 @@ func buildRootCommand(cxt *command.Context) *cobra.Command {
 	cmd.AddCommand(instance.NewDeprovisionCmd(cxt))
 	cmd.AddCommand(binding.NewBindCmd(cxt))
 	cmd.AddCommand(binding.NewUnbindCmd(cxt))
+	cmd.AddCommand(extra.NewMarketplaceCmd(cxt))
 	cmd.AddCommand(newSyncCmd(cxt))
 	if !plugin.IsPlugin() {
 		cmd.AddCommand(newInstallCmd(cxt))

--- a/cmd/svcat/output/class.go
+++ b/cmd/svcat/output/class.go
@@ -94,3 +94,33 @@ func WriteClassDetails(w io.Writer, class servicecatalog.Class) {
 	})
 	t.Render()
 }
+
+// WriteClassAndPlanDetails prints details for multiple classes and plans
+func WriteClassAndPlanDetails(w io.Writer, classes []servicecatalog.Class, plans [][]servicecatalog.Plan) {
+	t := NewListTable(w)
+	t.SetHeader([]string{
+		"Class",
+		"Plans",
+		"Description",
+	})
+	for i, class := range classes {
+		for i, plan := range plans[i] {
+			if i == 0 {
+				t.Append([]string{
+					class.GetExternalName(),
+					plan.GetName(),
+					class.GetSpec().Description,
+				})
+			} else {
+				t.Append([]string{
+					"",
+					plan.GetName(),
+					"",
+				})
+			}
+		}
+	}
+	t.table.SetAutoWrapText(true)
+	t.SetVariableColumn(3)
+	t.Render()
+}

--- a/cmd/svcat/testdata/output/completion-bash.txt
+++ b/cmd/svcat/testdata/output/completion-bash.txt
@@ -830,6 +830,36 @@ _svcat_install()
     noun_aliases=()
 }
 
+_svcat_marketplace()
+{
+    last_command="svcat_marketplace"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all-namespaces")
+    local_nonpersistent_flags+=("--all-namespaces")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--namespace=")
+    flags+=("--output=")
+    two_word_flags+=("-o")
+    local_nonpersistent_flags+=("--output=")
+    flags+=("--context=")
+    flags+=("--kubeconfig=")
+    flags+=("--logtostderr")
+    flags+=("--v=")
+    two_word_flags+=("-v")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _svcat_provision()
 {
     last_command="svcat_provision"
@@ -1097,6 +1127,7 @@ _svcat_root_command()
     commands+=("describe")
     commands+=("get")
     commands+=("install")
+    commands+=("marketplace")
     commands+=("provision")
     commands+=("register")
     commands+=("sync")

--- a/cmd/svcat/testdata/output/completion-zsh.txt
+++ b/cmd/svcat/testdata/output/completion-zsh.txt
@@ -964,6 +964,36 @@ _svcat_install()
     noun_aliases=()
 }
 
+_svcat_marketplace()
+{
+    last_command="svcat_marketplace"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all-namespaces")
+    local_nonpersistent_flags+=("--all-namespaces")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--namespace=")
+    flags+=("--output=")
+    two_word_flags+=("-o")
+    local_nonpersistent_flags+=("--output=")
+    flags+=("--context=")
+    flags+=("--kubeconfig=")
+    flags+=("--logtostderr")
+    flags+=("--v=")
+    two_word_flags+=("-v")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _svcat_provision()
 {
     last_command="svcat_provision"
@@ -1231,6 +1261,7 @@ _svcat_root_command()
     commands+=("describe")
     commands+=("get")
     commands+=("install")
+    commands+=("marketplace")
     commands+=("provision")
     commands+=("register")
     commands+=("sync")

--- a/cmd/svcat/testdata/plugin.yaml
+++ b/cmd/svcat/testdata/plugin.yaml
@@ -285,6 +285,19 @@ tree:
     - name: uuid
       shorthand: u
       desc: Whether or not to get the plan by UUID (the default is by name)
+- name: marketplace
+  use: marketplace
+  shortDesc: List available service offerings
+  example: "  svcat marketplace\n  \tsvcat marketplace --namespace dev"
+  command: ./svcat marketplace
+  flags:
+  - name: all-namespaces
+    desc: If present, list the requested object(s) across all namespaces. Namespace
+      in current context is ignored even if specified with --namespace
+  - name: output
+    shorthand: o
+    desc: The output format to use. Valid options are table, json or yaml. If not
+      present, defaults to table
 - name: provision
   use: provision NAME --plan PLAN --class CLASS
   shortDesc: Create a new instance of a service


### PR DESCRIPTION
This PR is a 
 - [x ] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
This PR implements `svcat marketplace`, a command for users to browse the catalog of services available to them without having to manually page through the service-catalog abstractions. 

**Which issue(s) this PR fixes** 
Fixes #2033 

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
