### PR TITLE
Add RetrievePlanByClassIDAndName to pkg/svcat

### DIFF
--- a/cmd/svcat/instance/provision_cmd.go
+++ b/cmd/svcat/instance/provision_cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/output"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/parameters"
+	servicecatalog "github.com/kubernetes-incubator/service-catalog/pkg/svcat/service-catalog"
 	"github.com/spf13/cobra"
 )
 
@@ -124,7 +125,13 @@ func (c *provisonCmd) Run() error {
 }
 
 func (c *provisonCmd) Provision() error {
-	instance, err := c.App.Provision(c.Namespace, c.instanceName, c.externalID, c.className, c.planName, c.params, c.secrets)
+	opts := &servicecatalog.ProvisionOptions{
+		ExternalID: c.externalID,
+		Namespace:  c.Namespace,
+		Params:     c.params,
+		Secrets:    c.secrets,
+	}
+	instance, err := c.App.Provision(c.instanceName, c.className, c.planName, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/svcat/service-catalog/instance.go
+++ b/pkg/svcat/service-catalog/instance.go
@@ -165,26 +165,24 @@ func (sdk *SDK) InstanceToServiceClassAndPlan(instance *v1beta1.ServiceInstance,
 }
 
 // Provision creates an instance of a service class and plan.
-func (sdk *SDK) Provision(namespace, instanceName, externalID, className, planName string,
-	params interface{}, secrets map[string]string) (*v1beta1.ServiceInstance, error) {
-
+func (sdk *SDK) Provision(instanceName, className, planName string, opts *ProvisionOptions) (*v1beta1.ServiceInstance, error) {
 	request := &v1beta1.ServiceInstance{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      instanceName,
-			Namespace: namespace,
+			Namespace: opts.Namespace,
 		},
 		Spec: v1beta1.ServiceInstanceSpec{
-			ExternalID: externalID,
+			ExternalID: opts.ExternalID,
 			PlanReference: v1beta1.PlanReference{
 				ClusterServiceClassExternalName: className,
 				ClusterServicePlanExternalName:  planName,
 			},
-			Parameters:     BuildParameters(params),
-			ParametersFrom: BuildParametersFrom(secrets),
+			Parameters:     BuildParameters(opts.Params),
+			ParametersFrom: BuildParametersFrom(opts.Secrets),
 		},
 	}
 
-	result, err := sdk.ServiceCatalog().ServiceInstances(namespace).Create(request)
+	result, err := sdk.ServiceCatalog().ServiceInstances(opts.Namespace).Create(request)
 	if err != nil {
 		return nil, fmt.Errorf("provision request failed (%s)", err)
 	}

--- a/pkg/svcat/service-catalog/instance_test.go
+++ b/pkg/svcat/service-catalog/instance_test.go
@@ -239,8 +239,14 @@ var _ = Describe("Instances", func() {
 			secrets["username"] = "admin"
 			secrets["password"] = "abc123"
 			retries := 3
+			opts := &ProvisionOptions{
+				ExternalID: "",
+				Namespace:  namespace,
+				Params:     params,
+				Secrets:    secrets,
+			}
 
-			provisionedInstance, err := sdk.Provision(namespace, instanceName, "", className, planName, params, secrets)
+			provisionedInstance, err := sdk.Provision(instanceName, className, planName, opts)
 			Expect(err).To(BeNil())
 			// once for the provision request
 			actions := svcCatClient.Actions()
@@ -492,8 +498,14 @@ var _ = Describe("Instances", func() {
 			secrets := make(map[string]string)
 			secrets["username"] = "admin"
 			secrets["password"] = "abc123"
+			opts := &ProvisionOptions{
+				ExternalID: externalID,
+				Namespace:  namespace,
+				Params:     params,
+				Secrets:    secrets,
+			}
 
-			service, err := sdk.Provision(namespace, instanceName, externalID, className, planName, params, secrets)
+			service, err := sdk.Provision(instanceName, className, planName, opts)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(service.Namespace).To(Equal(namespace))
@@ -541,8 +553,14 @@ var _ = Describe("Instances", func() {
 				return true, nil, fmt.Errorf(errorMessage)
 			})
 			sdk.ServiceCatalogClient = badClient
+			opts := &ProvisionOptions{
+				ExternalID: "",
+				Namespace:  namespace,
+				Params:     params,
+				Secrets:    secrets,
+			}
 
-			service, err := sdk.Provision(namespace, instanceName, "", className, planName, params, secrets)
+			service, err := sdk.Provision(instanceName, className, planName, opts)
 			Expect(service).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(errorMessage))

--- a/pkg/svcat/service-catalog/options.go
+++ b/pkg/svcat/service-catalog/options.go
@@ -38,3 +38,11 @@ type RegisterOptions struct {
 	RelistDuration    *metav1.Duration
 	SkipTLS           bool
 }
+
+// ProvisionOptions allows for the passing of optional fields to the instance Provision method.
+type ProvisionOptions struct {
+	ExternalID string
+	Namespace  string
+	Params     interface{}
+	Secrets    map[string]string
+}

--- a/pkg/svcat/service-catalog/sdk.go
+++ b/pkg/svcat/service-catalog/sdk.go
@@ -63,7 +63,7 @@ type SvcatClient interface {
 	InstanceToServiceClassAndPlan(*apiv1beta1.ServiceInstance) (*apiv1beta1.ClusterServiceClass, *apiv1beta1.ClusterServicePlan, error)
 	IsInstanceFailed(*apiv1beta1.ServiceInstance) bool
 	IsInstanceReady(*apiv1beta1.ServiceInstance) bool
-	Provision(string, string, string, string, string, interface{}, map[string]string) (*apiv1beta1.ServiceInstance, error)
+	Provision(string, string, string, *ProvisionOptions) (*apiv1beta1.ServiceInstance, error)
 	RetrieveInstance(string, string) (*apiv1beta1.ServiceInstance, error)
 	RetrieveInstanceByBinding(*apiv1beta1.ServiceBinding) (*apiv1beta1.ServiceInstance, error)
 	RetrieveInstances(string, string, string) (*apiv1beta1.ServiceInstanceList, error)
@@ -75,6 +75,7 @@ type SvcatClient interface {
 	RetrievePlans(string, ScopeOptions) ([]Plan, error)
 	RetrievePlanByName(string, ScopeOptions) (Plan, error)
 	RetrievePlanByClassAndName(string, string, ScopeOptions) (Plan, error)
+	RetrievePlanByClassIDAndName(string, string, ScopeOptions) (Plan, error)
 	RetrievePlanByID(string, ScopeOptions) (Plan, error)
 
 	RetrieveSecretByBinding(*apiv1beta1.ServiceBinding) (*apicorev1.Secret, error)

--- a/pkg/svcat/service-catalog/service-catalogfakes/fake_svcat_client.go
+++ b/pkg/svcat/service-catalog/service-catalogfakes/fake_svcat_client.go
@@ -411,16 +411,13 @@ type FakeSvcatClient struct {
 	isInstanceReadyReturnsOnCall map[int]struct {
 		result1 bool
 	}
-	ProvisionStub        func(string, string, string, string, string, interface{}, map[string]string) (*apiv1beta1.ServiceInstance, error)
+	ProvisionStub        func(string, string, string, *servicecatalog.ProvisionOptions) (*apiv1beta1.ServiceInstance, error)
 	provisionMutex       sync.RWMutex
 	provisionArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
-		arg4 string
-		arg5 string
-		arg6 interface{}
-		arg7 map[string]string
+		arg4 *servicecatalog.ProvisionOptions
 	}
 	provisionReturns struct {
 		result1 *apiv1beta1.ServiceInstance
@@ -570,6 +567,21 @@ type FakeSvcatClient struct {
 		result2 error
 	}
 	retrievePlanByClassAndNameReturnsOnCall map[int]struct {
+		result1 servicecatalog.Plan
+		result2 error
+	}
+	RetrievePlanByClassIDAndNameStub        func(string, string, servicecatalog.ScopeOptions) (servicecatalog.Plan, error)
+	retrievePlanByClassIDAndNameMutex       sync.RWMutex
+	retrievePlanByClassIDAndNameArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 servicecatalog.ScopeOptions
+	}
+	retrievePlanByClassIDAndNameReturns struct {
+		result1 servicecatalog.Plan
+		result2 error
+	}
+	retrievePlanByClassIDAndNameReturnsOnCall map[int]struct {
 		result1 servicecatalog.Plan
 		result2 error
 	}
@@ -2064,22 +2076,19 @@ func (fake *FakeSvcatClient) IsInstanceReadyReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
-func (fake *FakeSvcatClient) Provision(arg1 string, arg2 string, arg3 string, arg4 string, arg5 string, arg6 interface{}, arg7 map[string]string) (*apiv1beta1.ServiceInstance, error) {
+func (fake *FakeSvcatClient) Provision(arg1 string, arg2 string, arg3 string, arg4 *servicecatalog.ProvisionOptions) (*apiv1beta1.ServiceInstance, error) {
 	fake.provisionMutex.Lock()
 	ret, specificReturn := fake.provisionReturnsOnCall[len(fake.provisionArgsForCall)]
 	fake.provisionArgsForCall = append(fake.provisionArgsForCall, struct {
 		arg1 string
 		arg2 string
 		arg3 string
-		arg4 string
-		arg5 string
-		arg6 interface{}
-		arg7 map[string]string
-	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
-	fake.recordInvocation("Provision", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+		arg4 *servicecatalog.ProvisionOptions
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("Provision", []interface{}{arg1, arg2, arg3, arg4})
 	fake.provisionMutex.Unlock()
 	if fake.ProvisionStub != nil {
-		return fake.ProvisionStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+		return fake.ProvisionStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -2093,10 +2102,10 @@ func (fake *FakeSvcatClient) ProvisionCallCount() int {
 	return len(fake.provisionArgsForCall)
 }
 
-func (fake *FakeSvcatClient) ProvisionArgsForCall(i int) (string, string, string, string, string, interface{}, map[string]string) {
+func (fake *FakeSvcatClient) ProvisionArgsForCall(i int) (string, string, string, *servicecatalog.ProvisionOptions) {
 	fake.provisionMutex.RLock()
 	defer fake.provisionMutex.RUnlock()
-	return fake.provisionArgsForCall[i].arg1, fake.provisionArgsForCall[i].arg2, fake.provisionArgsForCall[i].arg3, fake.provisionArgsForCall[i].arg4, fake.provisionArgsForCall[i].arg5, fake.provisionArgsForCall[i].arg6, fake.provisionArgsForCall[i].arg7
+	return fake.provisionArgsForCall[i].arg1, fake.provisionArgsForCall[i].arg2, fake.provisionArgsForCall[i].arg3, fake.provisionArgsForCall[i].arg4
 }
 
 func (fake *FakeSvcatClient) ProvisionReturns(result1 *apiv1beta1.ServiceInstance, result2 error) {
@@ -2643,6 +2652,59 @@ func (fake *FakeSvcatClient) RetrievePlanByClassAndNameReturnsOnCall(i int, resu
 	}{result1, result2}
 }
 
+func (fake *FakeSvcatClient) RetrievePlanByClassIDAndName(arg1 string, arg2 string, arg3 servicecatalog.ScopeOptions) (servicecatalog.Plan, error) {
+	fake.retrievePlanByClassIDAndNameMutex.Lock()
+	ret, specificReturn := fake.retrievePlanByClassIDAndNameReturnsOnCall[len(fake.retrievePlanByClassIDAndNameArgsForCall)]
+	fake.retrievePlanByClassIDAndNameArgsForCall = append(fake.retrievePlanByClassIDAndNameArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 servicecatalog.ScopeOptions
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("RetrievePlanByClassIDAndName", []interface{}{arg1, arg2, arg3})
+	fake.retrievePlanByClassIDAndNameMutex.Unlock()
+	if fake.RetrievePlanByClassIDAndNameStub != nil {
+		return fake.RetrievePlanByClassIDAndNameStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.retrievePlanByClassIDAndNameReturns.result1, fake.retrievePlanByClassIDAndNameReturns.result2
+}
+
+func (fake *FakeSvcatClient) RetrievePlanByClassIDAndNameCallCount() int {
+	fake.retrievePlanByClassIDAndNameMutex.RLock()
+	defer fake.retrievePlanByClassIDAndNameMutex.RUnlock()
+	return len(fake.retrievePlanByClassIDAndNameArgsForCall)
+}
+
+func (fake *FakeSvcatClient) RetrievePlanByClassIDAndNameArgsForCall(i int) (string, string, servicecatalog.ScopeOptions) {
+	fake.retrievePlanByClassIDAndNameMutex.RLock()
+	defer fake.retrievePlanByClassIDAndNameMutex.RUnlock()
+	return fake.retrievePlanByClassIDAndNameArgsForCall[i].arg1, fake.retrievePlanByClassIDAndNameArgsForCall[i].arg2, fake.retrievePlanByClassIDAndNameArgsForCall[i].arg3
+}
+
+func (fake *FakeSvcatClient) RetrievePlanByClassIDAndNameReturns(result1 servicecatalog.Plan, result2 error) {
+	fake.RetrievePlanByClassIDAndNameStub = nil
+	fake.retrievePlanByClassIDAndNameReturns = struct {
+		result1 servicecatalog.Plan
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSvcatClient) RetrievePlanByClassIDAndNameReturnsOnCall(i int, result1 servicecatalog.Plan, result2 error) {
+	fake.RetrievePlanByClassIDAndNameStub = nil
+	if fake.retrievePlanByClassIDAndNameReturnsOnCall == nil {
+		fake.retrievePlanByClassIDAndNameReturnsOnCall = make(map[int]struct {
+			result1 servicecatalog.Plan
+			result2 error
+		})
+	}
+	fake.retrievePlanByClassIDAndNameReturnsOnCall[i] = struct {
+		result1 servicecatalog.Plan
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeSvcatClient) RetrievePlanByID(arg1 string, arg2 servicecatalog.ScopeOptions) (servicecatalog.Plan, error) {
 	fake.retrievePlanByIDMutex.Lock()
 	ret, specificReturn := fake.retrievePlanByIDReturnsOnCall[len(fake.retrievePlanByIDArgsForCall)]
@@ -2870,6 +2932,8 @@ func (fake *FakeSvcatClient) Invocations() map[string][][]interface{} {
 	defer fake.retrievePlanByNameMutex.RUnlock()
 	fake.retrievePlanByClassAndNameMutex.RLock()
 	defer fake.retrievePlanByClassAndNameMutex.RUnlock()
+	fake.retrievePlanByClassIDAndNameMutex.RLock()
+	defer fake.retrievePlanByClassIDAndNameMutex.RUnlock()
 	fake.retrievePlanByIDMutex.RLock()
 	defer fake.retrievePlanByIDMutex.RUnlock()
 	fake.retrieveSecretByBindingMutex.RLock()


### PR DESCRIPTION
This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation
 - [x] Refactor

**What this PR does / why we need it**:
In preparation for fixing provision/describe/etc. to support namespaced resources, I've added a new function in pkg/svcat, RetrievePlanByIDAndName. You supply a class (cluster or namespaced) Kubernetes Name and a plan external name, and it will fetch and return that plan object. It supports Cluster, Namespace, and All scopes, although I imagine All will probably be used the most. 

I also did some refactoring to remove more references to uuids, to make it clear that we mean the Kubernetes name.

**Which issue(s) this PR fixes** 
Works on #2371

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
