### PR TITLE
Follow constant convention for ErrorWithOriginatingIdentityReason

### DIFF
--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -61,7 +61,7 @@ const (
 	errorDeprovisionCallFailedReason           string = "DeprovisionCallFailed"
 	errorDeprovisionBlockedByCredentialsReason string = "DeprovisionBlockedByExistingCredentials"
 	errorPollingLastOperationReason            string = "ErrorPollingLastOperation"
-	errorWithOriginatingIdentity               string = "Error with Originating Identity"
+	errorWithOriginatingIdentity               string = "ErrorWithOriginatingIdentity"
 	errorWithOngoingAsyncOperation             string = "ErrorAsyncOperationInProgress"
 	errorWithOngoingAsyncOperationMessage      string = "Another operation for this service instance is in progress. "
 	errorNonexistentClusterServiceClassReason  string = "ReferencesNonexistentServiceClass"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [ x ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

All ServiceCatalog condition reasons are written in camel case, without spaces.
But errorwithOriginatingIdentity contains spaces.

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #2530 

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
