### PR TITLE
Fix typos: sucessfully->successfully, variuos->various

### DIFF
--- a/pkg/apiserver/etcd_config.go
+++ b/pkg/apiserver/etcd_config.go
@@ -113,7 +113,7 @@ func (c completedEtcdConfig) NewServer(stopCh <-chan struct{}) (*ServiceCatalogA
 		if err := s.GenericAPIServer.InstallAPIGroup(groupInfo); err != nil {
 			glog.Fatalf("Error installing API group %v: %v", provider.GroupName(), err)
 		} else {
-			// we've sucessfully installed, so hook the stopCh to the destroy func of all the sucessfully installed apigroups
+			// we've successfully installed, so hook the stopCh to the destroy func of all the sucessfully installed apigroups
 			for _, mappings := range groupInfo.VersionedResourcesStorageMap { // gv to resource mappings
 				for _, storage := range mappings { // resource name (brokers, brokers/status) to backing storage
 					go func(store rest.Storage) {

--- a/pkg/svcat/service-catalog/sdk.go
+++ b/pkg/svcat/service-catalog/sdk.go
@@ -29,7 +29,7 @@ import (
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-// SvcatClient is an interface containing the variuos actions in the svcat pkg lib
+// SvcatClient is an interface containing the various actions in the svcat pkg lib
 // This interface is then faked with Counterfeiter for the cmd/svcat unit tests
 type SvcatClient interface {
 	Bind(string, string, string, string, string, interface{}, map[string]string) (*apiv1beta1.ServiceBinding, error)


### PR DESCRIPTION
Signed-off-by: Bily Zhang <xcoder@tenxcloud.com>

 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [-] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
Fix typos: sucessfully->successfully, variuos->various

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
