### PR TITLE
Allow setting `--operation-polling-maximum-backoff-duration`

### DIFF
--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -72,6 +72,10 @@ spec:
         - --broker-relist-interval
         - {{ .Values.controllerManager.brokerRelistInterval }}
         {{- end }}
+        {{ if .Values.controllerManager.operationPollingMaximumBackoffDuration -}}
+        - --operation-polling-maximum-backoff-duration
+        - {{ .Values.controllerManager.operationPollingMaximumBackoffDuration }}
+        {{- end }}
         - --feature-gates
         - OriginatingIdentity={{.Values.originatingIdentityEnabled}}
         - --feature-gates

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -17,7 +17,7 @@ apiserver:
   # annotations is a collection of annotations to add to the apiserver pods.
   annotations: {}
   # nodeSelector to apply to the apiserver pods
-  nodeSelector: 
+  nodeSelector:
   # PodPreset is an optional feature and can be enabled by uncommenting the line below
   # featureGates: "PodPreset=true"
   aggregator:
@@ -69,7 +69,7 @@ apiserver:
         ## etcd-client-ca.crt - SSL Certificate Authority file used to secure etcd communication
         ## etcd-client.crt - SSL certification file used to secure etcd communication.
         ## etcd-client.key - SSL key file used to secure etcd communication.
-        clientCertSecretName: 
+        clientCertSecretName:
       # Whether to embed an etcd container in the apiserver pod
       # THIS IS INADEQUATE FOR PRODUCTION USE!
       useEmbedded: true
@@ -133,7 +133,7 @@ controllerManager:
   # annotations is a collection of annotations to add to the controllerManager pod.
   annotations: {}
   # nodeSelector to apply to the controllerManager pods
-  nodeSelector: 
+  nodeSelector:
   # healthcheck configures the readiness and liveliness probes for the controllerManager pod.
   healthcheck:
     enabled: true
@@ -143,9 +143,11 @@ controllerManager:
   resyncInterval: 5m
   # Broker relist interval; format is a duration (`20m`, `1h`, etc)
   brokerRelistInterval: 24h
-  # Whether or not the controller supports a --broker-relist-interval flag. If this is 
+  # Whether or not the controller supports a --broker-relist-interval flag. If this is
   # set to true, brokerRelistInterval will be used as the value for that flag
   brokerRelistIntervalActivated: true
+   # The maximum amount of time to back-off while polling an OSB API operation; format is a duration (`20m`, `1h`, etc)
+  operationPollingMaximumBackoffDuration: 20m
   # enables profiling via web interface host:port/debug/pprof/
   profiling:
     # Disable profiling via web interface host:port/debug/pprof/


### PR DESCRIPTION
The maximum amount of time to back-off while polling an OSB API operation"

 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [x] Server Flag for config
   - [x] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
