### PR TITLE
Fix bug in create service binding errors

### DIFF
--- a/cmd/controller-manager/app/controller_manager.go
+++ b/cmd/controller-manager/app/controller_manager.go
@@ -391,6 +391,7 @@ func StartControllers(s *options.ControllerManagerServer,
 		s.OperationPollingMaximumBackoffDuration,
 		s.ClusterIDConfigMapName,
 		s.ClusterIDConfigMapNamespace,
+		s.OSBAPITimeOut,
 	)
 	if err != nil {
 		return err

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -60,6 +60,7 @@ const (
 	defaultLeaderElectionNamespace                = "kube-system"
 	defaultReconciliationRetryDuration            = 7 * 24 * time.Hour
 	defaultOperationPollingMaximumBackoffDuration = 20 * time.Minute
+	defaultOSBAPITimeOut                          = 60 * time.Second
 )
 
 var defaultOSBAPIPreferredVersion = osb.LatestAPIVersion().HeaderValue()
@@ -86,6 +87,7 @@ func NewControllerManagerServer() *ControllerManagerServer {
 			ReconciliationRetryDuration:            defaultReconciliationRetryDuration,
 			OperationPollingMaximumBackoffDuration: defaultOperationPollingMaximumBackoffDuration,
 			SecureServingOptions:                   genericoptions.NewSecureServingOptions(),
+			OSBAPITimeOut:                          defaultOSBAPITimeOut,
 		},
 	}
 	// set defaults, these will be overridden by user specified flags
@@ -118,6 +120,7 @@ func (s *ControllerManagerServer) AddFlags(fs *pflag.FlagSet) {
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)
 	fs.StringVar(&s.LeaderElectionNamespace, "leader-election-namespace", s.LeaderElectionNamespace, "Namespace to use for leader election lock")
 	fs.DurationVar(&s.ReconciliationRetryDuration, "reconciliation-retry-duration", s.ReconciliationRetryDuration, "The maximum amount of time to retry reconciliations on a resource before failing")
+	fs.DurationVar(&s.OSBAPITimeOut, "osb-api-timeout", s.OSBAPITimeOut, "The length of the timeout of any request to the broker, in seconds.")
 	fs.DurationVar(&s.OperationPollingMaximumBackoffDuration, "operation-polling-maximum-backoff-duration", s.OperationPollingMaximumBackoffDuration, "The maximum amount of time to back-off while polling an OSB API operation")
 	s.SecureServingOptions.AddFlags(fs)
 	utilfeature.DefaultFeatureGate.AddFlag(fs)

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -77,6 +77,9 @@ type ControllerManagerConfiguration struct {
 	OSBAPIContextProfile   bool
 	OSBAPIPreferredVersion string
 
+	// OSBAPITimeOut the length of the timeout of any request to the broker, in seconds.
+	OSBAPITimeOut time.Duration
+
 	// ConcurrentSyncs is the number of resources, per resource type,
 	// that are allowed to sync concurrently. Larger number = more responsive
 	// SC operations, but more CPU (and network) load.

--- a/pkg/controller/controller_clusterservicebroker.go
+++ b/pkg/controller/controller_clusterservicebroker.go
@@ -137,7 +137,7 @@ func (c *controller) updateClusterServiceBrokerClient(broker *v1beta1.ClusterSer
 		}
 		return nil, err
 	}
-	clientConfig := NewClientConfigurationForBroker(broker.ObjectMeta, &broker.Spec.CommonServiceBrokerSpec, authConfig)
+	clientConfig := NewClientConfigurationForBroker(broker.ObjectMeta, &broker.Spec.CommonServiceBrokerSpec, authConfig, c.OSBAPITimeOut)
 	brokerClient, err := c.brokerClientManager.UpdateBrokerClient(NewClusterServiceBrokerKey(broker.Name), clientConfig)
 	if err != nil {
 		s := fmt.Sprintf("Error creating client for broker %q: %s", broker.Name, err)

--- a/pkg/controller/controller_servicebroker.go
+++ b/pkg/controller/controller_servicebroker.go
@@ -128,7 +128,7 @@ func (c *controller) updateServiceBrokerClient(broker *v1beta1.ServiceBroker) (o
 	}
 
 	// clientConfig := NewClientConfigurationForBroker(broker, authConfig)
-	clientConfig := NewClientConfigurationForBroker(broker.ObjectMeta, &broker.Spec.CommonServiceBrokerSpec, authConfig)
+	clientConfig := NewClientConfigurationForBroker(broker.ObjectMeta, &broker.Spec.CommonServiceBrokerSpec, authConfig, c.OSBAPITimeOut)
 
 	brokerClient, err := c.brokerClientManager.UpdateBrokerClient(NewServiceBrokerKey(broker.Namespace, broker.Name), clientConfig)
 	if err != nil {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2002,6 +2002,7 @@ func newTestController(t *testing.T, config fakeosb.FakeClientConfiguration) (
 		7*24*time.Hour,
 		DefaultClusterIDConfigMapName,
 		DefaultClusterIDConfigMapNamespace,
+		60*time.Second,
 	)
 
 	if err != nil {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -786,6 +786,7 @@ func newControllerTestTestController(ct *controllerTest) (
 		7*24*time.Hour,
 		controller.DefaultClusterIDConfigMapName,
 		controller.DefaultClusterIDConfigMapNamespace,
+		60*time.Second,
 	)
 	t.Log("controller start")
 	if err != nil {
@@ -946,6 +947,7 @@ func newTestController(t *testing.T) (
 		7*24*time.Hour,
 		controller.DefaultClusterIDConfigMapName,
 		controller.DefaultClusterIDConfigMapNamespace,
+		60*time.Second,
 	)
 	t.Log("controller start")
 	if err != nil {


### PR DESCRIPTION
We find the delay in creating instance binding varies. The current
default is to wait one minute, otherwise the creation is considered
a failure. So I do this patch to solve this problem. And I think this
delay is configured for different usage scenarios or brokers.
For example, when the maximum response time of my service is 1 minute,
we may set it to be 60, While yours is 3 minutes, and then you should
set it to be 180.

 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [x] New feature 
   - [ ] Tests
 - [x] Server Flag for config
   - [ ] Documentation needed for helm charts
