### PR TITLE
Controller redesign: perform all steps in a single reconciler invocation

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2521,10 +2521,6 @@ func assertServiceInstanceErrorBeforeRequest(t *testing.T, obj runtime.Object, r
 	assertServiceInstanceDeprovisionStatus(t, obj, originalInstance.Status.DeprovisionStatus)
 }
 
-func assertServiceInstanceOperationInProgress(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, planName, planID string, originalInstance *v1beta1.ServiceInstance) {
-	assertServiceInstanceOperationInProgressWithParameters(t, obj, operation, planName, planID, nil, "", originalInstance)
-}
-
 func assertServiceInstanceOperationInProgressWithParameters(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, planName, planID string, inProgressParameters map[string]interface{}, inProgressParametersChecksum string, originalInstance *v1beta1.ServiceInstance) {
 	reason := ""
 	var expectedObservedGeneration int64
@@ -2567,10 +2563,6 @@ func assertServiceInstanceStartingOrphanMitigation(t *testing.T, obj runtime.Obj
 	assertServiceInstanceOrphanMitigationTrue(t, obj, errorProvisionCallFailedReason)
 	assertServiceInstanceOrphanMitigationInProgressTrue(t, obj)
 	assertServiceInstanceDeprovisionStatus(t, obj, v1beta1.ServiceInstanceDeprovisionStatusRequired)
-}
-
-func assertServiceInstanceOperationSuccess(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, planName, planID string, originalInstance *v1beta1.ServiceInstance) {
-	assertServiceInstanceOperationSuccessWithParameters(t, obj, operation, planName, planID, nil, "", originalInstance)
 }
 
 func assertServiceInstanceOperationSuccessWithParameters(t *testing.T, obj runtime.Object, operation v1beta1.ServiceInstanceOperation, planName, planID string, externalParameters map[string]interface{}, externalParametersChecksum string, originalInstance *v1beta1.ServiceInstance) {
@@ -3481,7 +3473,7 @@ func assertListRestrictions(t *testing.T, e, a clientgotesting.ListRestrictions)
 func assertNumberOfBrokerActions(t *testing.T, actions []fakeosb.Action, number int) {
 	if e, a := number, len(actions); e != a {
 		t.Logf("%+v\n", actions)
-		fatalf(t, "Unexpected number of actions: expected %v, got %v\nactions: %+v", e, a, actions)
+		fatalf(t, "Unexpected number of broker actions: expected %v, got %v\nactions: %+v", e, a, actions)
 	}
 }
 


### PR DESCRIPTION
Previously, the controller performed only one step per invocation of the
reconcile function. It then updated the object (it's status) and exited.
When the watch event caused by the update came back to the controller,
it continued with the next step. This method of operation does not fit
well with exponential backoff on errors, because a successfully
performed step resets the backoff, rendering the whole backoff system
useless.

This commit solves this problem by performing all necessary actions
in a single invocation of the reconcile function. At the end of each step
(when it performs the status update), the controller takes the updated
object and works with it instead of the original object.

The watch events that come into the controller (as a result of the
status updates) are now ignored. This prevents the controller from doing
the same work multiple times.

 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #2076

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
