### PR TITLE
refactor svcat extra commands into single package

### DIFF
--- a/cmd/svcat/extra/completion_cmd.go
+++ b/cmd/svcat/extra/completion_cmd.go
@@ -14,14 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package completion
+package extra
 
 import (
 	"bytes"
 	"fmt"
+	"io"
+
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
 	"github.com/spf13/cobra"
-	"io"
 )
 
 var (
@@ -67,7 +68,9 @@ var (
 	}
 )
 
-type completionCmd struct {
+// CompletionCmd Contains the information needed to add auto-completion
+// to the user's shell
+type CompletionCmd struct {
 	*command.Context
 	command  *cobra.Command
 	shellgen func(w io.Writer, cmd *cobra.Command) error
@@ -75,7 +78,7 @@ type completionCmd struct {
 
 // NewCompletionCmd return command for executing "svcat completion" command
 func NewCompletionCmd(cxt *command.Context) *cobra.Command {
-	completionCmd := &completionCmd{Context: cxt}
+	completionCmd := &CompletionCmd{Context: cxt}
 
 	shells := []string{}
 	for s := range completionShells {
@@ -97,7 +100,9 @@ func NewCompletionCmd(cxt *command.Context) *cobra.Command {
 	return cmd
 }
 
-func (c *completionCmd) Validate(args []string) error {
+// Validate ensures the user entered the name
+// of a supported shell
+func (c *CompletionCmd) Validate(args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("Shell not specified")
 	}
@@ -114,7 +119,9 @@ func (c *completionCmd) Validate(args []string) error {
 	return nil
 }
 
-func (c *completionCmd) Run() error {
+// Run generated the completion data
+// and writes it to disk
+func (c *CompletionCmd) Run() error {
 	return c.shellgen(c.Output, c.command)
 }
 

--- a/cmd/svcat/extra/completion_cmd_test.go
+++ b/cmd/svcat/extra/completion_cmd_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extra_test
+
+import (
+	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
+	. "github.com/kubernetes-incubator/service-catalog/cmd/svcat/extra"
+	_ "github.com/kubernetes-incubator/service-catalog/internal/test"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Completion Command", func() {
+	Describe("NewCompletionCmd", func() {
+		It("Builds and returns a cobra command with the correct flags", func() {
+			cxt := &command.Context{}
+			cmd := NewCompletionCmd(cxt)
+			Expect(*cmd).NotTo(BeNil())
+
+			Expect(cmd.Use).To(Equal("completion SHELL"))
+			Expect(cmd.Short).To(ContainSubstring("Output shell completion code for the specified shell"))
+		})
+	})
+	Describe("Validate", func() {
+		It("succeeds if a shell name is provided", func() {
+			cmd := CompletionCmd{}
+			err := cmd.Validate([]string{"bash"})
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd = CompletionCmd{}
+			err = cmd.Validate([]string{"zsh"})
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("errors if a shell name is not provided", func() {
+			cmd := CompletionCmd{}
+			err := cmd.Validate([]string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Shell not specified"))
+		})
+		It("errors if provided the name of an unsupported shell", func() {
+			cmd := CompletionCmd{}
+			err := cmd.Validate([]string{"csh"})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Unsupported shell type"))
+		})
+	})
+	Describe("Run", func() {
+		It("floops the pig", func() {
+		})
+	})
+})

--- a/cmd/svcat/extra/version_cmd.go
+++ b/cmd/svcat/extra/version_cmd.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package versions
+package extra
 
 import (
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
@@ -23,15 +23,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type versionCmd struct {
+// VersionCmd contains the information needed to print the version
+// of svcat and the targeted Service Catalog to the user
+type VersionCmd struct {
 	*command.Context
-	client bool
-	server bool
+	Client bool
+	Server bool
 }
 
 // NewVersionCmd builds a "svcat version" command
 func NewVersionCmd(cxt *command.Context) *cobra.Command {
-	versionCmd := &versionCmd{Context: cxt}
+	versionCmd := &VersionCmd{Context: cxt}
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Provides the version for the Service Catalog client and server",
@@ -43,7 +45,7 @@ func NewVersionCmd(cxt *command.Context) *cobra.Command {
 		RunE:    command.RunE(versionCmd),
 	}
 	cmd.Flags().BoolVarP(
-		&versionCmd.client,
+		&versionCmd.Client,
 		"client",
 		"c",
 		false,
@@ -53,24 +55,27 @@ func NewVersionCmd(cxt *command.Context) *cobra.Command {
 	return cmd
 }
 
-func (c *versionCmd) Validate(args []string) error {
-	if !c.client && !c.server {
-		c.client = true
-		c.server = true
+// Validate defaults the client and server to true
+func (c *VersionCmd) Validate(args []string) error {
+	if !c.Client && !c.Server {
+		c.Client = true
+		c.Server = true
 	}
 	return nil
 }
 
-func (c *versionCmd) Run() error {
+// Run  determines the versions of svcat and/or
+// the platform and prints them
+func (c *VersionCmd) Run() error {
 	return c.version()
 }
 
-func (c *versionCmd) version() error {
-	if c.client {
+func (c *VersionCmd) version() error {
+	if c.Client {
 		output.WriteClientVersion(c.Output, pkg.VERSION)
 	}
 
-	if c.server {
+	if c.Server {
 		version, err := c.App.ServerVersion()
 		if err != nil {
 			return err

--- a/cmd/svcat/extra/version_cmd_test.go
+++ b/cmd/svcat/extra/version_cmd_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package versions
+package extra_test
 
 import (
 	"bytes"
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
+	. "github.com/kubernetes-incubator/service-catalog/cmd/svcat/extra"
 	"github.com/kubernetes-incubator/service-catalog/pkg"
 	svcatfake "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/fake"
 	"github.com/kubernetes-incubator/service-catalog/pkg/svcat"
@@ -66,10 +67,10 @@ func TestVersionCommand(t *testing.T) {
 				Output: output,
 				App:    fakeApp,
 			}
-			versionCommand := &versionCmd{
-				cxt,
-				tc.client,
-				tc.server,
+			versionCommand := &VersionCmd{
+				Context: cxt,
+				Client:  tc.client,
+				Server:  tc.server,
 			}
 
 			err := versionCommand.Run()

--- a/cmd/svcat/main.go
+++ b/cmd/svcat/main.go
@@ -30,12 +30,10 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/broker"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/class"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
-	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/completion"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/extra"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/instance"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/plan"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/plugin"
-	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/versions"
 	svcatclient "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
 	"github.com/kubernetes-incubator/service-catalog/pkg/svcat"
 	"github.com/kubernetes-incubator/service-catalog/pkg/util/kube"
@@ -125,14 +123,14 @@ func buildRootCommand(cxt *command.Context) *cobra.Command {
 	cmd.AddCommand(instance.NewDeprovisionCmd(cxt))
 	cmd.AddCommand(binding.NewBindCmd(cxt))
 	cmd.AddCommand(binding.NewUnbindCmd(cxt))
-	cmd.AddCommand(extra.NewMarketplaceCmd(cxt))
 	cmd.AddCommand(newSyncCmd(cxt))
 	if !plugin.IsPlugin() {
 		cmd.AddCommand(newInstallCmd(cxt))
 	}
 	cmd.AddCommand(newTouchCmd(cxt))
-	cmd.AddCommand(versions.NewVersionCmd(cxt))
-	cmd.AddCommand(newCompletionCmd(cxt))
+	cmd.AddCommand(extra.NewVersionCmd(cxt))
+	cmd.AddCommand(extra.NewMarketplaceCmd(cxt))
+	cmd.AddCommand(extra.NewCompletionCmd(cxt))
 
 	return cmd
 }
@@ -203,10 +201,6 @@ func newTouchCmd(cxt *command.Context) *cobra.Command {
 	}
 	cmd.AddCommand(instance.NewTouchCommand(cxt))
 	return cmd
-}
-
-func newCompletionCmd(ctx *command.Context) *cobra.Command {
-	return completion.NewCompletionCmd(ctx)
 }
 
 // getClients loads api clients based on the plugin context if present, otherwise the specified kube config.


### PR DESCRIPTION
This PR is a 
 - [ ] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation
 - [x] Refactor

**What this PR does / why we need it**:
Rather than having all these extra commands in their own directories, refactor them into a single location. I left the plugin stuff in its own dir because that is changing in the very near future and is subject to change/being deleted.

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
