### PR TITLE
Adjust validations to fit updated OSB API

### DIFF
--- a/pkg/apis/servicecatalog/validation/binding.go
+++ b/pkg/apis/servicecatalog/validation/binding.go
@@ -119,6 +119,9 @@ func validateServiceBindingStatus(status *sc.ServiceBindingStatus, fldPath *fiel
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("asyncOpInProgress"), "asyncOpInProgress cannot be true when there is no currentOperation"))
 		}
 	} else {
+		if status.LastOperation != nil && len(*status.LastOperation) > lastOperationMaxLength {
+			allErrs = append(allErrs, field.TooLong(fldPath.Child("lastOperation"), status.LastOperation, lastOperationMaxLength))
+		}
 		if status.OperationStartTime == nil && !status.OrphanMitigationInProgress {
 			allErrs = append(allErrs, field.Required(fldPath.Child("operationStartTime"), "operationStartTime is required when currentOperation is present and no orphan mitigation in progress"))
 		}

--- a/pkg/apis/servicecatalog/validation/binding_test.go
+++ b/pkg/apis/servicecatalog/validation/binding_test.go
@@ -62,6 +62,15 @@ func validServiceBindingPropertiesState() *servicecatalog.ServiceBindingProperti
 	}
 }
 
+func invalidServiceBindingStatusLastOperation() *string {
+	runes := make([]rune, 10001)
+	for i := range runes {
+		runes[i] = 'a'
+	}
+	lastOperation := string(runes)
+	return &lastOperation
+}
+
 func TestValidateServiceBinding(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -563,6 +572,15 @@ func TestValidateServiceBinding(t *testing.T) {
 				return b
 			}(),
 			valid: true,
+		},
+		{
+			name: "LastOperation too long",
+			binding: func() *servicecatalog.ServiceBinding {
+				b := validServiceBindingWithInProgressBind()
+				b.Status.LastOperation = invalidServiceBindingStatusLastOperation()
+				return b
+			}(),
+			valid: false,
 		},
 	}
 

--- a/pkg/apis/servicecatalog/validation/instance.go
+++ b/pkg/apis/servicecatalog/validation/instance.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"fmt"
+
 	"github.com/ghodss/yaml"
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/controller"
@@ -26,6 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
+
+const lastOperationMaxLength int = 10000
 
 // validateServiceInstanceName is the validation function for Instance names.
 var validateServiceInstanceName = apivalidation.NameIsDNSSubdomain
@@ -139,6 +142,9 @@ func validateServiceInstanceStatus(status *sc.ServiceInstanceStatus, fldPath *fi
 			if c.Type == sc.ServiceInstanceConditionReady && c.Status == sc.ConditionTrue {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("conditions").Index(i), "Can not set ServiceInstanceConditionReady to true when there is an operation in progress"))
 			}
+		}
+		if status.LastOperation != nil && len(*status.LastOperation) > lastOperationMaxLength {
+			allErrs = append(allErrs, field.TooLong(fldPath.Child("lastOperation"), status.LastOperation, lastOperationMaxLength))
 		}
 	}
 

--- a/pkg/apis/servicecatalog/validation/serviceclass.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass.go
@@ -17,8 +17,6 @@ limitations under the License.
 package validation
 
 import (
-	"regexp"
-
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -26,10 +24,7 @@ import (
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 )
 
-const commonServiceClassNameFmt string = `[-.a-zA-Z0-9]+`
 const commonServiceClassNameMaxLength int = 63
-
-var commonServiceClassNameRegexp = regexp.MustCompile("^" + commonServiceClassNameFmt + "$")
 
 const guidMaxLength int = 63
 
@@ -40,8 +35,8 @@ func validateCommonServiceClassName(value string, prefix bool) []string {
 	if len(value) > commonServiceClassNameMaxLength {
 		errs = append(errs, utilvalidation.MaxLenError(commonServiceClassNameMaxLength))
 	}
-	if !commonServiceClassNameRegexp.MatchString(value) {
-		errs = append(errs, utilvalidation.RegexError(commonServiceClassNameFmt, "service-name-40d-0983-1b89"))
+	if len(value) == 0 {
+		errs = append(errs, utilvalidation.EmptyError())
 	}
 
 	return errs

--- a/pkg/apis/servicecatalog/validation/serviceclass_test.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass_test.go
@@ -119,16 +119,7 @@ func TestValidateClusterServiceClass(t *testing.T) {
 			name: "invalid serviceClass - invalid externalName",
 			serviceClass: func() *servicecatalog.ClusterServiceClass {
 				s := validClusterServiceClass()
-				s.Spec.ExternalName = "****"
-				return s
-			}(),
-			valid: false,
-		},
-		{
-			name: "invalid serviceClass - underscore in externalName",
-			serviceClass: func() *servicecatalog.ClusterServiceClass {
-				s := validClusterServiceClass()
-				s.Spec.ExternalName = "test_serviceclass"
+				s.Spec.ExternalName = ""
 				return s
 			}(),
 			valid: false,
@@ -270,16 +261,7 @@ func TestValidateServiceClass(t *testing.T) {
 			name: "invalid serviceClass - invalid externalName",
 			serviceClass: func() *servicecatalog.ServiceClass {
 				s := validServiceClass()
-				s.Spec.ExternalName = "****"
-				return s
-			}(),
-			valid: false,
-		},
-		{
-			name: "invalid serviceClass - underscore in externalName",
-			serviceClass: func() *servicecatalog.ServiceClass {
-				s := validServiceClass()
-				s.Spec.ExternalName = "test_serviceclass"
+				s.Spec.ExternalName = ""
 				return s
 			}(),
 			valid: false,

--- a/pkg/apis/servicecatalog/validation/serviceplan.go
+++ b/pkg/apis/servicecatalog/validation/serviceplan.go
@@ -18,7 +18,6 @@ package validation
 
 import (
 	"fmt"
-	"regexp"
 
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
@@ -27,10 +26,7 @@ import (
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 )
 
-const commonServicePlanNameFmt string = `[-.a-zA-Z0-9]+`
 const commonServicePlanNameMaxLength int = 63
-
-var servicePlanNameRegexp = regexp.MustCompile("^" + commonServicePlanNameFmt + "$")
 
 // validateCommonServicePlanName is the common validation function for
 // service plan types.
@@ -39,8 +35,8 @@ func validateCommonServicePlanName(value string, prefix bool) []string {
 	if len(value) > commonServicePlanNameMaxLength {
 		errs = append(errs, utilvalidation.MaxLenError(commonServicePlanNameMaxLength))
 	}
-	if !servicePlanNameRegexp.MatchString(value) {
-		errs = append(errs, utilvalidation.RegexError(commonServicePlanNameFmt, "plan-name-40d-0983-1b89"))
+	if len(value) == 0 {
+		errs = append(errs, utilvalidation.EmptyError())
 	}
 
 	return errs

--- a/pkg/apis/servicecatalog/validation/serviceplan_test.go
+++ b/pkg/apis/servicecatalog/validation/serviceplan_test.go
@@ -93,24 +93,6 @@ func TestValidateClusterServicePlan(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "bad name",
-			clusterServicePlan: func() *servicecatalog.ClusterServicePlan {
-				s := validClusterServicePlan()
-				s.Name = "#"
-				return s
-			}(),
-			valid: false,
-		},
-		{
-			name: "bad externalName",
-			clusterServicePlan: func() *servicecatalog.ClusterServicePlan {
-				s := validClusterServicePlan()
-				s.Spec.ExternalName = "#"
-				return s
-			}(),
-			valid: false,
-		},
-		{
 			name: "mixed case Name",
 			clusterServicePlan: func() *servicecatalog.ClusterServicePlan {
 				s := validClusterServicePlan()
@@ -185,15 +167,6 @@ func TestValidateClusterServicePlan(t *testing.T) {
 			}(),
 			valid: false,
 		},
-		{
-			name: "bad serviceclass reference name",
-			clusterServicePlan: func() *servicecatalog.ClusterServicePlan {
-				s := validClusterServicePlan()
-				s.Spec.ClusterServiceClassRef.Name = "%"
-				return s
-			}(),
-			valid: false,
-		},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -235,24 +208,6 @@ func TestValidateServicePlan(t *testing.T) {
 			servicePlan: func() *servicecatalog.ServicePlan {
 				s := validServicePlan()
 				s.Name = ""
-				return s
-			}(),
-			valid: false,
-		},
-		{
-			name: "bad name",
-			servicePlan: func() *servicecatalog.ServicePlan {
-				s := validServicePlan()
-				s.Name = "#"
-				return s
-			}(),
-			valid: false,
-		},
-		{
-			name: "bad externalName",
-			servicePlan: func() *servicecatalog.ServicePlan {
-				s := validServicePlan()
-				s.Spec.ExternalName = "#"
 				return s
 			}(),
 			valid: false,
@@ -328,15 +283,6 @@ func TestValidateServicePlan(t *testing.T) {
 			servicePlan: func() *servicecatalog.ServicePlan {
 				s := validServicePlan()
 				s.Spec.ServiceClassRef.Name = ""
-				return s
-			}(),
-			valid: false,
-		},
-		{
-			name: "bad serviceclass reference name",
-			servicePlan: func() *servicecatalog.ServicePlan {
-				s := validServicePlan()
-				s.Spec.ServiceClassRef.Name = "%"
 				return s
 			}(),
 			valid: false,


### PR DESCRIPTION
This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
OSB API is [adjusting the spec](https://github.com/openservicebrokerapi/servicebroker/pull/609) to fit validations of various fields to the actual behavior of Cloud Foundry due to many real-life brokers being written to conform to Cloud Foundry's behavior. This PR adjusts our validations to fit the new checks. Mostly it's loosening validations so pre-existing brokers written to conform to Service Catalog should be fine. The only tightened restriction is a 10,000 character limit on the `operation` field for creation requests.

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
