### PR TITLE
link to the final charter in kubernetes/community

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The project was established 2016-Sept-12. The incubator team for the project is:
 - Sponsor: Brian Grant ([@bgrant0607](https://github.com/bgrant0607))
 - Champion: Paul Morie ([@pmorie](https://github.com/pmorie))
 - SIG: [sig-service-catalog](https://github.com/kubernetes/community/tree/master/sig-service-catalog)
-- See our "working" [SIG Charter](https://github.com/carolynvs/community/blob/sig-service-catalog-charter/sig-service-catalog/charter.md), which should be ratified by the Kubernetes Steering Committee soon.
+- Our [SIG Charter](https://github.com/kubernetes/community/blob/master/sig-service-catalog/charter.md)
 
 For more information about sig-service-catalog, such as meeting times and agenda,
 check out the [community site](https://github.com/kubernetes/community/tree/master/sig-service-catalog).


### PR DESCRIPTION
This PR is a 
 - Documentation

**What this PR does / why we need it**:
dead link to personal repo not caught by vlinker @duglin 

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] Do we need this line at all?

We link to the sig directory, so I'm not sure people get to this line, but the current link 404's in a personal repo, so we should probably avoid that. I don't understand vlinker, so maybe @duglin can check why it's being missed. 

/assign @carolynvs 
for whose personal repo the link formerly went to

/assign @duglin 
for vlinker debugging

/cc @jboyd01 @jberkhahn 