### PR TITLE
Add ClusterIP as a valid apiserver.service.type option

### DIFF
--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -47,7 +47,7 @@ apiserver:
     requestHeaderCA:
   # Attributes of the apiserver's service resource
   service:
-    # Type of service; valid values are "LoadBalancer" and "NodePort"
+    # Type of service; valid values are "LoadBalancer", "NodePort" or "ClusterIP"
     # NodePort is useful if deploying on bare metal or hacking locally on
     # minikube
     type: NodePort


### PR DESCRIPTION
This PR is a 
 - [ ] Feature Implementation
 - [ ] Bug Fix
 - [x] Documentation

**What this PR does / why we need it**:
Add ClusterIP as a valid apiserver.service.type option

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
