### PR TITLE
Initialize ClusterServiceBroker/ServiceBroker client only on add/update actions

### DIFF
--- a/pkg/controller/controller_clusterservicebroker.go
+++ b/pkg/controller/controller_clusterservicebroker.go
@@ -158,11 +158,6 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 	pcb := pretty.NewClusterServiceBrokerContextBuilder(broker)
 	glog.V(4).Infof(pcb.Message("Processing"))
 
-	brokerClient, err := c.updateClusterServiceBrokerClient(broker)
-	if err != nil {
-		return err
-	}
-
 	// * If the broker's ready condition is true and the RelistBehavior has been
 	// set to Manual, do not reconcile it.
 	// * If the broker's ready condition is true and the relist interval has not
@@ -173,6 +168,11 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 
 	if broker.DeletionTimestamp == nil { // Add or update
 		glog.V(4).Info(pcb.Message("Processing adding/update event"))
+
+		brokerClient, err := c.updateClusterServiceBrokerClient(broker)
+		if err != nil {
+			return err
+		}
 
 		// get the broker's catalog
 		now := metav1.Now()

--- a/pkg/controller/controller_servicebroker.go
+++ b/pkg/controller/controller_servicebroker.go
@@ -127,7 +127,6 @@ func (c *controller) updateServiceBrokerClient(broker *v1beta1.ServiceBroker) (o
 		return nil, err
 	}
 
-	// clientConfig := NewClientConfigurationForBroker(broker, authConfig)
 	clientConfig := NewClientConfigurationForBroker(broker.ObjectMeta, &broker.Spec.CommonServiceBrokerSpec, authConfig)
 
 	brokerClient, err := c.brokerClientManager.UpdateBrokerClient(NewServiceBrokerKey(broker.Namespace, broker.Name), clientConfig)
@@ -151,11 +150,6 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 	pcb := pretty.NewServiceBrokerContextBuilder(broker)
 	glog.V(4).Infof(pcb.Message("Processing"))
 
-	brokerClient, err := c.updateServiceBrokerClient(broker)
-	if err != nil {
-		return err
-	}
-
 	// * If the broker's ready condition is true and the RelistBehavior has been
 	// set to Manual, do not reconcile it.
 	// * If the broker's ready condition is true and the relist interval has not
@@ -166,6 +160,11 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 
 	if broker.DeletionTimestamp == nil { // Add or update
 		glog.V(4).Info(pcb.Message("Processing adding/update event"))
+
+		brokerClient, err := c.updateServiceBrokerClient(broker)
+		if err != nil {
+			return err
+		}
 
 		// get the broker's catalog
 		now := metav1.Now()

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -515,6 +515,39 @@ func getTestClusterServiceBrokerWithAuth(authInfo *v1beta1.ClusterServiceBrokerA
 	return broker
 }
 
+func getTestClusterBrokerBasicAuthInfo() *v1beta1.ClusterServiceBrokerAuthInfo {
+	return &v1beta1.ClusterServiceBrokerAuthInfo{
+		Basic: &v1beta1.ClusterBasicAuthConfig{
+			SecretRef: &v1beta1.ObjectReference{Namespace: "test-ns", Name: "auth-secret"},
+		},
+	}
+}
+
+func getTestClusterBrokerBearerAuthInfo() *v1beta1.ClusterServiceBrokerAuthInfo {
+	return &v1beta1.ClusterServiceBrokerAuthInfo{
+		Bearer: &v1beta1.ClusterBearerTokenAuthConfig{
+			SecretRef: &v1beta1.ObjectReference{Namespace: "test-ns", Name: "auth-secret"},
+		},
+	}
+}
+
+func getTestBasicAuthSecret() *corev1.Secret {
+	return &corev1.Secret{
+		Data: map[string][]byte{
+			v1beta1.BasicAuthUsernameKey: []byte("foo"),
+			v1beta1.BasicAuthPasswordKey: []byte("bar"),
+		},
+	}
+}
+
+func getTestBearerAuthSecret() *corev1.Secret {
+	return &corev1.Secret{
+		Data: map[string][]byte{
+			v1beta1.BearerTokenKey: []byte("token"),
+		},
+	}
+}
+
 // a bindable service class wired to the result of getTestClusterServiceBroker()
 func getTestClusterServiceClass() *v1beta1.ClusterServiceClass {
 	broker := getTestClusterServiceBroker()


### PR DESCRIPTION
This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
This PR fixes problem with deleting ClusterServiceBroker/ServiceBroker when they are in error state because of the missing Secret.

**Which issue(s) this PR fixes** 
Fixes #2492

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
