### PR TITLE
Randomly generate k8s names for classes and plans

### DIFF
--- a/docs/catalog-restrictions.md
+++ b/docs/catalog-restrictions.md
@@ -64,7 +64,6 @@ subset of properties on service class and service plan resources. The following
 
 | Property Key    | Description   | 
 | -------------   | ------------- |
-| name |  This key will match the ClusterServiceClass.Name property |
 | spec.externalName | This key will match the ClusterServiceClass.Spec.ExternalName property |
 | spec.externalID | This key will match the ClusterServiceClass.Spec.ExternalID property |
 
@@ -72,7 +71,6 @@ subset of properties on service class and service plan resources. The following
 
 | Property Key    | Description  |
 | ------------    | ------------ |
-| name |  This key will match the ServiceClass.Name |
 | spec.externalName | This key will match the ServiceClass.Spec.ExternalName property |
 | spec.externalID | This key will match the ServiceClass.Spec.ExternalID property |
 
@@ -80,7 +78,6 @@ subset of properties on service class and service plan resources. The following
 
 | Property Key    | Description  |
 | ------------    | ------------ |
-| name | This key will match the ClusterServicePlan.Name |
 | spec.externalName | This key will match the ClusterServicePlan.Spec.ExternalName property |
 | spec.externalID | This key will match the ClusterServicePlan.Spec.ExternalID property |
 | spec.free | This key will match the ClusterServicePlan.Spec.Free property |
@@ -90,7 +87,6 @@ subset of properties on service class and service plan resources. The following
 
 | Property Key    | Description  |
 | ------------    | ------------ |
-| name | This key will match the ServicePlan.Name property |
 | spec.externalName | This key will match the ServicePlan.Spec.ExternalName property |
 | spec.externalID | This key will match the ServicePlan.Spec.ExternalID property |
 | spec.free | This key will match the ServicePlan.Spec.Free property |
@@ -175,7 +171,7 @@ spec:
 
 You can also combine restrictions on classes and plans. An example that 
 allow all free plans with the externalName `Demo`, and not a specific service
- named `AABBB-CCDD-EEGG-HIJK`, you would create a YAML like:
+class with the externalName `MySQL`, you would create a YAML like:
 
 ```yaml
 apiVersion: servicecatalog.k8s.io/v1beta1
@@ -190,7 +186,7 @@ spec:
         namespace: brokers
   catalogRestrictions:
     serviceClass:
-    - "name!=AABBB-CCDD-EEGG-HIJK"
+    - "spec.externalName!=MySQL"
     servicePlan:
     - "spec.externalName in (Demo)"
     - "spec.free=true"

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -143,11 +143,9 @@ type CommonServiceBrokerSpec struct {
 // Multiple predicates are allowed to be chained with a comma (,)
 //
 // ServiceClass allowed property names:
-//   name - the value set to [Cluster]ServiceClass.Name
 //   spec.externalName - the value set to [Cluster]ServiceClass.Spec.ExternalName
 //   spec.externalID - the value set to [Cluster]ServiceClass.Spec.ExternalID
 // ServicePlan allowed property names:
-//   name - the value set to [Cluster]ServicePlan.Name
 //   spec.externalName - the value set to [Cluster]ServicePlan.Spec.ExternalName
 //   spec.externalID - the value set to [Cluster]ServicePlan.Spec.ExternalID
 //   spec.free - the value set to [Cluster]ServicePlan.Spec.Free

--- a/pkg/apis/servicecatalog/v1beta1/filter.go
+++ b/pkg/apis/servicecatalog/v1beta1/filter.go
@@ -34,7 +34,6 @@ func ConvertServiceClassToProperties(serviceClass *ServiceClass) filter.Properti
 		return labels.Set{}
 	}
 	return labels.Set{
-		FilterName:             serviceClass.Name,
 		FilterSpecExternalName: serviceClass.Spec.ExternalName,
 		FilterSpecExternalID:   serviceClass.Spec.ExternalID,
 	}
@@ -54,7 +53,6 @@ func ConvertServicePlanToProperties(servicePlan *ServicePlan) filter.Properties 
 		return labels.Set{}
 	}
 	return labels.Set{
-		FilterName:                 servicePlan.Name,
 		FilterSpecExternalName:     servicePlan.Spec.ExternalName,
 		FilterSpecExternalID:       servicePlan.Spec.ExternalID,
 		FilterSpecServiceClassName: servicePlan.Spec.ServiceClassRef.Name,
@@ -65,7 +63,7 @@ func ConvertServicePlanToProperties(servicePlan *ServicePlan) filter.Properties 
 // IsValidServicePlanProperty returns true if the specified property
 // is a valid filterable property of ServicePlans
 func IsValidServicePlanProperty(p string) bool {
-	return p == FilterName || p == FilterSpecExternalName || p == FilterSpecExternalID || p == FilterSpecServiceClassName || p == FilterSpecFree
+	return p == FilterSpecExternalName || p == FilterSpecExternalID || p == FilterSpecServiceClassName || p == FilterSpecFree
 }
 
 // ConvertClusterServiceClassToProperties takes a Service Class and pulls out the
@@ -76,7 +74,6 @@ func ConvertClusterServiceClassToProperties(serviceClass *ClusterServiceClass) f
 		return labels.Set{}
 	}
 	return labels.Set{
-		FilterName:             serviceClass.Name,
 		FilterSpecExternalName: serviceClass.Spec.ExternalName,
 		FilterSpecExternalID:   serviceClass.Spec.ExternalID,
 	}
@@ -85,7 +82,7 @@ func ConvertClusterServiceClassToProperties(serviceClass *ClusterServiceClass) f
 // IsValidClusterServiceClassProperty returns true if the specified property
 // is a valid filterable property of ClusterServiceClasses
 func IsValidClusterServiceClassProperty(p string) bool {
-	return p == FilterName || p == FilterSpecExternalName || p == FilterSpecExternalID
+	return p == FilterSpecExternalName || p == FilterSpecExternalID
 }
 
 // ConvertClusterServicePlanToProperties takes a Service Plan and pulls out the
@@ -96,7 +93,6 @@ func ConvertClusterServicePlanToProperties(servicePlan *ClusterServicePlan) filt
 		return labels.Set{}
 	}
 	return labels.Set{
-		FilterName:                        servicePlan.Name,
 		FilterSpecExternalName:            servicePlan.Spec.ExternalName,
 		FilterSpecExternalID:              servicePlan.Spec.ExternalID,
 		FilterSpecClusterServiceClassName: servicePlan.Spec.ClusterServiceClassRef.Name,
@@ -107,5 +103,5 @@ func ConvertClusterServicePlanToProperties(servicePlan *ClusterServicePlan) filt
 // IsValidClusterServicePlanProperty returns true if the specified property
 // is a valid filterable property of ServicePlans
 func IsValidClusterServicePlanProperty(p string) bool {
-	return p == FilterName || p == FilterSpecExternalName || p == FilterSpecExternalID || p == FilterSpecClusterServiceClassName || p == FilterSpecFree
+	return p == FilterSpecExternalName || p == FilterSpecExternalID || p == FilterSpecClusterServiceClassName || p == FilterSpecFree
 }

--- a/pkg/apis/servicecatalog/v1beta1/filter_test.go
+++ b/pkg/apis/servicecatalog/v1beta1/filter_test.go
@@ -44,7 +44,7 @@ func TestConvertServiceClassToProperties(t *testing.T) {
 					},
 				},
 			},
-			json: `{"name":"service-class","spec.externalID":"external-id","spec.externalName":"external-class-name"}`,
+			json: `{"spec.externalID":"external-id","spec.externalName":"external-class-name"}`,
 		},
 	}
 	for _, tc := range cases {
@@ -90,7 +90,7 @@ func TestConvertServicePlanToProperties(t *testing.T) {
 					},
 				},
 			},
-			json: `{"name":"service-plan","spec.externalID":"external-id","spec.externalName":"external-plan-name","spec.free":"true","spec.serviceClass.name":"service-class-name"}`,
+			json: `{"spec.externalID":"external-id","spec.externalName":"external-plan-name","spec.free":"true","spec.serviceClass.name":"service-class-name"}`,
 		},
 	}
 	for _, tc := range cases {
@@ -132,7 +132,7 @@ func TestConvertClusterServiceClassToProperties(t *testing.T) {
 					},
 				},
 			},
-			json: `{"name":"service-class","spec.externalID":"external-id","spec.externalName":"external-class-name"}`,
+			json: `{"spec.externalID":"external-id","spec.externalName":"external-class-name"}`,
 		},
 	}
 	for _, tc := range cases {
@@ -178,7 +178,7 @@ func TestConvertClusterServicePlanToProperties(t *testing.T) {
 					},
 				},
 			},
-			json: `{"name":"service-plan","spec.clusterServiceClass.name":"cluster-service-class-name","spec.externalID":"external-id","spec.externalName":"external-plan-name","spec.free":"true"}`,
+			json: `{"spec.clusterServiceClass.name":"cluster-service-class-name","spec.externalID":"external-id","spec.externalName":"external-plan-name","spec.free":"true"}`,
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -164,11 +164,9 @@ type CommonServiceBrokerSpec struct {
 // Multiple predicates are allowed to be chained with a comma (,)
 //
 // ServiceClass allowed property names:
-//   name - the value set to [Cluster]ServiceClass.Name
 //   spec.externalName - the value set to [Cluster]ServiceClass.Spec.ExternalName
 //   spec.externalID - the value set to [Cluster]ServiceClass.Spec.ExternalID
 // ServicePlan allowed property names:
-//   name - the value set to [Cluster]ServicePlan.Name
 //   spec.externalName - the value set to [Cluster]ServicePlan.Spec.ExternalName
 //   spec.externalID - the value set to [Cluster]ServicePlan.Spec.ExternalID
 //   spec.free - the value set to [Cluster]ServicePlan.Spec.Free

--- a/pkg/apis/servicecatalog/validation/broker_test.go
+++ b/pkg/apis/servicecatalog/validation/broker_test.go
@@ -370,26 +370,6 @@ func TestValidateClusterServiceBroker(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "valid clusterservicebroker - catalogRequirements.serviceClass",
-			broker: &servicecatalog.ClusterServiceBroker{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-broker",
-				},
-				Spec: servicecatalog.ClusterServiceBrokerSpec{
-					CommonServiceBrokerSpec: servicecatalog.CommonServiceBrokerSpec{
-						URL:            "http://example.com",
-						RelistBehavior: servicecatalog.ServiceBrokerRelistBehaviorManual,
-						CatalogRestrictions: &servicecatalog.CatalogRestrictions{
-							ServiceClass: []string{
-								"name==foobar",
-							},
-						},
-					},
-				},
-			},
-			valid: true,
-		},
-		{
 			name: "valid clusterservicebroker - complex catalogRequirements.serviceClass",
 			broker: &servicecatalog.ClusterServiceBroker{
 				ObjectMeta: metav1.ObjectMeta{
@@ -401,7 +381,6 @@ func TestValidateClusterServiceBroker(t *testing.T) {
 						RelistBehavior: servicecatalog.ServiceBrokerRelistBehaviorManual,
 						CatalogRestrictions: &servicecatalog.CatalogRestrictions{
 							ServiceClass: []string{
-								"name==foobar",
 								"spec.externalName in (foobar, bazboof, wizzbang)",
 							},
 						},
@@ -451,47 +430,6 @@ func TestValidateClusterServiceBroker(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "valid clusterservicebroker - catalogRequirements.servicePlan",
-			broker: &servicecatalog.ClusterServiceBroker{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-broker",
-				},
-				Spec: servicecatalog.ClusterServiceBrokerSpec{
-					CommonServiceBrokerSpec: servicecatalog.CommonServiceBrokerSpec{
-						URL:            "http://example.com",
-						RelistBehavior: servicecatalog.ServiceBrokerRelistBehaviorManual,
-						CatalogRestrictions: &servicecatalog.CatalogRestrictions{
-							ServicePlan: []string{
-								"name==foobar",
-							},
-						},
-					},
-				},
-			},
-			valid: true,
-		},
-		{
-			name: "valid clusterservicebroker - complex catalogRequirements.servicePlan",
-			broker: &servicecatalog.ClusterServiceBroker{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-broker",
-				},
-				Spec: servicecatalog.ClusterServiceBrokerSpec{
-					CommonServiceBrokerSpec: servicecatalog.CommonServiceBrokerSpec{
-						URL:            "http://example.com",
-						RelistBehavior: servicecatalog.ServiceBrokerRelistBehaviorManual,
-						CatalogRestrictions: &servicecatalog.CatalogRestrictions{
-							ServicePlan: []string{
-								"name==foobar",
-								"spec.externalName in (foobar, bazboof, wizzbang)",
-							},
-						},
-					},
-				},
-			},
-			valid: true,
-		},
-		{
 			name: "invalid clusterservicebroker - catalogRequirements.servicePlan",
 			broker: &servicecatalog.ClusterServiceBroker{
 				ObjectMeta: metav1.ObjectMeta{
@@ -530,31 +468,6 @@ func TestValidateClusterServiceBroker(t *testing.T) {
 				},
 			},
 			valid: false,
-		},
-		{
-			name: "valid clusterservicebroker - catalogRequirements with serviceClass and servicePlan",
-			broker: &servicecatalog.ClusterServiceBroker{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-broker",
-				},
-				Spec: servicecatalog.ClusterServiceBrokerSpec{
-					CommonServiceBrokerSpec: servicecatalog.CommonServiceBrokerSpec{
-						URL:            "http://example.com",
-						RelistBehavior: servicecatalog.ServiceBrokerRelistBehaviorManual,
-						CatalogRestrictions: &servicecatalog.CatalogRestrictions{
-							ServiceClass: []string{
-								"name=barfoobar",
-								"spec.externalName in (barfoobar, batbazboof, batwizzbang)",
-							},
-							ServicePlan: []string{
-								"name==foobar",
-								"spec.externalName in (foobar, bazboof, wizzbang)",
-							},
-						},
-					},
-				},
-			},
-			valid: true,
 		},
 	}
 

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -1149,7 +1149,7 @@ func verifyBrokerCreated(t *testing.T, client clientsetsc.ServicecatalogV1beta1I
 		t.Fatalf("error waiting for broker to become ready: %v", err)
 	}
 
-	if err := util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID); err != nil {
+	if err := util.WaitForClusterServiceClassToExist(client, testClassExternalID); err != nil {
 		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
 	}
 
@@ -1167,7 +1167,7 @@ func deleteBroker(t *testing.T, client clientsetsc.ServicecatalogV1beta1Interfac
 		t.Fatalf("broker should be deleted (%s)", err)
 	}
 
-	if err := util.WaitForClusterServiceClassToNotExist(client, testClusterServiceClassName); err != nil {
+	if err := util.WaitForClusterServiceClassToNotExist(client, testClassExternalID); err != nil {
 		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
 	}
 

--- a/test/integration/filtered_services_and_plans_test.go
+++ b/test/integration/filtered_services_and_plans_test.go
@@ -35,12 +35,12 @@ import (
 func TestClusterServiceClassRemovedFromCatalogAfterFiltering(t *testing.T) {
 
 	name := "Archonei"
-	uuid := generator.IDFrom(name)
+	externalID := generator.IDFrom(name)
 
 	broker := getTestBroker()
 	broker.Spec.RelistDuration = &metav1.Duration{Duration: time.Millisecond * 100}
 	broker.Spec.CatalogRestrictions = &v1beta1.CatalogRestrictions{
-		ServiceClass: []string{"name!=" + uuid},
+		ServiceClass: []string{"spec.externalID!=" + externalID},
 	}
 
 	ct := &controllerTest{
@@ -56,7 +56,7 @@ func TestClusterServiceClassRemovedFromCatalogAfterFiltering(t *testing.T) {
 
 		time.Sleep(time.Millisecond * 300)
 
-		err := util.WaitForClusterServiceClassToNotExist(ct.client, uuid)
+		err := util.WaitForClusterServiceClassToNotExist(ct.client, externalID)
 		if err != nil {
 			t.Fatalf("error waiting for remove ClusterServiceClass to not exist: %v", err)
 		}


### PR DESCRIPTION
This PR changes service catalog to start generating the k8s.name field as a random guid, rather than using the OSB API ExternalID, as the ExternalID can contain characters or be formatted in ways that are not valid k8s names.

This also removes the option to filter based on k8s.Names, as its no longer a useful feature.