### PR TITLE
WIP: Define default binding params on plans 

### DIFF
--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -478,6 +478,13 @@ type CommonServiceClassSpec struct {
 	// plan and then instance-defined parameters taking precedence over the class
 	// defaults.
 	DefaultProvisionParameters *runtime.RawExtension
+
+	// DefaultBindingParameters are default parameters passed to the broker
+	// when an instance of this class is binded. Any parameters defined on
+	// the plan and binding are merged with these defaults, with
+	// plan and then binding-defined parameters taking precedence over the class
+	// defaults.
+	DefaultBindingParameters *runtime.RawExtension
 }
 
 // ClusterServiceClassSpec represents the details about a ClusterServiceClass.
@@ -589,6 +596,12 @@ type CommonServicePlanSpec struct {
 	// the instance are merged with these defaults, with instance-defined
 	// parameters taking precedence over defaults.
 	DefaultProvisionParameters *runtime.RawExtension
+
+	// DefaultBindingParameters are default parameters passed to the broker
+	// when an instance of this plan is binded. Any parameters defined on
+	// the binding are merged with these defaults, with binding-defined
+	// parameters taking precedence over defaults.
+	DefaultBindingParameters *runtime.RawExtension
 }
 
 // ClusterServicePlanSpec represents details about the ClusterServicePlan
@@ -1148,6 +1161,10 @@ type ServiceBindingStatus struct {
 
 	// UnbindStatus describes what has been done to unbind a ServiceBinding
 	UnbindStatus ServiceBindingUnbindStatus
+
+	// DefaultBindingParameters are the default parameters applied to this
+	// binding.
+	DefaultBindingParameters *runtime.RawExtension
 }
 
 // ServiceBindingCondition condition information for a ServiceBinding.

--- a/pkg/apis/servicecatalog/unstructured_test.go
+++ b/pkg/apis/servicecatalog/unstructured_test.go
@@ -71,6 +71,7 @@ func doUnstructuredRoundTrip(t *testing.T, group testapi.TestGroup, kind string)
 		},
 		func(is *servicecatalog.CommonServicePlanSpec, c fuzz.Continue) {
 			c.FuzzNoCustom(is)
+			is.DefaultBindingParameters = nil
 			is.DefaultProvisionParameters = nil
 			is.ExternalMetadata = nil
 			is.ServiceBindingCreateParameterSchema = nil
@@ -80,6 +81,7 @@ func doUnstructuredRoundTrip(t *testing.T, group testapi.TestGroup, kind string)
 		},
 		func(cs *servicecatalog.CommonServiceClassSpec, c fuzz.Continue) {
 			c.FuzzNoCustom(cs)
+			cs.DefaultBindingParameters = nil
 			cs.DefaultProvisionParameters = nil
 			cs.ExternalMetadata = nil
 		},
@@ -94,6 +96,10 @@ func doUnstructuredRoundTrip(t *testing.T, group testapi.TestGroup, kind string)
 				bs.SecretName = c.RandString()
 			}
 			bs.Parameters = nil
+		},
+		func(bs *servicecatalog.ServiceBindingStatus, c fuzz.Continue) {
+			c.FuzzNoCustom(bs)
+			bs.DefaultBindingParameters = nil
 		},
 		func(ps *servicecatalog.ServiceInstancePropertiesState, c fuzz.Continue) {
 			c.FuzzNoCustom(ps)

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -521,6 +521,13 @@ type CommonServiceClassSpec struct {
 	// plan and then instance-defined parameters taking precedence over the class
 	// defaults.
 	DefaultProvisionParameters *runtime.RawExtension `json:"defaultProvisionParameters,omitempty"`
+
+	// DefaultBindingParameters are default parameters passed to the broker
+	// when an instance of this class is binded. Any parameters defined on
+	// the plan and binding are merged with these defaults, with
+	// plan and then binding-defined parameters taking precedence over the class
+	// defaults.
+	DefaultBindingParameters *runtime.RawExtension `json:"defaultBindingParameters,omitempty"`
 }
 
 // ClusterServiceClassSpec represents the details about a ClusterServiceClass
@@ -647,6 +654,12 @@ type CommonServicePlanSpec struct {
 	// the instance are merged with these defaults, with instance-defined
 	// parameters taking precedence over defaults.
 	DefaultProvisionParameters *runtime.RawExtension `json:"defaultProvisionParameters,omitempty"`
+
+	// DefaultBindingParameters are default parameters passed to the broker
+	// when an instance of this plan is binded. Any parameters defined on
+	// the binding are merged with these defaults, with binding-defined
+	// parameters taking precedence over defaults.
+	DefaultBindingParameters *runtime.RawExtension `json:"defaultBindingParameters,omitempty"`
 }
 
 // ClusterServicePlanSpec represents details about a ClusterServicePlan.
@@ -1248,6 +1261,10 @@ type ServiceBindingStatus struct {
 
 	// UnbindStatus describes what has been done to unbind the ServiceBinding.
 	UnbindStatus ServiceBindingUnbindStatus `json:"unbindStatus"`
+
+	// DefaultBindingParameters are the default parameters applied to this
+	// binding.
+	DefaultBindingParameters *runtime.RawExtension `json:"defaultBindingParameters,omitempty"`
 }
 
 // ServiceBindingCondition condition information for a ServiceBinding.

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.conversion.go
@@ -1236,6 +1236,7 @@ func autoConvert_v1beta1_CommonServiceClassSpec_To_servicecatalog_CommonServiceC
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	out.Requires = *(*[]string)(unsafe.Pointer(&in.Requires))
 	out.DefaultProvisionParameters = (*runtime.RawExtension)(unsafe.Pointer(in.DefaultProvisionParameters))
+	out.DefaultBindingParameters = (*runtime.RawExtension)(unsafe.Pointer(in.DefaultBindingParameters))
 	return nil
 }
 
@@ -1255,6 +1256,7 @@ func autoConvert_servicecatalog_CommonServiceClassSpec_To_v1beta1_CommonServiceC
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	out.Requires = *(*[]string)(unsafe.Pointer(&in.Requires))
 	out.DefaultProvisionParameters = (*runtime.RawExtension)(unsafe.Pointer(in.DefaultProvisionParameters))
+	out.DefaultBindingParameters = (*runtime.RawExtension)(unsafe.Pointer(in.DefaultBindingParameters))
 	return nil
 }
 
@@ -1295,6 +1297,7 @@ func autoConvert_v1beta1_CommonServicePlanSpec_To_servicecatalog_CommonServicePl
 	out.ServiceBindingCreateParameterSchema = (*runtime.RawExtension)(unsafe.Pointer(in.ServiceBindingCreateParameterSchema))
 	out.ServiceBindingCreateResponseSchema = (*runtime.RawExtension)(unsafe.Pointer(in.ServiceBindingCreateResponseSchema))
 	out.DefaultProvisionParameters = (*runtime.RawExtension)(unsafe.Pointer(in.DefaultProvisionParameters))
+	out.DefaultBindingParameters = (*runtime.RawExtension)(unsafe.Pointer(in.DefaultBindingParameters))
 	return nil
 }
 
@@ -1315,6 +1318,7 @@ func autoConvert_servicecatalog_CommonServicePlanSpec_To_v1beta1_CommonServicePl
 	out.ServiceBindingCreateParameterSchema = (*runtime.RawExtension)(unsafe.Pointer(in.ServiceBindingCreateParameterSchema))
 	out.ServiceBindingCreateResponseSchema = (*runtime.RawExtension)(unsafe.Pointer(in.ServiceBindingCreateResponseSchema))
 	out.DefaultProvisionParameters = (*runtime.RawExtension)(unsafe.Pointer(in.DefaultProvisionParameters))
+	out.DefaultBindingParameters = (*runtime.RawExtension)(unsafe.Pointer(in.DefaultBindingParameters))
 	return nil
 }
 
@@ -1690,6 +1694,7 @@ func autoConvert_v1beta1_ServiceBindingStatus_To_servicecatalog_ServiceBindingSt
 	out.ExternalProperties = (*servicecatalog.ServiceBindingPropertiesState)(unsafe.Pointer(in.ExternalProperties))
 	out.OrphanMitigationInProgress = in.OrphanMitigationInProgress
 	out.UnbindStatus = servicecatalog.ServiceBindingUnbindStatus(in.UnbindStatus)
+	out.DefaultBindingParameters = (*runtime.RawExtension)(unsafe.Pointer(in.DefaultBindingParameters))
 	return nil
 }
 
@@ -1709,6 +1714,7 @@ func autoConvert_servicecatalog_ServiceBindingStatus_To_v1beta1_ServiceBindingSt
 	out.ExternalProperties = (*ServiceBindingPropertiesState)(unsafe.Pointer(in.ExternalProperties))
 	out.OrphanMitigationInProgress = in.OrphanMitigationInProgress
 	out.UnbindStatus = ServiceBindingUnbindStatus(in.UnbindStatus)
+	out.DefaultBindingParameters = (*runtime.RawExtension)(unsafe.Pointer(in.DefaultBindingParameters))
 	return nil
 }
 

--- a/pkg/apis/servicecatalog/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/v1beta1/zz_generated.deepcopy.go
@@ -602,12 +602,13 @@ func (in *CommonServiceClassSpec) DeepCopyInto(out *CommonServiceClassSpec) {
 	}
 	if in.DefaultProvisionParameters != nil {
 		in, out := &in.DefaultProvisionParameters, &out.DefaultProvisionParameters
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(runtime.RawExtension)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.DefaultBindingParameters != nil {
+		in, out := &in.DefaultBindingParameters, &out.DefaultBindingParameters
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -673,6 +674,11 @@ func (in *CommonServicePlanSpec) DeepCopyInto(out *CommonServicePlanSpec) {
 	}
 	if in.DefaultProvisionParameters != nil {
 		in, out := &in.DefaultProvisionParameters, &out.DefaultProvisionParameters
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.DefaultBindingParameters != nil {
+		in, out := &in.DefaultBindingParameters, &out.DefaultBindingParameters
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
@@ -1050,6 +1056,11 @@ func (in *ServiceBindingStatus) DeepCopyInto(out *ServiceBindingStatus) {
 	if in.ExternalProperties != nil {
 		in, out := &in.ExternalProperties, &out.ExternalProperties
 		*out = new(ServiceBindingPropertiesState)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.DefaultBindingParameters != nil {
+		in, out := &in.DefaultBindingParameters, &out.DefaultBindingParameters
+		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
 	return

--- a/pkg/apis/servicecatalog/zz_generated.deepcopy.go
+++ b/pkg/apis/servicecatalog/zz_generated.deepcopy.go
@@ -602,12 +602,13 @@ func (in *CommonServiceClassSpec) DeepCopyInto(out *CommonServiceClassSpec) {
 	}
 	if in.DefaultProvisionParameters != nil {
 		in, out := &in.DefaultProvisionParameters, &out.DefaultProvisionParameters
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(runtime.RawExtension)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.DefaultBindingParameters != nil {
+		in, out := &in.DefaultBindingParameters, &out.DefaultBindingParameters
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -673,6 +674,11 @@ func (in *CommonServicePlanSpec) DeepCopyInto(out *CommonServicePlanSpec) {
 	}
 	if in.DefaultProvisionParameters != nil {
 		in, out := &in.DefaultProvisionParameters, &out.DefaultProvisionParameters
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.DefaultBindingParameters != nil {
+		in, out := &in.DefaultBindingParameters, &out.DefaultBindingParameters
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
@@ -1050,6 +1056,11 @@ func (in *ServiceBindingStatus) DeepCopyInto(out *ServiceBindingStatus) {
 	if in.ExternalProperties != nil {
 		in, out := &in.ExternalProperties, &out.ExternalProperties
 		*out = new(ServiceBindingPropertiesState)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.DefaultBindingParameters != nil {
+		in, out := &in.DefaultBindingParameters, &out.DefaultBindingParameters
+		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
 	return

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -234,14 +234,16 @@ func (c *controller) reconcileServiceBindingAdd(binding *v1beta1.ServiceBinding)
 			return c.processServiceBindingOperationError(binding, readyCond)
 		}
 
-		// Apply default binding parameters, this must be done after we've resolved the class and plan
-		modified, err := c.applyDefaultBindingParameters(binding, instance)
-		if err != nil {
-			return err
-		}
-		if modified {
-			// the binding was updated with new parameters, so we need to continue in the next iteration
-			return nil
+		if utilfeature.DefaultFeatureGate.Enabled(scfeatures.ServicePlanDefaults) {
+			// Apply default binding parameters, this must be done after we've resolved the class and plan
+			modified, err := c.applyDefaultBindingParameters(binding, instance)
+			if err != nil {
+				return err
+			}
+			if modified {
+				// the binding was updated with new parameters, so we need to continue in the next iteration
+				return nil
+			}
 		}
 
 		glog.V(4).Info(pcb.Message("Adding/Updating"))
@@ -281,14 +283,16 @@ func (c *controller) reconcileServiceBindingAdd(binding *v1beta1.ServiceBinding)
 			return c.processServiceBindingOperationError(binding, readyCond)
 		}
 
-		// Apply default binding parameters, this must be done after we've resolved the class and plan
-		modified, err := c.applyDefaultBindingParameters(binding, instance)
-		if err != nil {
-			return err
-		}
-		if modified {
-			// the binding was updated with new parameters, so we need to continue in the next iteration
-			return nil
+		if utilfeature.DefaultFeatureGate.Enabled(scfeatures.ServicePlanDefaults) {
+			// Apply default binding parameters, this must be done after we've resolved the class and plan
+			modified, err := c.applyDefaultBindingParameters(binding, instance)
+			if err != nil {
+				return err
+			}
+			if modified {
+				// the binding was updated with new parameters, so we need to continue in the next iteration
+				return nil
+			}
 		}
 
 		glog.V(4).Info(pcb.Message("Adding/Updating"))

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -542,7 +542,12 @@ func TestReconcileServiceBindingWithParameters(t *testing.T) {
 // TestReconcileBindingAppliesDefaultBindingParameters tests reconcileBinding to ensure a
 // binding with default parameters will be passed to the broker properly.
 func TestReconcileBindingAppliesDefaultBindingParameters(t *testing.T) {
-	fakeKubeClient, fakeCatalogClient, _, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
+	err := utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=true", scfeatures.ServicePlanDefaults))
+	if err != nil {
+		t.Fatal("Cloud not enable ServicePlanDefaults feature flag.")
+	}
+
+	_, fakeCatalogClient, _, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
 		BindReaction: &fakeosb.BindReaction{
 			Response: &osb.BindResponse{
 				Credentials: map[string]interface{}{
@@ -552,9 +557,6 @@ func TestReconcileBindingAppliesDefaultBindingParameters(t *testing.T) {
 			},
 		},
 	})
-
-	addGetNamespaceReaction(fakeKubeClient)
-	addGetSecretNotFoundReaction(fakeKubeClient)
 
 	sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(getTestClusterServiceBroker())
 	sc := getTestClusterServiceClass()
@@ -611,6 +613,68 @@ func TestReconcileBindingAppliesDefaultBindingParameters(t *testing.T) {
 	if gotParams != defaultBindingParams {
 		t.Fatalf("DefaultBindingParameters was not persisted to the service binding status during reconcile.\n\nWANT: %s\nGOT: %s",
 			defaultBindingParams, gotParams)
+	}
+}
+
+func TestReconcileServiceBindingRespectsServicePlanDefaultsFeatureGate(t *testing.T) {
+	err := utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%v=false", scfeatures.ServicePlanDefaults))
+	if err != nil {
+		t.Fatal("Cloud not disable ServicePlanDefaults feature flag.")
+	}
+
+	_, fakeCatalogClient, _, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
+		BindReaction: &fakeosb.BindReaction{
+			Response: &osb.BindResponse{
+				Credentials: map[string]interface{}{
+					"a": "b",
+					"c": "d",
+				},
+			},
+		},
+	})
+
+	sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(getTestClusterServiceBroker())
+	sc := getTestClusterServiceClass()
+	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(sc)
+	sp := getTestClusterServicePlan()
+
+	// Setup default parameters on the plan
+	defaultBindingParams := `{"name": "test-default-param"}`
+	sp.Spec.DefaultBindingParameters = &runtime.RawExtension{Raw: []byte(defaultBindingParams)}
+	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(sp)
+	sharedInformers.ServiceInstances().Informer().GetStore().Add(getTestServiceInstanceWithStatus(v1beta1.ConditionTrue))
+
+	binding := &v1beta1.ServiceBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testServiceBindingName,
+			Namespace:  testNamespace,
+			Finalizers: []string{v1beta1.FinalizerServiceCatalog},
+			Generation: 1,
+		},
+		Spec: v1beta1.ServiceBindingSpec{
+			ServiceInstanceRef: v1beta1.LocalObjectReference{Name: testServiceInstanceName},
+			ExternalID:         testServiceBindingGUID,
+			SecretName:         testServiceBindingSecretName,
+		},
+		Status: v1beta1.ServiceBindingStatus{
+			UnbindStatus: v1beta1.ServiceBindingUnbindStatusNotRequired,
+		},
+	}
+
+	if err := reconcileServiceBinding(t, testController, binding); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	actions := fakeCatalogClient.Actions()
+	assertNumberOfActions(t, actions, 1)
+
+	// Check that the default binding parameters were saved on the status
+	updatedServiceBinding, ok := assertUpdateStatus(t, actions[0], binding).(*v1beta1.ServiceBinding)
+	if !ok {
+		t.Fatal("couldn't convert to *v1beta1.ServiceBinding")
+	}
+	if updatedServiceBinding.Status.DefaultBindingParameters != nil {
+		t.Fatal("DefaultBindingParameters should not be set on the status because the feature is disabled")
 	}
 }
 


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

Similar to how we added DefaultProvisionParameters to plans in #2282, we also want the same type of functionality but for the parameters on ServiceBinding resources.

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #2348 

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update

TODO:
 - [x] reconcile binding and default params
 - [x] add test codes
 - [ ] add docs