### PR TITLE
Add UserProvided field to service instances

### DIFF
--- a/cmd/svcat/testdata/output/get-instance.json
+++ b/cmd/svcat/testdata/output/get-instance.json
@@ -36,7 +36,8 @@
          }
       ],
       "externalID": "7e2c42f3-6d94-4409-bb15-7610d60af544",
-      "updateRequests": 0
+      "updateRequests": 0,
+      "userProvided": false
    },
    "status": {
       "conditions": [
@@ -67,6 +68,7 @@
          "parameterChecksum": "23ca85e0f9fc05340ea0a13ef945602cd5cdc3f52d763e750cb0ab0cb172a94f"
       },
       "provisionStatus": "",
-      "deprovisionStatus": "Required"
+      "deprovisionStatus": "Required",
+      "userProvided": false
    }
 }

--- a/cmd/svcat/testdata/output/get-instance.yaml
+++ b/cmd/svcat/testdata/output/get-instance.yaml
@@ -26,6 +26,7 @@ spec:
       key: params
       name: instance-parameters
   updateRequests: 0
+  userProvided: false
 status:
   asyncOpInProgress: false
   conditions:
@@ -50,3 +51,4 @@ status:
   orphanMitigationInProgress: false
   provisionStatus: ""
   reconciledGeneration: 1
+  userProvided: false

--- a/cmd/svcat/testdata/output/get-instances.json
+++ b/cmd/svcat/testdata/output/get-instances.json
@@ -28,7 +28,8 @@
             },
             "parameters": {},
             "externalID": "7e2c42f3-6d94-4409-bb15-7610d60af544",
-            "updateRequests": 0
+            "updateRequests": 0,
+            "userProvided": false
          },
          "status": {
             "conditions": [
@@ -51,7 +52,8 @@
                "parameterChecksum": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
             },
             "provisionStatus": "",
-            "deprovisionStatus": "Required"
+            "deprovisionStatus": "Required",
+            "userProvided": false
          }
       }
    ]

--- a/cmd/svcat/testdata/output/get-instances.yaml
+++ b/cmd/svcat/testdata/output/get-instances.yaml
@@ -19,6 +19,7 @@ items:
     externalID: 7e2c42f3-6d94-4409-bb15-7610d60af544
     parameters: {}
     updateRequests: 0
+    userProvided: false
   status:
     asyncOpInProgress: false
     conditions:
@@ -37,6 +38,7 @@ items:
     orphanMitigationInProgress: false
     provisionStatus: ""
     reconciledGeneration: 1
+    userProvided: false
 metadata:
   resourceVersion: "109"
   selfLink: /apis/servicecatalog.k8s.io/v1beta1/serviceinstances

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -829,6 +829,11 @@ type ServiceInstanceSpec struct {
 	// allows for parameters to be updated with any out-of-band changes that have
 	// been made to the secrets from which the parameters are sourced.
 	UpdateRequests int64
+
+	// UserProvided indicates this instance is a user provided service instance.
+	// If true, bind requests will return "credentials" from the instance's
+	// parameters.
+	UserProvided bool
 }
 
 // ServiceInstanceStatus represents the current status of an Instance.
@@ -891,6 +896,11 @@ type ServiceInstanceStatus struct {
 	// DefaultProvisionParameters are the default parameters applied to this
 	// instance.
 	DefaultProvisionParameters *runtime.RawExtension
+
+	// UserProvided indicates this instance is a user provided service instance.
+	// If true, bind requests will return "credentials" from the instance's
+	// parameters.
+	UserProvided bool
 }
 
 // ServiceInstanceCondition contains condition information about an Instance.

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -918,6 +918,11 @@ type ServiceInstanceSpec struct {
 	// been made to the secrets from which the parameters are sourced.
 	// +optional
 	UpdateRequests int64 `json:"updateRequests"`
+
+	// UserProvided indicates this instance is a user provided service instance.
+	// If true, bind requests will return "credentials" from the instance's
+	// parameters.
+	UserProvided bool `json:"userProvided"`
 }
 
 // ServiceInstanceStatus represents the current status of an Instance.
@@ -980,6 +985,11 @@ type ServiceInstanceStatus struct {
 	// DefaultProvisionParameters are the default parameters applied to this
 	// instance.
 	DefaultProvisionParameters *runtime.RawExtension `json:"defaultProvisionParameters,omitempty"`
+
+	// UserProvided indicates this instance is a user provided service instance.
+	// If true, bind requests will return "credentials" from the instance's
+	// parameters.
+	UserProvided bool `json:"userProvided"`
 }
 
 // ServiceInstanceCondition contains condition information about an Instance.

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
@@ -2100,6 +2100,7 @@ func autoConvert_v1beta1_ServiceInstanceSpec_To_servicecatalog_ServiceInstanceSp
 	out.ExternalID = in.ExternalID
 	out.UserInfo = (*servicecatalog.UserInfo)(unsafe.Pointer(in.UserInfo))
 	out.UpdateRequests = in.UpdateRequests
+	out.UserProvided = in.UserProvided
 	return nil
 }
 
@@ -2121,6 +2122,7 @@ func autoConvert_servicecatalog_ServiceInstanceSpec_To_v1beta1_ServiceInstanceSp
 	out.ExternalID = in.ExternalID
 	out.UserInfo = (*UserInfo)(unsafe.Pointer(in.UserInfo))
 	out.UpdateRequests = in.UpdateRequests
+	out.UserProvided = in.UserProvided
 	return nil
 }
 
@@ -2144,6 +2146,7 @@ func autoConvert_v1beta1_ServiceInstanceStatus_To_servicecatalog_ServiceInstance
 	out.ProvisionStatus = servicecatalog.ServiceInstanceProvisionStatus(in.ProvisionStatus)
 	out.DeprovisionStatus = servicecatalog.ServiceInstanceDeprovisionStatus(in.DeprovisionStatus)
 	out.DefaultProvisionParameters = (*runtime.RawExtension)(unsafe.Pointer(in.DefaultProvisionParameters))
+	out.UserProvided = in.UserProvided
 	return nil
 }
 
@@ -2167,6 +2170,7 @@ func autoConvert_servicecatalog_ServiceInstanceStatus_To_v1beta1_ServiceInstance
 	out.ProvisionStatus = ServiceInstanceProvisionStatus(in.ProvisionStatus)
 	out.DeprovisionStatus = ServiceInstanceDeprovisionStatus(in.DeprovisionStatus)
 	out.DefaultProvisionParameters = (*runtime.RawExtension)(unsafe.Pointer(in.DefaultProvisionParameters))
+	out.UserProvided = in.UserProvided
 	return nil
 }
 

--- a/pkg/apis/servicecatalog/validation/instance_test.go
+++ b/pkg/apis/servicecatalog/validation/instance_test.go
@@ -156,6 +156,22 @@ func validServiceInstanceWithInProgressDeprovision() *servicecatalog.ServiceInst
 	return instance
 }
 
+func validServiceInstanceUserProvided() *servicecatalog.ServiceInstance {
+	return &servicecatalog.ServiceInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-instance",
+			Namespace:  "test-ns",
+			Generation: 1,
+		},
+		Spec: servicecatalog.ServiceInstanceSpec{
+			UserProvided: true,
+		},
+		Status: servicecatalog.ServiceInstanceStatus{
+			DeprovisionStatus: servicecatalog.ServiceInstanceDeprovisionStatusNotRequired,
+		},
+	}
+}
+
 func validServiceInstancePropertiesStateClusterPlan() *servicecatalog.ServiceInstancePropertiesState {
 	return &servicecatalog.ServiceInstancePropertiesState{
 		ClusterServicePlanExternalName: "plan-name",
@@ -887,6 +903,11 @@ func TestValidateServiceInstance(t *testing.T) {
 				return i
 			}(),
 			valid: false,
+		},
+		{
+			name:     "valid user provided instance",
+			instance: validServiceInstanceUserProvided(),
+			valid:    true,
 		},
 	}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -761,6 +761,15 @@ func getTestServiceInstanceWithNamespacedRefs() *v1beta1.ServiceInstance {
 	return sc
 }
 
+func getTestServiceInstanceUserProvided() *v1beta1.ServiceInstance {
+	sc := getTestServiceInstance()
+	sc.Spec.ClusterServiceClassExternalName = ""
+	sc.Spec.ClusterServicePlanExternalName = ""
+	sc.Spec.ExternalID = ""
+	sc.Spec.UserProvided = true
+	return sc
+}
+
 func getTestServiceInstanceWithRefsAndExternalProperties() *v1beta1.ServiceInstance {
 	sc := getTestServiceInstanceWithClusterRefs()
 	sc.Status.ExternalProperties = &v1beta1.ServiceInstancePropertiesState{

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3011,7 +3011,15 @@ func schema_pkg_apis_servicecatalog_v1beta1_ServiceInstanceSpec(ref common.Refer
 							Format:      "int64",
 						},
 					},
+					"userProvided": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UserProvided indicates this instance is a user provided service instance. If true, bind requests will return \"credentials\" from the instance's parameters.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
+				Required: []string{"userProvided"},
 			},
 		},
 		Dependencies: []string{
@@ -3125,8 +3133,15 @@ func schema_pkg_apis_servicecatalog_v1beta1_ServiceInstanceStatus(ref common.Ref
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
+					"UserProvided": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UserProvided indicates this instance is a user provided service instance. If true, bind requests will return \"credentials\" from the instance's parameters.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
-				Required: []string{"conditions", "asyncOpInProgress", "orphanMitigationInProgress", "reconciledGeneration", "observedGeneration", "provisionStatus", "deprovisionStatus"},
+				Required: []string{"conditions", "asyncOpInProgress", "orphanMitigationInProgress", "reconciledGeneration", "observedGeneration", "provisionStatus", "deprovisionStatus", "UserProvided"},
 			},
 		},
 		Dependencies: []string{

--- a/plugin/pkg/admission/serviceplan/defaultserviceplan/admission.go
+++ b/plugin/pkg/admission/serviceplan/defaultserviceplan/admission.go
@@ -73,9 +73,9 @@ func (d *defaultServicePlan) Admit(a admission.Attributes) error {
 		return apierrors.NewBadRequest("Resource was marked with kind ServiceInstance but was unable to be converted")
 	}
 
-	// If the plan is specified, let it through and have the controller
-	// deal with finding the right plan, etc.
-	if instance.Spec.ClusterServicePlanSpecified() || instance.Spec.ServicePlanSpecified() {
+	// If the plan is specified or the instance is a user-provided-service,
+	// let it through and have the controller deal with finding the right plan, etc.
+	if instance.Spec.ClusterServicePlanSpecified() || instance.Spec.ServicePlanSpecified() || instance.Spec.UserProvided {
 		return nil
 	}
 

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -50,6 +50,7 @@ func TestCreateServiceInstanceNonExistentClusterServiceClassOrPlan(t *testing.T)
 		classK8sName        string
 		planK8sName         string
 		expectedErrorReason string
+		userProvided        bool
 	}{
 		{
 			name:                "existent external class and plan name",
@@ -123,6 +124,11 @@ func TestCreateServiceInstanceNonExistentClusterServiceClassOrPlan(t *testing.T)
 			planK8sName:         "nothereplan",
 			expectedErrorReason: "ReferencesNonexistentServiceClass",
 		},
+		{
+			name:                "user provided service",
+			userProvided:        true,
+			expectedErrorReason: "",
+		},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -138,6 +144,7 @@ func TestCreateServiceInstanceNonExistentClusterServiceClassOrPlan(t *testing.T)
 					i.Spec.PlanReference.ClusterServicePlanExternalID = tc.planExternalID
 					i.Spec.PlanReference.ClusterServiceClassName = tc.classK8sName
 					i.Spec.PlanReference.ClusterServicePlanName = tc.planK8sName
+					i.Spec.UserProvided = tc.userProvided
 					return i
 				}(),
 				skipVerifyingInstanceSuccess: tc.expectedErrorReason != "",
@@ -928,15 +935,14 @@ func TestUpdateServiceInstanceUpdateParameters(t *testing.T) {
 // with/without retries.
 func TestCreateServiceInstanceWithRetries(t *testing.T) {
 	cases := []struct {
-		name                        string
-		setup                func(ct *controllerTest)
+		name  string
+		setup func(ct *controllerTest)
 	}{
 		{
 			name: "no retry",
 			setup: func(ct *controllerTest) {
 				ct.osbClient.ProvisionReaction = &fakeosb.ProvisionReaction{
-					Response: &osb.ProvisionResponse{
-					},
+					Response: &osb.ProvisionResponse{},
 				}
 			},
 		},
@@ -953,8 +959,7 @@ func TestCreateServiceInstanceWithRetries(t *testing.T) {
 							},
 						},
 						fakeosb.ProvisionReaction{
-							Response: &osb.ProvisionResponse{
-							},
+							Response: &osb.ProvisionResponse{},
 						},
 					}))
 			},
@@ -972,8 +977,7 @@ func TestCreateServiceInstanceWithRetries(t *testing.T) {
 							},
 						},
 						fakeosb.ProvisionReaction{
-							Response: &osb.ProvisionResponse{
-							},
+							Response: &osb.ProvisionResponse{},
 						},
 					}))
 			},
@@ -984,8 +988,8 @@ func TestCreateServiceInstanceWithRetries(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ct := &controllerTest{
-				t:      t,
-				broker: getTestBroker(),
+				t:        t,
+				broker:   getTestBroker(),
 				instance: getTestInstance(),
 			}
 			ct.setup = tc.setup


### PR DESCRIPTION
This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
This PR implements User Provided Services, where a user can provision a service instance that is not associated with an extant service plan, class, or broker. This is typically used to use some pre-existing database and manage use of it with the normal service-catalog workflow.

Docs to follow, submitting this now to get some input on the viability of this method of implementation.

**Which issue(s) this PR fixes** 
Fixes #2189

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
