### PR TITLE
Add readiness probes and split checks from liveness probes

### DIFF
--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -86,13 +86,13 @@ spec:
         readinessProbe:
           httpGet:
             port: 8443
-            path: /healthz
+            path: /healthz/ready
             scheme: HTTPS
           failureThreshold: 1
           initialDelaySeconds: 10
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 2
+          timeoutSeconds: 5
         livenessProbe:
           httpGet:
             port: 8443
@@ -102,7 +102,7 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 2
+          timeoutSeconds: 5
         {{- end }}
       {{- if and (eq .Values.apiserver.storage.type "etcd") .Values.apiserver.storage.etcd.useEmbedded }}
       - name: etcd

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -98,23 +98,23 @@ spec:
         readinessProbe:
           httpGet:
             port: 8444
-            path: /healthz
+            path: /healthz/ready
             scheme: HTTPS
           failureThreshold: 1
           initialDelaySeconds: 20
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 2
+          timeoutSeconds: 5
         livenessProbe:
           httpGet:
             port: 8444
             path: /healthz
             scheme: HTTPS
           failureThreshold: 3
-          initialDelaySeconds: 20
+          initialDelaySeconds: 40
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 2
+          timeoutSeconds: 5
         {{- end }}
       {{ if .Values.controllerManager.nodeSelector }}
       nodeSelector:

--- a/charts/catalog/templates/rbac.yaml
+++ b/charts/catalog/templates/rbac.yaml
@@ -192,4 +192,30 @@ items:
     kind: ServiceAccount
     name: "{{ .Values.controllerManager.serviceAccount }}"
     namespace: "{{ .Release.Namespace }}"
+
+# This allows anyone to get the Service Catalog readiness probe
+- apiVersion: {{template "rbacApiVersion" . }}
+  kind: ClusterRole
+  metadata:
+    name: "servicecatalog.k8s.io:service-catalog-readiness"
+  rules:
+  - nonResourceURLs:
+    - /healthz/ready
+    verbs:
+      - get
+- apiVersion: {{template "rbacApiVersion" . }}
+  kind: ClusterRoleBinding
+  metadata:
+    name: "servicecatalog.k8s.io:service-catalog-readiness"
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: "servicecatalog.k8s.io:service-catalog-readiness"
+  subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:unauthenticated
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated
 {{end}}

--- a/cmd/controller-manager/app/controller_manager.go
+++ b/cmd/controller-manager/app/controller_manager.go
@@ -61,6 +61,7 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/pkg/controller"
 
 	"context"
+
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -167,7 +168,12 @@ func Run(controllerManagerOptions *options.ControllerManagerServer) error {
 				ClientConfig: serviceCatalogKubeconfig,
 			},
 		}
-		healthz.InstallHandler(mux, healthz.PingHealthz, apiAvailableChecker)
+		// liveness registered at /healthz indicates if the container is responding
+		healthz.InstallHandler(mux, healthz.PingHealthz)
+
+		// readiness registered at /healthz/ready indicates if traffic should be routed to this container
+		healthz.InstallPathHandler(mux, "/healthz/ready", apiAvailableChecker)
+
 		configz.InstallHandler(mux)
 		metrics.RegisterMetricsAndInstallHandler(mux)
 


### PR DESCRIPTION
This PR is a 
 - [ ] Feature Implementation
 - [ X] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
Splits the checks that were in liveness probe into a liveness & readiness for both API Server and Controller Manager.  Liveness probes should be in indication of when the container is no longer responding and should be killed and restarted.   Readiness probe is an indicator that the container is ready to serve requests.

With both kinds of checks in liveness we cause unnecessary kill/restart of the container. 

API Server change:  add readiness endpoint (/healthz/ready) and move the etcd checker from the liveness proble to readiness.     Liveness probe now just uses the built in ping (are you alive and can you respond with a http 200).  Readiness probe now runs etcd checker.  If readiness fails the container is removed from the service endpoint and is re-added once it is healthy again.  When Liveness probe fails to answer with a 200, the kubelet will kill it after surpassing the failureThreshold.

Controller Manager change:  add readiness endpoint also at /healthz/ready and moved the APIAvailableChecker out of liveness and into readiness.

Tuned up the probe configurations for both probes.  


**Which issue(s) this PR fixes** 
Fixes #2380 

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
