### PR TITLE
Fix wrong svcat --version command in install docu

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -214,7 +214,7 @@ brew install kubernetes-service-catalog-client
 curl -sLO https://download.svcat.sh/cli/latest/darwin/amd64/svcat
 chmod +x ./svcat
 mv ./svcat /usr/local/bin/
-svcat version --client
+svcat --version
 ```
 
 ## Linux
@@ -223,7 +223,7 @@ svcat version --client
 curl -sLO https://download.svcat.sh/cli/latest/linux/amd64/svcat
 chmod +x ./svcat
 mv ./svcat /usr/local/bin/
-svcat version --client
+svcat --version
 ```
 
 ## Windows
@@ -235,7 +235,7 @@ You will need to find a permanent location for it and add it to your PATH.
 iwr 'https://download.svcat.sh/cli/latest/windows/amd64/svcat.exe' -UseBasicParsing -OutFile svcat.exe
 mkdir -f ~\bin
 $env:PATH += ";${pwd}\bin"
-svcat version --client
+svcat --version
 ```
 
 ## Manual


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [x] Documentation

**What this PR does / why we need it**:
Replace old `svcat version --client` command with `svcat --version` in the `docs/install.md`


Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
