### PR TITLE
Fix incorrect condition & event msg on retriable instance update failures

### DIFF
--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -755,14 +755,15 @@ func (c *controller) reconcileServiceInstanceUpdate(instance *v1beta1.ServiceIns
 	response, err := brokerClient.UpdateInstance(request)
 	if err != nil {
 		if httpErr, ok := osb.IsHTTPError(err); ok {
-			msg := fmt.Sprintf("ServiceBroker returned a failure for update call; update will not be retried: %v", httpErr)
-			readyCond := newServiceInstanceReadyCondition(v1beta1.ConditionFalse, errorUpdateInstanceCallFailedReason, msg)
-
 			if isRetriableHTTPStatus(httpErr.StatusCode) {
+				msg := fmt.Sprintf("ServiceBroker returned a failure for update call; update will be retried: %v", httpErr)
+				readyCond := newServiceInstanceReadyCondition(v1beta1.ConditionFalse, errorUpdateInstanceCallFailedReason, msg)
 				return c.processTemporaryUpdateServiceInstanceFailure(instance, readyCond)
 			}
 			// A failure with a given HTTP response code is treated as a terminal
 			// failure.
+			msg := fmt.Sprintf("ServiceBroker returned a failure for update call; update will not be retried: %v", httpErr)
+			readyCond := newServiceInstanceReadyCondition(v1beta1.ConditionFalse, errorUpdateInstanceCallFailedReason, msg)
 			failedCond := newServiceInstanceFailedCondition(v1beta1.ConditionTrue, errorUpdateInstanceCallFailedReason, msg)
 			return c.processTerminalUpdateServiceInstanceFailure(instance, readyCond, failedCond)
 		}

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -5202,64 +5202,101 @@ func TestReconcileServiceInstanceWithUpdateCallFailure(t *testing.T) {
 
 // TestReconcileServiceInstanceWithUpdateFailure tests that when the provision
 // call to the broker fails with an HTTP error, the ready condition becomes
-// false, and the failure condition is set.
+// false, and the failure condition is either set or not set (depending on
+// whether the failure is retriable or not).
 func TestReconcileServiceInstanceWithUpdateFailure(t *testing.T) {
-	fakeKubeClient, fakeCatalogClient, fakeClusterServiceBrokerClient, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
-		UpdateInstanceReaction: &fakeosb.UpdateInstanceReaction{
-			Error: osb.HTTPStatusCodeError{
+	cases := []struct {
+		name                  string
+		brokerHTTPError       osb.HTTPStatusCodeError
+		errorExpected         bool
+		expectedFailureReason string
+		expectedEventMessage  string
+	}{
+		{
+			name: "retriable failure",
+			brokerHTTPError: osb.HTTPStatusCodeError{
 				StatusCode:   http.StatusConflict,
 				ErrorMessage: strPtr("OutOfQuota"),
 				Description:  strPtr("You're out of quota!"),
 			},
+			errorExpected:         true,
+			expectedFailureReason: "",
+			expectedEventMessage: "ServiceBroker returned a failure for update call; update will be retried: " +
+				"Status: 409; ErrorMessage: OutOfQuota; Description: You're out of quota!; ResponseError: <nil>",
 		},
-	})
-
-	sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(getTestClusterServiceBroker())
-	sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(getTestClusterServiceClass())
-	sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
-
-	instance := getTestServiceInstanceUpdatingPlan()
-
-	if err := reconcileServiceInstance(t, testController, instance); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	instance = assertServiceInstanceUpdateInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
-	fakeCatalogClient.ClearActions()
-	fakeKubeClient.ClearActions()
-
-	if err := reconcileServiceInstance(t, testController, instance); err == nil {
-		t.Fatal("expected error to be returned")
+		{
+			name: "terminal failure",
+			brokerHTTPError: osb.HTTPStatusCodeError{
+				StatusCode:   http.StatusBadRequest,
+				ErrorMessage: strPtr("BadRequest"),
+				Description:  strPtr("Something's wrong with the request"),
+			},
+			errorExpected:         false,
+			expectedFailureReason: errorUpdateInstanceCallFailedReason,
+			expectedEventMessage: "ServiceBroker returned a failure for update call; update will not be retried: " +
+				"Status: 400; ErrorMessage: BadRequest; Description: Something's wrong with the request; ResponseError: <nil>",
+		},
 	}
 
-	brokerActions := fakeClusterServiceBrokerClient.Actions()
-	assertNumberOfBrokerActions(t, brokerActions, 1)
-	expectedPlanID := testClusterServicePlanGUID
-	assertUpdateInstance(t, brokerActions[0], &osb.UpdateInstanceRequest{
-		AcceptsIncomplete: true,
-		InstanceID:        testServiceInstanceGUID,
-		ServiceID:         testClusterServiceClassGUID,
-		PlanID:            &expectedPlanID,
-		Context:           testContext})
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeKubeClient, fakeCatalogClient, fakeClusterServiceBrokerClient, testController, sharedInformers := newTestController(t, fakeosb.FakeClientConfiguration{
+				UpdateInstanceReaction: &fakeosb.UpdateInstanceReaction{
+					Error: tc.brokerHTTPError,
+				},
+			})
 
-	// verify one kube action occurred
-	kubeActions := fakeKubeClient.Actions()
-	if err := checkKubeClientActions(kubeActions, []kubeClientAction{
-		{verb: "get", resourceName: "namespaces", checkType: checkGetActionType},
-	}); err != nil {
-		t.Fatal(err)
-	}
+			sharedInformers.ClusterServiceBrokers().Informer().GetStore().Add(getTestClusterServiceBroker())
+			sharedInformers.ClusterServiceClasses().Informer().GetStore().Add(getTestClusterServiceClass())
+			sharedInformers.ClusterServicePlans().Informer().GetStore().Add(getTestClusterServicePlan())
 
-	actions := fakeCatalogClient.Actions()
-	assertNumberOfActions(t, actions, 1)
+			instance := getTestServiceInstanceUpdatingPlan()
 
-	updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
-	assertServiceInstanceUpdateRequestFailingErrorNoOrphanMitigation(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, errorUpdateInstanceCallFailedReason, "", instance)
+			if err := reconcileServiceInstance(t, testController, instance); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			instance = assertServiceInstanceUpdateInProgressIsTheOnlyCatalogClientAction(t, fakeCatalogClient, instance)
+			fakeCatalogClient.ClearActions()
+			fakeKubeClient.ClearActions()
 
-	events := getRecordedEvents(testController)
+			err := reconcileServiceInstance(t, testController, instance)
+			if tc.errorExpected && err == nil {
+				t.Fatal("expected error to be returned")
+			} else if !tc.errorExpected && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-	expectedEvent := warningEventBuilder(errorUpdateInstanceCallFailedReason).msg("ServiceBroker returned a failure for update call; update will not be retried:").msg("Status: 409; ErrorMessage: OutOfQuota; Description: You're out of quota!; ResponseError: <nil>")
-	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
-		t.Fatal(err)
+			brokerActions := fakeClusterServiceBrokerClient.Actions()
+			assertNumberOfBrokerActions(t, brokerActions, 1)
+			expectedPlanID := testClusterServicePlanGUID
+			assertUpdateInstance(t, brokerActions[0], &osb.UpdateInstanceRequest{
+				AcceptsIncomplete: true,
+				InstanceID:        testServiceInstanceGUID,
+				ServiceID:         testClusterServiceClassGUID,
+				PlanID:            &expectedPlanID,
+				Context:           testContext})
+
+			// verify one kube action occurred
+			kubeActions := fakeKubeClient.Actions()
+			if err := checkKubeClientActions(kubeActions, []kubeClientAction{
+				{verb: "get", resourceName: "namespaces", checkType: checkGetActionType},
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			actions := fakeCatalogClient.Actions()
+			assertNumberOfActions(t, actions, 1)
+
+			updatedServiceInstance := assertUpdateStatus(t, actions[0], instance)
+			assertServiceInstanceUpdateRequestFailingErrorNoOrphanMitigation(t, updatedServiceInstance, v1beta1.ServiceInstanceOperationUpdate, errorUpdateInstanceCallFailedReason, tc.expectedFailureReason, instance)
+
+			events := getRecordedEvents(testController)
+
+			expectedEvent := warningEventBuilder(errorUpdateInstanceCallFailedReason).msg(tc.expectedEventMessage)
+			if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2351,7 +2351,7 @@ func assertServiceInstanceConditionMissing(t *testing.T, obj runtime.Object, con
 
 	for _, condition := range instance.Status.Conditions {
 		if condition.Type == conditionType {
-			fatalf(t, "%v condition expected to be missing", conditionType)
+			fatalf(t, "%v condition expected to be missing, but was present with the reason %q and message %q", conditionType, condition.Reason, condition.Message)
 			return
 		}
 	}


### PR DESCRIPTION
This PR is a 
 - [x] Bug Fix

**What this PR does / why we need it**:
When the broker responds with a retriable failure on an instance update
request, the controller sets the Ready condition's message (and also
produces an event with the same message) that says that the update
will NOT be retried, where, in fact, it will be.

This PR changes the message to "will be retried".


Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
