### PR TITLE
Simplify & improve performance of PrettyContextBuilder

### DIFF
--- a/pkg/pretty/context_builder.go
+++ b/pkg/pretty/context_builder.go
@@ -116,11 +116,11 @@ func (pcb ContextBuilder) String() string {
 		}
 	}
 	if pcb.Namespace != "" && pcb.Name != "" {
-		s += string('"') + pcb.Namespace + "/" + pcb.Name + string('"')
+		s += `"` + pcb.Namespace + "/" + pcb.Name + `"`
 	} else if pcb.Namespace != "" {
-		s += string('"') + pcb.Namespace + string('"')
+		s += `"` + pcb.Namespace + `"`
 	} else if pcb.Name != "" {
-		s += string('"') + pcb.Name + string('"')
+		s += `"`+ pcb.Name + `"`
 	}
 
 	if pcb.ResourceVersion != "" {

--- a/pkg/pretty/context_builder.go
+++ b/pkg/pretty/context_builder.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pretty
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
@@ -108,22 +109,42 @@ func (pcb *ContextBuilder) Messagef(format string, a ...interface{}) string {
 
 // TODO(n3wscott): Support <type> (K8S: <K8S-Type-Name> ExternalName: <External-Type-Name>)
 
+//func (pcb ContextBuilder) String() string {
+//	s := ""
+//	space := ""
+//	if pcb.Kind > 0 {
+//		s += fmt.Sprintf("%s", pcb.Kind)
+//		space = " "
+//	}
+//	if pcb.Namespace != "" && pcb.Name != "" {
+//		s += fmt.Sprintf(`%s"%s/%s"`, space, pcb.Namespace, pcb.Name)
+//	} else if pcb.Namespace != "" {
+//		s += fmt.Sprintf(`%s"%s"`, space, pcb.Namespace)
+//	} else if pcb.Name != "" {
+//		s += fmt.Sprintf(`%s"%s"`, space, pcb.Name)
+//	}
+//	if pcb.ResourceVersion != "" {
+//		s += fmt.Sprintf(" v%s", pcb.ResourceVersion)
+//	}
+//	return s
+//}
+
 func (pcb ContextBuilder) String() string {
-	s := ""
-	space := ""
+	var buffer bytes.Buffer
+	space := " "
 	if pcb.Kind > 0 {
-		s += fmt.Sprintf("%s", pcb.Kind)
-		space = " "
+		buffer.WriteString(fmt.Sprintf("%s", pcb.Kind))
 	}
+
 	if pcb.Namespace != "" && pcb.Name != "" {
-		s += fmt.Sprintf(`%s"%s/%s"`, space, pcb.Namespace, pcb.Name)
+		buffer.WriteString(fmt.Sprintf(`%s"%s/%s"`, space, pcb.Namespace, pcb.Name))
 	} else if pcb.Namespace != "" {
-		s += fmt.Sprintf(`%s"%s"`, space, pcb.Namespace)
+		buffer.WriteString(fmt.Sprintf(`%s"%s"`, space, pcb.Namespace))
 	} else if pcb.Name != "" {
-		s += fmt.Sprintf(`%s"%s"`, space, pcb.Name)
+		buffer.WriteString(fmt.Sprintf(`%s"%s"`, space, pcb.Name))
 	}
 	if pcb.ResourceVersion != "" {
-		s += fmt.Sprintf(" v%s", pcb.ResourceVersion)
+		buffer.WriteString(fmt.Sprintf(" v%s", pcb.ResourceVersion))
 	}
-	return s
+	return buffer.String()
 }

--- a/pkg/pretty/context_builder.go
+++ b/pkg/pretty/context_builder.go
@@ -19,7 +19,6 @@ package pretty
 import (
 	"bytes"
 	"fmt"
-
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -131,21 +130,22 @@ func (pcb *ContextBuilder) Messagef(format string, a ...interface{}) string {
 
 func (pcb ContextBuilder) String() string {
 	var buffer bytes.Buffer
-	space := ""
 	if pcb.Kind > 0 {
-		buffer.WriteString(fmt.Sprintf("%s", pcb.Kind))
-                space = " "
+		buffer.WriteString(pcb.Kind.String())
+		if pcb.Name != "" || pcb.Namespace != "" {
+			buffer.WriteString(" ")
+		}
+	}
+	if pcb.Namespace != "" && pcb.Name != "" {
+		buffer.WriteString("\"" + pcb.Namespace + "/" + pcb.Name + "\"")
+	} else if pcb.Namespace != "" {
+		buffer.WriteString("\"" + pcb.Namespace + "\"")
+	} else if pcb.Name != "" {
+		buffer.WriteString("\"" + pcb.Name + "\"")
 	}
 
-	if pcb.Namespace != "" && pcb.Name != "" {
-		buffer.WriteString(fmt.Sprintf(`%s"%s/%s"`, space, pcb.Namespace, pcb.Name))
-	} else if pcb.Namespace != "" {
-		buffer.WriteString(fmt.Sprintf(`%s"%s"`, space, pcb.Namespace))
-	} else if pcb.Name != "" {
-		buffer.WriteString(fmt.Sprintf(`%s"%s"`, space, pcb.Name))
-	}
 	if pcb.ResourceVersion != "" {
-		buffer.WriteString(fmt.Sprintf(" v%s", pcb.ResourceVersion))
+		buffer.WriteString("v" + pcb.ResourceVersion)
 	}
 	return buffer.String()
 }

--- a/pkg/pretty/context_builder.go
+++ b/pkg/pretty/context_builder.go
@@ -120,9 +120,8 @@ func (pcb ContextBuilder) String() string {
 	} else if pcb.Namespace != "" {
 		s += `"` + pcb.Namespace + `"`
 	} else if pcb.Name != "" {
-		s += `"`+ pcb.Name + `"`
+		s += `"` + pcb.Name + `"`
 	}
-
 	if pcb.ResourceVersion != "" {
 		s += " v" + pcb.ResourceVersion
 	}

--- a/pkg/pretty/context_builder.go
+++ b/pkg/pretty/context_builder.go
@@ -131,9 +131,10 @@ func (pcb *ContextBuilder) Messagef(format string, a ...interface{}) string {
 
 func (pcb ContextBuilder) String() string {
 	var buffer bytes.Buffer
-	space := " "
+	space := ""
 	if pcb.Kind > 0 {
 		buffer.WriteString(fmt.Sprintf("%s", pcb.Kind))
+                space = " "
 	}
 
 	if pcb.Namespace != "" && pcb.Name != "" {

--- a/pkg/pretty/context_builder.go
+++ b/pkg/pretty/context_builder.go
@@ -107,30 +107,6 @@ func (pcb *ContextBuilder) Messagef(format string, a ...interface{}) string {
 
 // TODO(n3wscott): Support <type> (K8S: <K8S-Type-Name> ExternalName: <External-Type-Name>)
 
-//no space no sprintf but buffer
-//func (pcb ContextBuilder) String() string {
-//	var buffer bytes.Buffer
-//	if pcb.Kind > 0 {
-//		buffer.WriteString(pcb.Kind.String())
-//		if pcb.Name != "" || pcb.Namespace != "" {
-//			buffer.WriteString(" ")
-//		}
-//	}
-//	if pcb.Namespace != "" && pcb.Name != "" {
-//		buffer.WriteString("\"" + pcb.Namespace + "/" + pcb.Name + "\"")
-//	} else if pcb.Namespace != "" {
-//		buffer.WriteString("\"" + pcb.Namespace + "\"")
-//	} else if pcb.Name != "" {
-//		buffer.WriteString("\"" + pcb.Name + "\"")
-//	}
-//
-//	if pcb.ResourceVersion != "" {
-//		buffer.WriteString("v" + pcb.ResourceVersion)
-//	}
-//	return buffer.String()
-//}
-
-//no space no sprintf
 func (pcb ContextBuilder) String() string {
 	s := ""
 	if pcb.Kind > 0 {
@@ -140,15 +116,15 @@ func (pcb ContextBuilder) String() string {
 		}
 	}
 	if pcb.Namespace != "" && pcb.Name != "" {
-		s += "\"" + pcb.Namespace + "/" + pcb.Name + "\""
+		s += string('"') + pcb.Namespace + "/" + pcb.Name + string('"')
 	} else if pcb.Namespace != "" {
-		s += "\"" + pcb.Namespace + "\""
+		s += string('"') + pcb.Namespace + string('"')
 	} else if pcb.Name != "" {
-		s += "\"" + pcb.Name + "\""
+		s += string('"') + pcb.Name + string('"')
 	}
 
 	if pcb.ResourceVersion != "" {
-		s += "v" + pcb.ResourceVersion
+		s += " v" + pcb.ResourceVersion
 	}
 	return s
 }

--- a/pkg/pretty/context_builder.go
+++ b/pkg/pretty/context_builder.go
@@ -17,7 +17,6 @@ limitations under the License.
 package pretty
 
 import (
-	"bytes"
 	"fmt"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,44 +107,48 @@ func (pcb *ContextBuilder) Messagef(format string, a ...interface{}) string {
 
 // TODO(n3wscott): Support <type> (K8S: <K8S-Type-Name> ExternalName: <External-Type-Name>)
 
+//no space no sprintf but buffer
 //func (pcb ContextBuilder) String() string {
-//	s := ""
-//	space := ""
+//	var buffer bytes.Buffer
 //	if pcb.Kind > 0 {
-//		s += fmt.Sprintf("%s", pcb.Kind)
-//		space = " "
+//		buffer.WriteString(pcb.Kind.String())
+//		if pcb.Name != "" || pcb.Namespace != "" {
+//			buffer.WriteString(" ")
+//		}
 //	}
 //	if pcb.Namespace != "" && pcb.Name != "" {
-//		s += fmt.Sprintf(`%s"%s/%s"`, space, pcb.Namespace, pcb.Name)
+//		buffer.WriteString("\"" + pcb.Namespace + "/" + pcb.Name + "\"")
 //	} else if pcb.Namespace != "" {
-//		s += fmt.Sprintf(`%s"%s"`, space, pcb.Namespace)
+//		buffer.WriteString("\"" + pcb.Namespace + "\"")
 //	} else if pcb.Name != "" {
-//		s += fmt.Sprintf(`%s"%s"`, space, pcb.Name)
+//		buffer.WriteString("\"" + pcb.Name + "\"")
 //	}
+//
 //	if pcb.ResourceVersion != "" {
-//		s += fmt.Sprintf(" v%s", pcb.ResourceVersion)
+//		buffer.WriteString("v" + pcb.ResourceVersion)
 //	}
-//	return s
+//	return buffer.String()
 //}
 
+//no space no sprintf
 func (pcb ContextBuilder) String() string {
-	var buffer bytes.Buffer
+	s := ""
 	if pcb.Kind > 0 {
-		buffer.WriteString(pcb.Kind.String())
+		s += pcb.Kind.String()
 		if pcb.Name != "" || pcb.Namespace != "" {
-			buffer.WriteString(" ")
+			s += " "
 		}
 	}
 	if pcb.Namespace != "" && pcb.Name != "" {
-		buffer.WriteString("\"" + pcb.Namespace + "/" + pcb.Name + "\"")
+		s += "\"" + pcb.Namespace + "/" + pcb.Name + "\""
 	} else if pcb.Namespace != "" {
-		buffer.WriteString("\"" + pcb.Namespace + "\"")
+		s += "\"" + pcb.Namespace + "\""
 	} else if pcb.Name != "" {
-		buffer.WriteString("\"" + pcb.Name + "\"")
+		s += "\"" + pcb.Name + "\""
 	}
 
 	if pcb.ResourceVersion != "" {
-		buffer.WriteString("v" + pcb.ResourceVersion)
+		s += "v" + pcb.ResourceVersion
 	}
-	return buffer.String()
+	return s
 }

--- a/pkg/pretty/context_builder_test.go
+++ b/pkg/pretty/context_builder_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package pretty
 
 import (
+	"fmt"
 	"testing"
+	"time"
 )
 
 func TestPrettyContextBuilderKind(t *testing.T) {
@@ -156,12 +158,25 @@ func TestPrettyContextBuilderContextMessagefAndContext(t *testing.T) {
 	}
 }
 
-func TestPrettyContextBuilderMessagefAndResourceVersion(t *testing.T) {
-	pcb := ContextBuilder{ResourceVersion: "877"}
-
-	e := ` v877`
+func TestPrettyContextBuilderNamespaceNameAndResourceVersion(t *testing.T) {
+	pcb := NewContextBuilder(ServiceInstance, "Namespace", "Name", "877")
+	e := `ServiceInstance "Namespace/Name" v877`
 	g := pcb.String()
+
 	if g != e {
 		t.Fatalf("Unexpected value of ContextBuilder String; expected %v, got %v", e, g)
 	}
+}
+
+func TestBenchmark(t *testing.T) {
+	t1 := time.Now()
+	count := 10000000
+	pcb := NewContextBuilder(ServiceInstance, "Namespace", "Name", "877")
+
+	for i := 0; i < count; i++ {
+		pcb.String()
+	}
+
+	elapsed := time.Since(t1)
+	fmt.Printf("pcb String() count %s in %d times", elapsed, count)
 }

--- a/pkg/pretty/context_builder_test.go
+++ b/pkg/pretty/context_builder_test.go
@@ -174,7 +174,8 @@ func TestBenchmark(t *testing.T) {
 	pcb := NewContextBuilder(ServiceInstance, "Namespace", "Name", "877")
 
 	for i := 0; i < count; i++ {
-		pcb.String()
+		g := pcb.String()
+		fmt.Printf("ContextBuilder string: %s", g)
 	}
 
 	elapsed := time.Since(t1)

--- a/pkg/pretty/context_builder_test.go
+++ b/pkg/pretty/context_builder_test.go
@@ -17,9 +17,7 @@ limitations under the License.
 package pretty
 
 import (
-	"fmt"
 	"testing"
-	"time"
 )
 
 func TestPrettyContextBuilderKind(t *testing.T) {
@@ -168,16 +166,16 @@ func TestPrettyContextBuilderNamespaceNameAndResourceVersion(t *testing.T) {
 	}
 }
 
-func TestBenchmark(t *testing.T) {
-	t1 := time.Now()
-	count := 10000000
+var bResult string
+
+func BenchmarkPCB(b *testing.B) {
 	pcb := NewContextBuilder(ServiceInstance, "Namespace", "Name", "877")
 
-	for i := 0; i < count; i++ {
-		g := pcb.String()
-		fmt.Printf("ContextBuilder string: %s", g)
+	b.ResetTimer()
+	var s string
+	for i := 0; i <= b.N; i++ {
+		s = pcb.String()
 	}
 
-	elapsed := time.Since(t1)
-	fmt.Printf("pcb String() count %s in %d times", elapsed, count)
+	bResult = s
 }

--- a/pkg/pretty/context_builder_test.go
+++ b/pkg/pretty/context_builder_test.go
@@ -155,3 +155,13 @@ func TestPrettyContextBuilderContextMessagefAndContext(t *testing.T) {
 		t.Fatalf("Unexpected value of ContextBuilder String; expected %v, got %v", e, g)
 	}
 }
+
+func TestPrettyContextBuilderMessagefAndResourceVersion(t *testing.T) {
+	pcb := ContextBuilder{ResourceVersion: "877"}
+
+	e := ` v877`
+	g := pcb.String()
+	if g != e {
+		t.Fatalf("Unexpected value of ContextBuilder String; expected %v, got %v", e, g)
+	}
+}


### PR DESCRIPTION
**contribution, modify += to "bytes.Buffer", may be good performance in context_builder.go String() method**
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
