### PR TITLE
revendor OSB Client to 0.0.12 picking up connection close fix

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -668,7 +668,7 @@
   revision = "a22138067af1c4942683050411a841ade67fe1eb"
 
 [[projects]]
-  digest = "1:8440a10c0b04e6a7b4ae70680e4dc6474fd4d472696361e5ef68de75afd08f32"
+  digest = "1:d0add9b073f4778471642b1c8cc65e9d921ba3377f0476a2c19fb3592299e544"
   name = "github.com/pmorie/go-open-service-broker-client"
   packages = [
     "v2",
@@ -676,8 +676,8 @@
     "v2/generator",
   ]
   pruneopts = "NUT"
-  revision = "9cc214e88d00504888af633376c9462e0ab2bd8b"
-  version = "0.0.11"
+  revision = "79b374a2302fe4a2c05c6f469262d195b765152f"
+  version = "0.0.12"
 
 [[projects]]
   digest = "1:84c59299d10402298277e3388120e91244b9f5fd1bdaf06c394ba3c6a9e85db2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -97,7 +97,7 @@ required = [
 
 [[constraint]]
   name = "github.com/pmorie/go-open-service-broker-client"
-  version = "=0.0.11"
+  version = "=0.0.12"
 
 [prune]
   non-go = true

--- a/vendor/github.com/pmorie/go-open-service-broker-client/v2/client.go
+++ b/vendor/github.com/pmorie/go-open-service-broker-client/v2/client.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -38,7 +39,21 @@ func NewClient(config *ClientConfiguration) (Client, error) {
 	httpClient := &http.Client{
 		Timeout: time.Duration(config.TimeoutSeconds) * time.Second,
 	}
-	transport := &http.Transport{}
+
+	// use default values lifted from DefaultTransport
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
 	if config.TLSConfig != nil {
 		transport.TLSClientConfig = config.TLSConfig
 	} else {


### PR DESCRIPTION
0.0.12 has a fix that sets good defaults on our custom http transport setting the Timeout, KeepAlive, MaxIdleConns, IdleConnTimeout etc to realistic values overriding the prior values of zero.   With this fix, when  connections are closed, they are really closed (after the IdleConnTimeout anyway).

