### PR TITLE
fix register cluster broker without auth info

### DIFF
--- a/pkg/svcat/service-catalog/broker.go
+++ b/pkg/svcat/service-catalog/broker.go
@@ -160,8 +160,8 @@ func (sdk *SDK) Register(brokerName string, url string, opts *RegisterOptions, s
 				CommonServiceBrokerSpec: commonServiceBrokerSpec,
 			},
 		}
-		request.Spec.AuthInfo = &v1beta1.ClusterServiceBrokerAuthInfo{}
 		if opts.BasicSecret != "" {
+			request.Spec.AuthInfo = &v1beta1.ClusterServiceBrokerAuthInfo{}
 			request.Spec.AuthInfo.Basic = &v1beta1.ClusterBasicAuthConfig{
 				SecretRef: &v1beta1.ObjectReference{
 					Name:      opts.BasicSecret,
@@ -169,6 +169,7 @@ func (sdk *SDK) Register(brokerName string, url string, opts *RegisterOptions, s
 				},
 			}
 		} else if opts.BearerSecret != "" {
+			request.Spec.AuthInfo = &v1beta1.ClusterServiceBrokerAuthInfo{}
 			request.Spec.AuthInfo.Bearer = &v1beta1.ClusterBearerTokenAuthConfig{
 				SecretRef: &v1beta1.ObjectReference{
 					Name:      opts.BearerSecret,

--- a/pkg/svcat/service-catalog/broker_test.go
+++ b/pkg/svcat/service-catalog/broker_test.go
@@ -441,6 +441,32 @@ var _ = Describe("Broker", func() {
 			Expect(objectFromRequest.Spec.URL).To(Equal(url))
 			Expect(objectFromRequest.Spec.AuthInfo.Bearer.SecretRef.Name).To(Equal(bearerSecret))
 		})
+		It("creates a cluster service broker without auth info", func() {
+			brokerName := "potato_broker"
+			url := "http://potato.com"
+			namespace := "potatonamespace"
+			opts := &RegisterOptions{
+				Namespace: namespace,
+			}
+			scopeOpts := &ScopeOptions{
+				Namespace: namespace,
+				Scope:     ClusterScope,
+			}
+
+			broker, err := sdk.Register(brokerName, url, opts, scopeOpts)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(broker).NotTo(BeNil())
+			Expect(broker.GetName()).To(Equal(brokerName))
+			Expect(broker.GetURL()).To(Equal(url))
+
+			actions := svcCatClient.Actions()
+			Expect(actions[0].Matches("create", "clusterservicebrokers")).To(BeTrue())
+			objectFromRequest := actions[0].(testing.CreateActionImpl).Object.(*v1beta1.ClusterServiceBroker)
+			Expect(objectFromRequest.ObjectMeta.Name).To(Equal(brokerName))
+			Expect(objectFromRequest.Spec.URL).To(Equal(url))
+			Expect(objectFromRequest.Spec.AuthInfo).To(BeNil())
+		})
 		It("Bubbles up cluster service broker errors", func() {
 			errorMessage := "error provisioning broker"
 			brokerName := "potato_broker"


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

we can not register a cluster broker without auth info

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #2445

