### PR TITLE
add handler to return version string for url /service-catalog-version

### DIFF
--- a/charts/catalog/templates/rbac.yaml
+++ b/charts/catalog/templates/rbac.yaml
@@ -193,3 +193,26 @@ items:
     name: "{{ .Values.controllerManager.serviceAccount }}"
     namespace: "{{ .Release.Namespace }}"
 {{end}}
+
+# This allows anyone to fetch the Service Catalog version
+- apiVersion: {{template "rbacApiVersion" . }}
+  kind: ClusterRole
+  metadata:
+    name: "servicecatalog.k8s.io:service-catalog-version"
+  rules:
+  - nonResourceURLs:
+    - /service-catalog-version
+    verbs:
+      - get
+- apiVersion: {{template "rbacApiVersion" . }}
+  kind: ClusterRoleBinding
+  metadata:
+    name: "servicecatalog.k8s.io:service-catalog-version"
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: "servicecatalog.k8s.io:service-catalog-version"
+  subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:unauthenticated

--- a/cmd/apiserver/app/server/run_server.go
+++ b/cmd/apiserver/app/server/run_server.go
@@ -18,8 +18,10 @@ package server
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 
+	"github.com/kubernetes-incubator/service-catalog/pkg"
 	"github.com/kubernetes-incubator/service-catalog/pkg/api"
 	genericapiserverstorage "k8s.io/apiserver/pkg/server/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3/preflight"
@@ -105,6 +107,11 @@ func runEtcdServer(opts *ServiceCatalogServerOptions, stopCh <-chan struct{}) er
 	// PingHealtz is installed by the default config, so it will
 	// run in addition the checkers being installed here.
 	server.GenericAPIServer.AddHealthzChecks(etcdChecker)
+
+	// Register handler to return Service Catalog version (version format is "v0.1.35-14+e21502afa7d08e")
+	server.GenericAPIServer.Handler.NonGoRestfulMux.HandleFunc("/service-catalog-version", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "%q", html.EscapeString(pkg.VERSION))
+	})
 
 	// do we need to do any post api installation setup? We should have set up the api already?
 	glog.Infoln("Running the API server")


### PR DESCRIPTION
to assist with addressing https://github.com/kubernetes-incubator/service-catalog/issues/2385

This PR is a 
 - [ x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
Register the url /service-catalog-version  with a handler that will return the Service Catalog version (ex v0.1.35-14+e21502afa7d08e)

#2385 still needs a PR to make the svcat invoke a GET to the new url

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
