### PR TITLE
Don't fail DELETE if instance was not provisioned due to terminal failure

### DIFF
--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -2382,8 +2382,8 @@ func (c *controller) prepareDeprovisionRequest(instance *v1beta1.ServiceInstance
 		}
 		rh.inProgressProperties = instance.Status.InProgressProperties
 	} else if instance.Status.CurrentOperation == "" && instance.Status.ProvisionStatus != v1beta1.ServiceInstanceProvisionStatusProvisioned {
-		// terminal provisioing failure
-		// we don't have neither ExternalProperties nor InProgressProperties in Status anymore, so we have to build tme
+		// terminal provisioning failure
+		// we don't have ExternalProperties and InProgressProperties in Status anymore, so we have to build them
 		if instance.Spec.ClusterServiceClassSpecified() {
 			servicePlan, err := c.clusterServicePlanLister.Get(instance.Spec.ClusterServicePlanRef.Name)
 			if nil != err {

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -2381,12 +2381,12 @@ func (c *controller) prepareDeprovisionRequest(instance *v1beta1.ServiceInstance
 			return nil, nil, stderrors.New("InProgressProperties must be set when there is an operation or orphan mitigation in progress")
 		}
 		rh.inProgressProperties = instance.Status.InProgressProperties
-	} else if instance.Status.CurrentOperation == "" && instance.Status.ProvisionStatus != v1beta1.ServiceInstanceProvisionStatusProvisioned {
+	} else if instance.Status.ProvisionStatus != v1beta1.ServiceInstanceProvisionStatusProvisioned {
 		// terminal provisioning failure
 		// we don't have ExternalProperties and InProgressProperties in Status anymore, so we have to build them
 		if instance.Spec.ClusterServiceClassSpecified() {
 			servicePlan, err := c.clusterServicePlanLister.Get(instance.Spec.ClusterServicePlanRef.Name)
-			if nil != err {
+			if err != nil {
 				return nil, nil, &operationError{
 					reason: errorNonexistentClusterServicePlanReason,
 					message: fmt.Sprintf(
@@ -2401,7 +2401,7 @@ func (c *controller) prepareDeprovisionRequest(instance *v1beta1.ServiceInstance
 			}
 		} else {
 			servicePlan, err := c.servicePlanLister.ServicePlans(instance.Namespace).Get(instance.Spec.ServicePlanRef.Name)
-			if nil != err {
+			if err != nil {
 				return nil, nil, &operationError{
 					reason: errorNonexistentServicePlanReason,
 					message: fmt.Sprintf(

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -2381,6 +2381,40 @@ func (c *controller) prepareDeprovisionRequest(instance *v1beta1.ServiceInstance
 			return nil, nil, stderrors.New("InProgressProperties must be set when there is an operation or orphan mitigation in progress")
 		}
 		rh.inProgressProperties = instance.Status.InProgressProperties
+	} else if instance.Status.CurrentOperation == "" && instance.Status.ProvisionStatus != v1beta1.ServiceInstanceProvisionStatusProvisioned {
+		// terminal provisioing failure
+		// we don't have neither ExternalProperties nor InProgressProperties in Status anymore, so we have to build tme
+		if instance.Spec.ClusterServiceClassSpecified() {
+			servicePlan, err := c.clusterServicePlanLister.Get(instance.Spec.ClusterServicePlanRef.Name)
+			if nil != err {
+				return nil, nil, &operationError{
+					reason: errorNonexistentClusterServicePlanReason,
+					message: fmt.Sprintf(
+						"The instance references a non-existent ClusterServicePlan %q - %v",
+						instance.Spec.ClusterServicePlanRef.Name, instance.Spec.PlanReference,
+					),
+				}
+			}
+			rh.inProgressProperties = &v1beta1.ServiceInstancePropertiesState{
+				ClusterServicePlanExternalName: servicePlan.Spec.ExternalName,
+				ClusterServicePlanExternalID:   servicePlan.Spec.ExternalID,
+			}
+		} else {
+			servicePlan, err := c.servicePlanLister.ServicePlans(instance.Namespace).Get(instance.Spec.ServicePlanRef.Name)
+			if nil != err {
+				return nil, nil, &operationError{
+					reason: errorNonexistentServicePlanReason,
+					message: fmt.Sprintf(
+						"The instance references a non-existent ServicePlan %q - %v",
+						instance.Spec.ServicePlanRef.Name, instance.Spec.PlanReference,
+					),
+				}
+			}
+			rh.inProgressProperties = &v1beta1.ServiceInstancePropertiesState{
+				ServicePlanExternalName: servicePlan.Spec.ExternalName,
+				ServicePlanExternalID:   servicePlan.Spec.ExternalID,
+			}
+		}
 	} else {
 		if instance.Status.ExternalProperties == nil {
 			return nil, nil, stderrors.New("ExternalProperties must be set before deprovisioning")

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -1957,71 +1957,91 @@ func TestReconcileServiceInstanceDeleteAsynchronous(t *testing.T) {
 // instance that failed to provision but for which a provision request was
 // made will have a deprovision request sent to the broker.
 func TestReconcileServiceInstanceDeleteFailedProvisionWithRequest(t *testing.T) {
-	fakeKubeClient, fakeCatalogClient, fakeClusterServiceBrokerClient, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
-		DeprovisionReaction: &fakeosb.DeprovisionReaction{
-			Response: &osb.DeprovisionResponse{},
+	cases := []struct {
+		name                 string
+		currentOperation     v1beta1.ServiceInstanceOperation
+		inProgressProperties *v1beta1.ServiceInstancePropertiesState
+	}{
+		{
+			name:             "With failed provisioning operation in progress",
+			currentOperation: v1beta1.ServiceInstanceOperationProvision,
+			inProgressProperties: &v1beta1.ServiceInstancePropertiesState{
+				ClusterServicePlanExternalName: testClusterServicePlanName,
+				ClusterServicePlanExternalID:   testClusterServicePlanGUID,
+			},
 		},
-	})
-
-	sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(getTestClusterServiceBroker())
-	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(getTestClusterServiceClass())
-	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
-
-	instance := getTestServiceInstanceWithFailedStatus()
-	instance.ObjectMeta.DeletionTimestamp = &metav1.Time{}
-	instance.ObjectMeta.Finalizers = []string{v1beta1.FinalizerServiceCatalog}
-	instance.Status.CurrentOperation = v1beta1.ServiceInstanceOperationProvision
-	instance.Status.InProgressProperties = &v1beta1.ServiceInstancePropertiesState{
-		ClusterServicePlanExternalName: testClusterServicePlanName,
-		ClusterServicePlanExternalID:   testClusterServicePlanGUID,
+		{
+			name:                 "With terminally failed provisioning",
+			currentOperation:     "",
+			inProgressProperties: nil,
+		},
 	}
-	instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeKubeClient, fakeCatalogClient, fakeClusterServiceBrokerClient, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
+				DeprovisionReaction: &fakeosb.DeprovisionReaction{
+					Response: &osb.DeprovisionResponse{},
+				},
+			})
 
-	instance.Generation = 2
-	instance.Status.ReconciledGeneration = 1
-	instance.Status.ObservedGeneration = 1
-	instance.Status.ProvisionStatus = v1beta1.ServiceInstanceProvisionStatusNotProvisioned
+			sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(getTestClusterServiceBroker())
+			sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(getTestClusterServiceClass())
+			sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
 
-	fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
-		return true, instance, nil
-	})
+			instance := getTestServiceInstanceWithFailedStatus()
+			instance.ObjectMeta.DeletionTimestamp = &metav1.Time{}
+			instance.ObjectMeta.Finalizers = []string{v1beta1.FinalizerServiceCatalog}
+			instance.Status.CurrentOperation = tc.currentOperation
+			instance.Status.InProgressProperties = tc.inProgressProperties
+			instance.Status.DeprovisionStatus = v1beta1.ServiceInstanceDeprovisionStatusRequired
 
-	if err := reconcileServiceInstance(t, testController, instance); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	instance = assertServiceInstanceDeprovisionInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
-	fakeCatalogClient.ClearActions()
-	fakeKubeClient.ClearActions()
+			instance.Generation = 2
+			instance.Status.ReconciledGeneration = 1
+			instance.Status.ObservedGeneration = 1
+			instance.Status.ProvisionStatus = v1beta1.ServiceInstanceProvisionStatusNotProvisioned
 
-	err := reconcileServiceInstance(t, testController, instance)
-	if err != nil {
-		t.Fatalf("Unexpected error from reconcileServiceInstance: %v", err)
-	}
+			fakeCatalogClient.AddReactor("get", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+				return true, instance, nil
+			})
 
-	brokerActions := fakeClusterServiceBrokerClient.Actions()
-	assertNumberOfBrokerActions(t, brokerActions, 1)
-	assertDeprovision(t, brokerActions[0], &osb.DeprovisionRequest{
-		AcceptsIncomplete: true,
-		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testClusterServiceClassGUID,
-		PlanID:            testClusterServicePlanGUID,
-	})
+			if err := reconcileServiceInstance(t, testController, instance); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			instance = assertServiceInstanceDeprovisionInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
+			fakeCatalogClient.ClearActions()
+			fakeKubeClient.ClearActions()
 
-	// Verify no core kube actions occurred
-	kubeActions := fakeKubeClient.Actions()
-	assertNumberOfActions(t, kubeActions, 0)
+			err := reconcileServiceInstance(t, testController, instance)
+			if err != nil {
+				t.Fatalf("Unexpected error from reconcileServiceInstance: %v", err)
+			}
 
-	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+			brokerActions := fakeClusterServiceBrokerClient.Actions()
+			assertNumberOfBrokerActions(t, brokerActions, 1)
+			assertDeprovision(t, brokerActions[0], &osb.DeprovisionRequest{
+				AcceptsIncomplete: true,
+				InstanceID:        testServiceInstanceGUID,
+				ServiceID:         testClusterServiceClassGUID,
+				PlanID:            testClusterServicePlanGUID,
+			})
 
-	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceOperationSuccess(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationDeprovision, testClusterServicePlanName, testClusterServicePlanGUID, instance)
+			// Verify no core kube actions occurred
+			kubeActions := fakeKubeClient.Actions()
+			assertNumberOfActions(t, kubeActions, 0)
 
-	events := getRecordedEvents(testController)
+			actions := fakeCatalogClient.Actions()
+			assertNumberOfActions(t, actions, 1)
 
-	expectedEvent := normalEventBuilder(successDeprovisionReason).msg("The instance was deprovisioned successfully")
-	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
-		t.Fatal(err)
+			updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
+			assertServiceInstanceOperationSuccess(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationDeprovision, testClusterServicePlanName, testClusterServicePlanGUID, instance)
+
+			events := getRecordedEvents(testController)
+
+			expectedEvent := normalEventBuilder(successDeprovisionReason).msg("The instance was deprovisioned successfully")
+			if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -755,17 +755,17 @@ func TestUpdateServiceInstanceUpdateParameters(t *testing.T) {
 			deleteParams:                true,
 		},
 		{
-			name: "add secret param",
+			name:                        "add secret param",
 			createdWithParamsFromSecret: false,
 			updateParamsFromSecret:      true,
 		},
 		{
-			name: "update secret param",
+			name:                        "update secret param",
 			createdWithParamsFromSecret: true,
 			updateParamsFromSecret:      true,
 		},
 		{
-			name: "delete secret param",
+			name:                        "delete secret param",
 			createdWithParamsFromSecret: true,
 			deleteParamsFromSecret:      true,
 		},
@@ -788,7 +788,7 @@ func TestUpdateServiceInstanceUpdateParameters(t *testing.T) {
 			deleteParamsFromSecret:      true,
 		},
 		{
-			name: "update secret",
+			name:                        "update secret",
 			createdWithParamsFromSecret: true,
 			updateSecret:                true,
 		},
@@ -928,15 +928,14 @@ func TestUpdateServiceInstanceUpdateParameters(t *testing.T) {
 // with/without retries.
 func TestCreateServiceInstanceWithRetries(t *testing.T) {
 	cases := []struct {
-		name                        string
-		setup                func(ct *controllerTest)
+		name  string
+		setup func(ct *controllerTest)
 	}{
 		{
 			name: "no retry",
 			setup: func(ct *controllerTest) {
 				ct.osbClient.ProvisionReaction = &fakeosb.ProvisionReaction{
-					Response: &osb.ProvisionResponse{
-					},
+					Response: &osb.ProvisionResponse{},
 				}
 			},
 		},
@@ -953,8 +952,7 @@ func TestCreateServiceInstanceWithRetries(t *testing.T) {
 							},
 						},
 						fakeosb.ProvisionReaction{
-							Response: &osb.ProvisionResponse{
-							},
+							Response: &osb.ProvisionResponse{},
 						},
 					}))
 			},
@@ -972,8 +970,7 @@ func TestCreateServiceInstanceWithRetries(t *testing.T) {
 							},
 						},
 						fakeosb.ProvisionReaction{
-							Response: &osb.ProvisionResponse{
-							},
+							Response: &osb.ProvisionResponse{},
 						},
 					}))
 			},
@@ -984,8 +981,8 @@ func TestCreateServiceInstanceWithRetries(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ct := &controllerTest{
-				t:      t,
-				broker: getTestBroker(),
+				t:        t,
+				broker:   getTestBroker(),
 				instance: getTestInstance(),
 			}
 			ct.setup = tc.setup
@@ -1507,7 +1504,7 @@ func TestDeleteServiceInstance(t *testing.T) {
 			},
 		},
 		{
-			name: "deprovision instance after in progress provision",
+			name:                         "deprovision instance after in progress provision",
 			skipVerifyingInstanceSuccess: true,
 			setup: func(ct *controllerTest) {
 				ct.osbClient.PollLastOperationReaction = fakeosb.DynamicPollLastOperationReaction(
@@ -1555,7 +1552,7 @@ func TestDeleteServiceInstance(t *testing.T) {
 				binding:                      tc.binding,
 				instance:                     getTestInstance(),
 				skipVerifyingInstanceSuccess: tc.skipVerifyingInstanceSuccess,
-				setup: tc.setup,
+				setup:                        tc.setup,
 			}
 			ct.run(tc.testFunction)
 		})
@@ -1718,10 +1715,10 @@ func TestPollServiceInstanceLastOperationSuccess(t *testing.T) {
 				broker:                       getTestBroker(),
 				instance:                     getTestInstance(),
 				skipVerifyingInstanceSuccess: tc.skipVerifyingInstanceSuccess,
-				setup:              tc.setup,
-				preDeleteBroker:    tc.preDeleteBroker,
-				preCreateInstance:  tc.preCreateInstance,
-				postCreateInstance: tc.postCreateInstance,
+				setup:                        tc.setup,
+				preDeleteBroker:              tc.preDeleteBroker,
+				preCreateInstance:            tc.preCreateInstance,
+				postCreateInstance:           tc.postCreateInstance,
 			}
 			ct.run(func(ct *controllerTest) {
 				if tc.verifyCondition != nil {
@@ -1811,7 +1808,7 @@ func TestPollServiceInstanceLastOperationFailure(t *testing.T) {
 				broker:                       getTestBroker(),
 				instance:                     getTestInstance(),
 				skipVerifyingInstanceSuccess: tc.skipVerifyingInstanceSuccess,
-				setup: tc.setup,
+				setup:                        tc.setup,
 			}
 			ct.run(func(ct *controllerTest) {
 				if err := util.WaitForInstanceCondition(ct.client, testNamespace, testInstanceName, *tc.successCondition); err != nil {


### PR DESCRIPTION
This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
DELETE after terminal provisioning failure (e.g. 400 from broker) fails. This PR fixes this. 

**Which issue(s) this PR fixes** 
Fixes #2467 

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
