### PR TITLE
Fix typos: verfies -> verifies

### DIFF
--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -2238,7 +2238,7 @@ func TestReconcileServiceInstanceDeleteFailedUpdate(t *testing.T) {
 	assertEmptyFinalizers(t, updatedServiceInstance)
 }
 
-// TestReconcileServiceInstanceDeleteDoesNotInvokeClusterServiceBroker verfies that if an instance
+// TestReconcileServiceInstanceDeleteDoesNotInvokeClusterServiceBroker verifies that if an instance
 // is created that is never actually provisioned the instance is able to be
 // deleted and is not blocked by any interaction with a broker (since its very
 // likely that a broker never actually existed).
@@ -2285,7 +2285,7 @@ func TestReconcileServiceInstanceDeleteDoesNotInvokeClusterServiceBroker(t *test
 	assertNumEvents(t, events, 0)
 }
 
-// TestFinalizerClearedWhen409ConflictEncounteredOnStatusUpdate verfies that the finalizer
+// TestFinalizerClearedWhen409ConflictEncounteredOnStatusUpdate verifies that the finalizer
 // is removed even when the status update gets back a 409 Conflict from the API server
 // because the controller is working with an old version of the ServiceInstance
 func TestFinalizerClearedWhen409ConflictEncounteredOnStatusUpdate(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Bily Zhang <xcoder@tenxcloud.com>

 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [- ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
Fix typos: verfies -> verifies

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
