### PR TITLE
Detect no-op status updates

### DIFF
--- a/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1beta1/fake/fake_update_references.go
+++ b/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1beta1/fake/fake_update_references.go
@@ -18,16 +18,20 @@ package fake
 
 import (
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	testing "k8s.io/client-go/testing"
 )
 
 // UpdateReferences is a non-generated fake to update with the reference subresource
 func (c *FakeServiceInstances) UpdateReferences(serviceInstance *v1beta1.ServiceInstance) (*v1beta1.ServiceInstance, error) {
+	instanceCopy := serviceInstance.DeepCopy()
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(serviceinstancesResource, "reference", c.ns, serviceInstance), serviceInstance)
+		Invokes(testing.NewUpdateSubresourceAction(serviceinstancesResource, "reference", c.ns, instanceCopy), instanceCopy)
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1beta1.ServiceInstance), err
+	updatedInstance := (obj.(*v1beta1.ServiceInstance))
+	updatedInstance.ResourceVersion = rand.String(10)
+	return updatedInstance, err
 }

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -1216,7 +1216,7 @@ func (c *controller) resolveClusterReferences(instance *v1beta1.ServiceInstance)
 		if err != nil {
 			pcb := pretty.NewInstanceContextBuilder(instance)
 			klog.Warning(pcb.Message(err.Error()))
-			c.updateServiceInstanceCondition(
+			updatedInstance, _ := c.updateServiceInstanceCondition(
 				instance,
 				v1beta1.ServiceInstanceConditionReady,
 				v1beta1.ConditionFalse,
@@ -1224,7 +1224,7 @@ func (c *controller) resolveClusterReferences(instance *v1beta1.ServiceInstance)
 				"The instance references a ClusterServiceClass that does not exist. "+err.Error(),
 			)
 			c.recorder.Event(instance, corev1.EventTypeWarning, errorNonexistentClusterServiceClassReason, err.Error())
-			return false, err
+			return updatedInstance.ResourceVersion != instance.ResourceVersion, err
 		}
 	}
 
@@ -1240,7 +1240,7 @@ func (c *controller) resolveClusterReferences(instance *v1beta1.ServiceInstance)
 		if err != nil {
 			pcb := pretty.NewInstanceContextBuilder(instance)
 			klog.Warning(pcb.Message(err.Error()))
-			c.updateServiceInstanceCondition(
+			updatedInstance, _ := c.updateServiceInstanceCondition(
 				instance,
 				v1beta1.ServiceInstanceConditionReady,
 				v1beta1.ConditionFalse,
@@ -1248,11 +1248,11 @@ func (c *controller) resolveClusterReferences(instance *v1beta1.ServiceInstance)
 				"The instance references a ClusterServicePlan that does not exist. "+err.Error(),
 			)
 			c.recorder.Event(instance, corev1.EventTypeWarning, errorNonexistentClusterServicePlanReason, err.Error())
-			return false, err
+			return updatedInstance.ResourceVersion != instance.ResourceVersion, err
 		}
 	}
-	_, err = c.updateServiceInstanceReferences(instance)
-	return err == nil, err
+	updatedInstance, err := c.updateServiceInstanceReferences(instance)
+	return updatedInstance.ResourceVersion != instance.ResourceVersion, err
 }
 
 func (c *controller) resolveNamespacedReferences(instance *v1beta1.ServiceInstance) (bool, error) {
@@ -1267,7 +1267,7 @@ func (c *controller) resolveNamespacedReferences(instance *v1beta1.ServiceInstan
 		if err != nil {
 			pcb := pretty.NewInstanceContextBuilder(instance)
 			klog.Warning(pcb.Message(err.Error()))
-			c.updateServiceInstanceCondition(
+			updatedInstance, _ := c.updateServiceInstanceCondition(
 				instance,
 				v1beta1.ServiceInstanceConditionReady,
 				v1beta1.ConditionFalse,
@@ -1275,7 +1275,7 @@ func (c *controller) resolveNamespacedReferences(instance *v1beta1.ServiceInstan
 				"The instance references a ServiceClass that does not exist. "+err.Error(),
 			)
 			c.recorder.Event(instance, corev1.EventTypeWarning, errorNonexistentServiceClassReason, err.Error())
-			return false, err
+			return updatedInstance.ResourceVersion != instance.ResourceVersion, err
 		}
 	}
 
@@ -1291,7 +1291,7 @@ func (c *controller) resolveNamespacedReferences(instance *v1beta1.ServiceInstan
 		if err != nil {
 			pcb := pretty.NewInstanceContextBuilder(instance)
 			klog.Warning(pcb.Message(err.Error()))
-			c.updateServiceInstanceCondition(
+			updatedInstance, _ := c.updateServiceInstanceCondition(
 				instance,
 				v1beta1.ServiceInstanceConditionReady,
 				v1beta1.ConditionFalse,
@@ -1299,11 +1299,11 @@ func (c *controller) resolveNamespacedReferences(instance *v1beta1.ServiceInstan
 				"The instance references a ServicePlan that does not exist. "+err.Error(),
 			)
 			c.recorder.Event(instance, corev1.EventTypeWarning, errorNonexistentServicePlanReason, err.Error())
-			return false, err
+			return updatedInstance.ResourceVersion != instance.ResourceVersion, err
 		}
 	}
-	_, err = c.updateServiceInstanceReferences(instance)
-	return err == nil, err
+	updatedInstance, err := c.updateServiceInstanceReferences(instance)
+	return updatedInstance.ResourceVersion != instance.ResourceVersion, err
 }
 
 // resolveClusterServiceClassRef resolves a reference  to a ClusterServiceClass

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -3772,7 +3772,7 @@ func TestUpdateServiceInstanceCondition(t *testing.T) {
 
 			inputClone := tc.input.DeepCopy()
 
-			err := testController.updateServiceInstanceCondition(tc.input, v1beta1.ServiceInstanceConditionReady, tc.status, tc.reason, tc.message)
+			_, err := testController.updateServiceInstanceCondition(tc.input, v1beta1.ServiceInstanceConditionReady, tc.status, tc.reason, tc.message)
 			if err != nil {
 				t.Fatalf("%v: error updating instance condition: %v", tc.name, err)
 			}

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -4542,8 +4542,8 @@ func TestResolveReferencesNoClusterServiceClass(t *testing.T) {
 		t.Fatalf("Did not get the expected error message %q got %q", e, a)
 	}
 
-	if modified {
-		t.Fatalf("Should have returned false")
+	if !modified {
+		t.Fatalf("Should have returned true")
 	}
 
 	// We should get the following actions:
@@ -4828,8 +4828,8 @@ func TestResolveReferencesNoClusterServicePlan(t *testing.T) {
 		t.Fatalf("Did not get the expected error message %q got %q", e, a)
 	}
 
-	if modified {
-		t.Fatalf("Should have returned false")
+	if !modified {
+		t.Fatalf("Should have returned true")
 	}
 
 	// We should get the following actions:

--- a/test/fake/serviceinstances.go
+++ b/test/fake/serviceinstances.go
@@ -19,6 +19,7 @@ package fake
 import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 	watch "k8s.io/apimachinery/pkg/watch"
 
 	v1beta1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
@@ -37,13 +38,21 @@ func (c *ServiceInstances) Create(serviceInstance *v1beta1.ServiceInstance) (res
 }
 
 func (c *ServiceInstances) Update(serviceInstance *v1beta1.ServiceInstance) (result *v1beta1.ServiceInstance, err error) {
-	return c.ServiceInstanceInterface.Update(serviceInstance)
+	instanceCopy := serviceInstance.DeepCopy()
+	updatedInstance, err := c.ServiceInstanceInterface.Update(instanceCopy)
+	if updatedInstance != nil {
+		updatedInstance.ResourceVersion = rand.String(10)
+	}
+	return updatedInstance, err
 }
 
 func (c *ServiceInstances) UpdateStatus(serviceInstance *v1beta1.ServiceInstance) (*v1beta1.ServiceInstance, error) {
 	instanceCopy := serviceInstance.DeepCopy()
-	_, err := c.ServiceInstanceInterface.UpdateStatus(instanceCopy)
-	return serviceInstance, err
+	updatedInstance, err := c.ServiceInstanceInterface.UpdateStatus(instanceCopy)
+	if updatedInstance != nil {
+		updatedInstance.ResourceVersion = rand.String(10)
+	}
+	return updatedInstance, err
 }
 
 func (c *ServiceInstances) Delete(name string, options *v1.DeleteOptions) error {


### PR DESCRIPTION
This PR is a 
 - [x] Bug Fix

**What this PR does / why we need it**:
When the controller updates the status of an object (e.g. ServiceInstance), it stops reconciling the object and waits for the watch event to come back from the API server, which is when it then resumes the reconciliation. In some cases, the status update does _not_ produce a watch event, because the controller doesn't actually modify the object in the status update (i.e. the state of the object in the request matches the existing object state in the API server). The controller should detect this and continue reconciling the object instead of stopping. 

This PR makes the controller detect such no-op status updates. It also fixes a few other problems, where the controller assumed the object was updated, when it really wasn't.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
