### PR TITLE
Escape '/' characters when creating k8s names for classes and plans

### DIFF
--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -717,7 +717,7 @@ func TestReconcileServiceBindingNonbindableClusterServiceClass(t *testing.T) {
 
 	expectedEvent := warningEventBuilder(errorNonbindableClusterServiceClassReason).msgf(
 		"References a non-bindable ClusterServiceClass (K8S: %q ExternalName: %q) and Plan (%q) combination",
-		"UNBINDABLE-CLUSTERSERVICECLASS", "test-unbindable-clusterserviceclass", "test-unbindable-clusterserviceplan",
+		"unbindable-clusterserviceclass", "test-unbindable-clusterserviceclass", "test-unbindable-clusterserviceplan",
 	).String()
 	expectedEvents := []string{expectedEvent, expectedEvent}
 	if err := checkEvents(events, expectedEvents); err != nil {
@@ -893,7 +893,7 @@ func TestReconcileServiceBindingBindableClusterServiceClassNonbindablePlan(t *te
 
 	expectedEvent := warningEventBuilder(errorNonbindableClusterServiceClassReason).msgf(
 		"References a non-bindable ClusterServiceClass (K8S: %q ExternalName: %q) and Plan (%q) combination",
-		"CSCGUID", "test-clusterserviceclass", "test-unbindable-clusterserviceplan",
+		"cscguid", "test-clusterserviceclass", "test-unbindable-clusterserviceplan",
 	).String()
 	expectedEvents := []string{
 		expectedEvent,
@@ -1499,7 +1499,7 @@ func TestReconcileServiceBindingWithClusterServiceBrokerError(t *testing.T) {
 
 	expectedEvent := warningEventBuilder(errorBindCallReason).msgf(
 		"Error creating ServiceBinding for ServiceInstance %q of ClusterServiceClass (K8S: %q ExternalName: %q) at ClusterServiceBroker %q:",
-		"test-ns/test-instance", "CSCGUID", "test-clusterserviceclass", "test-clusterservicebroker",
+		"test-ns/test-instance", "cscguid", "test-clusterserviceclass", "test-clusterservicebroker",
 	).msg("Unexpected action")
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)
@@ -1666,7 +1666,7 @@ func TestReconcileServiceBindingWithServiceBindingCallFailure(t *testing.T) {
 
 	expectedEvent := warningEventBuilder(errorBindCallReason).msgf(
 		"Error creating ServiceBinding for ServiceInstance %q of ClusterServiceClass (K8S: %q ExternalName: %q) at ClusterServiceBroker %q:",
-		"test-ns/test-instance", "CSCGUID", "test-clusterserviceclass", "test-clusterservicebroker",
+		"test-ns/test-instance", "cscguid", "test-clusterserviceclass", "test-clusterservicebroker",
 	).msg("fake creation failure")
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)
@@ -1946,7 +1946,7 @@ func TestReconcileUnbindingWithClusterServiceBrokerError(t *testing.T) {
 
 	expectedEvent := warningEventBuilder(errorUnbindCallReason).msgf(
 		"Error unbinding from ServiceInstance %q of ClusterServiceClass (K8S: %q ExternalName: %q) at ClusterServiceBroker %q:",
-		"test-ns/test-instance", "CSCGUID", "test-clusterserviceclass", "test-clusterservicebroker",
+		"test-ns/test-instance", "cscguid", "test-clusterserviceclass", "test-clusterservicebroker",
 	).msg("Unexpected action")
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)
@@ -2014,7 +2014,7 @@ func TestReconcileUnbindingWithClusterServiceBrokerHTTPError(t *testing.T) {
 
 	expectedEvent := warningEventBuilder(errorUnbindCallReason).msgf(
 		"Error unbinding from ServiceInstance %q of ClusterServiceClass (K8S: %q ExternalName: %q) at ClusterServiceBroker %q:",
-		"test-ns/test-instance", "CSCGUID", "test-clusterserviceclass", "test-clusterservicebroker",
+		"test-ns/test-instance", "cscguid", "test-clusterserviceclass", "test-clusterservicebroker",
 	).msg("Status: 410; ErrorMessage: <nil>; Description: <nil>; ResponseError: <nil>")
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)

--- a/pkg/controller/controller_clusterservicebroker.go
+++ b/pkg/controller/controller_clusterservicebroker.go
@@ -219,22 +219,6 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 			}
 		}
 
-		// convert the broker's catalog payload into our API objects
-		klog.V(4).Info(pcb.Message("Converting catalog response into service-catalog API"))
-
-		payloadServiceClasses, payloadServicePlans, err := convertAndFilterCatalog(brokerCatalog, broker.Spec.CatalogRestrictions)
-		if err != nil {
-			s := fmt.Sprintf("Error converting catalog payload for broker %q to service-catalog API: %s", broker.Name, err)
-			klog.Warning(pcb.Message(s))
-			c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
-			if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason, errorSyncingCatalogMessage+s); err != nil {
-				return err
-			}
-			return err
-		}
-
-		klog.V(5).Info(pcb.Message("Successfully converted catalog payload from to service-catalog API"))
-
 		// get the existing services and plans for this broker so that we can
 		// detect when services and plans are removed from the broker's
 		// catalog
@@ -246,11 +230,29 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 		existingServiceClassMap := convertClusterServiceClassListToMap(existingServiceClasses)
 		existingServicePlanMap := convertClusterServicePlanListToMap(existingServicePlans)
 
+		// convert the broker's catalog payload into our API objects
+		klog.V(4).Info(pcb.Message("Converting catalog response into service-catalog API"))
+		payloadServiceClasses, payloadServicePlans, err := convertAndFilterCatalog(brokerCatalog, broker.Spec.CatalogRestrictions, existingServiceClassMap, existingServicePlanMap)
+		if err != nil {
+			s := fmt.Sprintf("Error converting catalog payload for broker %q to service-catalog API: %s", broker.Name, err)
+			klog.Warning(pcb.Message(s))
+			c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
+			if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason, errorSyncingCatalogMessage+s); err != nil {
+				return err
+			}
+			return err
+		}
+		klog.V(5).Info(pcb.Message("Successfully converted catalog payload from to service-catalog API"))
+
 		// reconcile the serviceClasses that were part of the broker's catalog
 		// payload
 		for _, payloadServiceClass := range payloadServiceClasses {
 			existingServiceClass, _ := existingServiceClassMap[payloadServiceClass.Name]
 			delete(existingServiceClassMap, payloadServiceClass.Name)
+			if existingServiceClass == nil {
+				existingServiceClass, _ = existingServiceClassMap[payloadServiceClass.Spec.ExternalID]
+				delete(existingServiceClassMap, payloadServiceClass.Spec.ExternalID)
+			}
 
 			klog.V(4).Info(pcb.Messagef("Reconciling %s", pretty.ClusterServiceClassName(payloadServiceClass)))
 			if err := c.reconcileClusterServiceClassFromClusterServiceBrokerCatalog(broker, payloadServiceClass, existingServiceClass); err != nil {
@@ -304,6 +306,10 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 		for _, payloadServicePlan := range payloadServicePlans {
 			existingServicePlan, _ := existingServicePlanMap[payloadServicePlan.Name]
 			delete(existingServicePlanMap, payloadServicePlan.Name)
+			if existingServicePlan == nil {
+				existingServicePlan, _ = existingServicePlanMap[payloadServicePlan.Spec.ExternalID]
+				delete(existingServicePlanMap, payloadServicePlan.Spec.ExternalID)
+			}
 
 			klog.V(4).Infof(
 				"ClusterServiceBroker %q: reconciling %s",

--- a/pkg/controller/controller_clusterserviceclass_test.go
+++ b/pkg/controller/controller_clusterserviceclass_test.go
@@ -18,16 +18,16 @@ package controller
 
 import (
 	"errors"
+	"reflect"
 	"testing"
-
-	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
-	"github.com/kubernetes-incubator/service-catalog/test/fake"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
-	"reflect"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/test/fake"
 )
 
 func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
@@ -59,7 +59,7 @@ func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
 			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
-					Fields: fields.OneTermEqualSelector("spec.clusterServiceClassRef.name", "CSCGUID"),
+					Fields: fields.OneTermEqualSelector("spec.clusterServiceClassRef.name", "cscguid"),
 				}
 
 				assertNumberOfActions(t, actions, 1)
@@ -74,7 +74,7 @@ func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
 			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
-					Fields: fields.OneTermEqualSelector("spec.clusterServiceClassRef.name", "CSCGUID"),
+					Fields: fields.OneTermEqualSelector("spec.clusterServiceClassRef.name", "cscguid"),
 				}
 
 				assertNumberOfActions(t, actions, 2)
@@ -96,7 +96,7 @@ func TestReconcileClusterServiceClassRemovedFromCatalog(t *testing.T) {
 			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
-					Fields: fields.OneTermEqualSelector("spec.clusterServiceClassRef.name", "CSCGUID"),
+					Fields: fields.OneTermEqualSelector("spec.clusterServiceClassRef.name", "cscguid"),
 				}
 
 				assertNumberOfActions(t, actions, 2)

--- a/pkg/controller/controller_clusterserviceplan_test.go
+++ b/pkg/controller/controller_clusterserviceplan_test.go
@@ -24,10 +24,11 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/test/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"reflect"
+
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	clientgotesting "k8s.io/client-go/testing"
-	"reflect"
 )
 
 func TestReconcileClusterServicePlanRemovedFromCatalog(t *testing.T) {
@@ -59,7 +60,7 @@ func TestReconcileClusterServicePlanRemovedFromCatalog(t *testing.T) {
 			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
-					Fields: fields.OneTermEqualSelector("spec.clusterServicePlanRef.name", "CSPGUID"),
+					Fields: fields.OneTermEqualSelector("spec.clusterServicePlanRef.name", "cspguid"),
 				}
 
 				assertNumberOfActions(t, actions, 1)
@@ -74,7 +75,7 @@ func TestReconcileClusterServicePlanRemovedFromCatalog(t *testing.T) {
 			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
-					Fields: fields.OneTermEqualSelector("spec.clusterServicePlanRef.name", "CSPGUID"),
+					Fields: fields.OneTermEqualSelector("spec.clusterServicePlanRef.name", "cspguid"),
 				}
 
 				assertNumberOfActions(t, actions, 2)
@@ -96,7 +97,7 @@ func TestReconcileClusterServicePlanRemovedFromCatalog(t *testing.T) {
 			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
-					Fields: fields.OneTermEqualSelector("spec.clusterServicePlanRef.name", "CSPGUID"),
+					Fields: fields.OneTermEqualSelector("spec.clusterServicePlanRef.name", "cspguid"),
 				}
 
 				assertNumberOfActions(t, actions, 2)

--- a/pkg/controller/controller_instance_ns_test.go
+++ b/pkg/controller/controller_instance_ns_test.go
@@ -829,7 +829,7 @@ func TestResolveNamespacedReferencesWorks(t *testing.T) {
 
 	listRestrictions = clientgotesting.ListRestrictions{
 		Labels: labels.Everything(),
-		Fields: fields.ParseSelectorOrDie("spec.externalName=test-serviceplan,spec.serviceBrokerName=test-servicebroker,spec.serviceClassRef.name=SCGUID"),
+		Fields: fields.ParseSelectorOrDie("spec.externalName=test-serviceplan,spec.serviceBrokerName=test-servicebroker,spec.serviceClassRef.name=scguid"),
 	}
 	assertList(t, actions[1], &v1beta1.ServicePlan{}, listRestrictions)
 

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -264,7 +264,7 @@ func TestReconcileServiceInstanceNonExistentClusterServicePlan(t *testing.T) {
 	assertNumberOfActions(t, actions, 2)
 	listRestrictions := clientgotesting.ListRestrictions{
 		Labels: labels.Everything(),
-		Fields: fields.ParseSelectorOrDie("spec.externalName=nothere,spec.clusterServiceBrokerName=test-clusterservicebroker,spec.clusterServiceClassRef.name=CSCGUID"),
+		Fields: fields.ParseSelectorOrDie("spec.externalName=nothere,spec.clusterServiceBrokerName=test-clusterservicebroker,spec.clusterServiceClassRef.name=cscguid"),
 	}
 	assertList(t, actions[0], &v1beta1.ClusterServicePlan{}, listRestrictions)
 
@@ -745,7 +745,7 @@ func TestReconcileServiceInstanceResolvesReferences(t *testing.T) {
 
 	listRestrictions = clientgotesting.ListRestrictions{
 		Labels: labels.Everything(),
-		Fields: fields.ParseSelectorOrDie("spec.externalName=test-clusterserviceplan,spec.clusterServiceBrokerName=test-clusterservicebroker,spec.clusterServiceClassRef.name=CSCGUID"),
+		Fields: fields.ParseSelectorOrDie("spec.externalName=test-clusterserviceplan,spec.clusterServiceBrokerName=test-clusterservicebroker,spec.clusterServiceClassRef.name=cscguid"),
 	}
 	assertList(t, actions[1], &v1beta1.ClusterServicePlan{}, listRestrictions)
 
@@ -755,10 +755,10 @@ func TestReconcileServiceInstanceResolvesReferences(t *testing.T) {
 	if !ok {
 		t.Fatalf("couldn't convert to *v1beta1.ServiceInstance")
 	}
-	if updateObject.Spec.ClusterServiceClassRef == nil || updateObject.Spec.ClusterServiceClassRef.Name != "CSCGUID" {
+	if updateObject.Spec.ClusterServiceClassRef == nil || updateObject.Spec.ClusterServiceClassRef.Name != "cscguid" {
 		t.Fatalf("ClusterServiceClassRef was not resolved correctly during reconcile")
 	}
-	if updateObject.Spec.ClusterServicePlanRef == nil || updateObject.Spec.ClusterServicePlanRef.Name != "CSPGUID" {
+	if updateObject.Spec.ClusterServicePlanRef == nil || updateObject.Spec.ClusterServicePlanRef.Name != "cspguid" {
 		t.Fatalf("ClusterServicePlanRef was not resolved correctly during reconcile")
 	}
 
@@ -943,7 +943,7 @@ func TestReconcileServiceInstanceResolvesReferencesClusterServiceClassRefAlready
 
 	listRestrictions := clientgotesting.ListRestrictions{
 		Labels: labels.Everything(),
-		Fields: fields.ParseSelectorOrDie("spec.externalName=test-clusterserviceplan,spec.clusterServiceBrokerName=test-clusterservicebroker,spec.clusterServiceClassRef.name=CSCGUID"),
+		Fields: fields.ParseSelectorOrDie("spec.externalName=test-clusterserviceplan,spec.clusterServiceBrokerName=test-clusterservicebroker,spec.clusterServiceClassRef.name=cscguid"),
 	}
 	assertList(t, actions[0], &v1beta1.ClusterServicePlan{}, listRestrictions)
 
@@ -953,10 +953,10 @@ func TestReconcileServiceInstanceResolvesReferencesClusterServiceClassRefAlready
 	if !ok {
 		t.Fatalf("couldn't convert to *v1beta1.ServiceInstance")
 	}
-	if updateObject.Spec.ClusterServiceClassRef == nil || updateObject.Spec.ClusterServiceClassRef.Name != "CSCGUID" {
+	if updateObject.Spec.ClusterServiceClassRef == nil || updateObject.Spec.ClusterServiceClassRef.Name != "cscguid" {
 		t.Fatalf("ClusterServiceClassRef was not resolved correctly during reconcile")
 	}
-	if updateObject.Spec.ClusterServicePlanRef == nil || updateObject.Spec.ClusterServicePlanRef.Name != "CSPGUID" {
+	if updateObject.Spec.ClusterServicePlanRef == nil || updateObject.Spec.ClusterServicePlanRef.Name != "cspguid" {
 		t.Fatalf("ClusterServicePlanRef was not resolved correctly during reconcile")
 	}
 
@@ -1132,7 +1132,7 @@ func TestReconcileServiceInstanceWithTemporaryProvisionFailure(t *testing.T) {
 
 	message := fmt.Sprintf(
 		"Error provisioning ServiceInstance of ClusterServiceClass (K8S: %q ExternalName: %q) at ClusterServiceBroker %q: Status: %v; ErrorMessage: %s",
-		"CSCGUID", "test-clusterserviceclass", "test-clusterservicebroker", 500, "InternalServerError; Description: Something went wrong!; ResponseError: <nil>",
+		"cscguid", "test-clusterserviceclass", "test-clusterservicebroker", 500, "InternalServerError; Description: Something went wrong!; ResponseError: <nil>",
 	)
 	expectedProvisionCallEvent := warningEventBuilder(errorProvisionCallFailedReason).msg(message)
 	expectedOrphanMitigationEvent := warningEventBuilder(startingInstanceOrphanMitigationReason).
@@ -1214,7 +1214,7 @@ func TestReconcileServiceInstanceWithTerminalProvisionFailure(t *testing.T) {
 
 	message := fmt.Sprintf(
 		"Error provisioning ServiceInstance of ClusterServiceClass (K8S: %q ExternalName: %q) at ClusterServiceBroker %q: Status: %v; ErrorMessage: %s",
-		"CSCGUID", "test-clusterserviceclass", "test-clusterservicebroker", 400, "BadRequest; Description: Your parameters are incorrect!; ResponseError: <nil>",
+		"cscguid", "test-clusterserviceclass", "test-clusterservicebroker", 400, "BadRequest; Description: Your parameters are incorrect!; ResponseError: <nil>",
 	)
 	expectedEvents := []string{
 		warningEventBuilder(errorProvisionCallFailedReason).msg(message).String(),
@@ -1343,7 +1343,7 @@ func TestReconcileServiceInstanceFailsWithDeletedPlan(t *testing.T) {
 
 	expectedEvent := warningEventBuilder(errorDeletedClusterServicePlanReason).msgf(
 		"ClusterServicePlan (K8S: %q ExternalName: %q) has been deleted; cannot provision.",
-		"CSPGUID", "test-clusterserviceplan",
+		"cspguid", "test-clusterserviceplan",
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)
@@ -1393,7 +1393,7 @@ func TestReconcileServiceInstanceFailsWithDeletedClass(t *testing.T) {
 
 	expectedEvent := warningEventBuilder(errorDeletedClusterServiceClassReason).msgf(
 		"ClusterServiceClass (K8S: %q ExternalName: %q) has been deleted; cannot provision.",
-		"CSCGUID", "test-clusterserviceclass",
+		"cscguid", "test-clusterserviceclass",
 	)
 	if err := checkEvents(events, expectedEvent.stringArr()); err != nil {
 		t.Fatal(err)
@@ -1429,10 +1429,10 @@ func TestReconcileServiceInstanceSuccessWithK8SNames(t *testing.T) {
 	if !ok {
 		t.Fatalf("couldn't convert to *v1beta1.ServiceInstance")
 	}
-	if updateObject.Spec.ClusterServiceClassRef == nil || updateObject.Spec.ClusterServiceClassRef.Name != "CSCGUID" {
+	if updateObject.Spec.ClusterServiceClassRef == nil || updateObject.Spec.ClusterServiceClassRef.Name != "cscguid" {
 		t.Fatalf("ClusterServiceClassRef was not resolved correctly during reconcile")
 	}
-	if updateObject.Spec.ClusterServicePlanRef == nil || updateObject.Spec.ClusterServicePlanRef.Name != "CSPGUID" {
+	if updateObject.Spec.ClusterServicePlanRef == nil || updateObject.Spec.ClusterServicePlanRef.Name != "cspguid" {
 		t.Fatalf("ClusterServicePlanRef was not resolved correctly during reconcile")
 	}
 
@@ -4847,7 +4847,7 @@ func TestResolveReferencesNoClusterServicePlan(t *testing.T) {
 
 	listRestrictions = clientgotesting.ListRestrictions{
 		Labels: labels.Everything(),
-		Fields: fields.ParseSelectorOrDie("spec.externalName=test-clusterserviceplan,spec.clusterServiceBrokerName=test-clusterservicebroker,spec.clusterServiceClassRef.name=CSCGUID"),
+		Fields: fields.ParseSelectorOrDie("spec.externalName=test-clusterserviceplan,spec.clusterServiceBrokerName=test-clusterservicebroker,spec.clusterServiceClassRef.name=cscguid"),
 	}
 	assertList(t, actions[1], &v1beta1.ClusterServicePlan{}, listRestrictions)
 
@@ -5307,7 +5307,7 @@ func TestResolveReferencesWorks(t *testing.T) {
 
 	listRestrictions = clientgotesting.ListRestrictions{
 		Labels: labels.Everything(),
-		Fields: fields.ParseSelectorOrDie("spec.externalName=test-clusterserviceplan,spec.clusterServiceBrokerName=test-clusterservicebroker,spec.clusterServiceClassRef.name=CSCGUID"),
+		Fields: fields.ParseSelectorOrDie("spec.externalName=test-clusterserviceplan,spec.clusterServiceBrokerName=test-clusterservicebroker,spec.clusterServiceClassRef.name=cscguid"),
 	}
 	assertList(t, actions[1], &v1beta1.ClusterServicePlan{}, listRestrictions)
 
@@ -5380,7 +5380,7 @@ func TestResolveReferencesForPlanChange(t *testing.T) {
 
 	listRestrictions := clientgotesting.ListRestrictions{
 		Labels: labels.Everything(),
-		Fields: fields.ParseSelectorOrDie("spec.externalName=new-plan-name,spec.clusterServiceBrokerName=test-clusterservicebroker,spec.clusterServiceClassRef.name=CSCGUID"),
+		Fields: fields.ParseSelectorOrDie("spec.externalName=new-plan-name,spec.clusterServiceBrokerName=test-clusterservicebroker,spec.clusterServiceClassRef.name=cscguid"),
 	}
 	assertList(t, actions[0], &v1beta1.ClusterServicePlan{}, listRestrictions)
 

--- a/pkg/controller/controller_ns_test.go
+++ b/pkg/controller/controller_ns_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	testServiceClassGUID  = "SCGUID"
-	testServicePlanGUID   = "SPGUID"
+	testServiceClassGUID  = "scguid"
+	testServicePlanGUID   = "spguid"
 	testServiceBrokerName = "test-servicebroker"
 	testServiceClassName  = "test-serviceclass"
 	testServicePlanName   = "test-serviceplan"

--- a/pkg/controller/controller_serviceclass_test.go
+++ b/pkg/controller/controller_serviceclass_test.go
@@ -24,10 +24,11 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/test/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"reflect"
+
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	clientgotesting "k8s.io/client-go/testing"
-	"reflect"
 )
 
 func TestReconcileServiceClassRemovedFromCatalog(t *testing.T) {
@@ -59,7 +60,7 @@ func TestReconcileServiceClassRemovedFromCatalog(t *testing.T) {
 			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
-					Fields: fields.OneTermEqualSelector("spec.serviceClassRef.name", "SCGUID"),
+					Fields: fields.OneTermEqualSelector("spec.serviceClassRef.name", "scguid"),
 				}
 
 				assertNumberOfActions(t, actions, 1)
@@ -74,7 +75,7 @@ func TestReconcileServiceClassRemovedFromCatalog(t *testing.T) {
 			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
-					Fields: fields.OneTermEqualSelector("spec.serviceClassRef.name", "SCGUID"),
+					Fields: fields.OneTermEqualSelector("spec.serviceClassRef.name", "scguid"),
 				}
 
 				assertNumberOfActions(t, actions, 2)
@@ -96,7 +97,7 @@ func TestReconcileServiceClassRemovedFromCatalog(t *testing.T) {
 			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
-					Fields: fields.OneTermEqualSelector("spec.serviceClassRef.name", "SCGUID"),
+					Fields: fields.OneTermEqualSelector("spec.serviceClassRef.name", "scguid"),
 				}
 
 				assertNumberOfActions(t, actions, 2)

--- a/pkg/controller/controller_serviceplan_test.go
+++ b/pkg/controller/controller_serviceplan_test.go
@@ -24,10 +24,11 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/test/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"reflect"
+
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	clientgotesting "k8s.io/client-go/testing"
-	"reflect"
 )
 
 func TestReconcileServicePlanRemovedFromCatalog(t *testing.T) {
@@ -59,7 +60,7 @@ func TestReconcileServicePlanRemovedFromCatalog(t *testing.T) {
 			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
-					Fields: fields.OneTermEqualSelector("spec.servicePlanRef.name", "SPGUID"),
+					Fields: fields.OneTermEqualSelector("spec.servicePlanRef.name", "spguid"),
 				}
 
 				assertNumberOfActions(t, actions, 1)
@@ -74,7 +75,7 @@ func TestReconcileServicePlanRemovedFromCatalog(t *testing.T) {
 			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
-					Fields: fields.OneTermEqualSelector("spec.servicePlanRef.name", "SPGUID"),
+					Fields: fields.OneTermEqualSelector("spec.servicePlanRef.name", "spguid"),
 				}
 
 				assertNumberOfActions(t, actions, 2)
@@ -96,7 +97,7 @@ func TestReconcileServicePlanRemovedFromCatalog(t *testing.T) {
 			catalogActionsCheckFunc: func(t *testing.T, actions []clientgotesting.Action) {
 				listRestrictions := clientgotesting.ListRestrictions{
 					Labels: labels.Everything(),
-					Fields: fields.OneTermEqualSelector("spec.servicePlanRef.name", "SPGUID"),
+					Fields: fields.OneTermEqualSelector("spec.servicePlanRef.name", "spguid"),
 				}
 
 				assertNumberOfActions(t, actions, 2)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -61,15 +61,15 @@ import (
 // loops for the different catalog API resources.
 
 const (
-	testClusterServiceClassGUID            = "CSCGUID"
-	testClusterServicePlanGUID             = "CSPGUID"
-	testNonbindableClusterServiceClassGUID = "UNBINDABLE-CLUSTERSERVICECLASS"
-	testNonbindableClusterServicePlanGUID  = "UNBINDABLE-CLUSTERSERVICEPLAN"
-	testServiceInstanceGUID                = "IGUID"
-	testServiceBindingGUID                 = "BGUID"
+	testClusterServiceClassGUID            = "cscguid"
+	testClusterServicePlanGUID             = "cspguid"
+	testNonbindableClusterServiceClassGUID = "unbindable-clusterserviceclass"
+	testNonbindableClusterServicePlanGUID  = "unbindable-clusterserviceplan"
+	testServiceInstanceGUID                = "iguid"
+	testServiceBindingGUID                 = "bguid"
 	testNamespaceGUID                      = "test-ns-uid"
-	testRemovedClusterServiceClassGUID     = "REMOVED-CLUSTERSERVICECLASS"
-	testRemovedClusterServicePlanGUID      = "REMOVED-CLUSTERSERVICEPLAN"
+	testRemovedClusterServiceClassGUID     = "removed-clusterserviceclass"
+	testRemovedClusterServicePlanGUID      = "removed-clusterserviceplan"
 
 	testClusterServiceBrokerName            = "test-clusterservicebroker"
 	testClusterServiceClassName             = "test-clusterserviceclass"
@@ -91,8 +91,10 @@ const (
 )
 
 var (
-	testDashboardURL = "http://dashboard"
-	testContext      = map[string]interface{}{
+	emptyServiceClasses = make(map[string]*v1beta1.ClusterServiceClass)
+	emptyServicePlans   = make(map[string]*v1beta1.ClusterServicePlan)
+	testDashboardURL    = "http://dashboard"
+	testContext         = map[string]interface{}{
 		"platform":           ContextProfilePlatformKubernetes,
 		"namespace":          testNamespace,
 		clusterIdentifierKey: testClusterID,
@@ -102,7 +104,7 @@ var (
 const testCatalog = `{
   "services": [{
     "name": "fake-service",
-    "id": "acb56d7c-XXXX-XXXX-XXXX-feb140a59a66",
+    "id": "acb56d7c-xxxx-xxxx-xxxx-feb140a59a66",
     "description": "fake service",
     "tags": ["no-sql", "relational"],
     "requires": ["route_forwarding"],
@@ -120,14 +122,14 @@ const testCatalog = `{
       "displayName": "The Fake ClusterServiceBroker"
     },
     "dashboard_client": {
-      "id": "398e2f8e-XXXX-XXXX-XXXX-19a71ecbcf64",
-      "secret": "277cabb0-XXXX-XXXX-XXXX-7822c0a90e5d",
+      "id": "398e2f8e-xxxx-xxxx-xxxx-19a71ecbcf64",
+      "secret": "277cabb0-xxxx-xxxx-xxxx-7822c0a90e5d",
       "redirect_uri": "http://localhost:1234"
     },
     "plan_updateable": true,
     "plans": [{
       "name": "fake-plan-1",
-      "id": "d3031751-XXXX-XXXX-XXXX-a42377d3320e",
+      "id": "d3031751-xxxx-xxxx-xxxx-a42377d3320e",
       "description": "Shared fake Server, 5tb persistent disk, 40 max concurrent connections",
       "max_storage_tb": 5,
       "metadata": {
@@ -153,7 +155,7 @@ const testCatalog = `{
       }
     }, {
       "name": "fake-plan-2",
-      "id": "0f4008b5-XXXX-XXXX-XXXX-dace631cd648",
+      "id": "0f4008b5-xxxx-xxxx-xxxx-dace631cd648",
       "description": "Shared fake Server, 5tb persistent disk, 40 max concurrent connections. 100 async",
       "max_storage_tb": 5,
       "metadata": {
@@ -182,7 +184,7 @@ const testCatalog = `{
 const alphaParameterSchemaCatalogBytes = `{
   "services": [{
     "name": "fake-service",
-    "id": "acb56d7c-XXXX-XXXX-XXXX-feb140a59a66",
+    "id": "acb56d7c-xxxx-xxxx-xxxx-feb140a59a66",
     "description": "fake service",
     "tags": ["tag1", "tag2"],
     "requires": ["route_forwarding"],
@@ -192,14 +194,14 @@ const alphaParameterSchemaCatalogBytes = `{
     	"c": "d"
     },
     "dashboard_client": {
-      "id": "398e2f8e-XXXX-XXXX-XXXX-19a71ecbcf64",
-      "secret": "277cabb0-XXXX-XXXX-XXXX-7822c0a90e5d",
+      "id": "398e2f8e-xxxx-xxxx-xxxx-19a71ecbcf64",
+      "secret": "277cabb0-xxxx-xxxx-xxxx-7822c0a90e5d",
       "redirect_uri": "http://localhost:1234"
     },
     "plan_updateable": true,
     "plans": [{
       "name": "fake-plan-1",
-      "id": "d3031751-XXXX-XXXX-XXXX-a42377d3320e",
+      "id": "d3031751-xxxx-xxxx-xxxx-a42377d3320e",
       "description": "description1",
       "metadata": {
       	"b": "c",
@@ -1250,7 +1252,7 @@ type bindingParameters struct {
 }
 
 func TestEmptyCatalogConversion(t *testing.T) {
-	serviceClasses, servicePlans, err := convertAndFilterCatalog(&osb.CatalogResponse{}, nil)
+	serviceClasses, servicePlans, err := convertAndFilterCatalog(&osb.CatalogResponse{}, nil, emptyServiceClasses, emptyServicePlans)
 	if err != nil {
 		t.Fatalf("Failed to convertAndFilterCatalog: %v", err)
 	}
@@ -1268,7 +1270,7 @@ func TestCatalogConversion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to unmarshal test catalog: %v", err)
 	}
-	serviceClasses, servicePlans, err := convertAndFilterCatalog(catalog, nil)
+	serviceClasses, servicePlans, err := convertAndFilterCatalog(catalog, nil, emptyServiceClasses, emptyServicePlans)
 	if err != nil {
 		t.Fatalf("Failed to convertAndFilterCatalog: %v", err)
 	}
@@ -1279,8 +1281,46 @@ func TestCatalogConversion(t *testing.T) {
 		t.Fatalf("Expected 2 plans for testCatalog, but got: %d", len(servicePlans))
 	}
 
-	checkPlan(servicePlans[0], "d3031751-XXXX-XXXX-XXXX-a42377d3320e", "fake-plan-1", "Shared fake Server, 5tb persistent disk, 40 max concurrent connections", t)
-	checkPlan(servicePlans[1], "0f4008b5-XXXX-XXXX-XXXX-dace631cd648", "fake-plan-2", "Shared fake Server, 5tb persistent disk, 40 max concurrent connections. 100 async", t)
+	checkPlan(servicePlans[0], "d3031751-xxxx-xxxx-xxxx-a42377d3320e", "d3031751-xxxx-xxxx-xxxx-a42377d3320e", "fake-plan-1", "Shared fake Server, 5tb persistent disk, 40 max concurrent connections", t)
+	checkPlan(servicePlans[1], "0f4008b5-xxxx-xxxx-xxxx-dace631cd648", "0f4008b5-xxxx-xxxx-xxxx-dace631cd648", "fake-plan-2", "Shared fake Server, 5tb persistent disk, 40 max concurrent connections. 100 async", t)
+}
+
+func TestCatalogConversionWithPreexistingClassesAndPlans(t *testing.T) {
+	catalog := &osb.CatalogResponse{}
+	err := json.Unmarshal([]byte(testCatalog), &catalog)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal test catalog: %v", err)
+	}
+	testClassExternalID := "foo-bar"
+	testPlanExternalID := "foo-bar-plan"
+	catalog.Services[0].ID = testClassExternalID
+	catalog.Services[0].Plans[0].ID = testPlanExternalID
+
+	oldServiceClasses := make(map[string]*v1beta1.ClusterServiceClass)
+	oldServiceClass := getTestClusterServiceClass()
+	oldServiceClass.Name = testClassExternalID
+	oldServiceClass.Spec.ExternalID = testClassExternalID
+	oldServiceClasses[catalog.Services[0].ID] = oldServiceClass
+
+	oldServicePlans := make(map[string]*v1beta1.ClusterServicePlan)
+	oldServicePlan := getTestClusterServicePlan()
+	oldServiceClass.Spec.ExternalID = testPlanExternalID
+	oldServicePlans[catalog.Services[0].Plans[0].ID] = oldServicePlan
+
+	serviceClasses, servicePlans, err := convertAndFilterCatalog(catalog, nil, oldServiceClasses, oldServicePlans)
+	if err != nil {
+		t.Fatalf("Failed to convertAndFilterCatalog: %v", err)
+	}
+	if len(serviceClasses) != 1 {
+		t.Fatalf("Expected 1 serviceclasses for testCatalog, but got: %d", len(serviceClasses))
+	}
+	checkClass(serviceClasses[0], testClassExternalID, testClassExternalID, "fake-service", "fake service", t)
+
+	if len(servicePlans) != 2 {
+		t.Fatalf("Expected 2 plans for testCatalog, but got: %d", len(servicePlans))
+	}
+	checkPlan(servicePlans[0], oldServicePlan.Spec.ExternalID, testPlanExternalID, "fake-plan-1", "Shared fake Server, 5tb persistent disk, 40 max concurrent connections", t)
+	checkPlan(servicePlans[1], "0f4008b5-xxxx-xxxx-xxxx-dace631cd648", "0f4008b5-xxxx-xxxx-xxxx-dace631cd648", "fake-plan-2", "Shared fake Server, 5tb persistent disk, 40 max concurrent connections. 100 async", t)
 }
 
 func TestCatalogConversionWithParameterSchemas(t *testing.T) {
@@ -1292,7 +1332,7 @@ func TestCatalogConversionWithParameterSchemas(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to unmarshal test catalog: %v", err)
 	}
-	serviceClasses, servicePlans, err := convertAndFilterCatalog(catalog, nil)
+	serviceClasses, servicePlans, err := convertAndFilterCatalog(catalog, nil, emptyServiceClasses, emptyServicePlans)
 	if err != nil {
 		t.Fatalf("Failed to convertAndFilterCatalog: %v", err)
 	}
@@ -1351,9 +1391,24 @@ func TestCatalogConversionWithParameterSchemas(t *testing.T) {
 	}
 }
 
-func checkPlan(plan *v1beta1.ClusterServicePlan, planID, planName, planDescription string, t *testing.T) {
-	if plan.Name != planID {
-		t.Errorf("Expected plan name to be %q, but was: %q", planID, plan.Name)
+func checkClass(class *v1beta1.ClusterServiceClass, classK8sName, classID, className, classDescription string, t *testing.T) {
+	if class.Name != classK8sName {
+		t.Errorf("Expected class name to be %q, but was: %q", classK8sName, class.Name)
+	}
+	if class.Spec.ExternalID != classID {
+		t.Errorf("Expected class ExternalID to be %q, but was: %q", classID, class.Spec.ExternalID)
+	}
+	if class.Spec.ExternalName != className {
+		t.Errorf("Expected plan ExternalName to be %q, but was: %q", className, class.Spec.ExternalName)
+	}
+	if class.Spec.Description != classDescription {
+		t.Errorf("Expected class description to be %q, but was: %q", classDescription, class.Spec.Description)
+	}
+}
+
+func checkPlan(plan *v1beta1.ClusterServicePlan, planK8sName, planID, planName, planDescription string, t *testing.T) {
+	if plan.Name != planK8sName {
+		t.Errorf("Expected plan name to be %q, but was: %q", planK8sName, plan.Name)
 	}
 	if plan.Spec.ExternalID != planID {
 		t.Errorf("Expected plan ExternalID to be %q, but was: %q", planID, plan.Spec.ExternalID)
@@ -1594,7 +1649,7 @@ func TestConvertAndFilterCatalog(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to unmarshal test catalog: %v", err)
 			}
-			classes, plans, err := convertAndFilterCatalog(catalog, tc.restrictions)
+			classes, plans, err := convertAndFilterCatalog(catalog, tc.restrictions, emptyServiceClasses, emptyServicePlans)
 			if err != nil {
 				if tc.error {
 					return
@@ -1670,7 +1725,7 @@ func TestFilterServicePlans(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to unmarshal test catalog: %v", err)
 			}
-			_, servicePlans, err := convertAndFilterCatalog(catalog, nil)
+			_, servicePlans, err := convertAndFilterCatalog(catalog, nil, emptyServiceClasses, emptyServicePlans)
 			if err != nil {
 				t.Fatalf("Failed to convertAndFilterCatalog: %v", err)
 			}
@@ -1703,11 +1758,11 @@ const testCatalogForClusterServicePlanBindableOverride = `{
       "bindable": true,
       "plans": [{
         "name": "bindable-bindable",
-        "id": "s1_plan1_id"
+        "id": "s1-plan1-id"
       },
       {
         "name": "bindable-unbindable",
-        "id": "s1_plan2_id",
+        "id": "s1-plan2-id",
         "bindable": false
       }]
     },
@@ -1717,11 +1772,11 @@ const testCatalogForClusterServicePlanBindableOverride = `{
       "bindable": false,
       "plans": [{
         "name": "unbindable-unbindable",
-        "id": "s2_plan1_id"
+        "id": "s2-plan1-id"
       },
       {
         "name": "unbindable-bindable",
-        "id": "s2_plan2_id",
+        "id": "s2-plan2-id",
         "bindable": true
       }]
     }
@@ -1748,7 +1803,7 @@ func TestCatalogConversionClusterServicePlanBindable(t *testing.T) {
 		t.Fatalf("Failed to unmarshal test catalog: %v", err)
 	}
 
-	aclasses, aplans, err := convertAndFilterCatalog(catalog, nil)
+	aclasses, aplans, err := convertAndFilterCatalog(catalog, nil, emptyServiceClasses, emptyServicePlans)
 	if err != nil {
 		t.Fatalf("Failed to convertAndFilterCatalog: %v", err)
 	}
@@ -1783,11 +1838,11 @@ func TestCatalogConversionClusterServicePlanBindable(t *testing.T) {
 	eplans := []*v1beta1.ClusterServicePlan{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "s1_plan1_id",
+				Name: "s1-plan1-id",
 			},
 			Spec: v1beta1.ClusterServicePlanSpec{
 				CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
-					ExternalID:   "s1_plan1_id",
+					ExternalID:   "s1-plan1-id",
 					ExternalName: "bindable-bindable",
 					Bindable:     nil,
 				},
@@ -1798,12 +1853,12 @@ func TestCatalogConversionClusterServicePlanBindable(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "s1_plan2_id",
+				Name: "s1-plan2-id",
 			},
 			Spec: v1beta1.ClusterServicePlanSpec{
 				CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
 					ExternalName: "bindable-unbindable",
-					ExternalID:   "s1_plan2_id",
+					ExternalID:   "s1-plan2-id",
 					Bindable:     falsePtr(),
 				},
 				ClusterServiceClassRef: v1beta1.ClusterObjectReference{
@@ -1813,12 +1868,12 @@ func TestCatalogConversionClusterServicePlanBindable(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "s2_plan1_id",
+				Name: "s2-plan1-id",
 			},
 			Spec: v1beta1.ClusterServicePlanSpec{
 				CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
 					ExternalName: "unbindable-unbindable",
-					ExternalID:   "s2_plan1_id",
+					ExternalID:   "s2-plan1-id",
 					Bindable:     nil,
 				},
 				ClusterServiceClassRef: v1beta1.ClusterObjectReference{
@@ -1828,12 +1883,12 @@ func TestCatalogConversionClusterServicePlanBindable(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "s2_plan2_id",
+				Name: "s2-plan2-id",
 			},
 			Spec: v1beta1.ClusterServicePlanSpec{
 				CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
 					ExternalName: "unbindable-bindable",
-					ExternalID:   "s2_plan2_id",
+					ExternalID:   "s2-plan2-id",
 					Bindable:     truePtr(),
 				},
 				ClusterServiceClassRef: v1beta1.ClusterObjectReference{
@@ -1850,6 +1905,265 @@ func TestCatalogConversionClusterServicePlanBindable(t *testing.T) {
 		t.Errorf("Unexpected diff between expected and actual serviceplans: %v", diff.ObjectReflectDiff(eplans, aplans))
 	}
 
+}
+
+const testCatalogForClusterServiceClassAndPlanWithInvalidExternalIDCharacters = `{
+  "services": [
+    {
+      "name": "mysql",
+      "id": "mysqlclass-1234-A",
+      "plans": [{
+        "name": "normal-characters",
+        "id": "mysql-100mb"
+      },
+      {
+        "name": "contains-escape-chars",
+        "id": "abz-class"
+      },
+      {
+        "name": "invalid-internal-characters",
+        "id": "invalid/characters"
+      },
+			{
+				"name": "invalid-starting-ending-characters",
+				"id": "InvalidstarT"
+      },
+			{
+				"name": "starting-ending-periods",
+				"id": ".start."
+      },
+			{
+				"name": "period-next-to-invalid-character",
+				"id": "foo.Bar"
+      },
+			{
+				"name": "internal-period",
+				"id": "foo.bar"
+      },
+			{
+				"name": "too-long",
+				"id": "thisnameisreallyreallywaytoolonghowcouldanyonepossiblyreadthisplansname"
+      },
+			{
+				"name": "too-long-with-problem-chars",
+				"id": "thisnameisreallyreallywaytool-onghowcouldanyonepossiblyreadthisplansname"
+      },
+			{
+				"name": "too-long-with-problem-period",
+				"id": "thisnameisreallyreallywaytool.onghowcouldanyonepossiblyreadthisplansname"
+			}]
+    }
+]}`
+
+func TestCatalogConversionInvalidCharactersInExternalID(t *testing.T) {
+	catalog := &osb.CatalogResponse{}
+	err := json.Unmarshal([]byte(testCatalogForClusterServiceClassAndPlanWithInvalidExternalIDCharacters), &catalog)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal test catalog: %v", err)
+	}
+
+	aclasses, aplans, err := convertAndFilterCatalog(catalog, nil, emptyServiceClasses, emptyServicePlans)
+	if err != nil {
+		t.Fatalf("Failed to convertAndFilterCatalog: %v", err)
+	}
+
+	eclasses := []*v1beta1.ClusterServiceClass{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mysqlclass-1234-z41z",
+			},
+			Spec: v1beta1.ClusterServiceClassSpec{
+				CommonServiceClassSpec: v1beta1.CommonServiceClassSpec{
+					ExternalName: "mysql",
+					ExternalID:   "mysqlclass-1234-A",
+				},
+			},
+		},
+	}
+
+	eplans := []*v1beta1.ClusterServicePlan{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mysql-100mb",
+			},
+			Spec: v1beta1.ClusterServicePlanSpec{
+				CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+					ExternalName: "normal-characters",
+					ExternalID:   "mysql-100mb",
+				},
+				ClusterServiceClassRef: v1beta1.ClusterObjectReference{
+					Name: "mysqlclass-1234-z41z",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "abz7az-class",
+			},
+			Spec: v1beta1.ClusterServicePlanSpec{
+				CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+					ExternalName: "contains-escape-chars",
+					ExternalID:   "abz-class",
+				},
+				ClusterServiceClassRef: v1beta1.ClusterObjectReference{
+					Name: "mysqlclass-1234-z41z",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "invalidz2fzcharacters",
+			},
+			Spec: v1beta1.ClusterServicePlanSpec{
+				CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+					ExternalName: "invalid-internal-characters",
+					ExternalID:   "invalid/characters",
+				},
+				ClusterServiceClassRef: v1beta1.ClusterObjectReference{
+					Name: "mysqlclass-1234-z41z",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "z49znvalidstarz54z",
+			},
+			Spec: v1beta1.ClusterServicePlanSpec{
+				CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+					ExternalName: "invalid-starting-ending-characters",
+					ExternalID:   "InvalidstarT",
+				},
+				ClusterServiceClassRef: v1beta1.ClusterObjectReference{
+					Name: "mysqlclass-1234-z41z",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "z2ezstartz2ez",
+			},
+			Spec: v1beta1.ClusterServicePlanSpec{
+				CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+					ExternalName: "starting-ending-periods",
+					ExternalID:   ".start.",
+				},
+				ClusterServiceClassRef: v1beta1.ClusterObjectReference{
+					Name: "mysqlclass-1234-z41z",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo.z42zar",
+			},
+			Spec: v1beta1.ClusterServicePlanSpec{
+				CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+					ExternalName: "period-next-to-invalid-character",
+					ExternalID:   "foo.Bar",
+				},
+				ClusterServiceClassRef: v1beta1.ClusterObjectReference{
+					Name: "mysqlclass-1234-z41z",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo.bar",
+			},
+			Spec: v1beta1.ClusterServicePlanSpec{
+				CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+					ExternalName: "internal-period",
+					ExternalID:   "foo.bar",
+				},
+				ClusterServiceClassRef: v1beta1.ClusterObjectReference{
+					Name: "mysqlclass-1234-z41z",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "thisnameisreallyreallywaytoolo-3f54131bf8c96c7d946ee1d7a32136dd",
+			},
+			Spec: v1beta1.ClusterServicePlanSpec{
+				CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+					ExternalName: "too-long",
+					ExternalID:   "thisnameisreallyreallywaytoolonghowcouldanyonepossiblyreadthisplansname",
+				},
+				ClusterServiceClassRef: v1beta1.ClusterObjectReference{
+					Name: "mysqlclass-1234-z41z",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "thisnameisreallyreallywaytool--ca868df5f4322294bd65bd7e81866660",
+			},
+			Spec: v1beta1.ClusterServicePlanSpec{
+				CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+					ExternalName: "too-long-with-problem-chars",
+					ExternalID:   "thisnameisreallyreallywaytool-onghowcouldanyonepossiblyreadthisplansname",
+				},
+				ClusterServiceClassRef: v1beta1.ClusterObjectReference{
+					Name: "mysqlclass-1234-z41z",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "thisnameisreallyreallywaytool-fa00db817d4c467b3bf3893240ed04a1",
+			},
+			Spec: v1beta1.ClusterServicePlanSpec{
+				CommonServicePlanSpec: v1beta1.CommonServicePlanSpec{
+					ExternalName: "too-long-with-problem-period",
+					ExternalID:   "thisnameisreallyreallywaytool.onghowcouldanyonepossiblyreadthisplansname",
+				},
+				ClusterServiceClassRef: v1beta1.ClusterObjectReference{
+					Name: "mysqlclass-1234-z41z",
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(eclasses, aclasses) {
+		t.Errorf("Unexpected diff between expected and actual serviceclasses: %v", diff.ObjectReflectDiff(eclasses, aclasses))
+	}
+	if !reflect.DeepEqual(eplans, aplans) {
+		t.Errorf("Unexpected diff between expected and actual serviceplans: %v", diff.ObjectReflectDiff(eplans, aplans))
+	}
+
+}
+
+func TestGenerateEscapedName(t *testing.T) {
+	externalIDs := []string{
+		"simple",
+		"contains-escape-char-z",
+		"ContainsCaps",
+		".starts-and-ends-with-periods.",
+		"-starts-and-ends-with-hyphens-",
+		"adjacent.-specialchars",
+		"otherorderadjacent-.specialchars",
+		"waytoomany-.-.-.-.-adjacentspecialchars",
+		"thisnameisreallyreallywaytoolonghowcouldanyonepossiblyreadthisplansname",
+		"thisnameisreallyreallywaytool.onghowcouldanyonepossiblyreadthisplansnamewithproblemperiod",
+	}
+	eEscapedNames := []string{
+		"simple",
+		"contains-escape-char-z7az",
+		"z43zontainsz43zaps",
+		"z2ezstarts-and-ends-with-periodsz2ez",
+		"z2dzstarts-and-ends-with-hyphensz2dz",
+		"adjacent.z2dzspecialchars",
+		"otherorderadjacent-z2ezspecialchars",
+		"waytoomany-z2ez-z2ez-z2ez-z2ez-adjacentspecialchars",
+		"thisnameisreallyreallywaytoolo-3f54131bf8c96c7d946ee1d7a32136dd",
+		"thisnameisreallyreallywaytool-84b392d072a2cbe3a18f87e7f7776d94",
+	}
+	for i, v := range externalIDs {
+		aEscapedName := GenerateEscapedName(v)
+		if eEscapedNames[i] != aEscapedName {
+			t.Errorf("Unexpected diff between expected and actual escaped name: %v", diff.ObjectReflectDiff(eEscapedNames[i], aEscapedName))
+		}
+	}
 }
 
 func TestIsClusterServiceBrokerReady(t *testing.T) {

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -518,7 +518,7 @@ func TestUpdateServiceInstanceNewDashboardResponse(t *testing.T) {
 // ServiceInstance.
 func TestUpdateServiceInstanceChangePlans(t *testing.T) {
 	otherPlanName := "otherplanname"
-	otherPlanID := "other-plan-id"
+	otherPlanID := "otherplanid"
 	cases := []struct {
 		name                          string
 		useExternalNames              bool
@@ -755,17 +755,17 @@ func TestUpdateServiceInstanceUpdateParameters(t *testing.T) {
 			deleteParams:                true,
 		},
 		{
-			name:                        "add secret param",
+			name: "add secret param",
 			createdWithParamsFromSecret: false,
 			updateParamsFromSecret:      true,
 		},
 		{
-			name:                        "update secret param",
+			name: "update secret param",
 			createdWithParamsFromSecret: true,
 			updateParamsFromSecret:      true,
 		},
 		{
-			name:                        "delete secret param",
+			name: "delete secret param",
 			createdWithParamsFromSecret: true,
 			deleteParamsFromSecret:      true,
 		},
@@ -788,7 +788,7 @@ func TestUpdateServiceInstanceUpdateParameters(t *testing.T) {
 			deleteParamsFromSecret:      true,
 		},
 		{
-			name:                        "update secret",
+			name: "update secret",
 			createdWithParamsFromSecret: true,
 			updateSecret:                true,
 		},
@@ -1296,7 +1296,7 @@ func TestCreateServiceInstanceFailsWithNonexistentPlan(t *testing.T) {
 		skipVerifyingInstanceSuccess: true,
 		preCreateInstance: func(ct *controllerTest) {
 			otherPlanName := "otherplanname"
-			otherPlanID := "other-plan-id"
+			otherPlanID := "otherplanid"
 			catalogResponse := ct.osbClient.CatalogReaction.(*fakeosb.CatalogReaction).Response
 			catalogResponse.Services[0].PlanUpdatable = truePtr()
 			catalogResponse.Services[0].Plans = []osb.Plan{
@@ -1502,7 +1502,7 @@ func TestDeleteServiceInstance(t *testing.T) {
 			},
 		},
 		{
-			name:                         "deprovision instance after in progress provision",
+			name: "deprovision instance after in progress provision",
 			skipVerifyingInstanceSuccess: true,
 			setup: func(ct *controllerTest) {
 				ct.osbClient.PollLastOperationReaction = fakeosb.DynamicPollLastOperationReaction(
@@ -1550,7 +1550,7 @@ func TestDeleteServiceInstance(t *testing.T) {
 				binding:                      tc.binding,
 				instance:                     getTestInstance(),
 				skipVerifyingInstanceSuccess: tc.skipVerifyingInstanceSuccess,
-				setup:                        tc.setup,
+				setup: tc.setup,
 			}
 			ct.run(tc.testFunction)
 		})
@@ -1713,10 +1713,10 @@ func TestPollServiceInstanceLastOperationSuccess(t *testing.T) {
 				broker:                       getTestBroker(),
 				instance:                     getTestInstance(),
 				skipVerifyingInstanceSuccess: tc.skipVerifyingInstanceSuccess,
-				setup:                        tc.setup,
-				preDeleteBroker:              tc.preDeleteBroker,
-				preCreateInstance:            tc.preCreateInstance,
-				postCreateInstance:           tc.postCreateInstance,
+				setup:              tc.setup,
+				preDeleteBroker:    tc.preDeleteBroker,
+				preCreateInstance:  tc.preCreateInstance,
+				postCreateInstance: tc.postCreateInstance,
 			}
 			ct.run(func(ct *controllerTest) {
 				if tc.verifyCondition != nil {


### PR DESCRIPTION
Kubernetes names cannot contain / characters. This PR replaces those with the utf-8 hex code for /.

