### PR TITLE
Replaced glog with klog logger and constants for info levels

### DIFF
--- a/cmd/apiserver/app/server/options.go
+++ b/cmd/apiserver/app/server/options.go
@@ -19,7 +19,7 @@ package server
 import (
 	"os"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/spf13/pflag"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	genericserveroptions "k8s.io/apiserver/pkg/server/options"
@@ -135,7 +135,7 @@ func (s *ServiceCatalogServerOptions) Validate() error {
 	// etcd options
 	etcdErrs := s.EtcdOptions.Validate()
 	if len(etcdErrs) > 0 {
-		glog.Errorln("Error validating etcd options, do you have `--etcd-servers localhost` set?")
+		klog.Errorln("Error validating etcd options, do you have `--etcd-servers localhost` set?")
 	}
 	errors = append(errors, etcdErrs...)
 	// TODO add alternative storage validation

--- a/cmd/apiserver/app/server/run_server.go
+++ b/cmd/apiserver/app/server/run_server.go
@@ -25,9 +25,10 @@ import (
 	genericapiserverstorage "k8s.io/apiserver/pkg/server/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3/preflight"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apiserver"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apiserver/options"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 )
 
 // RunServer runs an API server with configuration according to opts
@@ -48,13 +49,13 @@ func RunServer(opts *ServiceCatalogServerOptions, stopCh <-chan struct{}) error 
 
 func runEtcdServer(opts *ServiceCatalogServerOptions, stopCh <-chan struct{}) error {
 	etcdOpts := opts.EtcdOptions
-	glog.V(4).Infoln("Preparing to run API server")
+	klog.V(common.DefaultInfoLogLevel).Infoln("Preparing to run API server")
 	genericConfig, scConfig, err := buildGenericConfig(opts)
 	if err != nil {
 		return err
 	}
 
-	glog.V(4).Infoln("Creating storage factory")
+	klog.V(common.DefaultInfoLogLevel).Infoln("Creating storage factory")
 
 	// The API server stores objects using a particular API version for each
 	// group, regardless of API version of the object when it was created.
@@ -81,7 +82,7 @@ func runEtcdServer(opts *ServiceCatalogServerOptions, stopCh <-chan struct{}) er
 		nil, /* resource config overrides */
 	)
 	if err != nil {
-		glog.Errorf("error creating storage factory: %v", err)
+		klog.Errorf("error creating storage factory: %v", err)
 		return err
 	}
 
@@ -92,7 +93,7 @@ func runEtcdServer(opts *ServiceCatalogServerOptions, stopCh <-chan struct{}) er
 	completed := config.Complete()
 
 	// make the server
-	glog.V(4).Infoln("Completing API server configuration")
+	klog.V(common.DefaultInfoLogLevel).Infoln("Completing API server configuration")
 	server, err := completed.NewServer(stopCh)
 	if err != nil {
 		return fmt.Errorf("error completing API server configuration: %v", err)
@@ -114,7 +115,7 @@ func runEtcdServer(opts *ServiceCatalogServerOptions, stopCh <-chan struct{}) er
 	healthz.InstallPathHandler(server.GenericAPIServer.Handler.NonGoRestfulMux, "/healthz/ready", etcdChecker)
 
 	// do we need to do any post api installation setup? We should have set up the api already?
-	glog.Infoln("Running the API server")
+	klog.Infoln("Running the API server")
 	server.PrepareRun().Run(stopCh)
 
 	return nil
@@ -131,16 +132,16 @@ func (c checkEtcdConnectable) Name() string {
 }
 
 func (c checkEtcdConnectable) Check(_ *http.Request) error {
-	glog.Info("etcd checker called")
+	klog.Infof("etcd checker called")
 	serverReachable, err := preflight.EtcdConnection{ServerList: c.ServerList}.CheckEtcdServers()
 
 	if err != nil {
-		glog.Errorf("etcd checker failed with err: %v", err)
+		klog.Errorf("etcd checker failed with err: %v", err)
 		return err
 	}
 	if !serverReachable {
 		msg := "etcd failed to reach any server"
-		glog.Error(msg)
+		klog.Errorf(msg)
 		return fmt.Errorf(msg)
 	}
 	return nil

--- a/cmd/apiserver/app/server/util.go
+++ b/cmd/apiserver/app/server/util.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/spec"
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -64,7 +64,7 @@ type serviceCatalogConfig struct {
 func buildGenericConfig(s *ServiceCatalogServerOptions) (*genericapiserver.RecommendedConfig, *serviceCatalogConfig, error) {
 	// check if we are running in standalone mode (for test scenarios)
 	if s.StandaloneMode {
-		glog.Infof("service catalog is in standalone mode")
+		klog.Infof("service catalog is in standalone mode")
 	}
 	// server configuration options
 	if err := s.SecureServingOptions.MaybeDefaultWithSelfSignedCerts(s.GenericServerRunOptions.AdvertiseAddress.String(), nil /*alternateDNS*/, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
@@ -86,7 +86,7 @@ func buildGenericConfig(s *ServiceCatalogServerOptions) (*genericapiserver.Recom
 		}
 	} else {
 		// always warn when auth is disabled, since this should only be used for testing
-		glog.Warning("Authentication and authorization disabled for testing purposes")
+		klog.Warningf("Authentication and authorization disabled for testing purposes")
 		genericConfig.Authentication.Authenticator = &authenticator.AnyUserAuthenticator{}
 		genericConfig.Authorization.Authorizer = authorizerfactory.NewAlwaysAllowAuthorizer()
 	}
@@ -109,7 +109,7 @@ func buildGenericConfig(s *ServiceCatalogServerOptions) (*genericapiserver.Recom
 			}
 		}
 	} else {
-		glog.Warning("OpenAPI spec will not be served")
+		klog.Warningf("OpenAPI spec will not be served")
 	}
 
 	genericConfig.SwaggerConfig = genericapiserver.DefaultSwaggerConfig()
@@ -124,7 +124,7 @@ func buildGenericConfig(s *ServiceCatalogServerOptions) (*genericapiserver.Recom
 	// FUTURE: use protobuf for communication back to itself?
 	client, err := internalclientset.NewForConfig(genericConfig.LoopbackClientConfig)
 	if err != nil {
-		glog.Errorf("Failed to create clientset for service catalog self-communication: %v", err)
+		klog.Errorf("Failed to create clientset for service catalog self-communication: %v", err)
 		return nil, nil, err
 	}
 	sharedInformers := informers.NewSharedInformerFactory(client, 10*time.Minute)
@@ -136,14 +136,14 @@ func buildGenericConfig(s *ServiceCatalogServerOptions) (*genericapiserver.Recom
 	if !s.StandaloneMode {
 		clusterConfig, err := kube.LoadConfig(s.KubeconfigPath, "")
 		if err != nil {
-			glog.Errorf("Failed to parse kube client config: %v", err)
+			klog.Errorf("Failed to parse kube client config: %v", err)
 			return nil, nil, err
 		}
 		// If clusterConfig is nil, look at the default in-cluster config.
 		if clusterConfig == nil {
 			clusterConfig, err = restclient.InClusterConfig()
 			if err != nil {
-				glog.Errorf("Failed to get kube client config: %v", err)
+				klog.Errorf("Failed to get kube client config: %v", err)
 				return nil, nil, err
 			}
 		}
@@ -151,7 +151,7 @@ func buildGenericConfig(s *ServiceCatalogServerOptions) (*genericapiserver.Recom
 
 		kubeClient, err := kubeclientset.NewForConfig(clusterConfig)
 		if err != nil {
-			glog.Errorf("Failed to create clientset interface: %v", err)
+			klog.Errorf("Failed to create clientset interface: %v", err)
 			return nil, nil, err
 		}
 
@@ -179,7 +179,7 @@ func buildAdmission(c *genericapiserver.RecommendedConfig, s *ServiceCatalogServ
 	kubeClient kubeclientset.Interface, kubeSharedInformers kubeinformers.SharedInformerFactory) (admission.Interface, error) {
 
 	pluginNames := enabledPluginNames(s.AdmissionOptions)
-	glog.Infof("Admission control plugin names: %v", pluginNames)
+	klog.Infof("Admission control plugin names: %v", pluginNames)
 
 	genericInitializer := initializer.New(kubeClient, kubeSharedInformers, c.Authorization.Authorizer, api.Scheme)
 	scPluginInitializer := scadmission.NewPluginInitializer(client, sharedInformers, kubeClient, kubeSharedInformers)
@@ -229,12 +229,12 @@ func enabledPluginNames(a *genericserveroptions.AdmissionOptions) []string {
 // addPostStartHooks adds the common post start hooks we invoke when using either server storage option.
 func addPostStartHooks(server *genericapiserver.GenericAPIServer, scConfig *serviceCatalogConfig, stopCh <-chan struct{}) {
 	server.AddPostStartHook("start-service-catalog-apiserver-informers", func(context genericapiserver.PostStartHookContext) error {
-		glog.Infof("Starting shared informers")
+		klog.Infof("Starting shared informers")
 		scConfig.sharedInformers.Start(stopCh)
 		if scConfig.kubeSharedInformers != nil {
 			scConfig.kubeSharedInformers.Start(stopCh)
 		}
-		glog.Infof("Started shared informers")
+		klog.Infof("Started shared informers")
 		return nil
 	})
 }

--- a/cmd/controller-manager/app/controller_manager.go
+++ b/cmd/controller-manager/app/controller_manager.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 	"github.com/kubernetes-incubator/service-catalog/pkg/kubernetes/pkg/util/configz"
 	"github.com/kubernetes-incubator/service-catalog/pkg/metrics"
 	"github.com/kubernetes-incubator/service-catalog/pkg/metrics/osbclientproxy"
@@ -63,7 +64,7 @@ import (
 
 	"context"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -96,15 +97,15 @@ func Run(controllerManagerOptions *options.ControllerManagerServer) error {
 	// if c, err := configz.New("componentconfig"); err == nil {
 	// 	c.Set(controllerManagerOptions.KubeControllerManagerConfiguration)
 	// } else {
-	// 	glog.Errorf("unable to register configz: %s", err)
+	// 	klog.Errorf("unable to register configz: %s", err)
 	// }
 
 	if controllerManagerOptions.Port > 0 {
-		glog.Warning("program option --port is obsolete and ignored, specify --secure-port instead")
+		klog.Warningf("program option --port is obsolete and ignored, specify --secure-port instead")
 	}
 
 	// Build the K8s kubeconfig / client / clientBuilder
-	glog.V(4).Info("Building k8s kubeconfig")
+	klog.V(common.DefaultInfoLogLevel).Infof("Building k8s kubeconfig")
 
 	var err error
 	var k8sKubeconfig *rest.Config
@@ -132,14 +133,14 @@ func Run(controllerManagerOptions *options.ControllerManagerServer) error {
 	}
 	leaderElectionClient := kubernetes.NewForConfigOrDie(rest.AddUserAgent(k8sKubeconfig, "leader-election"))
 
-	glog.V(4).Infof("Building service-catalog kubeconfig for url: %v\n", controllerManagerOptions.ServiceCatalogAPIServerURL)
+	klog.V(common.DefaultInfoLogLevel).Infof("Building service-catalog kubeconfig for url: %v\n", controllerManagerOptions.ServiceCatalogAPIServerURL)
 
 	var serviceCatalogKubeconfig *rest.Config
 	// Build the service-catalog kubeconfig / clientBuilder
 	if controllerManagerOptions.ServiceCatalogAPIServerURL == "" && controllerManagerOptions.ServiceCatalogKubeconfigPath == "" {
 		// explicitly fall back to InClusterConfig, assuming we're talking to an API server which does aggregation
 		// (BuildConfigFromFlags does this, but gives a more generic warning message than we do here)
-		glog.V(4).Infof("Using inClusterConfig to talk to service catalog API server -- make sure your API server is registered with the aggregator")
+		klog.V(common.StatesDetailsInfoLogLevel).Infof("Using inClusterConfig to talk to service catalog API server -- make sure your API server is registered with the aggregator")
 		serviceCatalogKubeconfig, err = rest.InClusterConfig()
 	} else {
 		serviceCatalogKubeconfig, err = clientcmd.BuildConfigFromFlags(
@@ -160,7 +161,7 @@ func Run(controllerManagerOptions *options.ControllerManagerServer) error {
 		return fmt.Errorf("failed to establish SecureServingOptions %v", err)
 	}
 
-	glog.V(4).Info("Starting http server and mux")
+	klog.V(common.DefaultInfoLogLevel).Infof("Starting http server and mux")
 	// Start http server and handlers
 	go func() {
 		mux := http.NewServeMux()
@@ -192,12 +193,12 @@ func Run(controllerManagerOptions *options.ControllerManagerServer) error {
 				strconv.Itoa(int(controllerManagerOptions.SecureServingOptions.BindPort))),
 			Handler: mux,
 		}
-		glog.Fatal(server.ListenAndServeTLS(controllerManagerOptions.SecureServingOptions.ServerCert.CertKey.CertFile,
+		klog.Fatal(server.ListenAndServeTLS(controllerManagerOptions.SecureServingOptions.ServerCert.CertKey.CertFile,
 			controllerManagerOptions.SecureServingOptions.ServerCert.CertKey.KeyFile))
 	}()
 
 	// Create event broadcaster
-	glog.V(4).Info("Creating event broadcaster")
+	klog.V(common.DefaultInfoLogLevel).Infof("Creating event broadcaster")
 	eventsScheme := runtime.NewScheme()
 	// We use ConfigMapLock/EndpointsLock which emit events for ConfigMap/Endpoints and hence we need core/v1 types for it
 	if err = corev1.AddToScheme(eventsScheme); err != nil {
@@ -212,7 +213,7 @@ func Run(controllerManagerOptions *options.ControllerManagerServer) error {
 	}
 
 	eventBroadcaster := record.NewBroadcaster()
-	loggingWatch := eventBroadcaster.StartLogging(glog.Infof)
+	loggingWatch := eventBroadcaster.StartLogging(klog.Infof)
 	defer loggingWatch.Stop()
 	recordingWatch := eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: k8sKubeClient.CoreV1().Events("")})
 	defer recordingWatch.Stop()
@@ -237,7 +238,7 @@ func Run(controllerManagerOptions *options.ControllerManagerServer) error {
 		// }
 
 		err := StartControllers(controllerManagerOptions, k8sKubeconfig, serviceCatalogClientBuilder, recorder, ctx.Done())
-		glog.Fatalf("error running controllers: %v", err)
+		klog.Errorf("error running controllers: %v", err)
 		panic("unreachable")
 	}
 
@@ -252,7 +253,7 @@ func Run(controllerManagerOptions *options.ControllerManagerServer) error {
 		return err
 	}
 
-	glog.V(5).Infof("Using namespace %v for leader election lock", controllerManagerOptions.LeaderElectionNamespace)
+	klog.V(common.StatesInfoLogLevel).Infof("Using namespace %v for leader election lock", controllerManagerOptions.LeaderElectionNamespace)
 
 	// Lock required for leader election
 	rl, err := resourcelock.New(
@@ -277,7 +278,7 @@ func Run(controllerManagerOptions *options.ControllerManagerServer) error {
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: run,
 			OnStoppedLeading: func() {
-				glog.Fatalf("leaderelection lost")
+				klog.Errorf("leaderelection lost")
 			},
 		},
 	})
@@ -297,16 +298,16 @@ func getAvailableResources(clientBuilder controller.ClientBuilder, version schem
 		var client clientset.Interface
 		client, clientError = clientBuilder.Client(controllerDiscoveryAgentName)
 		if clientError != nil {
-			glog.Errorf("Failed to get api versions from server: %v", clientError)
+			klog.Errorf("Failed to get api versions from server: %v", clientError)
 			return false, nil
 		}
 
-		glog.V(4).Info("Created client for API discovery")
+		klog.V(common.DefaultInfoLogLevel).Infof("Created client for API discovery")
 
 		discoveryClient := client.Discovery()
 		apiResourceList, clientError = discoveryClient.ServerResourcesForGroupVersion(version.String())
 		if clientError != nil {
-			glog.Errorf("Failed to get supported resources from server: %v", clientError)
+			klog.Errorf("Failed to get supported resources from server: %v", clientError)
 			return false, nil
 		}
 
@@ -364,9 +365,9 @@ func StartControllers(s *options.ControllerManagerServer,
 	coreKubeconfig = rest.AddUserAgent(coreKubeconfig, controllerManagerAgentName)
 	coreClient, err := kubernetes.NewForConfig(coreKubeconfig)
 	if err != nil {
-		glog.Fatal(err)
+		klog.Fatal(err)
 	}
-	glog.V(5).Infof("Creating shared informers; resync interval: %v", s.ResyncInterval)
+	klog.V(common.StatesInfoLogLevel).Infof("Creating shared informers; resync interval: %v", s.ResyncInterval)
 
 	// Build the informer factory for service-catalog resources
 	informerFactory := servicecataloginformers.NewSharedInformerFactory(
@@ -376,7 +377,7 @@ func StartControllers(s *options.ControllerManagerServer,
 	// All shared informers are v1beta1 API level
 	serviceCatalogSharedInformers := informerFactory.Servicecatalog().V1beta1()
 
-	glog.V(5).Infof("Creating controller; broker relist interval: %v", s.ServiceBrokerRelistInterval)
+	klog.V(common.StatesInfoLogLevel).Infof("Creating controller; broker relist interval: %v", s.ServiceBrokerRelistInterval)
 	serviceCatalogController, err := controller.NewController(
 		coreClient,
 		serviceCatalogClientBuilder.ClientOrDie(controllerManagerAgentName).ServicecatalogV1beta1(),
@@ -401,13 +402,13 @@ func StartControllers(s *options.ControllerManagerServer,
 		return err
 	}
 
-	glog.V(1).Info("Starting shared informers")
+	klog.V(common.DefaultInfoLogLevel).Infof("Starting shared informers")
 	informerFactory.Start(stop)
 
-	glog.V(5).Info("Waiting for caches to sync")
+	klog.V(common.DefaultInfoLogLevel).Infof("Waiting for caches to sync")
 	informerFactory.WaitForCacheSync(stop)
 
-	glog.V(5).Info("Running controller")
+	klog.V(common.DefaultInfoLogLevel).Infof("Running controller")
 	go serviceCatalogController.Run(s.ConcurrentSyncs, stop)
 
 	select {}
@@ -424,7 +425,7 @@ func (c checkAPIAvailableResources) Name() string {
 }
 
 func (c checkAPIAvailableResources) Check(_ *http.Request) error {
-	glog.Info("Health-checking connection with service-catalog API server")
+	klog.Infof("Health-checking connection with service-catalog API server")
 	availableResources, err := getAvailableResources(c.serviceCatalogClientBuilder, servicecatalogv1beta1.SchemeGroupVersion)
 	if err != nil {
 		return err

--- a/cmd/healthcheck/framework/http.go
+++ b/cmd/healthcheck/framework/http.go
@@ -22,8 +22,10 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"k8s.io/apiserver/pkg/server/healthz"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 )
 
 // ServeHTTP starts a new Http Server thread for /metrics and health probing
@@ -34,7 +36,7 @@ func ServeHTTP(healthcheckOptions *HealthCheckServer) error {
 		return fmt.Errorf("failed to establish SecureServingOptions %v", err)
 	}
 
-	glog.V(3).Infof("Starting http server and mux on port %v", healthcheckOptions.SecureServingOptions.BindPort)
+	klog.V(common.StatesDetailsInfoLogLevel).Infof("Starting http server and mux on port %v", healthcheckOptions.SecureServingOptions.BindPort)
 
 	go func() {
 		mux := http.NewServeMux()
@@ -47,7 +49,7 @@ func ServeHTTP(healthcheckOptions *HealthCheckServer) error {
 				strconv.Itoa(healthcheckOptions.SecureServingOptions.BindPort)),
 			Handler: mux,
 		}
-		glog.Fatal(server.ListenAndServeTLS(healthcheckOptions.SecureServingOptions.ServerCert.CertKey.CertFile,
+		klog.Fatal(server.ListenAndServeTLS(healthcheckOptions.SecureServingOptions.ServerCert.CertKey.CertFile,
 			healthcheckOptions.SecureServingOptions.ServerCert.CertKey.KeyFile))
 	}()
 	return nil

--- a/cmd/healthcheck/framework/metrics.go
+++ b/cmd/healthcheck/framework/metrics.go
@@ -21,9 +21,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 )
 
 var registerMetrics sync.Once
@@ -86,5 +88,5 @@ func RegisterMetricsAndInstallHandler(m *http.ServeMux) {
 	registry := prometheus.NewRegistry()
 	register(registry)
 	m.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}))
-	glog.V(3).Info("Registered /metrics with prometheus")
+	klog.V(common.StatesInfoLogLevel).Infof("Registered /metrics with prometheus")
 }

--- a/cmd/healthcheck/framework/utils.go
+++ b/cmd/healthcheck/framework/utils.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,7 +78,7 @@ func CreateKubeNamespace(c kubernetes.Interface) (*corev1.Namespace, error) {
 		var err error
 		got, err = c.CoreV1().Namespaces().Create(ns)
 		if err != nil {
-			glog.Errorf("Unexpected error while creating namespace: %v", err)
+			klog.Errorf("Unexpected error while creating namespace: %v", err)
 			return false, err
 		}
 		return true, nil

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -19,13 +19,13 @@ package main
 import (
 	"os"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/kubernetes-incubator/service-catalog/cmd/healthcheck/framework"
 )
 
 func main() {
 	err := framework.Execute()
-	glog.Flush()
+	klog.Flush()
 	if err != nil {
 		os.Exit(1)
 	}

--- a/cmd/svcat/main.go
+++ b/cmd/svcat/main.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubectl/pkg/pluginutils"
 
-	_ "github.com/golang/glog" // Initialize glog flags
+	_ "github.com/kubernetes/klog" // Initialize klog flags
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/binding"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/broker"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/browsing"
@@ -63,8 +63,8 @@ func main() {
 }
 
 func buildRootCommand(cxt *command.Context) *cobra.Command {
-	// Make cobra aware of select glog flags
-	// Enabling all flags causes unwanted deprecation warnings from glog to always print in plugin mode
+	// Make cobra aware of select klog flags
+	// Enabling all flags causes unwanted deprecation warnings from klog to always print in plugin mode
 	pflag.CommandLine.AddGoFlag(flag.CommandLine.Lookup("v"))
 	pflag.CommandLine.AddGoFlag(flag.CommandLine.Lookup("logtostderr"))
 	pflag.CommandLine.Set("logtostderr", "true")

--- a/cmd/svcat/plugin/plugin.go
+++ b/cmd/svcat/plugin/plugin.go
@@ -66,7 +66,7 @@ func BindEnvironmentVariables(vip *viper.Viper, cmd *cobra.Command) {
 	// computed by kubectl.
 	vip.BindEnv("namespace", EnvPluginNamespace)
 
-	// Manually bind relevant glog variables
+	// Manually bind relevant klog variables
 	vip.BindEnv("v", EnvPluginVerbose)
 
 	// kubectl intercepts all flags passed to a plugin, and replaces them

--- a/contrib/cmd/user-broker/user-broker.go
+++ b/contrib/cmd/user-broker/user-broker.go
@@ -26,7 +26,7 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/golang/glog"
+	"github.com/golang/klog"
 	"github.com/kubernetes-incubator/service-catalog/contrib/pkg/broker/server"
 	"github.com/kubernetes-incubator/service-catalog/contrib/pkg/broker/user_provided/controller"
 	"github.com/kubernetes-incubator/service-catalog/pkg"
@@ -47,7 +47,7 @@ func init() {
 
 func main() {
 	if err := run(); err != nil && err != context.Canceled && err != context.DeadlineExceeded {
-		glog.Fatalln(err)
+		klog.Fatalln(err)
 	}
 }
 

--- a/contrib/pkg/broker/server/server.go
+++ b/contrib/pkg/broker/server/server.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/golang/klog"
 	"github.com/kubernetes-incubator/service-catalog/contrib/pkg/broker/controller"
 	"github.com/kubernetes-incubator/service-catalog/contrib/pkg/brokerapi"
 	"github.com/kubernetes-incubator/service-catalog/pkg/util"
@@ -91,7 +91,7 @@ func RunTLS(ctx context.Context, addr string, cert string, key string, c control
 }
 
 func run(ctx context.Context, addr string, listenAndServe func(srv *http.Server) error, c controller.Controller) error {
-	glog.Infof("Starting server on %s\n", addr)
+	klog.Infof("Starting server on %s\n", addr)
 	srv := &http.Server{
 		Addr:    addr,
 		Handler: createHandler(c),
@@ -108,7 +108,7 @@ func run(ctx context.Context, addr string, listenAndServe func(srv *http.Server)
 }
 
 func (s *server) catalog(w http.ResponseWriter, r *http.Request) {
-	glog.Infof("Get Service Broker Catalog...")
+	klog.Infof("Get Service Broker Catalog...")
 
 	if result, err := s.controller.Catalog(); err == nil {
 		util.WriteResponse(w, http.StatusOK, result)
@@ -123,7 +123,7 @@ func (s *server) getServiceInstanceLastOperation(w http.ResponseWriter, r *http.
 	serviceID := q.Get("service_id")
 	planID := q.Get("plan_id")
 	operation := q.Get("operation")
-	glog.Infof("GetServiceInstance ... %s\n", instanceID)
+	klog.Infof("GetServiceInstance ... %s\n", instanceID)
 
 	if result, err := s.controller.GetServiceInstanceLastOperation(instanceID, serviceID, planID, operation); err == nil {
 		util.WriteResponse(w, http.StatusOK, result)
@@ -134,11 +134,11 @@ func (s *server) getServiceInstanceLastOperation(w http.ResponseWriter, r *http.
 
 func (s *server) createServiceInstance(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["instance_id"]
-	glog.Infof("CreateServiceInstance %s...\n", id)
+	klog.Infof("CreateServiceInstance %s...\n", id)
 
 	var req brokerapi.CreateServiceInstanceRequest
 	if err := util.BodyToObject(r, &req); err != nil {
-		glog.Errorf("error unmarshalling: %v", err)
+		klog.Errorf("error unmarshalling: %v", err)
 		util.WriteErrorResponse(w, http.StatusBadRequest, err)
 		return
 	}
@@ -163,7 +163,7 @@ func (s *server) removeServiceInstance(w http.ResponseWriter, r *http.Request) {
 	serviceID := q.Get("service_id")
 	planID := q.Get("plan_id")
 	acceptsIncomplete := q.Get("accepts_incomplete") == "true"
-	glog.Infof("RemoveServiceInstance %s...\n", instanceID)
+	klog.Infof("RemoveServiceInstance %s...\n", instanceID)
 
 	if result, err := s.controller.RemoveServiceInstance(instanceID, serviceID, planID, acceptsIncomplete); err == nil {
 		util.WriteResponse(w, http.StatusOK, result)
@@ -176,12 +176,12 @@ func (s *server) bind(w http.ResponseWriter, r *http.Request) {
 	bindingID := mux.Vars(r)["binding_id"]
 	instanceID := mux.Vars(r)["instance_id"]
 
-	glog.Infof("Bind binding_id=%s, instance_id=%s\n", bindingID, instanceID)
+	klog.Infof("Bind binding_id=%s, instance_id=%s\n", bindingID, instanceID)
 
 	var req brokerapi.BindingRequest
 
 	if err := util.BodyToObject(r, &req); err != nil {
-		glog.Errorf("Failed to unmarshall request: %v", err)
+		klog.Errorf("Failed to unmarshall request: %v", err)
 		util.WriteErrorResponse(w, http.StatusBadRequest, err)
 		return
 	}
@@ -209,7 +209,7 @@ func (s *server) unBind(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	serviceID := q.Get("service_id")
 	planID := q.Get("plan_id")
-	glog.Infof("UnBind: Service instance guid: %s:%s", bindingID, instanceID)
+	klog.Infof("UnBind: Service instance guid: %s:%s", bindingID, instanceID)
 
 	if err := s.controller.UnBind(instanceID, bindingID, serviceID, planID); err == nil {
 		w.WriteHeader(http.StatusOK)

--- a/contrib/pkg/broker/user_provided/controller/controller.go
+++ b/contrib/pkg/broker/user_provided/controller/controller.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/golang/glog"
+	"github.com/golang/klog"
 	"github.com/kubernetes-incubator/service-catalog/contrib/pkg/broker/controller"
 	"github.com/kubernetes-incubator/service-catalog/contrib/pkg/brokerapi"
 )
@@ -54,7 +54,7 @@ func CreateController() controller.Controller {
 }
 
 func (c *userProvidedController) Catalog() (*brokerapi.Catalog, error) {
-	glog.Info("Catalog()")
+	klog.Infof("Catalog()")
 	return &brokerapi.Catalog{
 		Services: []*brokerapi.Service{
 			{
@@ -189,20 +189,20 @@ func (c *userProvidedController) CreateServiceInstance(
 	id string,
 	req *brokerapi.CreateServiceInstanceRequest,
 ) (*brokerapi.CreateServiceInstanceResponse, error) {
-	glog.Info("CreateServiceInstance()")
+	klog.Infof("CreateServiceInstance()")
 	credString, ok := req.Parameters["credentials"]
 	c.rwMutex.Lock()
 	defer c.rwMutex.Unlock()
 	if ok {
 		jsonCred, err := json.Marshal(credString)
 		if err != nil {
-			glog.Errorf("Failed to marshal credentials: %v", err)
+			klog.Errorf("Failed to marshal credentials: %v", err)
 			return nil, err
 		}
 		var cred brokerapi.Credential
 		err = json.Unmarshal(jsonCred, &cred)
 		if err != nil {
-			glog.Errorf("Failed to unmarshal credentials: %v", err)
+			klog.Errorf("Failed to unmarshal credentials: %v", err)
 			return nil, err
 		}
 
@@ -220,7 +220,7 @@ func (c *userProvidedController) CreateServiceInstance(
 		}
 	}
 
-	glog.Infof("Created User Provided Service Instance:\n%v\n", c.instanceMap[id])
+	klog.Infof("Created User Provided Service Instance:\n%v\n", c.instanceMap[id])
 	return &brokerapi.CreateServiceInstanceResponse{}, nil
 }
 
@@ -230,7 +230,7 @@ func (c *userProvidedController) GetServiceInstanceLastOperation(
 	planID,
 	operation string,
 ) (*brokerapi.LastOperationResponse, error) {
-	glog.Info("GetServiceInstanceLastOperation()")
+	klog.Infof("GetServiceInstanceLastOperation()")
 	return nil, errors.New("Unimplemented")
 }
 
@@ -240,7 +240,7 @@ func (c *userProvidedController) RemoveServiceInstance(
 	planID string,
 	acceptsIncomplete bool,
 ) (*brokerapi.DeleteServiceInstanceResponse, error) {
-	glog.Info("RemoveServiceInstance()")
+	klog.Infof("RemoveServiceInstance()")
 	c.rwMutex.Lock()
 	defer c.rwMutex.Unlock()
 	_, ok := c.instanceMap[instanceID]
@@ -257,7 +257,7 @@ func (c *userProvidedController) Bind(
 	bindingID string,
 	req *brokerapi.BindingRequest,
 ) (*brokerapi.CreateServiceBindingResponse, error) {
-	glog.Info("Bind()")
+	klog.Infof("Bind()")
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
 	instance, ok := c.instanceMap[instanceID]
@@ -269,7 +269,7 @@ func (c *userProvidedController) Bind(
 }
 
 func (c *userProvidedController) UnBind(instanceID, bindingID, serviceID, planID string) error {
-	glog.Info("UnBind()")
+	klog.Infof("UnBind()")
 	// Since we don't persist the binding, there's nothing to do here.
 	return nil
 }

--- a/contrib/pkg/brokerapi/openservicebroker/open_service_broker_client.go
+++ b/contrib/pkg/brokerapi/openservicebroker/open_service_broker_client.go
@@ -27,8 +27,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/kubernetes-incubator/service-catalog/contrib/pkg/brokerapi"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 	"github.com/kubernetes-incubator/service-catalog/pkg/util"
 
 	"github.com/kubernetes-incubator/service-catalog/contrib/pkg/brokerapi/openservicebroker/constants"
@@ -120,13 +121,13 @@ func (c *openServiceBrokerClient) GetCatalog() (*brokerapi.Catalog, error) {
 
 	resp, err := c.Do(req)
 	if err != nil {
-		glog.Errorf("Failed to fetch catalog %q from %s: response: %v error: %#v", c.name, catalogURL, resp, err)
+		klog.Errorf("Failed to fetch catalog %q from %s: response: %v error: %#v", c.name, catalogURL, resp, err)
 		return nil, err
 	}
 
 	var catalog brokerapi.Catalog
 	if err = util.ResponseBodyToObject(resp, &catalog); err != nil {
-		glog.Errorf("Failed to unmarshal catalog from broker %q: %#v", c.name, err)
+		klog.Errorf("Failed to unmarshal catalog from broker %q: %#v", c.name, err)
 		return nil, err
 	}
 
@@ -146,7 +147,7 @@ func (c *openServiceBrokerClient) CreateServiceInstance(ID string, req *brokerap
 		req,
 	)
 	if err != nil {
-		glog.Errorf("Error sending create service instance request to broker %q at %v: response: %v error: %#v", c.name, serviceInstanceURL, resp, err)
+		klog.Errorf("Error sending create service instance request to broker %q at %v: response: %v error: %#v", c.name, serviceInstanceURL, resp, err)
 		errReq := errRequest{message: err.Error()}
 		if resp == nil {
 			return nil, 0, errReq
@@ -157,7 +158,7 @@ func (c *openServiceBrokerClient) CreateServiceInstance(ID string, req *brokerap
 
 	createServiceInstanceResponse := brokerapi.CreateServiceInstanceResponse{}
 	if err := util.ResponseBodyToObject(resp, &createServiceInstanceResponse); err != nil {
-		glog.Errorf("Error unmarshalling create service instance response from broker %q: %#v", c.name, err)
+		klog.Errorf("Error unmarshalling create service instance response from broker %q: %#v", c.name, err)
 		return nil, resp.StatusCode, errResponse{message: err.Error()}
 	}
 
@@ -167,7 +168,7 @@ func (c *openServiceBrokerClient) CreateServiceInstance(ID string, req *brokerap
 	case http.StatusOK:
 		return &createServiceInstanceResponse, resp.StatusCode, nil
 	case http.StatusAccepted:
-		glog.V(3).Infof("Asynchronous response received.")
+		klog.V(common.StatesInfoLogLevel).Infof("Asynchronous response received.")
 		return &createServiceInstanceResponse, resp.StatusCode, nil
 	case http.StatusConflict:
 		return nil, resp.StatusCode, errConflict
@@ -198,14 +199,14 @@ func (c *openServiceBrokerClient) DeleteServiceInstance(ID string, req *brokerap
 		req,
 	)
 	if err != nil {
-		glog.Errorf("Error sending delete service instance request to broker %q at %v: response: %v error: %#v", c.name, serviceInstanceURL, resp, err)
+		klog.Errorf("Error sending delete service instance request to broker %q at %v: response: %v error: %#v", c.name, serviceInstanceURL, resp, err)
 		return nil, resp.StatusCode, errRequest{message: err.Error()}
 	}
 	defer resp.Body.Close()
 
 	deleteServiceInstanceResponse := brokerapi.DeleteServiceInstanceResponse{}
 	if err := util.ResponseBodyToObject(resp, &deleteServiceInstanceResponse); err != nil {
-		glog.Errorf("Error unmarshalling delete service instance response from broker %q: %#v", c.name, err)
+		klog.Errorf("Error unmarshalling delete service instance response from broker %q: %#v", c.name, err)
 		return nil, resp.StatusCode, errResponse{message: err.Error()}
 	}
 
@@ -213,7 +214,7 @@ func (c *openServiceBrokerClient) DeleteServiceInstance(ID string, req *brokerap
 	case http.StatusOK:
 		return &deleteServiceInstanceResponse, resp.StatusCode, nil
 	case http.StatusAccepted:
-		glog.V(3).Infof("Asynchronous response received.")
+		klog.V(common.StatesInfoLogLevel).Infof("Asynchronous response received.")
 		return &deleteServiceInstanceResponse, resp.StatusCode, nil
 	case http.StatusGone:
 		return &deleteServiceInstanceResponse, resp.StatusCode, nil
@@ -227,7 +228,7 @@ func (c *openServiceBrokerClient) DeleteServiceInstance(ID string, req *brokerap
 func (c *openServiceBrokerClient) CreateServiceBinding(instanceID, bindingID string, req *brokerapi.BindingRequest) (*brokerapi.CreateServiceBindingResponse, error) {
 	jsonBytes, err := json.Marshal(req)
 	if err != nil {
-		glog.Errorf("Failed to marshal: %#v", err)
+		klog.Errorf("Failed to marshal: %#v", err)
 		return nil, err
 	}
 
@@ -243,17 +244,17 @@ func (c *openServiceBrokerClient) CreateServiceBinding(instanceID, bindingID str
 		return nil, err
 	}
 
-	glog.Infof("Doing a request to: %s", serviceBindingURL)
+	klog.Infof("Doing a request to: %s", serviceBindingURL)
 	resp, err := c.Do(createHTTPReq)
 	if err != nil {
-		glog.Errorf("Failed to PUT: %#v", err)
+		klog.Errorf("Failed to PUT: %#v", err)
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	createServiceBindingResponse := brokerapi.CreateServiceBindingResponse{}
 	if err := util.ResponseBodyToObject(resp, &createServiceBindingResponse); err != nil {
-		glog.Errorf("Error unmarshalling create binding response from broker: %#v", err)
+		klog.Errorf("Error unmarshalling create binding response from broker: %#v", err)
 		return nil, err
 	}
 
@@ -282,14 +283,14 @@ func (c *openServiceBrokerClient) DeleteServiceBinding(instanceID, bindingID, se
 		nil,
 	)
 	if err != nil {
-		glog.Errorf("Failed to create new HTTP request: %v", err)
+		klog.Errorf("Failed to create new HTTP request: %v", err)
 		return err
 	}
 
-	glog.Infof("Doing a request to: %s", serviceBindingURL)
+	klog.Infof("Doing a request to: %s", serviceBindingURL)
 	resp, err := c.Do(deleteHTTPReq)
 	if err != nil {
-		glog.Errorf("Failed to DELETE: %#v", err)
+		klog.Errorf("Failed to DELETE: %#v", err)
 		return err
 	}
 	defer resp.Body.Close()
@@ -325,7 +326,7 @@ func (c *openServiceBrokerClient) PollServiceInstance(ID string, req *brokerapi.
 		nil,
 	)
 	if err != nil {
-		glog.Errorf("Failed to create new HTTP request: %v", err)
+		klog.Errorf("Failed to create new HTTP request: %v", err)
 		return nil, 0, err
 	}
 	defer resp.Body.Close()

--- a/contrib/pkg/brokerapi/openservicebroker/util/fake_broker_server.go
+++ b/contrib/pkg/brokerapi/openservicebroker/util/fake_broker_server.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/gorilla/mux"
 
 	"github.com/kubernetes-incubator/service-catalog/contrib/pkg/brokerapi"
@@ -70,7 +70,7 @@ func (f *FakeServiceBrokerServer) Start() string {
 // Stop shuts down the server.
 func (f *FakeServiceBrokerServer) Stop() {
 	f.server.Close()
-	glog.Info("fake broker stopped")
+	klog.Infof("fake broker stopped")
 }
 
 // SetResponseStatus sets the default response status of the broker to the
@@ -92,12 +92,12 @@ func (f *FakeServiceBrokerServer) SetLastOperationState(state string) {
 // HANDLERS
 
 func (f *FakeServiceBrokerServer) catalogHandler(w http.ResponseWriter, r *http.Request) {
-	glog.Info("fake catalog called")
+	klog.Infof("fake catalog called")
 	util.WriteResponse(w, http.StatusOK, &brokerapi.Catalog{})
 }
 
 func (f *FakeServiceBrokerServer) lastOperationHandler(w http.ResponseWriter, r *http.Request) {
-	glog.Info("fake lastOperation called")
+	klog.Infof("fake lastOperation called")
 	f.Request = r
 	req := &brokerapi.LastOperationRequest{}
 	if err := util.BodyToObject(r, req); err != nil {
@@ -119,7 +119,7 @@ func (f *FakeServiceBrokerServer) lastOperationHandler(w http.ResponseWriter, r 
 }
 
 func (f *FakeServiceBrokerServer) provisionHandler(w http.ResponseWriter, r *http.Request) {
-	glog.Info("fake provision called")
+	klog.Infof("fake provision called")
 	f.Request = r
 	req := &brokerapi.CreateServiceInstanceRequest{}
 	if err := util.BodyToObject(r, req); err != nil {
@@ -141,7 +141,7 @@ func (f *FakeServiceBrokerServer) provisionHandler(w http.ResponseWriter, r *htt
 }
 
 func (f *FakeServiceBrokerServer) deprovisionHandler(w http.ResponseWriter, r *http.Request) {
-	glog.Info("fake deprovision called")
+	klog.Infof("fake deprovision called")
 	f.Request = r
 	req := &brokerapi.DeleteServiceInstanceRequest{
 		ServiceID: r.URL.Query().Get("service_id"),
@@ -167,13 +167,13 @@ func (f *FakeServiceBrokerServer) deprovisionHandler(w http.ResponseWriter, r *h
 }
 
 func (f *FakeServiceBrokerServer) updateHandler(w http.ResponseWriter, r *http.Request) {
-	glog.Info("fake update called")
+	klog.Infof("fake update called")
 	// TODO: Implement
 	util.WriteResponse(w, http.StatusForbidden, nil)
 }
 
 func (f *FakeServiceBrokerServer) bindHandler(w http.ResponseWriter, r *http.Request) {
-	glog.Info("fake bind called")
+	klog.Infof("fake bind called")
 	f.Request = r
 	req := &brokerapi.BindingRequest{}
 	if err := util.BodyToObject(r, req); err != nil {
@@ -185,7 +185,7 @@ func (f *FakeServiceBrokerServer) bindHandler(w http.ResponseWriter, r *http.Req
 }
 
 func (f *FakeServiceBrokerServer) unbindHandler(w http.ResponseWriter, r *http.Request) {
-	glog.Info("fake unbind called")
+	klog.Infof("fake unbind called")
 	f.Request = r
 	util.WriteResponse(w, f.responseStatus, &brokerapi.DeleteServiceInstanceResponse{})
 }

--- a/pkg/apiserver/etcd_config.go
+++ b/pkg/apiserver/etcd_config.go
@@ -17,12 +17,14 @@ limitations under the License.
 package apiserver
 
 import (
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/storage"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 )
 
 // EtcdConfig contains a generic API server Config along with config specific to
@@ -85,7 +87,7 @@ func (c completedEtcdConfig) NewServer(stopCh <-chan struct{}) (*ServiceCatalogA
 	if err != nil {
 		return nil, err
 	}
-	glog.V(4).Infoln("Created skeleton API server")
+	klog.V(common.DefaultInfoLogLevel).Infoln("Created skeleton API server")
 
 	roFactory := etcdRESTOptionsFactory{
 		deleteCollectionWorkers: c.extraConfig.deleteCollectionWorkers,
@@ -96,22 +98,22 @@ func (c completedEtcdConfig) NewServer(stopCh <-chan struct{}) (*ServiceCatalogA
 		storageDecorator:        generic.UndecoratedStorage,
 	}
 
-	glog.V(4).Infoln("Installing API groups")
+	klog.V(common.DefaultInfoLogLevel).Infoln("Installing API groups")
 	// default namespace doesn't matter for etcd
 	providers := restStorageProviders("" /* default namespace */, nil)
 	for _, provider := range providers {
 		groupInfo, err := provider.NewRESTStorage(c.apiResourceConfigSource, roFactory)
 		if IsErrAPIGroupDisabled(err) {
-			glog.Warningf("Skipping API group %v because it is not enabled", provider.GroupName())
+			klog.Warningf("Skipping API group %v because it is not enabled", provider.GroupName())
 			continue
 		} else if err != nil {
-			glog.Errorf("Error initializing storage for provider %v: %v", provider.GroupName(), err)
+			klog.Errorf("Error initializing storage for provider %v: %v", provider.GroupName(), err)
 			return nil, err
 		}
 
-		glog.V(4).Infof("Installing API group %v", provider.GroupName())
+		klog.V(common.DefaultInfoLogLevel).Infof("Installing API group %v", provider.GroupName())
 		if err := s.GenericAPIServer.InstallAPIGroup(groupInfo); err != nil {
-			glog.Fatalf("Error installing API group %v: %v", provider.GroupName(), err)
+			klog.Errorf("Error installing API group %v: %v", provider.GroupName(), err)
 		} else {
 			// we've successfully installed, so hook the stopCh to the destroy func of all the sucessfully installed apigroups
 			for _, mappings := range groupInfo.VersionedResourcesStorageMap { // gv to resource mappings
@@ -128,7 +130,7 @@ func (c completedEtcdConfig) NewServer(stopCh <-chan struct{}) (*ServiceCatalogA
 		}
 	}
 
-	glog.Infoln("Finished installing API groups")
+	klog.Infoln("Finished installing API groups")
 
 	return s, nil
 }

--- a/pkg/common/constant.go
+++ b/pkg/common/constant.go
@@ -1,0 +1,10 @@
+package common
+
+const (
+	ErrorDetailsInfoLogLevel = iota
+	DefaultInfoLogLevel
+	StatesInfoLogLevel
+	StatesDetailsInfoLogLevel
+	DebugInfoLogLevel
+	TraceInfoLogLevel
+)

--- a/pkg/controller/broker_client_manager.go
+++ b/pkg/controller/broker_client_manager.go
@@ -21,8 +21,10 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 )
 
 // BrokerKey defines a key which points to a broker (cluster wide or namespaced)
@@ -85,7 +87,7 @@ func (m *BrokerClientManager) UpdateBrokerClient(brokerKey BrokerKey, clientConf
 	existing, found := m.clients[brokerKey]
 
 	if !found || configHasChanged(existing.clientConfig, clientConfig) {
-		glog.V(4).Infof("Updating OSB client for broker %q, URL: %s", brokerKey.String(), clientConfig.URL)
+		klog.V(common.DefaultInfoLogLevel).Infof("Updating OSB client for broker %q, URL: %s", brokerKey.String(), clientConfig.URL)
 		return m.createClient(brokerKey, clientConfig)
 	}
 
@@ -97,7 +99,7 @@ func (m *BrokerClientManager) RemoveBrokerClient(brokerKey BrokerKey) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	glog.V(4).Infof("Removing OSB client for broker %q", brokerKey.String())
+	klog.V(common.DefaultInfoLogLevel).Infof("Removing OSB client for broker %q", brokerKey.String())
 	delete(m.clients, brokerKey)
 }
 

--- a/pkg/controller/client_builder.go
+++ b/pkg/controller/client_builder.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 )
 
 // ClientBuilder allows you to get clients and configs for controllers
@@ -57,7 +57,7 @@ func (b SimpleClientBuilder) Config(name string) (*restclient.Config, error) {
 func (b SimpleClientBuilder) ConfigOrDie(name string) *restclient.Config {
 	clientConfig, err := b.Config(name)
 	if err != nil {
-		glog.Fatal(err)
+		klog.Fatal(err)
 	}
 	return clientConfig
 }
@@ -78,7 +78,7 @@ func (b SimpleClientBuilder) Client(name string) (clientset.Interface, error) {
 func (b SimpleClientBuilder) ClientOrDie(name string) clientset.Interface {
 	client, err := b.Client(name)
 	if err != nil {
-		glog.Fatal(err)
+		klog.Fatal(err)
 	}
 	return client
 }

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 	scfeatures "github.com/kubernetes-incubator/service-catalog/pkg/features"
 	"github.com/kubernetes-incubator/service-catalog/pkg/pretty"
 	corev1 "k8s.io/api/core/v1"
@@ -72,18 +73,18 @@ func (c *controller) bindingAdd(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		pcb := pretty.NewContextBuilder(pretty.ServiceBinding, "", "", "")
-		glog.Errorf(pcb.Messagef("Couldn't get key for object %+v: %v", obj, err))
+		klog.Errorf(pcb.Messagef("Couldn't get key for object %+v: %v", obj, err))
 		return
 	}
 	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, "", key, "")
 
 	acc, err := meta.Accessor(obj)
 	if err != nil {
-		glog.Errorf(pcb.Messagef("error creating meta accessor: %v", err))
+		klog.Errorf(pcb.Messagef("error creating meta accessor: %v", err))
 		return
 	}
 
-	glog.V(6).Info(pcb.Messagef(
+	klog.V(common.StatesInfoLogLevel).Infof(pcb.Messagef(
 		"received ADD/UPDATE event for: resourceVersion: %v",
 		acc.GetResourceVersion()),
 	)
@@ -108,7 +109,7 @@ func (c *controller) bindingDelete(obj interface{}) {
 	}
 
 	pcb := pretty.NewBindingContextBuilder(binding)
-	glog.V(4).Info(pcb.Messagef("Received DELETE event; no further processing will occur; resourceVersion %v", binding.ResourceVersion))
+	klog.V(common.StatesInfoLogLevel).Infof(pcb.Messagef("Received DELETE event; no further processing will occur; resourceVersion %v", binding.ResourceVersion))
 }
 
 func (c *controller) reconcileServiceBindingKey(key string) error {
@@ -119,11 +120,11 @@ func (c *controller) reconcileServiceBindingKey(key string) error {
 	pcb := pretty.NewContextBuilder(pretty.ServiceBinding, namespace, name, "")
 	binding, err := c.bindingLister.ServiceBindings(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
-		glog.Info(pcb.Message("Not doing work because the ServiceBinding has been deleted"))
+		klog.Infof(pcb.Message("Not doing work because the ServiceBinding has been deleted"))
 		return nil
 	}
 	if err != nil {
-		glog.Info(pcb.Messagef("Unable to retrieve store: %v", err))
+		klog.Infof(pcb.Messagef("Unable to retrieve store: %v", err))
 		return err
 	}
 
@@ -157,7 +158,7 @@ func getReconciliationActionForServiceBinding(binding *v1beta1.ServiceBinding) R
 // processed and should be resubmitted at a later time.
 func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) error {
 	pcb := pretty.NewBindingContextBuilder(binding)
-	glog.V(6).Info(pcb.Messagef(`beginning to process resourceVersion: %v`, binding.ResourceVersion))
+	klog.V(common.StatesDetailsInfoLogLevel).Infof(pcb.Messagef(`beginning to process resourceVersion: %v`, binding.ResourceVersion))
 
 	reconciliationAction := getReconciliationActionForServiceBinding(binding)
 	switch reconciliationAction {
@@ -178,16 +179,16 @@ func (c *controller) reconcileServiceBindingAdd(binding *v1beta1.ServiceBinding)
 	pcb := pretty.NewBindingContextBuilder(binding)
 
 	if isServiceBindingFailed(binding) {
-		glog.V(4).Info(pcb.Message("not processing event; status showed that it has failed"))
+		klog.V(common.ErrorDetailsInfoLogLevel).Infof(pcb.Message("not processing event; status showed that it has failed"))
 		return nil
 	}
 
 	if binding.Status.ReconciledGeneration == binding.Generation {
-		glog.V(4).Info(pcb.Message("Not processing event; reconciled generation showed there is no work to do"))
+		klog.V(common.ErrorDetailsInfoLogLevel).Infof(pcb.Message("Not processing event; reconciled generation showed there is no work to do"))
 		return nil
 	}
 
-	glog.V(4).Info(pcb.Message("Processing"))
+	klog.V(common.DebugInfoLogLevel).Infof(pcb.Message("Processing"))
 
 	binding = binding.DeepCopy()
 
@@ -231,7 +232,7 @@ func (c *controller) reconcileServiceBindingAdd(binding *v1beta1.ServiceBinding)
 			return c.processServiceBindingOperationError(binding, readyCond)
 		}
 
-		glog.V(4).Info(pcb.Message("Adding/Updating"))
+		klog.V(common.DebugInfoLogLevel).Infof(pcb.Message("Adding/Updating"))
 
 		request, inProgressProperties, err = c.prepareBindRequest(binding, instance)
 		if err != nil {
@@ -268,7 +269,7 @@ func (c *controller) reconcileServiceBindingAdd(binding *v1beta1.ServiceBinding)
 			return c.processServiceBindingOperationError(binding, readyCond)
 		}
 
-		glog.V(4).Info(pcb.Message("Adding/Updating"))
+		klog.V(common.DebugInfoLogLevel).Infof(pcb.Message("Adding/Updating"))
 
 		request, inProgressProperties, err = c.prepareBindRequest(binding, instance)
 		if err != nil {
@@ -360,11 +361,11 @@ func (c *controller) reconcileServiceBindingDelete(binding *v1beta1.ServiceBindi
 
 	// If unbind has failed, do not do anything more
 	if binding.Status.UnbindStatus == v1beta1.ServiceBindingUnbindStatusFailed {
-		glog.V(4).Info(pcb.Message("Not processing delete event because unbinding has failed"))
+		klog.V(common.ErrorDetailsInfoLogLevel).Infof(pcb.Message("Not processing delete event because unbinding has failed"))
 		return nil
 	}
 
-	glog.V(4).Info(pcb.Message("Processing Delete"))
+	klog.V(common.DebugInfoLogLevel).Infof(pcb.Message("Processing Delete"))
 
 	binding = binding.DeepCopy()
 
@@ -516,7 +517,7 @@ func isServicePlanBindable(serviceClass *v1beta1.ServiceClass, plan *v1beta1.Ser
 
 func (c *controller) injectServiceBinding(binding *v1beta1.ServiceBinding, credentials map[string]interface{}) error {
 	pcb := pretty.NewBindingContextBuilder(binding)
-	glog.V(5).Info(pcb.Messagef(`Creating/updating Secret "%s/%s" with %d keys`,
+	klog.V(common.DefaultInfoLogLevel).Infof(pcb.Messagef(`Creating/updating Secret "%s/%s" with %d keys`,
 		binding.Namespace, binding.Spec.SecretName, len(credentials),
 	))
 
@@ -640,7 +641,7 @@ func evaluateJSONPath(jsonPath string, credentials map[string]interface{}) (stri
 func (c *controller) ejectServiceBinding(binding *v1beta1.ServiceBinding) error {
 	var err error
 	pcb := pretty.NewBindingContextBuilder(binding)
-	glog.V(5).Info(pcb.Messagef(`Deleting Secret "%s/%s"`,
+	klog.V(common.DefaultInfoLogLevel).Infof(pcb.Messagef(`Deleting Secret "%s/%s"`,
 		binding.Namespace, binding.Spec.SecretName,
 	))
 	err = c.kubeClient.CoreV1().Secrets(binding.Namespace).Delete(binding.Spec.SecretName, &metav1.DeleteOptions{})
@@ -677,8 +678,8 @@ func setServiceBindingConditionInternal(toUpdate *v1beta1.ServiceBinding,
 	reason, message string,
 	t metav1.Time) {
 	pcb := pretty.NewBindingContextBuilder(toUpdate)
-	glog.Info(pcb.Message(message))
-	glog.V(5).Info(pcb.Messagef(
+	klog.Infof(pcb.Message(message))
+	klog.V(common.StatesInfoLogLevel).Infof(pcb.Messagef(
 		"Setting condition %q to %v",
 		conditionType, status,
 	))
@@ -691,7 +692,7 @@ func setServiceBindingConditionInternal(toUpdate *v1beta1.ServiceBinding,
 	}
 
 	if len(toUpdate.Status.Conditions) == 0 {
-		glog.Info(pcb.Messagef(
+		klog.Infof(pcb.Messagef(
 			"Setting lastTransitionTime for condition %q to %v",
 			conditionType, t,
 		))
@@ -702,7 +703,7 @@ func setServiceBindingConditionInternal(toUpdate *v1beta1.ServiceBinding,
 	for i, cond := range toUpdate.Status.Conditions {
 		if cond.Type == conditionType {
 			if cond.Status != newCondition.Status {
-				glog.V(3).Info(pcb.Messagef(
+				klog.V(common.StatesDetailsInfoLogLevel).Infof(pcb.Messagef(
 					"Found status change for condition %q: %q -> %q; setting lastTransitionTime to %v",
 					conditionType, cond.Status, status, t,
 				))
@@ -716,7 +717,7 @@ func setServiceBindingConditionInternal(toUpdate *v1beta1.ServiceBinding,
 		}
 	}
 
-	glog.V(3).Info(
+	klog.V(common.StatesInfoLogLevel).Infof(
 		pcb.Messagef("Setting lastTransitionTime for condition %q to %v",
 			conditionType, t,
 		))
@@ -727,12 +728,12 @@ func setServiceBindingConditionInternal(toUpdate *v1beta1.ServiceBinding,
 
 func (c *controller) updateServiceBindingStatus(toUpdate *v1beta1.ServiceBinding) (*v1beta1.ServiceBinding, error) {
 	pcb := pretty.NewBindingContextBuilder(toUpdate)
-	glog.V(4).Info(pcb.Message("Updating status"))
+	klog.V(common.StatesInfoLogLevel).Infof(pcb.Message("Updating status"))
 	updatedBinding, err := c.serviceCatalogClient.ServiceBindings(toUpdate.Namespace).UpdateStatus(toUpdate)
 	if err != nil {
-		glog.Errorf(pcb.Messagef("Error updating status: %v", err))
+		klog.Errorf(pcb.Messagef("Error updating status: %v", err))
 	} else {
-		glog.V(6).Info(pcb.Messagef(`Updated status of resourceVersion: %v; got resourceVersion: %v`,
+		klog.V(common.StatesInfoLogLevel).Infof(pcb.Messagef(`Updated status of resourceVersion: %v; got resourceVersion: %v`,
 			toUpdate.ResourceVersion, updatedBinding.ResourceVersion),
 		)
 	}
@@ -753,13 +754,13 @@ func (c *controller) updateServiceBindingCondition(
 
 	setServiceBindingCondition(toUpdate, conditionType, status, reason, message)
 
-	glog.V(4).Info(pcb.Messagef(
+	klog.V(common.StatesInfoLogLevel).Infof(pcb.Messagef(
 		"Updating %v condition to %v (Reason: %q, Message: %q)",
 		conditionType, status, reason, message,
 	))
 	_, err := c.serviceCatalogClient.ServiceBindings(binding.Namespace).UpdateStatus(toUpdate)
 	if err != nil {
-		glog.Errorf(pcb.Messagef(
+		klog.Errorf(pcb.Messagef(
 			"Error updating %v condition to %v: %v",
 			conditionType, status, err,
 		))
@@ -829,7 +830,7 @@ func clearServiceBindingCurrentOperation(toUpdate *v1beta1.ServiceBinding) {
 // operation, see PR 1708/Issue 1587.
 func rollbackBindingReconciledGenerationOnDeletion(binding *v1beta1.ServiceBinding, currentReconciledGeneration int64) {
 	if binding.DeletionTimestamp != nil {
-		glog.V(4).Infof("Not updating ReconciledGeneration after async operation because there is a deletion pending.")
+		klog.V(common.ErrorDetailsInfoLogLevel).Infof("Not updating ReconciledGeneration after async operation because there is a deletion pending.")
 		binding.Status.ReconciledGeneration = currentReconciledGeneration
 	}
 }
@@ -845,7 +846,7 @@ func (c *controller) requeueServiceBindingForPoll(key string) error {
 func (c *controller) beginPollingServiceBinding(binding *v1beta1.ServiceBinding) error {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(binding)
 	if err != nil {
-		glog.Errorf("Couldn't create a key for object %+v: %v", binding, err)
+		klog.Errorf("Couldn't create a key for object %+v: %v", binding, err)
 		return fmt.Errorf("Couldn't create a key for object %+v: %v", binding, err)
 	}
 
@@ -865,7 +866,7 @@ func (c *controller) continuePollingServiceBinding(binding *v1beta1.ServiceBindi
 func (c *controller) finishPollingServiceBinding(binding *v1beta1.ServiceBinding) error {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(binding)
 	if err != nil {
-		glog.Errorf("Couldn't create a key for object %+v: %v", binding, err)
+		klog.Errorf("Couldn't create a key for object %+v: %v", binding, err)
 		return fmt.Errorf("Couldn't create a key for object %+v: %v", binding, err)
 	}
 
@@ -876,7 +877,7 @@ func (c *controller) finishPollingServiceBinding(binding *v1beta1.ServiceBinding
 
 func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
 	pcb := pretty.NewBindingContextBuilder(binding)
-	glog.V(4).Infof(pcb.Message("Processing"))
+	klog.V(common.DebugInfoLogLevel).Infof(pcb.Message("Processing"))
 
 	binding = binding.DeepCopy()
 
@@ -903,7 +904,7 @@ func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
 		return c.handleServiceBindingReconciliationError(binding, err)
 	}
 
-	glog.V(5).Info(pcb.Message("Polling last operation"))
+	klog.V(common.DebugInfoLogLevel).Infof(pcb.Message("Polling last operation"))
 
 	response, err := brokerClient.PollBindingLastOperation(request)
 	if err != nil {
@@ -922,7 +923,7 @@ func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
 		// The binding's Ready condition should already be False, so we
 		// just need to record an event.
 		s := fmt.Sprintf("Error polling last operation: %v", err)
-		glog.V(4).Info(pcb.Message(s))
+		klog.V(common.ErrorDetailsInfoLogLevel).Infof(pcb.Message(s))
 		c.recorder.Event(binding, corev1.EventTypeWarning, errorPollingLastOperationReason, s)
 
 		if c.reconciliationRetryDurationExceeded(binding.Status.OperationStartTime) {
@@ -936,7 +937,7 @@ func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
 	if response.Description != nil {
 		description = *response.Description
 	}
-	glog.V(4).Info(pcb.Messagef("Poll returned %q : %q", response.State, description))
+	klog.V(common.StatesDetailsInfoLogLevel).Infof(pcb.Messagef("Poll returned %q : %q", response.State, description))
 
 	switch response.State {
 	case osb.StateInProgress:
@@ -962,7 +963,7 @@ func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
 			}
 		}
 
-		glog.V(4).Info(pcb.Message("Last operation not completed (still in progress)"))
+		klog.V(common.ErrorDetailsInfoLogLevel).Infof(pcb.Message("Last operation not completed (still in progress)"))
 		return c.continuePollingServiceBinding(binding)
 	case osb.StateSucceeded:
 		if deleting {
@@ -1051,7 +1052,7 @@ func (c *controller) pollServiceBinding(binding *v1beta1.ServiceBinding) error {
 		c.finishPollingServiceBinding(binding)
 		return fmt.Errorf(readyCond.Message)
 	default:
-		glog.Warning(pcb.Messagef("Got invalid state in LastOperationResponse: %q", response.State))
+		klog.Warningf(pcb.Messagef("Got invalid state in LastOperationResponse: %q", response.State))
 
 		if c.reconciliationRetryDurationExceeded(binding.Status.OperationStartTime) {
 			return c.processServiceBindingPollingFailureRetryTimeout(binding, nil)
@@ -1492,7 +1493,7 @@ func (c *controller) processServiceBindingGracefulDeletionSuccess(binding *v1bet
 	}
 
 	pcb := pretty.NewBindingContextBuilder(binding)
-	glog.Info(pcb.Message("Cleared finalizer"))
+	klog.Infof(pcb.Message("Cleared finalizer"))
 
 	return nil
 }
@@ -1589,6 +1590,6 @@ func (c *controller) handleServiceBindingPollingError(binding *v1beta1.ServiceBi
 	//		- if successful, we can return nil to avoid regular queue
 	//		- if failure, return err to fall back to regular queue
 	pcb := pretty.NewBindingContextBuilder(binding)
-	glog.V(4).Info(pcb.Messagef("Error during polling: %v", err))
+	klog.V(common.ErrorDetailsInfoLogLevel).Infof(pcb.Messagef("Error during polling: %v", err))
 	return c.continuePollingServiceBinding(binding)
 }

--- a/pkg/controller/controller_clusterservicebroker.go
+++ b/pkg/controller/controller_clusterservicebroker.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 	"github.com/kubernetes-incubator/service-catalog/pkg/metrics"
 	"github.com/kubernetes-incubator/service-catalog/pkg/pretty"
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
@@ -71,7 +72,7 @@ func (c *controller) clusterServiceBrokerAdd(obj interface{}) {
 	// just "name" for cluster scoped resources.
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		klog.Errorf("Couldn't get key for object %+v: %v", obj, err)
 		return
 	}
 	c.clusterServiceBrokerQueue.Add(key)
@@ -87,7 +88,7 @@ func (c *controller) clusterServiceBrokerDelete(obj interface{}) {
 		return
 	}
 
-	glog.V(4).Infof("Received delete event for ClusterServiceBroker %v; no further processing will occur", broker.Name)
+	klog.V(common.StatesDetailsInfoLogLevel).Infof("Received delete event for ClusterServiceBroker %v; no further processing will occur", broker.Name)
 }
 
 // shouldReconcileClusterServiceBroker determines whether a broker should be reconciled; it
@@ -109,15 +110,15 @@ func (c *controller) reconcileClusterServiceBrokerKey(key string) error {
 	broker, err := c.clusterServiceBrokerLister.Get(key)
 	pcb := pretty.NewContextBuilder(pretty.ClusterServiceBroker, "", key, "")
 
-	glog.V(4).Info(pcb.Message("Processing service broker"))
+	klog.V(common.DebugInfoLogLevel).Infof(pcb.Message("Processing service broker"))
 
 	if errors.IsNotFound(err) {
-		glog.Info(pcb.Message("Not doing work because it has been deleted"))
+		klog.Infof(pcb.Message("Not doing work because it has been deleted"))
 		c.brokerClientManager.RemoveBrokerClient(NewClusterServiceBrokerKey(key))
 		return nil
 	}
 	if err != nil {
-		glog.Info(pcb.Messagef("Unable to retrieve object from store: %v", err))
+		klog.Infof(pcb.Messagef("Unable to retrieve object from store: %v", err))
 		return err
 	}
 
@@ -126,11 +127,11 @@ func (c *controller) reconcileClusterServiceBrokerKey(key string) error {
 
 func (c *controller) updateClusterServiceBrokerClient(broker *v1beta1.ClusterServiceBroker) (osb.Client, error) {
 	pcb := pretty.NewClusterServiceBrokerContextBuilder(broker)
-	glog.V(4).Info(pcb.Message("Updating broker client"))
+	klog.V(common.DefaultInfoLogLevel).Infof(pcb.Message("Updating broker client"))
 	authConfig, err := getAuthCredentialsFromClusterServiceBroker(c.kubeClient, broker)
 	if err != nil {
 		s := fmt.Sprintf("Error getting broker auth credentials: %s", err)
-		glog.Info(pcb.Message(s))
+		klog.Infof(pcb.Message(s))
 		c.recorder.Event(broker, corev1.EventTypeWarning, errorAuthCredentialsReason, s)
 		if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorFetchingCatalogReason, errorFetchingCatalogMessage+s); err != nil {
 			return nil, err
@@ -141,7 +142,7 @@ func (c *controller) updateClusterServiceBrokerClient(broker *v1beta1.ClusterSer
 	brokerClient, err := c.brokerClientManager.UpdateBrokerClient(NewClusterServiceBrokerKey(broker.Name), clientConfig)
 	if err != nil {
 		s := fmt.Sprintf("Error creating client for broker %q: %s", broker.Name, err)
-		glog.Info(pcb.Message(s))
+		klog.Infof(pcb.Message(s))
 		c.recorder.Event(broker, corev1.EventTypeWarning, errorAuthCredentialsReason, s)
 		if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorFetchingCatalogReason, errorFetchingCatalogMessage+s); err != nil {
 			return nil, err
@@ -156,7 +157,7 @@ func (c *controller) updateClusterServiceBrokerClient(broker *v1beta1.ClusterSer
 // processed and should be resubmitted at a later time.
 func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServiceBroker) error {
 	pcb := pretty.NewClusterServiceBrokerContextBuilder(broker)
-	glog.V(4).Infof(pcb.Message("Processing"))
+	klog.V(common.DebugInfoLogLevel).Infof(pcb.Message("Processing"))
 
 	brokerClient, err := c.updateClusterServiceBrokerClient(broker)
 	if err != nil {
@@ -172,14 +173,14 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 	}
 
 	if broker.DeletionTimestamp == nil { // Add or update
-		glog.V(4).Info(pcb.Message("Processing adding/update event"))
+		klog.V(common.DebugInfoLogLevel).Infof(pcb.Message("Processing adding/update event"))
 
 		// get the broker's catalog
 		now := metav1.Now()
 		brokerCatalog, err := brokerClient.GetCatalog()
 		if err != nil {
 			s := fmt.Sprintf("Error getting broker catalog: %s", err)
-			glog.Warning(pcb.Message(s))
+			klog.Warningf(pcb.Message(s))
 			c.recorder.Eventf(broker, corev1.EventTypeWarning, errorFetchingCatalogReason, s)
 			if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorFetchingCatalogReason, errorFetchingCatalogMessage+s); err != nil {
 				return err
@@ -188,12 +189,12 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 				toUpdate := broker.DeepCopy()
 				toUpdate.Status.OperationStartTime = &now
 				if _, err := c.serviceCatalogClient.ClusterServiceBrokers().UpdateStatus(toUpdate); err != nil {
-					glog.Error(pcb.Messagef("Error updating operation start time: %v", err))
+					klog.Errorf(pcb.Messagef("Error updating operation start time: %v", err))
 					return err
 				}
 			} else if !time.Now().Before(broker.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
 				s := "Stopping reconciliation retries because too much time has elapsed"
-				glog.Info(pcb.Message(s))
+				klog.Infof(pcb.Message(s))
 				c.recorder.Event(broker, corev1.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
 				toUpdate := broker.DeepCopy()
 				toUpdate.Status.OperationStartTime = nil
@@ -207,25 +208,25 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 			return err
 		}
 
-		glog.V(5).Info(pcb.Messagef("Successfully fetched %v catalog entries", len(brokerCatalog.Services)))
+		klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Successfully fetched %v catalog entries", len(brokerCatalog.Services)))
 
 		// set the operation start time if not already set
 		if broker.Status.OperationStartTime != nil {
 			toUpdate := broker.DeepCopy()
 			toUpdate.Status.OperationStartTime = nil
 			if _, err := c.serviceCatalogClient.ClusterServiceBrokers().UpdateStatus(toUpdate); err != nil {
-				glog.Error(pcb.Messagef("Error updating operation start time: %v", err))
+				klog.Errorf(pcb.Messagef("Error updating operation start time: %v", err))
 				return err
 			}
 		}
 
 		// convert the broker's catalog payload into our API objects
-		glog.V(4).Info(pcb.Message("Converting catalog response into service-catalog API"))
+		klog.V(common.StatesDetailsInfoLogLevel).Infof(pcb.Message("Converting catalog response into service-catalog API"))
 
 		payloadServiceClasses, payloadServicePlans, err := convertAndFilterCatalog(brokerCatalog, broker.Spec.CatalogRestrictions)
 		if err != nil {
 			s := fmt.Sprintf("Error converting catalog payload for broker %q to service-catalog API: %s", broker.Name, err)
-			glog.Warning(pcb.Message(s))
+			klog.Warningf(pcb.Message(s))
 			c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
 			if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason, errorSyncingCatalogMessage+s); err != nil {
 				return err
@@ -233,7 +234,7 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 			return err
 		}
 
-		glog.V(5).Info(pcb.Message("Successfully converted catalog payload from to service-catalog API"))
+		klog.V(common.StatesDetailsInfoLogLevel).Infof(pcb.Message("Successfully converted catalog payload from to service-catalog API"))
 
 		// get the existing services and plans for this broker so that we can
 		// detect when services and plans are removed from the broker's
@@ -252,13 +253,13 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 			existingServiceClass, _ := existingServiceClassMap[payloadServiceClass.Name]
 			delete(existingServiceClassMap, payloadServiceClass.Name)
 
-			glog.V(4).Info(pcb.Messagef("Reconciling %s", pretty.ClusterServiceClassName(payloadServiceClass)))
+			klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Reconciling %s", pretty.ClusterServiceClassName(payloadServiceClass)))
 			if err := c.reconcileClusterServiceClassFromClusterServiceBrokerCatalog(broker, payloadServiceClass, existingServiceClass); err != nil {
 				s := fmt.Sprintf(
 					"Error reconciling %s (broker %q): %s",
 					pretty.ClusterServiceClassName(payloadServiceClass), broker.Name, err,
 				)
-				glog.Warning(pcb.Message(s))
+				klog.Warningf(pcb.Message(s))
 				c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
 				if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason,
 					errorSyncingCatalogMessage+s); err != nil {
@@ -267,7 +268,7 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 				return err
 			}
 
-			glog.V(5).Info(pcb.Messagef("Reconciled %s", pretty.ClusterServiceClassName(payloadServiceClass)))
+			klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Reconciled %s", pretty.ClusterServiceClassName(payloadServiceClass)))
 		}
 
 		// handle the serviceClasses that were not in the broker's payload;
@@ -282,7 +283,7 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 				continue
 			}
 
-			glog.V(4).Info(pcb.Messagef("%s has been removed from broker's catalog; marking", pretty.ClusterServiceClassName(existingServiceClass)))
+			klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("%s has been removed from broker's catalog; marking", pretty.ClusterServiceClassName(existingServiceClass)))
 			existingServiceClass.Status.RemovedFromBrokerCatalog = true
 			_, err := c.serviceCatalogClient.ClusterServiceClasses().UpdateStatus(existingServiceClass)
 			if err != nil {
@@ -290,7 +291,7 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 					"Error updating status of %s: %v",
 					pretty.ClusterServiceClassName(existingServiceClass), err,
 				)
-				glog.Warning(pcb.Message(s))
+				klog.Warningf(pcb.Message(s))
 				c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
 				if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason,
 					errorSyncingCatalogMessage+s); err != nil {
@@ -305,7 +306,7 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 			existingServicePlan, _ := existingServicePlanMap[payloadServicePlan.Name]
 			delete(existingServicePlanMap, payloadServicePlan.Name)
 
-			glog.V(4).Infof(
+			klog.V(common.DebugInfoLogLevel).Infof(
 				"ClusterServiceBroker %q: reconciling %s",
 				broker.Name, pretty.ClusterServicePlanName(payloadServicePlan),
 			)
@@ -314,13 +315,13 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 					"Error reconciling %s: %s",
 					pretty.ClusterServicePlanName(payloadServicePlan), err,
 				)
-				glog.Warning(pcb.Message(s))
+				klog.Warningf(pcb.Message(s))
 				c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
 				c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason,
 					errorSyncingCatalogMessage+s)
 				return err
 			}
-			glog.V(5).Info(pcb.Messagef("Reconciled %s", pretty.ClusterServicePlanName(payloadServicePlan)))
+			klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Reconciled %s", pretty.ClusterServicePlanName(payloadServicePlan)))
 
 		}
 
@@ -336,7 +337,7 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 				continue
 			}
 
-			glog.V(4).Info(pcb.Messagef("%s has been removed from broker's catalog; marking", pretty.ClusterServicePlanName(existingServicePlan)))
+			klog.V(common.StatesDetailsInfoLogLevel).Infof(pcb.Messagef("%s has been removed from broker's catalog; marking", pretty.ClusterServicePlanName(existingServicePlan)))
 			existingServicePlan.Status.RemovedFromBrokerCatalog = true
 			_, err := c.serviceCatalogClient.ClusterServicePlans().UpdateStatus(existingServicePlan)
 			if err != nil {
@@ -345,7 +346,7 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 					pretty.ClusterServicePlanName(existingServicePlan),
 					err,
 				)
-				glog.Warning(pcb.Message(s))
+				klog.Warningf(pcb.Message(s))
 				c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
 				if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason,
 					errorSyncingCatalogMessage+s); err != nil {
@@ -374,21 +375,21 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 	// and returned early. If we reach this point, we're dealing with an update
 	// that's actually a soft delete-- i.e. we have some finalization to do.
 	if finalizers := sets.NewString(broker.Finalizers...); finalizers.Has(v1beta1.FinalizerServiceCatalog) {
-		glog.V(4).Info(pcb.Message("Finalizing"))
+		klog.V(common.DebugInfoLogLevel).Infof(pcb.Message("Finalizing"))
 
 		existingServiceClasses, existingServicePlans, err := c.getCurrentServiceClassesAndPlansForBroker(broker)
 		if err != nil {
 			return err
 		}
 
-		glog.V(4).Info(pcb.Messagef("Found %d ClusterServiceClasses and %d ClusterServicePlans to delete", len(existingServiceClasses), len(existingServicePlans)))
+		klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Found %d ClusterServiceClasses and %d ClusterServicePlans to delete", len(existingServiceClasses), len(existingServicePlans)))
 
 		for _, plan := range existingServicePlans {
-			glog.V(4).Info(pcb.Messagef("Deleting %s", pretty.ClusterServicePlanName(&plan)))
+			klog.V(common.DefaultInfoLogLevel).Infof(pcb.Messagef("Deleting %s", pretty.ClusterServicePlanName(&plan)))
 			err := c.serviceCatalogClient.ClusterServicePlans().Delete(plan.Name, &metav1.DeleteOptions{})
 			if err != nil && !errors.IsNotFound(err) {
 				s := fmt.Sprintf("Error deleting %s: %s", pretty.ClusterServicePlanName(&plan), err)
-				glog.Warning(pcb.Message(s))
+				klog.Warningf(pcb.Message(s))
 				c.updateClusterServiceBrokerCondition(
 					broker,
 					v1beta1.ServiceBrokerConditionReady,
@@ -402,11 +403,11 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 		}
 
 		for _, svcClass := range existingServiceClasses {
-			glog.V(4).Info(pcb.Messagef("Deleting %s", pretty.ClusterServiceClassName(&svcClass)))
+			klog.V(common.DefaultInfoLogLevel).Infof(pcb.Messagef("Deleting %s", pretty.ClusterServiceClassName(&svcClass)))
 			err = c.serviceCatalogClient.ClusterServiceClasses().Delete(svcClass.Name, &metav1.DeleteOptions{})
 			if err != nil && !errors.IsNotFound(err) {
 				s := fmt.Sprintf("Error deleting %s: %s", pretty.ClusterServiceClassName(&svcClass), err)
-				glog.Warning(pcb.Message(s))
+				klog.Warningf(pcb.Message(s))
 				c.recorder.Eventf(broker, corev1.EventTypeWarning, errorDeletingClusterServiceClassReason, "%v %v", errorDeletingClusterServiceClassMessage, s)
 				if err := c.updateClusterServiceBrokerCondition(
 					broker,
@@ -435,7 +436,7 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 		c.updateClusterServiceBrokerFinalizers(broker, finalizers.List())
 
 		c.recorder.Eventf(broker, corev1.EventTypeNormal, successClusterServiceBrokerDeletedReason, successClusterServiceBrokerDeletedMessage, broker.Name)
-		glog.V(5).Info(pcb.Message("Successfully deleted"))
+		klog.V(common.DefaultInfoLogLevel).Infof(pcb.Message("Successfully deleted"))
 
 		// delete the metrics associated with this broker
 		metrics.BrokerServiceClassCount.DeleteLabelValues(broker.Name)
@@ -471,16 +472,16 @@ func (c *controller) reconcileClusterServiceClassFromClusterServiceBrokerCatalog
 				errMsg := fmt.Sprintf("%s already exists for Broker %q",
 					pretty.ClusterServiceClassName(serviceClass), otherServiceClass.Spec.ClusterServiceBrokerName,
 				)
-				glog.Error(pcb.Message(errMsg))
+				klog.Errorf(pcb.Message(errMsg))
 				return fmt.Errorf(errMsg)
 			}
 		}
 
 		markAsServiceCatalogManagedResource(serviceClass, broker)
 
-		glog.V(5).Info(pcb.Messagef("Fresh %s; creating", pretty.ClusterServiceClassName(serviceClass)))
+		klog.V(common.DefaultInfoLogLevel).Infof(pcb.Messagef("Fresh %s; creating", pretty.ClusterServiceClassName(serviceClass)))
 		if _, err := c.serviceCatalogClient.ClusterServiceClasses().Create(serviceClass); err != nil {
-			glog.Error(pcb.Messagef("Error creating %s: %v", pretty.ClusterServiceClassName(serviceClass), err))
+			klog.Errorf(pcb.Messagef("Error creating %s: %v", pretty.ClusterServiceClassName(serviceClass), err))
 			return err
 		}
 
@@ -492,11 +493,11 @@ func (c *controller) reconcileClusterServiceClassFromClusterServiceBrokerCatalog
 			"%s already exists with OSB guid %q, received different guid %q",
 			pretty.ClusterServiceClassName(serviceClass), existingServiceClass.Name, serviceClass.Name,
 		)
-		glog.Error(pcb.Message(errMsg))
+		klog.Errorf(pcb.Message(errMsg))
 		return fmt.Errorf(errMsg)
 	}
 
-	glog.V(5).Info(pcb.Messagef("Found existing %s; updating", pretty.ClusterServiceClassName(serviceClass)))
+	klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Found existing %s; updating", pretty.ClusterServiceClassName(serviceClass)))
 
 	// There was an existing service class -- project the update onto it and
 	// update it.
@@ -514,17 +515,17 @@ func (c *controller) reconcileClusterServiceClassFromClusterServiceBrokerCatalog
 
 	updatedServiceClass, err := c.serviceCatalogClient.ClusterServiceClasses().Update(toUpdate)
 	if err != nil {
-		glog.Error(pcb.Messagef("Error updating %s: %v", pretty.ClusterServiceClassName(serviceClass), err))
+		klog.Errorf(pcb.Messagef("Error updating %s: %v", pretty.ClusterServiceClassName(serviceClass), err))
 		return err
 	}
 
 	if updatedServiceClass.Status.RemovedFromBrokerCatalog {
-		glog.V(4).Info(pcb.Messagef("Resetting RemovedFromBrokerCatalog status on %s", pretty.ClusterServiceClassName(serviceClass)))
+		klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Resetting RemovedFromBrokerCatalog status on %s", pretty.ClusterServiceClassName(serviceClass)))
 		updatedServiceClass.Status.RemovedFromBrokerCatalog = false
 		_, err := c.serviceCatalogClient.ClusterServiceClasses().UpdateStatus(updatedServiceClass)
 		if err != nil {
 			s := fmt.Sprintf("Error updating status of %s: %v", pretty.ClusterServiceClassName(updatedServiceClass), err)
-			glog.Warning(pcb.Message(s))
+			klog.Warningf(pcb.Message(s))
 			c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
 			if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason, errorSyncingCatalogMessage+s); err != nil {
 				return err
@@ -559,7 +560,7 @@ func (c *controller) reconcileClusterServicePlanFromClusterServiceBrokerCatalog(
 					"%s already exists for Broker %q",
 					pretty.ClusterServicePlanName(servicePlan), otherServicePlan.Spec.ClusterServiceBrokerName,
 				)
-				glog.Error(pcb.Message(errMsg))
+				klog.Errorf(pcb.Message(errMsg))
 				return fmt.Errorf(errMsg)
 			}
 		}
@@ -569,7 +570,7 @@ func (c *controller) reconcileClusterServicePlanFromClusterServiceBrokerCatalog(
 		// An error returned from a lister Get call means that the object does
 		// not exist.  Create a new ClusterServicePlan.
 		if _, err := c.serviceCatalogClient.ClusterServicePlans().Create(servicePlan); err != nil {
-			glog.Error(pcb.Messagef("Error creating %s: %v", pretty.ClusterServicePlanName(servicePlan), err))
+			klog.Errorf(pcb.Messagef("Error creating %s: %v", pretty.ClusterServicePlanName(servicePlan), err))
 			return err
 		}
 
@@ -581,11 +582,11 @@ func (c *controller) reconcileClusterServicePlanFromClusterServiceBrokerCatalog(
 			"%s already exists with OSB guid %q, received different guid %q",
 			pretty.ClusterServicePlanName(servicePlan), existingServicePlan.Spec.ExternalID, servicePlan.Spec.ExternalID,
 		)
-		glog.Error(pcb.Message(errMsg))
+		klog.Errorf(pcb.Message(errMsg))
 		return fmt.Errorf(errMsg)
 	}
 
-	glog.V(5).Info(pcb.Messagef("Found existing %s; updating", pretty.ClusterServicePlanName(servicePlan)))
+	klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Found existing %s; updating", pretty.ClusterServicePlanName(servicePlan)))
 
 	// There was an existing service plan -- project the update onto it and
 	// update it.
@@ -603,18 +604,18 @@ func (c *controller) reconcileClusterServicePlanFromClusterServiceBrokerCatalog(
 
 	updatedPlan, err := c.serviceCatalogClient.ClusterServicePlans().Update(toUpdate)
 	if err != nil {
-		glog.Error(pcb.Messagef("Error updating %s: %v", pretty.ClusterServicePlanName(servicePlan), err))
+		klog.Errorf(pcb.Messagef("Error updating %s: %v", pretty.ClusterServicePlanName(servicePlan), err))
 		return err
 	}
 
 	if updatedPlan.Status.RemovedFromBrokerCatalog {
 		updatedPlan.Status.RemovedFromBrokerCatalog = false
-		glog.V(4).Info(pcb.Messagef("Resetting RemovedFromBrokerCatalog status on %s", pretty.ClusterServicePlanName(updatedPlan)))
+		klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Resetting RemovedFromBrokerCatalog status on %s", pretty.ClusterServicePlanName(updatedPlan)))
 
 		_, err := c.serviceCatalogClient.ClusterServicePlans().UpdateStatus(updatedPlan)
 		if err != nil {
 			s := fmt.Sprintf("Error updating status of %s: %v", pretty.ClusterServicePlanName(updatedPlan), err)
-			glog.Error(pcb.Message(s))
+			klog.Errorf(pcb.Message(s))
 			c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
 			if err := c.updateClusterServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason, errorSyncingCatalogMessage+s); err != nil {
 				return err
@@ -641,14 +642,14 @@ func (c *controller) updateClusterServiceBrokerCondition(broker *v1beta1.Cluster
 	t := time.Now()
 
 	if len(broker.Status.Conditions) == 0 {
-		glog.Info(pcb.Messagef("Setting lastTransitionTime for condition %q to %v", conditionType, t))
+		klog.Infof(pcb.Messagef("Setting lastTransitionTime for condition %q to %v", conditionType, t))
 		newCondition.LastTransitionTime = metav1.NewTime(t)
 		toUpdate.Status.Conditions = []v1beta1.ServiceBrokerCondition{newCondition}
 	} else {
 		for i, cond := range broker.Status.Conditions {
 			if cond.Type == conditionType {
 				if cond.Status != newCondition.Status {
-					glog.Info(pcb.Messagef(
+					klog.Infof(pcb.Messagef(
 						"Found status change for condition %q: %q -> %q; setting lastTransitionTime to %v",
 						conditionType, cond.Status, status, t,
 					))
@@ -671,12 +672,12 @@ func (c *controller) updateClusterServiceBrokerCondition(broker *v1beta1.Cluster
 		toUpdate.Status.LastCatalogRetrievalTime = &now
 	}
 
-	glog.V(4).Info(pcb.Messagef("Updating ready condition to %v", status))
+	klog.V(common.DefaultInfoLogLevel).Infof(pcb.Messagef("Updating ready condition to %v", status))
 	_, err := c.serviceCatalogClient.ClusterServiceBrokers().UpdateStatus(toUpdate)
 	if err != nil {
-		glog.Error(pcb.Messagef("Error updating ready condition: %v", err))
+		klog.Errorf(pcb.Messagef("Error updating ready condition: %v", err))
 	} else {
-		glog.V(5).Info(pcb.Messagef("Updated ready condition to %v", status))
+		klog.V(common.DefaultInfoLogLevel).Infof(pcb.Messagef("Updated ready condition to %v", status))
 	}
 
 	return err
@@ -693,7 +694,7 @@ func (c *controller) updateClusterServiceBrokerFinalizers(
 	// now removing the last finalizer).
 	broker, err := c.serviceCatalogClient.ClusterServiceBrokers().Get(broker.Name, metav1.GetOptions{})
 	if err != nil {
-		glog.Error(pcb.Messagef("Error finalizing: %v", err))
+		klog.Errorf(pcb.Messagef("Error finalizing: %v", err))
 	}
 
 	toUpdate := broker.DeepCopy()
@@ -701,10 +702,10 @@ func (c *controller) updateClusterServiceBrokerFinalizers(
 
 	logContext := fmt.Sprint(pcb.Messagef("Updating finalizers to %v", finalizers))
 
-	glog.V(4).Info(pcb.Messagef("Updating %v", logContext))
+	klog.V(common.DefaultInfoLogLevel).Infof(pcb.Messagef("Updating %v", logContext))
 	_, err = c.serviceCatalogClient.ClusterServiceBrokers().UpdateStatus(toUpdate)
 	if err != nil {
-		glog.Error(pcb.Messagef("Error updating %v: %v", logContext, err))
+		klog.Errorf(pcb.Messagef("Error updating %v: %v", logContext, err))
 	}
 	return err
 }

--- a/pkg/controller/controller_clusterserviceclass.go
+++ b/pkg/controller/controller_clusterserviceclass.go
@@ -17,8 +17,9 @@ limitations under the License.
 package controller
 
 import (
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +32,7 @@ import (
 func (c *controller) clusterServiceClassAdd(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		klog.Errorf("Couldn't get key for object %+v: %v", obj, err)
 		return
 	}
 	c.clusterServiceClassQueue.Add(key)
@@ -47,7 +48,7 @@ func (c *controller) clusterServiceClassDelete(obj interface{}) {
 		return
 	}
 
-	glog.V(4).Infof("Received delete event for ServiceClass %v; no further processing will occur", serviceClass.Name)
+	klog.V(common.DebugInfoLogLevel).Infof("Received delete event for ServiceClass %v; no further processing will occur", serviceClass.Name)
 }
 
 // reconcileServiceClassKey reconciles a ClusterServiceClass due to controller resync
@@ -57,11 +58,11 @@ func (c *controller) clusterServiceClassDelete(obj interface{}) {
 func (c *controller) reconcileClusterServiceClassKey(key string) error {
 	class, err := c.clusterServiceClassLister.Get(key)
 	if errors.IsNotFound(err) {
-		glog.Infof("ClusterServiceClass %q: Not doing work because it has been deleted", key)
+		klog.Infof("ClusterServiceClass %q: Not doing work because it has been deleted", key)
 		return nil
 	}
 	if err != nil {
-		glog.Infof("ClusterServiceClass %q: Unable to retrieve object from store: %v", key, err)
+		klog.Infof("ClusterServiceClass %q: Unable to retrieve object from store: %v", key, err)
 		return err
 	}
 
@@ -69,13 +70,13 @@ func (c *controller) reconcileClusterServiceClassKey(key string) error {
 }
 
 func (c *controller) reconcileClusterServiceClass(serviceClass *v1beta1.ClusterServiceClass) error {
-	glog.Infof("ClusterServiceClass %q (ExternalName: %q): processing", serviceClass.Name, serviceClass.Spec.ExternalName)
+	klog.Infof("ClusterServiceClass %q (ExternalName: %q): processing", serviceClass.Name, serviceClass.Spec.ExternalName)
 
 	if !serviceClass.Status.RemovedFromBrokerCatalog {
 		return nil
 	}
 
-	glog.Infof("ClusterServiceClass %q (ExternalName: %q): has been removed from broker catalog; determining whether there are instances remaining", serviceClass.Name, serviceClass.Spec.ExternalName)
+	klog.Infof("ClusterServiceClass %q (ExternalName: %q): has been removed from broker catalog; determining whether there are instances remaining", serviceClass.Name, serviceClass.Spec.ExternalName)
 
 	serviceInstances, err := c.findServiceInstancesOnClusterServiceClass(serviceClass)
 	if err != nil {
@@ -86,7 +87,7 @@ func (c *controller) reconcileClusterServiceClass(serviceClass *v1beta1.ClusterS
 		return nil
 	}
 
-	glog.Infof("ClusterServiceClass %q (ExternalName: %q): has been removed from broker catalog and has zero instances remaining; deleting", serviceClass.Name, serviceClass.Spec.ExternalName)
+	klog.Infof("ClusterServiceClass %q (ExternalName: %q): has been removed from broker catalog and has zero instances remaining; deleting", serviceClass.Name, serviceClass.Spec.ExternalName)
 	return c.serviceCatalogClient.ClusterServiceClasses().Delete(serviceClass.Name, &metav1.DeleteOptions{})
 }
 

--- a/pkg/controller/controller_clusterserviceplan.go
+++ b/pkg/controller/controller_clusterserviceplan.go
@@ -17,8 +17,9 @@ limitations under the License.
 package controller
 
 import (
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +32,7 @@ import (
 func (c *controller) clusterServicePlanAdd(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		glog.Errorf("ClusterServicePlan: Couldn't get key for object %+v: %v", obj, err)
+		klog.Errorf("ClusterServicePlan: Couldn't get key for object %+v: %v", obj, err)
 		return
 	}
 	c.clusterServicePlanQueue.Add(key)
@@ -47,7 +48,7 @@ func (c *controller) clusterServicePlanDelete(obj interface{}) {
 		return
 	}
 
-	glog.V(4).Infof("ClusterServicePlan: Received delete event for %v; no further processing will occur", clusterServicePlan.Name)
+	klog.V(common.DebugInfoLogLevel).Infof("ClusterServicePlan: Received delete event for %v; no further processing will occur", clusterServicePlan.Name)
 }
 
 // reconcileClusterServicePlanKey reconciles a ClusterServicePlan due to resync
@@ -58,11 +59,11 @@ func (c *controller) clusterServicePlanDelete(obj interface{}) {
 func (c *controller) reconcileClusterServicePlanKey(key string) error {
 	plan, err := c.clusterServicePlanLister.Get(key)
 	if errors.IsNotFound(err) {
-		glog.Infof("ClusterServicePlan %q: Not doing work because it has been deleted", key)
+		klog.Infof("ClusterServicePlan %q: Not doing work because it has been deleted", key)
 		return nil
 	}
 	if err != nil {
-		glog.Infof("ClusterServicePlan %q: Unable to retrieve object from store: %v", key, err)
+		klog.Infof("ClusterServicePlan %q: Unable to retrieve object from store: %v", key, err)
 		return err
 	}
 
@@ -70,13 +71,13 @@ func (c *controller) reconcileClusterServicePlanKey(key string) error {
 }
 
 func (c *controller) reconcileClusterServicePlan(clusterServicePlan *v1beta1.ClusterServicePlan) error {
-	glog.Infof("ClusterServicePlan %q (ExternalName: %q): processing", clusterServicePlan.Name, clusterServicePlan.Spec.ExternalName)
+	klog.Infof("ClusterServicePlan %q (ExternalName: %q): processing", clusterServicePlan.Name, clusterServicePlan.Spec.ExternalName)
 
 	if !clusterServicePlan.Status.RemovedFromBrokerCatalog {
 		return nil
 	}
 
-	glog.Infof("ClusterServicePlan %q (ExternalName: %q): has been removed from broker catalog; determining whether there are instances remaining", clusterServicePlan.Name, clusterServicePlan.Spec.ExternalName)
+	klog.Infof("ClusterServicePlan %q (ExternalName: %q): has been removed from broker catalog; determining whether there are instances remaining", clusterServicePlan.Name, clusterServicePlan.Spec.ExternalName)
 
 	serviceInstances, err := c.findServiceInstancesOnClusterServicePlan(clusterServicePlan)
 	if err != nil {
@@ -87,7 +88,7 @@ func (c *controller) reconcileClusterServicePlan(clusterServicePlan *v1beta1.Clu
 		return nil
 	}
 
-	glog.Infof("ClusterServicePlan %q (ExternalName: %q): has been removed from broker catalog and has zero instances remaining; deleting", clusterServicePlan.Name, clusterServicePlan.Spec.ExternalName)
+	klog.Infof("ClusterServicePlan %q (ExternalName: %q): has been removed from broker catalog and has zero instances remaining; deleting", clusterServicePlan.Name, clusterServicePlan.Spec.ExternalName)
 	return c.serviceCatalogClient.ClusterServicePlans().Delete(clusterServicePlan.Name, &metav1.DeleteOptions{})
 }
 

--- a/pkg/controller/controller_servicebroker.go
+++ b/pkg/controller/controller_servicebroker.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 	"github.com/kubernetes-incubator/service-catalog/pkg/metrics"
 	"github.com/kubernetes-incubator/service-catalog/pkg/pretty"
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
@@ -60,7 +61,7 @@ func (c *controller) serviceBrokerAdd(obj interface{}) {
 	// just "name" for cluster scoped resources.
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		klog.Errorf("Couldn't get key for object %+v: %v", obj, err)
 		return
 	}
 	c.serviceBrokerQueue.Add(key)
@@ -76,7 +77,7 @@ func (c *controller) serviceBrokerDelete(obj interface{}) {
 		return
 	}
 
-	glog.V(4).Infof("Received delete event for ServiceBroker %v; no further processing will occur", broker.Name)
+	klog.V(common.DebugInfoLogLevel).Infof("Received delete event for ServiceBroker %v; no further processing will occur", broker.Name)
 }
 
 // shouldReconcileServiceBroker determines whether a broker should be reconciled; it
@@ -102,12 +103,12 @@ func (c *controller) reconcileServiceBrokerKey(key string) error {
 	pcb := pretty.NewContextBuilder(pretty.ServiceBroker, namespace, name, "")
 	broker, err := c.serviceBrokerLister.ServiceBrokers(namespace).Get(name)
 	if errors.IsNotFound(err) {
-		glog.Info(pcb.Message("Not doing work because the ServiceBroker has been deleted"))
+		klog.Infof(pcb.Message("Not doing work because the ServiceBroker has been deleted"))
 		c.brokerClientManager.RemoveBrokerClient(NewServiceBrokerKey(namespace, name))
 		return nil
 	}
 	if err != nil {
-		glog.Info(pcb.Messagef("Unable to retrieve ServiceBroker: %v", err))
+		klog.Infof(pcb.Messagef("Unable to retrieve ServiceBroker: %v", err))
 		return err
 	}
 
@@ -119,7 +120,7 @@ func (c *controller) updateServiceBrokerClient(broker *v1beta1.ServiceBroker) (o
 	authConfig, err := getAuthCredentialsFromServiceBroker(c.kubeClient, broker)
 	if err != nil {
 		s := fmt.Sprintf("Error getting broker auth credentials: %s", err)
-		glog.Info(pcb.Message(s))
+		klog.Infof(pcb.Message(s))
 		c.recorder.Event(broker, corev1.EventTypeWarning, errorAuthCredentialsReason, s)
 		if err := c.updateServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorFetchingCatalogReason, errorFetchingCatalogMessage+s); err != nil {
 			return nil, err
@@ -133,7 +134,7 @@ func (c *controller) updateServiceBrokerClient(broker *v1beta1.ServiceBroker) (o
 	brokerClient, err := c.brokerClientManager.UpdateBrokerClient(NewServiceBrokerKey(broker.Namespace, broker.Name), clientConfig)
 	if err != nil {
 		s := fmt.Sprintf("Error creating client for broker %q: %s", broker.Name, err)
-		glog.Info(pcb.Message(s))
+		klog.Infof(pcb.Message(s))
 		c.recorder.Event(broker, corev1.EventTypeWarning, errorAuthCredentialsReason, s)
 		if err := c.updateServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorFetchingCatalogReason, errorFetchingCatalogMessage+s); err != nil {
 			return nil, err
@@ -149,7 +150,7 @@ func (c *controller) updateServiceBrokerClient(broker *v1beta1.ServiceBroker) (o
 // processed and should be resubmitted at a later time.
 func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error {
 	pcb := pretty.NewServiceBrokerContextBuilder(broker)
-	glog.V(4).Infof(pcb.Message("Processing"))
+	klog.V(common.DebugInfoLogLevel).Infof(pcb.Message("Processing"))
 
 	brokerClient, err := c.updateServiceBrokerClient(broker)
 	if err != nil {
@@ -165,14 +166,14 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 	}
 
 	if broker.DeletionTimestamp == nil { // Add or update
-		glog.V(4).Info(pcb.Message("Processing adding/update event"))
+		klog.V(common.DebugInfoLogLevel).Infof(pcb.Message("Processing adding/update event"))
 
 		// get the broker's catalog
 		now := metav1.Now()
 		brokerCatalog, err := brokerClient.GetCatalog()
 		if err != nil {
 			s := fmt.Sprintf("Error getting broker catalog: %s", err)
-			glog.Warning(pcb.Message(s))
+			klog.Warningf(pcb.Message(s))
 			c.recorder.Eventf(broker, corev1.EventTypeWarning, errorFetchingCatalogReason, s)
 			if err := c.updateServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorFetchingCatalogReason, errorFetchingCatalogMessage+s); err != nil {
 				return err
@@ -181,12 +182,12 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 				toUpdate := broker.DeepCopy()
 				toUpdate.Status.OperationStartTime = &now
 				if _, err := c.serviceCatalogClient.ServiceBrokers(broker.Namespace).UpdateStatus(toUpdate); err != nil {
-					glog.Error(pcb.Messagef("Error updating operation start time: %v", err))
+					klog.Errorf(pcb.Messagef("Error updating operation start time: %v", err))
 					return err
 				}
 			} else if !time.Now().Before(broker.Status.OperationStartTime.Time.Add(c.reconciliationRetryDuration)) {
 				s := "Stopping reconciliation retries because too much time has elapsed"
-				glog.Info(pcb.Message(s))
+				klog.Infof(pcb.Message(s))
 				c.recorder.Event(broker, corev1.EventTypeWarning, errorReconciliationRetryTimeoutReason, s)
 				toUpdate := broker.DeepCopy()
 				toUpdate.Status.OperationStartTime = nil
@@ -200,25 +201,25 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 			return err
 		}
 
-		glog.V(5).Info(pcb.Messagef("Successfully fetched %v catalog entries", len(brokerCatalog.Services)))
+		klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Successfully fetched %v catalog entries", len(brokerCatalog.Services)))
 
 		// set the operation start time if not already set
 		if broker.Status.OperationStartTime != nil {
 			toUpdate := broker.DeepCopy()
 			toUpdate.Status.OperationStartTime = nil
 			if _, err := c.serviceCatalogClient.ServiceBrokers(broker.Namespace).UpdateStatus(toUpdate); err != nil {
-				glog.Error(pcb.Messagef("Error updating operation start time: %v", err))
+				klog.Errorf(pcb.Messagef("Error updating operation start time: %v", err))
 				return err
 			}
 		}
 
 		// convert the broker's catalog payload into our API objects
-		glog.V(4).Info(pcb.Message("Converting catalog response into service-catalog API"))
+		klog.V(common.DefaultInfoLogLevel).Infof(pcb.Message("Converting catalog response into service-catalog API"))
 
 		payloadServiceClasses, payloadServicePlans, err := convertAndFilterCatalogToNamespacedTypes(broker.Namespace, brokerCatalog, broker.Spec.CatalogRestrictions)
 		if err != nil {
 			s := fmt.Sprintf("Error converting catalog payload for broker %q to service-catalog API: %s", broker.Name, err)
-			glog.Warning(pcb.Message(s))
+			klog.Warningf(pcb.Message(s))
 			c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
 			if err := c.updateServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason, errorSyncingCatalogMessage+s); err != nil {
 				return err
@@ -226,7 +227,7 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 			return err
 		}
 
-		glog.V(5).Info(pcb.Message("Successfully converted catalog payload from to service-catalog API"))
+		klog.V(common.DebugInfoLogLevel).Infof(pcb.Message("Successfully converted catalog payload from to service-catalog API"))
 
 		// get the existing services and plans for this broker so that we can
 		// detect when services and plans are removed from the broker's
@@ -245,13 +246,13 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 			existingServiceClass, _ := existingServiceClassMap[payloadServiceClass.Name]
 			delete(existingServiceClassMap, payloadServiceClass.Name)
 
-			glog.V(4).Info(pcb.Messagef("Reconciling %s", pretty.ServiceClassName(payloadServiceClass)))
+			klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Reconciling %s", pretty.ServiceClassName(payloadServiceClass)))
 			if err := c.reconcileServiceClassFromServiceBrokerCatalog(broker, payloadServiceClass, existingServiceClass); err != nil {
 				s := fmt.Sprintf(
 					"Error reconciling %s (broker %q): %s",
 					pretty.ServiceClassName(payloadServiceClass), broker.Name, err,
 				)
-				glog.Warning(pcb.Message(s))
+				klog.Warningf(pcb.Message(s))
 				c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
 				if err := c.updateServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason,
 					errorSyncingCatalogMessage+s); err != nil {
@@ -260,7 +261,7 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 				return err
 			}
 
-			glog.V(5).Info(pcb.Messagef("Reconciled %s", pretty.ServiceClassName(payloadServiceClass)))
+			klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Reconciled %s", pretty.ServiceClassName(payloadServiceClass)))
 		}
 
 		// handle the serviceClasses that were not in the broker's payload;
@@ -270,7 +271,7 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 				continue
 			}
 
-			glog.V(4).Info(pcb.Messagef("%s has been removed from broker's catalog; marking", pretty.ServiceClassName(existingServiceClass)))
+			klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("%s has been removed from broker's catalog; marking", pretty.ServiceClassName(existingServiceClass)))
 			existingServiceClass.Status.RemovedFromBrokerCatalog = true
 			_, err := c.serviceCatalogClient.ServiceClasses(broker.Namespace).UpdateStatus(existingServiceClass)
 			if err != nil {
@@ -278,7 +279,7 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 					"Error updating status of %s: %v",
 					pretty.ServiceClassName(existingServiceClass), err,
 				)
-				glog.Warning(pcb.Message(s))
+				klog.Warningf(pcb.Message(s))
 				c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
 				if err := c.updateServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason,
 					errorSyncingCatalogMessage+s); err != nil {
@@ -293,7 +294,7 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 			existingServicePlan, _ := existingServicePlanMap[payloadServicePlan.Name]
 			delete(existingServicePlanMap, payloadServicePlan.Name)
 
-			glog.V(4).Infof(
+			klog.V(common.DebugInfoLogLevel).Infof(
 				"ServiceBroker %q: reconciling %s",
 				broker.Name, pretty.ServicePlanName(payloadServicePlan),
 			)
@@ -302,13 +303,13 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 					"Error reconciling %s: %s",
 					pretty.ServicePlanName(payloadServicePlan), err,
 				)
-				glog.Warning(pcb.Message(s))
+				klog.Warningf(pcb.Message(s))
 				c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
 				c.updateServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason,
 					errorSyncingCatalogMessage+s)
 				return err
 			}
-			glog.V(5).Info(pcb.Messagef("Reconciled %s", pretty.ServicePlanName(payloadServicePlan)))
+			klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Reconciled %s", pretty.ServicePlanName(payloadServicePlan)))
 
 		}
 
@@ -318,7 +319,7 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 			if existingServicePlan.Status.RemovedFromBrokerCatalog {
 				continue
 			}
-			glog.V(4).Info(pcb.Messagef("%s has been removed from broker's catalog; marking", pretty.ServicePlanName(existingServicePlan)))
+			klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("%s has been removed from broker's catalog; marking", pretty.ServicePlanName(existingServicePlan)))
 			existingServicePlan.Status.RemovedFromBrokerCatalog = true
 			_, err := c.serviceCatalogClient.ServicePlans(broker.Namespace).UpdateStatus(existingServicePlan)
 			if err != nil {
@@ -327,7 +328,7 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 					pretty.ServicePlanName(existingServicePlan),
 					err,
 				)
-				glog.Warning(pcb.Message(s))
+				klog.Warningf(pcb.Message(s))
 				c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
 				if err := c.updateServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason,
 					errorSyncingCatalogMessage+s); err != nil {
@@ -356,21 +357,21 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 	// and returned early. If we reach this point, we're dealing with an update
 	// that's actually a soft delete-- i.e. we have some finalization to do.
 	if finalizers := sets.NewString(broker.Finalizers...); finalizers.Has(v1beta1.FinalizerServiceCatalog) {
-		glog.V(4).Info(pcb.Message("Finalizing"))
+		klog.V(common.DebugInfoLogLevel).Infof(pcb.Message("Finalizing"))
 
 		existingServiceClasses, existingServicePlans, err := c.getCurrentServiceClassesAndPlansForNamespacedBroker(broker)
 		if err != nil {
 			return err
 		}
 
-		glog.V(4).Info(pcb.Messagef("Found %d ServiceClasses and %d ServicePlans to delete", len(existingServiceClasses), len(existingServicePlans)))
+		klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Found %d ServiceClasses and %d ServicePlans to delete", len(existingServiceClasses), len(existingServicePlans)))
 
 		for _, plan := range existingServicePlans {
-			glog.V(4).Info(pcb.Messagef("Deleting %s", pretty.ServicePlanName(&plan)))
+			klog.V(common.DefaultInfoLogLevel).Infof(pcb.Messagef("Deleting %s", pretty.ServicePlanName(&plan)))
 			err := c.serviceCatalogClient.ServicePlans(broker.Namespace).Delete(plan.Name, &metav1.DeleteOptions{})
 			if err != nil && !errors.IsNotFound(err) {
 				s := fmt.Sprintf("Error deleting %s: %s", pretty.ServicePlanName(&plan), err)
-				glog.Warning(pcb.Message(s))
+				klog.Warningf(pcb.Message(s))
 				c.updateServiceBrokerCondition(
 					broker,
 					v1beta1.ServiceBrokerConditionReady,
@@ -384,11 +385,11 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 		}
 
 		for _, svcClass := range existingServiceClasses {
-			glog.V(4).Info(pcb.Messagef("Deleting %s", pretty.ServiceClassName(&svcClass)))
+			klog.V(common.DefaultInfoLogLevel).Infof(pcb.Messagef("Deleting %s", pretty.ServiceClassName(&svcClass)))
 			err = c.serviceCatalogClient.ServiceClasses(broker.Namespace).Delete(svcClass.Name, &metav1.DeleteOptions{})
 			if err != nil && !errors.IsNotFound(err) {
 				s := fmt.Sprintf("Error deleting %s: %s", pretty.ServiceClassName(&svcClass), err)
-				glog.Warning(pcb.Message(s))
+				klog.Warningf(pcb.Message(s))
 				c.recorder.Eventf(broker, corev1.EventTypeWarning, errorDeletingServiceClassReason, "%v %v", errorDeletingServiceClassMessage, s)
 				if err := c.updateServiceBrokerCondition(
 					broker,
@@ -417,7 +418,7 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 		c.updateServiceBrokerFinalizers(broker, finalizers.List())
 
 		c.recorder.Eventf(broker, corev1.EventTypeNormal, successServiceBrokerDeletedReason, successServiceBrokerDeletedMessage, broker.Name)
-		glog.V(5).Info(pcb.Message("Successfully deleted"))
+		klog.V(common.DefaultInfoLogLevel).Infof(pcb.Message("Successfully deleted"))
 
 		// delete the metrics associated with this broker
 		metrics.BrokerServiceClassCount.DeleteLabelValues(broker.Name)
@@ -453,14 +454,14 @@ func (c *controller) reconcileServiceClassFromServiceBrokerCatalog(broker *v1bet
 				errMsg := fmt.Sprintf("%s already exists for Broker %q",
 					pretty.ServiceClassName(serviceClass), otherServiceClass.Spec.ServiceBrokerName,
 				)
-				glog.Error(pcb.Message(errMsg))
+				klog.Errorf(pcb.Message(errMsg))
 				return fmt.Errorf(errMsg)
 			}
 		}
 
-		glog.V(5).Info(pcb.Messagef("Fresh %s; creating", pretty.ServiceClassName(serviceClass)))
+		klog.V(common.DefaultInfoLogLevel).Infof(pcb.Messagef("Fresh %s; creating", pretty.ServiceClassName(serviceClass)))
 		if _, err := c.serviceCatalogClient.ServiceClasses(broker.Namespace).Create(serviceClass); err != nil {
-			glog.Error(pcb.Messagef("Error creating %s: %v", pretty.ServiceClassName(serviceClass), err))
+			klog.Errorf(pcb.Messagef("Error creating %s: %v", pretty.ServiceClassName(serviceClass), err))
 			return err
 		}
 
@@ -472,11 +473,11 @@ func (c *controller) reconcileServiceClassFromServiceBrokerCatalog(broker *v1bet
 			"%s already exists with OSB guid %q, received different guid %q",
 			pretty.ServiceClassName(serviceClass), existingServiceClass.Name, serviceClass.Name,
 		)
-		glog.Error(pcb.Message(errMsg))
+		klog.Errorf(pcb.Message(errMsg))
 		return fmt.Errorf(errMsg)
 	}
 
-	glog.V(5).Info(pcb.Messagef("Found existing %s; updating", pretty.ServiceClassName(serviceClass)))
+	klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Found existing %s; updating", pretty.ServiceClassName(serviceClass)))
 
 	// There was an existing service class -- project the update onto it and
 	// update it.
@@ -492,17 +493,17 @@ func (c *controller) reconcileServiceClassFromServiceBrokerCatalog(broker *v1bet
 
 	updatedServiceClass, err := c.serviceCatalogClient.ServiceClasses(broker.Namespace).Update(toUpdate)
 	if err != nil {
-		glog.Error(pcb.Messagef("Error updating %s: %v", pretty.ServiceClassName(serviceClass), err))
+		klog.Errorf(pcb.Messagef("Error updating %s: %v", pretty.ServiceClassName(serviceClass), err))
 		return err
 	}
 
 	if updatedServiceClass.Status.RemovedFromBrokerCatalog {
-		glog.V(4).Info(pcb.Messagef("Resetting RemovedFromBrokerCatalog status on %s", pretty.ServiceClassName(serviceClass)))
+		klog.V(common.StatesInfoLogLevel).Infof(pcb.Messagef("Resetting RemovedFromBrokerCatalog status on %s", pretty.ServiceClassName(serviceClass)))
 		updatedServiceClass.Status.RemovedFromBrokerCatalog = false
 		_, err := c.serviceCatalogClient.ServiceClasses(broker.Namespace).UpdateStatus(updatedServiceClass)
 		if err != nil {
 			s := fmt.Sprintf("Error updating status of %s: %v", pretty.ServiceClassName(updatedServiceClass), err)
-			glog.Warning(pcb.Message(s))
+			klog.Warningf(pcb.Message(s))
 			c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
 			if err := c.updateServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason, errorSyncingCatalogMessage+s); err != nil {
 				return err
@@ -537,7 +538,7 @@ func (c *controller) reconcileServicePlanFromServiceBrokerCatalog(broker *v1beta
 					"%s already exists for Broker %q",
 					pretty.ServicePlanName(servicePlan), otherServicePlan.Spec.ServiceBrokerName,
 				)
-				glog.Error(pcb.Message(errMsg))
+				klog.Errorf(pcb.Message(errMsg))
 				return fmt.Errorf(errMsg)
 			}
 		}
@@ -545,7 +546,7 @@ func (c *controller) reconcileServicePlanFromServiceBrokerCatalog(broker *v1beta
 		// An error returned from a lister Get call means that the object does
 		// not exist.  Create a new ServicePlan.
 		if _, err := c.serviceCatalogClient.ServicePlans(broker.Namespace).Create(servicePlan); err != nil {
-			glog.Error(pcb.Messagef("Error creating %s: %v", pretty.ServicePlanName(servicePlan), err))
+			klog.Errorf(pcb.Messagef("Error creating %s: %v", pretty.ServicePlanName(servicePlan), err))
 			return err
 		}
 
@@ -557,11 +558,11 @@ func (c *controller) reconcileServicePlanFromServiceBrokerCatalog(broker *v1beta
 			"%s already exists with OSB guid %q, received different guid %q",
 			pretty.ServicePlanName(servicePlan), existingServicePlan.Spec.ExternalID, servicePlan.Spec.ExternalID,
 		)
-		glog.Error(pcb.Message(errMsg))
+		klog.Errorf(pcb.Message(errMsg))
 		return fmt.Errorf(errMsg)
 	}
 
-	glog.V(5).Info(pcb.Messagef("Found existing %s; updating", pretty.ServicePlanName(servicePlan)))
+	klog.V(common.DebugInfoLogLevel).Infof(pcb.Messagef("Found existing %s; updating", pretty.ServicePlanName(servicePlan)))
 
 	// There was an existing service plan -- project the update onto it and
 	// update it.
@@ -577,18 +578,18 @@ func (c *controller) reconcileServicePlanFromServiceBrokerCatalog(broker *v1beta
 
 	updatedPlan, err := c.serviceCatalogClient.ServicePlans(broker.Namespace).Update(toUpdate)
 	if err != nil {
-		glog.Error(pcb.Messagef("Error updating %s: %v", pretty.ServicePlanName(servicePlan), err))
+		klog.Errorf(pcb.Messagef("Error updating %s: %v", pretty.ServicePlanName(servicePlan), err))
 		return err
 	}
 
 	if updatedPlan.Status.RemovedFromBrokerCatalog {
 		updatedPlan.Status.RemovedFromBrokerCatalog = false
-		glog.V(4).Info(pcb.Messagef("Resetting RemovedFromBrokerCatalog status on %s", pretty.ServicePlanName(updatedPlan)))
+		klog.V(common.StatesInfoLogLevel).Infof(pcb.Messagef("Resetting RemovedFromBrokerCatalog status on %s", pretty.ServicePlanName(updatedPlan)))
 
 		_, err := c.serviceCatalogClient.ServicePlans(broker.Namespace).UpdateStatus(updatedPlan)
 		if err != nil {
 			s := fmt.Sprintf("Error updating status of %s: %v", pretty.ServicePlanName(updatedPlan), err)
-			glog.Error(pcb.Message(s))
+			klog.Errorf(pcb.Message(s))
 			c.recorder.Eventf(broker, corev1.EventTypeWarning, errorSyncingCatalogReason, s)
 			if err := c.updateServiceBrokerCondition(broker, v1beta1.ServiceBrokerConditionReady, v1beta1.ConditionFalse, errorSyncingCatalogReason, errorSyncingCatalogMessage+s); err != nil {
 				return err
@@ -613,14 +614,14 @@ func updateCommonStatusCondition(pcb *pretty.ContextBuilder, meta metav1.ObjectM
 	t := time.Now()
 
 	if len(commonStatus.Conditions) == 0 {
-		glog.Info(pcb.Messagef("Setting lastTransitionTime for condition %q to %v", conditionType, t))
+		klog.Infof(pcb.Messagef("Setting lastTransitionTime for condition %q to %v", conditionType, t))
 		newCondition.LastTransitionTime = metav1.NewTime(t)
 		commonStatus.Conditions = []v1beta1.ServiceBrokerCondition{newCondition}
 	} else {
 		for i, cond := range commonStatus.Conditions {
 			if cond.Type == conditionType {
 				if cond.Status != newCondition.Status {
-					glog.Info(pcb.Messagef(
+					klog.Infof(pcb.Messagef(
 						"Found status change for condition %q: %q -> %q; setting lastTransitionTime to %v",
 						conditionType, cond.Status, status, t,
 					))
@@ -651,12 +652,12 @@ func (c *controller) updateServiceBrokerCondition(broker *v1beta1.ServiceBroker,
 	pcb := pretty.NewServiceBrokerContextBuilder(toUpdate)
 	updateCommonStatusCondition(pcb, toUpdate.ObjectMeta, &toUpdate.Status.CommonServiceBrokerStatus, conditionType, status, reason, message)
 
-	glog.V(4).Info(pcb.Messagef("Updating ready condition to %v", status))
+	klog.V(common.DefaultInfoLogLevel).Infof(pcb.Messagef("Updating ready condition to %v", status))
 	_, err := c.serviceCatalogClient.ServiceBrokers(broker.Namespace).UpdateStatus(toUpdate)
 	if err != nil {
-		glog.Error(pcb.Messagef("Error updating ready condition: %v", err))
+		klog.Errorf(pcb.Messagef("Error updating ready condition: %v", err))
 	} else {
-		glog.V(5).Info(pcb.Messagef("Updated ready condition to %v", status))
+		klog.V(common.DefaultInfoLogLevel).Infof(pcb.Messagef("Updated ready condition to %v", status))
 	}
 
 	return err
@@ -673,7 +674,7 @@ func (c *controller) updateServiceBrokerFinalizers(
 	// now removing the last finalizer).
 	broker, err := c.serviceCatalogClient.ServiceBrokers(broker.Namespace).Get(broker.Name, metav1.GetOptions{})
 	if err != nil {
-		glog.Error(pcb.Messagef("Error finalizing: %v", err))
+		klog.Errorf(pcb.Messagef("Error finalizing: %v", err))
 	}
 
 	toUpdate := broker.DeepCopy()
@@ -681,10 +682,10 @@ func (c *controller) updateServiceBrokerFinalizers(
 
 	logContext := fmt.Sprint(pcb.Messagef("Updating finalizers to %v", finalizers))
 
-	glog.V(4).Info(pcb.Messagef("Updating %v", logContext))
+	klog.V(common.DefaultInfoLogLevel).Infof(pcb.Messagef("Updating %v", logContext))
 	_, err = c.serviceCatalogClient.ServiceBrokers(broker.Namespace).UpdateStatus(toUpdate)
 	if err != nil {
-		glog.Error(pcb.Messagef("Error updating %v: %v", logContext, err))
+		klog.Errorf(pcb.Messagef("Error updating %v: %v", logContext, err))
 	}
 	return err
 }

--- a/pkg/controller/controller_serviceclass.go
+++ b/pkg/controller/controller_serviceclass.go
@@ -17,8 +17,9 @@ limitations under the License.
 package controller
 
 import (
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/pretty"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -30,7 +31,7 @@ import (
 func (c *controller) serviceClassAdd(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		klog.Errorf("Couldn't get key for object %+v: %v", obj, err)
 		return
 	}
 	c.serviceClassQueue.Add(key)
@@ -46,7 +47,7 @@ func (c *controller) serviceClassDelete(obj interface{}) {
 		return
 	}
 
-	glog.V(4).Infof("Received delete event for ServiceClass %v; no further processing will occur", serviceClass.Name)
+	klog.V(common.DebugInfoLogLevel).Infof("Received delete event for ServiceClass %v; no further processing will occur", serviceClass.Name)
 }
 
 // reconcileServiceClassKey reconciles a ServiceClass due to controller resync
@@ -61,11 +62,11 @@ func (c *controller) reconcileServiceClassKey(key string) error {
 	pcb := pretty.NewContextBuilder(pretty.ServiceClass, namespace, name, "")
 	class, err := c.serviceClassLister.ServiceClasses(namespace).Get(name)
 	if errors.IsNotFound(err) {
-		glog.Info(pcb.Message("Not doing work because the ServiceClass has been deleted"))
+		klog.Infof(pcb.Message("Not doing work because the ServiceClass has been deleted"))
 		return nil
 	}
 	if err != nil {
-		glog.Infof(pcb.Message("Unable to retrieve"))
+		klog.Infof(pcb.Message("Unable to retrieve"))
 		return err
 	}
 
@@ -74,13 +75,13 @@ func (c *controller) reconcileServiceClassKey(key string) error {
 
 func (c *controller) reconcileServiceClass(serviceClass *v1beta1.ServiceClass) error {
 	pcb := pretty.NewContextBuilder(pretty.ServiceClass, serviceClass.Namespace, serviceClass.Name, "")
-	glog.Info(pcb.Message("Processing"))
+	klog.Infof(pcb.Message("Processing"))
 
 	if !serviceClass.Status.RemovedFromBrokerCatalog {
 		return nil
 	}
 
-	glog.Info(pcb.Message("Removed from broker catalog; determining whether there are instances remaining"))
+	klog.Infof(pcb.Message("Removed from broker catalog; determining whether there are instances remaining"))
 
 	serviceInstances, err := c.findServiceInstancesOnServiceClass(serviceClass)
 	if err != nil {
@@ -91,7 +92,7 @@ func (c *controller) reconcileServiceClass(serviceClass *v1beta1.ServiceClass) e
 		return nil
 	}
 
-	glog.Info(pcb.Message("Removed from broker catalog and has zero instances remaining; deleting"))
+	klog.Infof(pcb.Message("Removed from broker catalog and has zero instances remaining; deleting"))
 	return c.serviceCatalogClient.ServiceClasses(serviceClass.Namespace).Delete(serviceClass.Name, &metav1.DeleteOptions{})
 }
 

--- a/pkg/controller/controller_serviceplan.go
+++ b/pkg/controller/controller_serviceplan.go
@@ -17,8 +17,9 @@ limitations under the License.
 package controller
 
 import (
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/pretty"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -32,7 +33,7 @@ import (
 func (c *controller) servicePlanAdd(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		glog.Errorf("ServicePlan: Couldn't get key for object %+v: %v", obj, err)
+		klog.Errorf("ServicePlan: Couldn't get key for object %+v: %v", obj, err)
 		return
 	}
 	c.servicePlanQueue.Add(key)
@@ -48,7 +49,7 @@ func (c *controller) servicePlanDelete(obj interface{}) {
 		return
 	}
 
-	glog.V(4).Infof("ServicePlan: Received delete event for %v; no further processing will occur", servicePlan.Name)
+	klog.V(common.DebugInfoLogLevel).Infof("ServicePlan: Received delete event for %v; no further processing will occur", servicePlan.Name)
 }
 
 // reconcileServicePlanKey reconciles a ServicePlan due to resync
@@ -63,11 +64,11 @@ func (c *controller) reconcileServicePlanKey(key string) error {
 	pcb := pretty.NewContextBuilder(pretty.ServicePlan, namespace, name, "")
 	plan, err := c.servicePlanLister.ServicePlans(namespace).Get(key)
 	if errors.IsNotFound(err) {
-		glog.Infof(pcb.Message("not doing work because plan has been deleted"))
+		klog.Infof(pcb.Message("not doing work because plan has been deleted"))
 		return nil
 	}
 	if err != nil {
-		glog.Infof(pcb.Message("unable to retrieve object from store: %v"))
+		klog.Infof(pcb.Message("unable to retrieve object from store: %v"))
 		return err
 	}
 
@@ -76,13 +77,13 @@ func (c *controller) reconcileServicePlanKey(key string) error {
 
 func (c *controller) reconcileServicePlan(servicePlan *v1beta1.ServicePlan) error {
 	pcb := pretty.NewContextBuilder(pretty.ServicePlan, servicePlan.Namespace, servicePlan.Name, "")
-	glog.Infof("ServicePlan %q (ExternalName: %q): processing", servicePlan.Name, servicePlan.Spec.ExternalName)
+	klog.Infof("ServicePlan %q (ExternalName: %q): processing", servicePlan.Name, servicePlan.Spec.ExternalName)
 
 	if !servicePlan.Status.RemovedFromBrokerCatalog {
 		return nil
 	}
 
-	glog.Infof(pcb.Message("removed from broker catalog; determining whether there are instances remaining"))
+	klog.Infof(pcb.Message("removed from broker catalog; determining whether there are instances remaining"))
 
 	serviceInstances, err := c.findServiceInstancesOnServicePlan(servicePlan)
 	if err != nil {
@@ -93,7 +94,7 @@ func (c *controller) reconcileServicePlan(servicePlan *v1beta1.ServicePlan) erro
 		return nil
 	}
 
-	glog.Infof(pcb.Message("removed from broker catalog and has zero instances remaining; deleting"))
+	klog.Infof(pcb.Message("removed from broker catalog and has zero instances remaining; deleting"))
 	return c.serviceCatalogClient.ServicePlans(servicePlan.Namespace).Delete(servicePlan.Name, &metav1.DeleteOptions{})
 }
 

--- a/pkg/hyperkube/hyperkube.go
+++ b/pkg/hyperkube/hyperkube.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/version"
 
 	"github.com/spf13/pflag"
@@ -189,7 +189,7 @@ RunAgain:
 
 	logs.InitLogs()
 	defer logs.FlushLogs()
-	glog.Infof("Service Catalog version %s (built %s)", version.Get().String(), version.Get().BuildDate)
+	klog.Infof("Service Catalog version %s (built %s)", version.Get().String(), version.Get().BuildDate)
 	if !s.RespectsStopCh {
 		// For commands that do not respect the stopCh, we run them in a go
 		// routine and leave them running when stopCh is closed.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -22,9 +22,11 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 )
 
 var registerMetrics sync.Once
@@ -89,5 +91,5 @@ func RegisterMetricsAndInstallHandler(m *http.ServeMux) {
 	registry := prometheus.NewRegistry()
 	register(registry)
 	m.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}))
-	glog.V(4).Info("Registered /metrics with prometheus")
+	klog.V(common.DebugInfoLogLevel).Infof("Registered /metrics with prometheus")
 }

--- a/pkg/metrics/osbclientproxy/osbproxy.go
+++ b/pkg/metrics/osbclientproxy/osbproxy.go
@@ -21,8 +21,10 @@ package osbclientproxy
 import (
 	"fmt"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 	"github.com/kubernetes-incubator/service-catalog/pkg/metrics"
+
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
 )
 
@@ -63,7 +65,7 @@ const (
 // proxying the method to the underlying implementation and capturing request
 // metrics.
 func (pc proxyclient) GetCatalog() (*osb.CatalogResponse, error) {
-	glog.V(9).Info("OSBClientProxy getCatalog()")
+	klog.V(common.StatesInfoLogLevel).Infof("OSBClientProxy getCatalog()")
 	response, err := pc.realOSBClient.GetCatalog()
 	pc.updateMetrics(getCatalog, err)
 	return response, err
@@ -73,7 +75,7 @@ func (pc proxyclient) GetCatalog() (*osb.CatalogResponse, error) {
 // go-open-service-broker-client/v2/Client.ProvisionInstance by proxying the
 // method to the underlying implementation and capturing request metrics.
 func (pc proxyclient) ProvisionInstance(r *osb.ProvisionRequest) (*osb.ProvisionResponse, error) {
-	glog.V(9).Info("OSBClientProxy ProvisionInstance()")
+	klog.V(common.StatesInfoLogLevel).Infof("OSBClientProxy ProvisionInstance()")
 	response, err := pc.realOSBClient.ProvisionInstance(r)
 	pc.updateMetrics(provisionInstance, err)
 	return response, err
@@ -84,7 +86,7 @@ func (pc proxyclient) ProvisionInstance(r *osb.ProvisionRequest) (*osb.Provision
 // go-open-service-broker-client/v2/Client.UpdateInstance by proxying the method
 // to the underlying implementation and capturing request metrics.
 func (pc proxyclient) UpdateInstance(r *osb.UpdateInstanceRequest) (*osb.UpdateInstanceResponse, error) {
-	glog.V(9).Info("OSBClientProxy UpdateInstance()")
+	klog.V(common.StatesInfoLogLevel).Infof("OSBClientProxy UpdateInstance()")
 	response, err := pc.realOSBClient.UpdateInstance(r)
 	pc.updateMetrics(updateInstance, err)
 	return response, err
@@ -94,7 +96,7 @@ func (pc proxyclient) UpdateInstance(r *osb.UpdateInstanceRequest) (*osb.UpdateI
 // go-open-service-broker-client/v2/Client.DeprovisionInstance by proxying the
 // method to the underlying implementation and capturing request metrics.
 func (pc proxyclient) DeprovisionInstance(r *osb.DeprovisionRequest) (*osb.DeprovisionResponse, error) {
-	glog.V(9).Info("OSBClientProxy DeprovisionInstance()")
+	klog.V(common.StatesInfoLogLevel).Infof("OSBClientProxy DeprovisionInstance()")
 	response, err := pc.realOSBClient.DeprovisionInstance(r)
 	pc.updateMetrics(deprovisionInstance, err)
 	return response, err
@@ -104,7 +106,7 @@ func (pc proxyclient) DeprovisionInstance(r *osb.DeprovisionRequest) (*osb.Depro
 // go-open-service-broker-client/v2/Client.PollLastOperation by proxying the
 // method to the underlying implementation and capturing request metrics.
 func (pc proxyclient) PollLastOperation(r *osb.LastOperationRequest) (*osb.LastOperationResponse, error) {
-	glog.V(9).Info("OSBClientProxy PollLastOperation()")
+	klog.V(common.StatesInfoLogLevel).Infof("OSBClientProxy PollLastOperation()")
 	response, err := pc.realOSBClient.PollLastOperation(r)
 	pc.updateMetrics(pollLastOperation, err)
 	return response, err
@@ -114,7 +116,7 @@ func (pc proxyclient) PollLastOperation(r *osb.LastOperationRequest) (*osb.LastO
 // go-open-service-broker-client/v2/Client.PollBindingLastOperation by proxying
 // the method to the underlying implementation and capturing request metrics.
 func (pc proxyclient) PollBindingLastOperation(r *osb.BindingLastOperationRequest) (*osb.LastOperationResponse, error) {
-	glog.V(9).Info("OSBClientProxy PollBindingLastOperation()")
+	klog.V(common.StatesInfoLogLevel).Infof("OSBClientProxy PollBindingLastOperation()")
 	response, err := pc.realOSBClient.PollBindingLastOperation(r)
 	pc.updateMetrics(pollBindingLastOperation, err)
 	return response, err
@@ -123,7 +125,7 @@ func (pc proxyclient) PollBindingLastOperation(r *osb.BindingLastOperationReques
 // Bind implements go-open-service-broker-client/v2/Client.Bind by proxying the
 // method to the underlying implementation and capturing request metrics.
 func (pc proxyclient) Bind(r *osb.BindRequest) (*osb.BindResponse, error) {
-	glog.V(9).Info("OSBClientProxy Bind().")
+	klog.V(common.StatesInfoLogLevel).Infof("OSBClientProxy Bind().")
 	response, err := pc.realOSBClient.Bind(r)
 	pc.updateMetrics(bind, err)
 	return response, err
@@ -132,7 +134,7 @@ func (pc proxyclient) Bind(r *osb.BindRequest) (*osb.BindResponse, error) {
 // Unbind implements go-open-service-broker-client/v2/Client.Unbind by proxying
 // the method to the underlying implementation and capturing request metrics.
 func (pc proxyclient) Unbind(r *osb.UnbindRequest) (*osb.UnbindResponse, error) {
-	glog.V(9).Info("OSBClientProxy Unbind()")
+	klog.V(common.StatesInfoLogLevel).Infof("OSBClientProxy Unbind()")
 	response, err := pc.realOSBClient.Unbind(r)
 	pc.updateMetrics(unbind, err)
 	return response, err
@@ -142,7 +144,7 @@ func (pc proxyclient) Unbind(r *osb.UnbindRequest) (*osb.UnbindResponse, error) 
 // proxying the method to the underlying implementation and capturing request
 // metrics.
 func (pc proxyclient) GetBinding(r *osb.GetBindingRequest) (*osb.GetBindingResponse, error) {
-	glog.V(9).Info("OSBClientProxy GetBinding()")
+	klog.V(common.StatesInfoLogLevel).Infof("OSBClientProxy GetBinding()")
 	response, err := pc.realOSBClient.GetBinding(r)
 	pc.updateMetrics(getBinding, err)
 	return response, err

--- a/pkg/registry/servicecatalog/binding/strategy.go
+++ b/pkg/registry/servicecatalog/binding/strategy.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	scv "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation"
 	scfeatures "github.com/kubernetes-incubator/service-catalog/pkg/features"
@@ -79,7 +79,7 @@ var (
 func (bindingRESTStrategy) Canonicalize(obj runtime.Object) {
 	_, ok := obj.(*sc.ServiceBinding)
 	if !ok {
-		glog.Fatal("received a non-binding object to create")
+		klog.Fatal("received a non-binding object to create")
 	}
 }
 
@@ -94,7 +94,7 @@ func (bindingRESTStrategy) NamespaceScoped() bool {
 func (bindingRESTStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	binding, ok := obj.(*sc.ServiceBinding)
 	if !ok {
-		glog.Fatal("received a non-binding object to create")
+		klog.Fatal("received a non-binding object to create")
 	}
 
 	if binding.Spec.ExternalID == "" {
@@ -132,11 +132,11 @@ func (bindingRESTStrategy) AllowUnconditionalUpdate() bool {
 func (bindingRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newServiceBinding, ok := new.(*sc.ServiceBinding)
 	if !ok {
-		glog.Fatal("received a non-binding object to update to")
+		klog.Fatal("received a non-binding object to update to")
 	}
 	oldServiceBinding, ok := old.(*sc.ServiceBinding)
 	if !ok {
-		glog.Fatal("received a non-binding object to update from")
+		klog.Fatal("received a non-binding object to update from")
 	}
 	newServiceBinding.Status = oldServiceBinding.Status
 
@@ -163,11 +163,11 @@ func (bindingRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtim
 func (bindingRESTStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newServiceBinding, ok := new.(*sc.ServiceBinding)
 	if !ok {
-		glog.Fatal("received a non-binding object to validate to")
+		klog.Fatal("received a non-binding object to validate to")
 	}
 	oldServiceBinding, ok := old.(*sc.ServiceBinding)
 	if !ok {
-		glog.Fatal("received a non-binding object to validate from")
+		klog.Fatal("received a non-binding object to validate from")
 	}
 
 	return scv.ValidateServiceBindingUpdate(newServiceBinding, oldServiceBinding)
@@ -182,7 +182,7 @@ func (bindingRESTStrategy) CheckGracefulDelete(ctx context.Context, obj runtime.
 	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {
 		serviceInstanceCredential, ok := obj.(*sc.ServiceBinding)
 		if !ok {
-			glog.Fatal("received a non-ServiceBinding object to delete")
+			klog.Fatal("received a non-ServiceBinding object to delete")
 		}
 		setServiceBindingUserInfo(ctx, serviceInstanceCredential)
 	}
@@ -193,11 +193,11 @@ func (bindingRESTStrategy) CheckGracefulDelete(ctx context.Context, obj runtime.
 func (bindingStatusRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newServiceBinding, ok := new.(*sc.ServiceBinding)
 	if !ok {
-		glog.Fatal("received a non-binding object to update to")
+		klog.Fatal("received a non-binding object to update to")
 	}
 	oldServiceBinding, ok := old.(*sc.ServiceBinding)
 	if !ok {
-		glog.Fatal("received a non-binding object to update from")
+		klog.Fatal("received a non-binding object to update from")
 	}
 	// status changes are not allowed to update spec
 	newServiceBinding.Spec = oldServiceBinding.Spec
@@ -206,11 +206,11 @@ func (bindingStatusRESTStrategy) PrepareForUpdate(ctx context.Context, new, old 
 func (bindingStatusRESTStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newServiceBinding, ok := new.(*sc.ServiceBinding)
 	if !ok {
-		glog.Fatal("received a non-binding object to validate to")
+		klog.Fatal("received a non-binding object to validate to")
 	}
 	oldServiceBinding, ok := old.(*sc.ServiceBinding)
 	if !ok {
-		glog.Fatal("received a non-binding object to validate from")
+		klog.Fatal("received a non-binding object to validate from")
 	}
 
 	return scv.ValidateServiceBindingStatusUpdate(newServiceBinding, oldServiceBinding)

--- a/pkg/registry/servicecatalog/clusterservicebroker/strategy.go
+++ b/pkg/registry/servicecatalog/clusterservicebroker/strategy.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	scv "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation"
 )
@@ -74,7 +74,7 @@ var (
 func (clusterServiceBrokerRESTStrategy) Canonicalize(obj runtime.Object) {
 	_, ok := obj.(*sc.ClusterServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-clusterservicebroker object to create")
+		klog.Fatal("received a non-clusterservicebroker object to create")
 	}
 }
 
@@ -89,7 +89,7 @@ func (clusterServiceBrokerRESTStrategy) NamespaceScoped() bool {
 func (clusterServiceBrokerRESTStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	broker, ok := obj.(*sc.ClusterServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-clusterservicebroker object to create")
+		klog.Fatal("received a non-clusterservicebroker object to create")
 	}
 	// Is there anything to pull out of the context `ctx`?
 
@@ -118,11 +118,11 @@ func (clusterServiceBrokerRESTStrategy) AllowUnconditionalUpdate() bool {
 func (clusterServiceBrokerRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newClusterServiceBroker, ok := new.(*sc.ClusterServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-clusterservicebroker object to update to")
+		klog.Fatal("received a non-clusterservicebroker object to update to")
 	}
 	oldClusterServiceBroker, ok := old.(*sc.ClusterServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-clusterservicebroker object to update from")
+		klog.Fatal("received a non-clusterservicebroker object to update from")
 	}
 
 	newClusterServiceBroker.Status = oldClusterServiceBroker.Status
@@ -142,11 +142,11 @@ func (clusterServiceBrokerRESTStrategy) PrepareForUpdate(ctx context.Context, ne
 func (clusterServiceBrokerRESTStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newClusterServiceBroker, ok := new.(*sc.ClusterServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-clusterservicebroker object to validate to")
+		klog.Fatal("received a non-clusterservicebroker object to validate to")
 	}
 	oldClusterServiceBroker, ok := old.(*sc.ClusterServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-clusterservicebroker object to validate from")
+		klog.Fatal("received a non-clusterservicebroker object to validate from")
 	}
 
 	return scv.ValidateClusterServiceBrokerUpdate(newClusterServiceBroker, oldClusterServiceBroker)
@@ -155,11 +155,11 @@ func (clusterServiceBrokerRESTStrategy) ValidateUpdate(ctx context.Context, new,
 func (clusterServiceBrokerStatusRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newClusterServiceBroker, ok := new.(*sc.ClusterServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-clusterservicebroker object to update to")
+		klog.Fatal("received a non-clusterservicebroker object to update to")
 	}
 	oldClusterServiceBroker, ok := old.(*sc.ClusterServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-clusterservicebroker object to update from")
+		klog.Fatal("received a non-clusterservicebroker object to update from")
 	}
 	// status changes are not allowed to update spec
 	newClusterServiceBroker.Spec = oldClusterServiceBroker.Spec
@@ -168,11 +168,11 @@ func (clusterServiceBrokerStatusRESTStrategy) PrepareForUpdate(ctx context.Conte
 func (clusterServiceBrokerStatusRESTStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newClusterServiceBroker, ok := new.(*sc.ClusterServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-clusterservicebroker object to validate to")
+		klog.Fatal("received a non-clusterservicebroker object to validate to")
 	}
 	oldClusterServiceBroker, ok := old.(*sc.ClusterServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-clusterservicebroker object to validate from")
+		klog.Fatal("received a non-clusterservicebroker object to validate from")
 	}
 
 	return scv.ValidateClusterServiceBrokerStatusUpdate(newClusterServiceBroker, oldClusterServiceBroker)

--- a/pkg/registry/servicecatalog/clusterserviceclass/strategy.go
+++ b/pkg/registry/servicecatalog/clusterserviceclass/strategy.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	scv "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation"
 )
@@ -76,7 +76,7 @@ var (
 func (clusterServiceClassRESTStrategy) Canonicalize(obj runtime.Object) {
 	_, ok := obj.(*sc.ClusterServiceClass)
 	if !ok {
-		glog.Fatal("received a non-clusterserviceclass object to create")
+		klog.Fatal("received a non-clusterserviceclass object to create")
 	}
 }
 
@@ -90,7 +90,7 @@ func (clusterServiceClassRESTStrategy) NamespaceScoped() bool {
 func (clusterServiceClassRESTStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	clusterServiceClass, ok := obj.(*sc.ClusterServiceClass)
 	if !ok {
-		glog.Fatal("received a non-clusterserviceclass object to create")
+		klog.Fatal("received a non-clusterserviceclass object to create")
 	}
 	clusterServiceClass.Status = sc.ClusterServiceClassStatus{}
 }
@@ -110,11 +110,11 @@ func (clusterServiceClassRESTStrategy) AllowUnconditionalUpdate() bool {
 func (clusterServiceClassRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newServiceClass, ok := new.(*sc.ClusterServiceClass)
 	if !ok {
-		glog.Fatal("received a non-clusterserviceclass object to update to")
+		klog.Fatal("received a non-clusterserviceclass object to update to")
 	}
 	oldServiceClass, ok := old.(*sc.ClusterServiceClass)
 	if !ok {
-		glog.Fatal("received a non-clusterserviceclass object to update from")
+		klog.Fatal("received a non-clusterserviceclass object to update from")
 	}
 
 	// Update should not change the status
@@ -126,11 +126,11 @@ func (clusterServiceClassRESTStrategy) PrepareForUpdate(ctx context.Context, new
 func (clusterServiceClassRESTStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newServiceclass, ok := new.(*sc.ClusterServiceClass)
 	if !ok {
-		glog.Fatal("received a non-clusterserviceclass object to validate to")
+		klog.Fatal("received a non-clusterserviceclass object to validate to")
 	}
 	oldServiceclass, ok := old.(*sc.ClusterServiceClass)
 	if !ok {
-		glog.Fatal("received a non-clusterserviceclass object to validate from")
+		klog.Fatal("received a non-clusterserviceclass object to validate from")
 	}
 
 	return scv.ValidateClusterServiceClassUpdate(newServiceclass, oldServiceclass)
@@ -139,11 +139,11 @@ func (clusterServiceClassRESTStrategy) ValidateUpdate(ctx context.Context, new, 
 func (clusterServiceClassStatusRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newServiceClass, ok := new.(*sc.ClusterServiceClass)
 	if !ok {
-		glog.Fatal("received a non-clusterserviceClass object to update to")
+		klog.Fatal("received a non-clusterserviceClass object to update to")
 	}
 	oldServiceClass, ok := old.(*sc.ClusterServiceClass)
 	if !ok {
-		glog.Fatal("received a non-clusterserviceClass object to update from")
+		klog.Fatal("received a non-clusterserviceClass object to update from")
 	}
 	// Status changes are not allowed to update spec
 	newServiceClass.Spec = oldServiceClass.Spec

--- a/pkg/registry/servicecatalog/clusterserviceplan/strategy.go
+++ b/pkg/registry/servicecatalog/clusterserviceplan/strategy.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	scv "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation"
 )
@@ -73,7 +73,7 @@ var (
 func (clusterServicePlanRESTStrategy) Canonicalize(obj runtime.Object) {
 	_, ok := obj.(*sc.ClusterServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ClusterServicePlan object to create")
+		klog.Fatal("received a non-ClusterServicePlan object to create")
 	}
 }
 
@@ -86,7 +86,7 @@ func (clusterServicePlanRESTStrategy) NamespaceScoped() bool {
 func (clusterServicePlanRESTStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	_, ok := obj.(*sc.ClusterServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ClusterServicePlan object to create")
+		klog.Fatal("received a non-ClusterServicePlan object to create")
 	}
 	// service plan is a data record and has no status to track
 }
@@ -106,11 +106,11 @@ func (clusterServicePlanRESTStrategy) AllowUnconditionalUpdate() bool {
 func (clusterServicePlanRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newServicePlan, ok := new.(*sc.ClusterServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ClusterServicePlan object to update to")
+		klog.Fatal("received a non-ClusterServicePlan object to update to")
 	}
 	oldServicePlan, ok := old.(*sc.ClusterServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ClusterServicePlan object to update from")
+		klog.Fatal("received a non-ClusterServicePlan object to update from")
 	}
 
 	newServicePlan.Spec.ClusterServiceClassRef = oldServicePlan.Spec.ClusterServiceClassRef
@@ -120,11 +120,11 @@ func (clusterServicePlanRESTStrategy) PrepareForUpdate(ctx context.Context, new,
 func (clusterServicePlanRESTStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newServicePlan, ok := new.(*sc.ClusterServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ClusterServicePlan object to validate to")
+		klog.Fatal("received a non-ClusterServicePlan object to validate to")
 	}
 	oldServicePlan, ok := old.(*sc.ClusterServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ClusterServicePlan object to validate from")
+		klog.Fatal("received a non-ClusterServicePlan object to validate from")
 	}
 
 	return scv.ValidateClusterServicePlanUpdate(newServicePlan, oldServicePlan)
@@ -133,11 +133,11 @@ func (clusterServicePlanRESTStrategy) ValidateUpdate(ctx context.Context, new, o
 func (clusterServicePlanStatusRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newServiceClass, ok := new.(*sc.ClusterServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ClusterServicePlan object to update to")
+		klog.Fatal("received a non-ClusterServicePlan object to update to")
 	}
 	oldServiceClass, ok := old.(*sc.ClusterServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ClusterServicePlan object to update from")
+		klog.Fatal("received a non-ClusterServicePlan object to update from")
 	}
 	// Status changes are not allowed to update spec
 	newServiceClass.Spec = oldServiceClass.Spec
@@ -146,11 +146,11 @@ func (clusterServicePlanStatusRESTStrategy) PrepareForUpdate(ctx context.Context
 func (clusterServicePlanStatusRESTStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newServicePlan, ok := new.(*sc.ClusterServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ClusterServicePlan object to validate to")
+		klog.Fatal("received a non-ClusterServicePlan object to validate to")
 	}
 	oldServicePlan, ok := old.(*sc.ClusterServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ClusterServicePlan object to validate from")
+		klog.Fatal("received a non-ClusterServicePlan object to validate from")
 	}
 
 	return scv.ValidateClusterServicePlanUpdate(newServicePlan, oldServicePlan)

--- a/pkg/registry/servicecatalog/instance/strategy.go
+++ b/pkg/registry/servicecatalog/instance/strategy.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	scv "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation"
 	scfeatures "github.com/kubernetes-incubator/service-catalog/pkg/features"
@@ -93,7 +93,7 @@ var (
 func (instanceRESTStrategy) Canonicalize(obj runtime.Object) {
 	_, ok := obj.(*sc.ServiceInstance)
 	if !ok {
-		glog.Fatal("received a non-instance object to create")
+		klog.Fatal("received a non-instance object to create")
 	}
 }
 
@@ -108,7 +108,7 @@ func (instanceRESTStrategy) NamespaceScoped() bool {
 func (instanceRESTStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	instance, ok := obj.(*sc.ServiceInstance)
 	if !ok {
-		glog.Fatal("received a non-instance object to create")
+		klog.Fatal("received a non-instance object to create")
 	}
 
 	if instance.Spec.ExternalID == "" {
@@ -149,11 +149,11 @@ func (instanceRESTStrategy) AllowUnconditionalUpdate() bool {
 func (instanceRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newServiceInstance, ok := new.(*sc.ServiceInstance)
 	if !ok {
-		glog.Fatal("received a non-instance object to update to")
+		klog.Fatal("received a non-instance object to update to")
 	}
 	oldServiceInstance, ok := old.(*sc.ServiceInstance)
 	if !ok {
-		glog.Fatal("received a non-instance object to update from")
+		klog.Fatal("received a non-instance object to update from")
 	}
 
 	// Do not allow any updates to the Status field while updating the Spec
@@ -189,11 +189,11 @@ func (instanceRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runti
 func (instanceRESTStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newServiceInstance, ok := new.(*sc.ServiceInstance)
 	if !ok {
-		glog.Fatal("received a non-instance object to validate to")
+		klog.Fatal("received a non-instance object to validate to")
 	}
 	oldServiceInstance, ok := old.(*sc.ServiceInstance)
 	if !ok {
-		glog.Fatal("received a non-instance object to validate from")
+		klog.Fatal("received a non-instance object to validate from")
 	}
 
 	return scv.ValidateServiceInstanceUpdate(newServiceInstance, oldServiceInstance)
@@ -208,7 +208,7 @@ func (instanceRESTStrategy) CheckGracefulDelete(ctx context.Context, obj runtime
 	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {
 		serviceInstance, ok := obj.(*sc.ServiceInstance)
 		if !ok {
-			glog.Fatal("received a non-instance object to delete")
+			klog.Fatal("received a non-instance object to delete")
 		}
 		setServiceInstanceUserInfo(ctx, serviceInstance)
 	}
@@ -219,11 +219,11 @@ func (instanceRESTStrategy) CheckGracefulDelete(ctx context.Context, obj runtime
 func (instanceStatusRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newServiceInstance, ok := new.(*sc.ServiceInstance)
 	if !ok {
-		glog.Fatal("received a non-instance object to update to")
+		klog.Fatal("received a non-instance object to update to")
 	}
 	oldServiceInstance, ok := old.(*sc.ServiceInstance)
 	if !ok {
-		glog.Fatal("received a non-instance object to update from")
+		klog.Fatal("received a non-instance object to update from")
 	}
 	// Status changes are not allowed to update spec
 	newServiceInstance.Spec = oldServiceInstance.Spec
@@ -232,11 +232,11 @@ func (instanceStatusRESTStrategy) PrepareForUpdate(ctx context.Context, new, old
 func (instanceStatusRESTStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newServiceInstance, ok := new.(*sc.ServiceInstance)
 	if !ok {
-		glog.Fatal("received a non-instance object to validate to")
+		klog.Fatal("received a non-instance object to validate to")
 	}
 	oldServiceInstance, ok := old.(*sc.ServiceInstance)
 	if !ok {
-		glog.Fatal("received a non-instance object to validate from")
+		klog.Fatal("received a non-instance object to validate from")
 	}
 
 	return scv.ValidateServiceInstanceStatusUpdate(newServiceInstance, oldServiceInstance)
@@ -245,11 +245,11 @@ func (instanceStatusRESTStrategy) ValidateUpdate(ctx context.Context, new, old r
 func (instanceReferenceRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newServiceInstance, ok := new.(*sc.ServiceInstance)
 	if !ok {
-		glog.Fatal("received a non-instance object to update to")
+		klog.Fatal("received a non-instance object to update to")
 	}
 	oldServiceInstance, ok := old.(*sc.ServiceInstance)
 	if !ok {
-		glog.Fatal("received a non-instance object to update from")
+		klog.Fatal("received a non-instance object to update from")
 	}
 	// Reference changes are not allowed to update spec, so stash the new
 	// ones away and overwrite with all the old ones and then update them
@@ -275,11 +275,11 @@ func (instanceReferenceRESTStrategy) PrepareForUpdate(ctx context.Context, new, 
 func (instanceReferenceRESTStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newServiceInstance, ok := new.(*sc.ServiceInstance)
 	if !ok {
-		glog.Fatal("received a non-instance object to validate to")
+		klog.Fatal("received a non-instance object to validate to")
 	}
 	oldServiceInstance, ok := old.(*sc.ServiceInstance)
 	if !ok {
-		glog.Fatal("received a non-instance object to validate from")
+		klog.Fatal("received a non-instance object to validate from")
 	}
 
 	return scv.ValidateServiceInstanceReferencesUpdate(newServiceInstance, oldServiceInstance)

--- a/pkg/registry/servicecatalog/servicebroker/strategy.go
+++ b/pkg/registry/servicecatalog/servicebroker/strategy.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	scv "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation"
 )
@@ -74,7 +74,7 @@ var (
 func (serviceBrokerRESTStrategy) Canonicalize(obj runtime.Object) {
 	_, ok := obj.(*sc.ServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-servicebroker object to create")
+		klog.Fatal("received a non-servicebroker object to create")
 	}
 }
 
@@ -88,7 +88,7 @@ func (serviceBrokerRESTStrategy) NamespaceScoped() bool {
 func (serviceBrokerRESTStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	broker, ok := obj.(*sc.ServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-servicebroker object to create")
+		klog.Fatal("received a non-servicebroker object to create")
 	}
 	// Is there anything to pull out of the context `ctx`?
 
@@ -117,11 +117,11 @@ func (serviceBrokerRESTStrategy) AllowUnconditionalUpdate() bool {
 func (serviceBrokerRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newServiceBroker, ok := new.(*sc.ServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-servicebroker object to update to")
+		klog.Fatal("received a non-servicebroker object to update to")
 	}
 	oldServiceBroker, ok := old.(*sc.ServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-servicebroker object to update from")
+		klog.Fatal("received a non-servicebroker object to update from")
 	}
 
 	newServiceBroker.Status = oldServiceBroker.Status
@@ -141,11 +141,11 @@ func (serviceBrokerRESTStrategy) PrepareForUpdate(ctx context.Context, new, old 
 func (serviceBrokerRESTStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newServiceBroker, ok := new.(*sc.ServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-servicebroker object to validate to")
+		klog.Fatal("received a non-servicebroker object to validate to")
 	}
 	oldServiceBroker, ok := old.(*sc.ServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-servicebroker object to validate from")
+		klog.Fatal("received a non-servicebroker object to validate from")
 	}
 
 	return scv.ValidateServiceBrokerUpdate(newServiceBroker, oldServiceBroker)
@@ -154,11 +154,11 @@ func (serviceBrokerRESTStrategy) ValidateUpdate(ctx context.Context, new, old ru
 func (serviceBrokerStatusRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newServiceBroker, ok := new.(*sc.ServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-servicebroker object to update to")
+		klog.Fatal("received a non-servicebroker object to update to")
 	}
 	oldServiceBroker, ok := old.(*sc.ServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-servicebroker object to update from")
+		klog.Fatal("received a non-servicebroker object to update from")
 	}
 	// status changes are not allowed to update spec
 	newServiceBroker.Spec = oldServiceBroker.Spec
@@ -167,11 +167,11 @@ func (serviceBrokerStatusRESTStrategy) PrepareForUpdate(ctx context.Context, new
 func (serviceBrokerStatusRESTStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newServiceBroker, ok := new.(*sc.ServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-servicebroker object to validate to")
+		klog.Fatal("received a non-servicebroker object to validate to")
 	}
 	oldServiceBroker, ok := old.(*sc.ServiceBroker)
 	if !ok {
-		glog.Fatal("received a non-servicebroker object to validate from")
+		klog.Fatal("received a non-servicebroker object to validate from")
 	}
 
 	return scv.ValidateServiceBrokerStatusUpdate(newServiceBroker, oldServiceBroker)

--- a/pkg/registry/servicecatalog/serviceclass/strategy.go
+++ b/pkg/registry/servicecatalog/serviceclass/strategy.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	scv "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation"
 )
@@ -76,7 +76,7 @@ var (
 func (serviceClassRESTStrategy) Canonicalize(obj runtime.Object) {
 	_, ok := obj.(*sc.ServiceClass)
 	if !ok {
-		glog.Fatal("received a non-serviceclass object to create")
+		klog.Fatal("received a non-serviceclass object to create")
 	}
 }
 
@@ -89,7 +89,7 @@ func (serviceClassRESTStrategy) NamespaceScoped() bool {
 func (serviceClassRESTStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	serviceClass, ok := obj.(*sc.ServiceClass)
 	if !ok {
-		glog.Fatal("received a non-serviceclass object to create")
+		klog.Fatal("received a non-serviceclass object to create")
 	}
 	serviceClass.Status = sc.ServiceClassStatus{}
 }
@@ -109,11 +109,11 @@ func (serviceClassRESTStrategy) AllowUnconditionalUpdate() bool {
 func (serviceClassRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newServiceClass, ok := new.(*sc.ServiceClass)
 	if !ok {
-		glog.Fatal("received a non-serviceclass object to update to")
+		klog.Fatal("received a non-serviceclass object to update to")
 	}
 	oldServiceClass, ok := old.(*sc.ServiceClass)
 	if !ok {
-		glog.Fatal("received a non-serviceclass object to update from")
+		klog.Fatal("received a non-serviceclass object to update from")
 	}
 
 	// Update should not change the status
@@ -125,11 +125,11 @@ func (serviceClassRESTStrategy) PrepareForUpdate(ctx context.Context, new, old r
 func (serviceClassRESTStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newServiceclass, ok := new.(*sc.ServiceClass)
 	if !ok {
-		glog.Fatal("received a non-serviceclass object to validate to")
+		klog.Fatal("received a non-serviceclass object to validate to")
 	}
 	oldServiceclass, ok := old.(*sc.ServiceClass)
 	if !ok {
-		glog.Fatal("received a non-serviceclass object to validate from")
+		klog.Fatal("received a non-serviceclass object to validate from")
 	}
 
 	return scv.ValidateServiceClassUpdate(newServiceclass, oldServiceclass)
@@ -138,11 +138,11 @@ func (serviceClassRESTStrategy) ValidateUpdate(ctx context.Context, new, old run
 func (serviceClassStatusRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newServiceClass, ok := new.(*sc.ServiceClass)
 	if !ok {
-		glog.Fatal("received a non-serviceclass object to update to")
+		klog.Fatal("received a non-serviceclass object to update to")
 	}
 	oldServiceClass, ok := old.(*sc.ServiceClass)
 	if !ok {
-		glog.Fatal("received a non-serviceclass object to update from")
+		klog.Fatal("received a non-serviceclass object to update from")
 	}
 	// Status changes are not allowed to update spec
 	newServiceClass.Spec = oldServiceClass.Spec

--- a/pkg/registry/servicecatalog/serviceplan/strategy.go
+++ b/pkg/registry/servicecatalog/serviceplan/strategy.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	sc "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	scv "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation"
 )
@@ -73,7 +73,7 @@ var (
 func (servicePlanRESTStrategy) Canonicalize(obj runtime.Object) {
 	_, ok := obj.(*sc.ServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ServicePlan object to create")
+		klog.Fatal("received a non-ServicePlan object to create")
 	}
 }
 
@@ -86,7 +86,7 @@ func (servicePlanRESTStrategy) NamespaceScoped() bool {
 func (servicePlanRESTStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	_, ok := obj.(*sc.ServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ServicePlan object to create")
+		klog.Fatal("received a non-ServicePlan object to create")
 	}
 	// service plan is a data record and has no status to track
 }
@@ -106,11 +106,11 @@ func (servicePlanRESTStrategy) AllowUnconditionalUpdate() bool {
 func (servicePlanRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newServicePlan, ok := new.(*sc.ServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ServicePlan object to update to")
+		klog.Fatal("received a non-ServicePlan object to update to")
 	}
 	oldServicePlan, ok := old.(*sc.ServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ServicePlan object to update from")
+		klog.Fatal("received a non-ServicePlan object to update from")
 	}
 
 	newServicePlan.Spec.ServiceClassRef = oldServicePlan.Spec.ServiceClassRef
@@ -120,11 +120,11 @@ func (servicePlanRESTStrategy) PrepareForUpdate(ctx context.Context, new, old ru
 func (servicePlanRESTStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newServicePlan, ok := new.(*sc.ServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ServicePlan object to validate to")
+		klog.Fatal("received a non-ServicePlan object to validate to")
 	}
 	oldServicePlan, ok := old.(*sc.ServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ServicePlan object to validate from")
+		klog.Fatal("received a non-ServicePlan object to validate from")
 	}
 
 	return scv.ValidateServicePlanUpdate(newServicePlan, oldServicePlan)
@@ -133,11 +133,11 @@ func (servicePlanRESTStrategy) ValidateUpdate(ctx context.Context, new, old runt
 func (servicePlanStatusRESTStrategy) PrepareForUpdate(ctx context.Context, new, old runtime.Object) {
 	newServiceClass, ok := new.(*sc.ServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ServicePlan object to update to")
+		klog.Fatal("received a non-ServicePlan object to update to")
 	}
 	oldServiceClass, ok := old.(*sc.ServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ServicePlan object to update from")
+		klog.Fatal("received a non-ServicePlan object to update from")
 	}
 	// Status changes are not allowed to update spec
 	newServiceClass.Spec = oldServiceClass.Spec
@@ -146,11 +146,11 @@ func (servicePlanStatusRESTStrategy) PrepareForUpdate(ctx context.Context, new, 
 func (servicePlanStatusRESTStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newServicePlan, ok := new.(*sc.ServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ServicePlan object to validate to")
+		klog.Fatal("received a non-ServicePlan object to validate to")
 	}
 	oldServicePlan, ok := old.(*sc.ServicePlan)
 	if !ok {
-		glog.Fatal("received a non-ServicePlan object to validate from")
+		klog.Fatal("received a non-ServicePlan object to validate from")
 	}
 
 	return scv.ValidateServicePlanUpdate(newServicePlan, oldServicePlan)

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -24,7 +24,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 )
 
 // WriteResponse will serialize 'object' to the HTTP ResponseWriter
@@ -76,7 +76,7 @@ func ResponseBodyToObject(r *http.Response, object interface{}) error {
 	if err != nil {
 		return err
 	}
-	glog.Info(string(body))
+	klog.Infof(string(body))
 
 	err = json.Unmarshal(body, object)
 	if err != nil {

--- a/plugin/pkg/admission/broker/authsarcheck/admission.go
+++ b/plugin/pkg/admission/broker/authsarcheck/admission.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 
 	authorizationapi "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -95,7 +96,7 @@ func (s *sarcheck) Admit(a admission.Attributes) error {
 	if secretRef == nil {
 		return nil
 	}
-	glog.V(5).Infof("ClusterServiceBroker %+v: evaluating auth secret ref, with authInfo %q", clusterServiceBroker, secretRef)
+	klog.V(common.DebugInfoLogLevel).Infof("ClusterServiceBroker %+v: evaluating auth secret ref, with authInfo %q", clusterServiceBroker, secretRef)
 	userInfo := a.GetUserInfo()
 
 	sar := &authorizationapi.SubjectAccessReview{

--- a/plugin/pkg/admission/servicebindings/lifecycle/admission.go
+++ b/plugin/pkg/admission/servicebindings/lifecycle/admission.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 	informers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/internalversion"
@@ -86,7 +86,7 @@ func (b *enforceNoNewCredentialsForDeletedInstance) Admit(a admission.Attributes
 			credentials.Name,
 			credentials.Namespace,
 			instanceRef.Name)
-		glog.Info(warning, err)
+		klog.Infof(warning, err)
 		return admission.NewForbidden(a, fmt.Errorf(warning))
 	}
 

--- a/plugin/pkg/admission/serviceplan/changevalidator/admission.go
+++ b/plugin/pkg/admission/serviceplan/changevalidator/admission.go
@@ -21,7 +21,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/admission"
@@ -79,10 +80,10 @@ func (d *denyPlanChangeIfNotUpdatable) Admit(a admission.Attributes) error {
 	sc, err := d.scLister.Get(instance.Spec.ClusterServiceClassRef.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			glog.V(5).Infof("Could not locate service class %v, can not determine if UpdateablePlan.", instance.Spec.ClusterServiceClassRef.Name)
+			klog.V(common.ErrorDetailsInfoLogLevel).Infof("Could not locate service class %v, can not determine if UpdateablePlan.", instance.Spec.ClusterServiceClassRef.Name)
 			return nil // should this be `return err`? why would we allow the instance in if we cannot determine it is updatable?
 		}
-		glog.Error(err)
+		klog.Error(err)
 		return admission.NewForbidden(a, err)
 	}
 
@@ -94,7 +95,7 @@ func (d *denyPlanChangeIfNotUpdatable) Admit(a admission.Attributes) error {
 		lister := d.instanceLister.ServiceInstances(instance.Namespace)
 		origInstance, err := lister.Get(instance.Name)
 		if err != nil {
-			glog.Errorf("Error locating instance %v/%v", instance.Namespace, instance.Name)
+			klog.Errorf("Error locating instance %v/%v", instance.Namespace, instance.Name)
 			return err
 		}
 
@@ -113,9 +114,9 @@ func (d *denyPlanChangeIfNotUpdatable) Admit(a admission.Attributes) error {
 				oldPlan = origInstance.Spec.ClusterServicePlanName
 				newPlan = instance.Spec.ClusterServicePlanName
 			}
-			glog.V(4).Infof("update Service Instance %v/%v request specified Plan %v while original instance had %v", instance.Namespace, instance.Name, newPlan, oldPlan)
+			klog.V(common.DefaultInfoLogLevel).Infof("update Service Instance %v/%v request specified Plan %v while original instance had %v", instance.Namespace, instance.Name, newPlan, oldPlan)
 			msg := fmt.Sprintf("The Service Class %v does not allow plan changes.", sc.Name)
-			glog.Error(msg)
+			klog.Errorf(msg)
 			return admission.NewForbidden(a, errors.New(msg))
 		}
 	}

--- a/plugin/pkg/admission/serviceplan/defaultserviceplan/admission.go
+++ b/plugin/pkg/admission/serviceplan/defaultserviceplan/admission.go
@@ -21,7 +21,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachineryv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,7 +98,7 @@ func (d *defaultServicePlan) handleDefaultClusterServicePlan(a admission.Attribu
 		}
 		msg := fmt.Sprintf("ClusterServiceClass %c does not exist, can not figure out the default ClusterServicePlan.",
 			instance.Spec.PlanReference)
-		glog.V(4).Info(msg)
+		klog.V(common.ErrorDetailsInfoLogLevel).Infof(msg)
 		return admission.NewForbidden(a, errors.New(msg))
 	}
 
@@ -112,7 +113,7 @@ func (d *defaultServicePlan) handleDefaultClusterServicePlan(a admission.Attribu
 	plans, err := d.getClusterServicePlansByClusterServiceClassName(sc.Name)
 	if err != nil {
 		msg := fmt.Sprintf("Error listing ClusterServicePlans for ClusterServiceClass (K8S: %v ExternalName: %v) - retry and specify desired ClusterServicePlan", sc.Name, sc.Spec.ExternalName)
-		glog.V(4).Infof(`ServiceInstance "%s/%s": %s`, instance.Namespace, instance.Name, msg)
+		klog.V(common.DebugInfoLogLevel).Infof(`ServiceInstance "%s/%s": %s`, instance.Namespace, instance.Name, msg)
 		return admission.NewForbidden(a, errors.New(msg))
 	}
 
@@ -120,20 +121,20 @@ func (d *defaultServicePlan) handleDefaultClusterServicePlan(a admission.Attribu
 	// TODO: in combination with not allowing classes with no plans, this should be impossible
 	if len(plans) == 0 {
 		msg := fmt.Sprintf("no ClusterServicePlans found at all for ClusterServiceClass %q", sc.Spec.ExternalName)
-		glog.V(4).Infof(`ServiceInstance "%s/%s": %s`, instance.Namespace, instance.Name, msg)
+		klog.V(common.DebugInfoLogLevel).Infof(`ServiceInstance "%s/%s": %s`, instance.Namespace, instance.Name, msg)
 		return admission.NewForbidden(a, errors.New(msg))
 	}
 
 	// check if more than one service plan was found and error
 	if len(plans) > 1 {
 		msg := fmt.Sprintf("ClusterServiceClass (K8S: %v ExternalName: %v) has more than one plan, PlanName must be specified", sc.Name, sc.Spec.ExternalName)
-		glog.V(4).Infof(`ServiceInstance "%s/%s": %s`, instance.Namespace, instance.Name, msg)
+		klog.V(common.DebugInfoLogLevel).Infof(`ServiceInstance "%s/%s": %s`, instance.Namespace, instance.Name, msg)
 		return admission.NewForbidden(a, errors.New(msg))
 	}
 	// otherwise, by default, pick the only plan that exists for the service class
 
 	p := plans[0]
-	glog.V(4).Infof(`ServiceInstance "%s/%s": Using default plan %q (K8S: %q) for Service Class %q`,
+	klog.V(common.DebugInfoLogLevel).Infof(`ServiceInstance "%s/%s": Using default plan %q (K8S: %q) for Service Class %q`,
 		instance.Namespace, instance.Name, p.Spec.ExternalName, p.Name, sc.Spec.ExternalName)
 	if instance.Spec.ClusterServiceClassExternalName != "" {
 		instance.Spec.ClusterServicePlanExternalName = p.Spec.ExternalName
@@ -158,7 +159,7 @@ func (d *defaultServicePlan) handleDefaultServicePlan(a admission.Attributes, in
 		}
 		msg := fmt.Sprintf("ServiceClass %c does not exist, can not figure out the default ServicePlan.",
 			instance.Spec.PlanReference)
-		glog.V(4).Info(msg)
+		klog.V(common.ErrorDetailsInfoLogLevel).Infof(msg)
 		return admission.NewForbidden(a, errors.New(msg))
 	}
 
@@ -173,7 +174,7 @@ func (d *defaultServicePlan) handleDefaultServicePlan(a admission.Attributes, in
 	plans, err := d.getServicePlansByServiceClassName(sc.Name)
 	if err != nil {
 		msg := fmt.Sprintf("Error listing ServicePlans for ServiceClass (K8S: %v ExternalName: %v) - retry and specify desired ServicePlan", sc.Name, sc.Spec.ExternalName)
-		glog.V(4).Infof(`ServiceInstance "%s/%s": %s`, instance.Namespace, instance.Name, msg)
+		klog.V(common.DebugInfoLogLevel).Infof(`ServiceInstance "%s/%s": %s`, instance.Namespace, instance.Name, msg)
 		return admission.NewForbidden(a, errors.New(msg))
 	}
 
@@ -181,20 +182,20 @@ func (d *defaultServicePlan) handleDefaultServicePlan(a admission.Attributes, in
 	// TODO: in combination with not allowing classes with no plans, this should be impossible
 	if len(plans) == 0 {
 		msg := fmt.Sprintf("no ServicePlans found at all for ServiceClass %q", sc.Spec.ExternalName)
-		glog.V(4).Infof(`ServiceInstance "%s/%s": %s`, instance.Namespace, instance.Name, msg)
+		klog.V(common.DebugInfoLogLevel).Infof(`ServiceInstance "%s/%s": %s`, instance.Namespace, instance.Name, msg)
 		return admission.NewForbidden(a, errors.New(msg))
 	}
 
 	// check if more than one service plan was found and error
 	if len(plans) > 1 {
 		msg := fmt.Sprintf("ServiceClass (K8S: %v ExternalName: %v) has more than one plan, PlanName must be specified", sc.Name, sc.Spec.ExternalName)
-		glog.V(4).Infof(`ServiceInstance "%s/%s": %s`, instance.Namespace, instance.Name, msg)
+		klog.V(common.DebugInfoLogLevel).Infof(`ServiceInstance "%s/%s": %s`, instance.Namespace, instance.Name, msg)
 		return admission.NewForbidden(a, errors.New(msg))
 	}
 	// otherwise, by default, pick the only plan that exists for the service class
 
 	p := plans[0]
-	glog.V(4).Infof(`ServiceInstance "%s/%s": Using default plan %q (K8S: %q) for Service Class %q`,
+	klog.V(common.DebugInfoLogLevel).Infof(`ServiceInstance "%s/%s": Using default plan %q (K8S: %q) for Service Class %q`,
 		instance.Namespace, instance.Name, p.Spec.ExternalName, p.Name, sc.Spec.ExternalName)
 	if instance.Spec.ServiceClassExternalName != "" {
 		instance.Spec.ServicePlanExternalName = p.Spec.ExternalName
@@ -250,12 +251,12 @@ func (d *defaultServicePlan) getServiceClassByPlanReference(a admission.Attribut
 }
 
 func (d *defaultServicePlan) getClusterServiceClassByK8SName(a admission.Attributes, scK8SName string) (*servicecatalog.ClusterServiceClass, error) {
-	glog.V(4).Infof("Fetching ClusterServiceClass by k8s name %q", scK8SName)
+	klog.V(common.DebugInfoLogLevel).Infof("Fetching ClusterServiceClass by k8s name %q", scK8SName)
 	return d.cscClient.Get(scK8SName, apimachineryv1.GetOptions{})
 }
 
 func (d *defaultServicePlan) getServiceClassByK8SName(a admission.Attributes, scK8SName string) (*servicecatalog.ServiceClass, error) {
-	glog.V(4).Infof("Fetching ServiceClass by k8s name %q", scK8SName)
+	klog.V(common.DebugInfoLogLevel).Infof("Fetching ServiceClass by k8s name %q", scK8SName)
 	return d.scClient.Get(scK8SName, apimachineryv1.GetOptions{})
 }
 
@@ -263,7 +264,7 @@ func (d *defaultServicePlan) getClusterServiceClassByField(a admission.Attribute
 	filterField := ref.GetClusterServiceClassFilterFieldName()
 	filterValue := ref.GetSpecifiedClusterServiceClass()
 
-	glog.V(4).Infof("Fetching ClusterServiceClass filtered by %q = %q", filterField, filterValue)
+	klog.V(common.DebugInfoLogLevel).Infof("Fetching ClusterServiceClass filtered by %q = %q", filterField, filterValue)
 	fieldSet := fields.Set{
 		filterField: filterValue,
 	}
@@ -271,15 +272,15 @@ func (d *defaultServicePlan) getClusterServiceClassByField(a admission.Attribute
 	listOpts := apimachineryv1.ListOptions{FieldSelector: fieldSelector}
 	serviceClasses, err := d.cscClient.List(listOpts)
 	if err != nil {
-		glog.V(4).Infof("Listing ClusterServiceClasses failed: %q", err)
+		klog.V(common.ErrorDetailsInfoLogLevel).Infof("Listing ClusterServiceClasses failed: %q", err)
 		return nil, err
 	}
 	if len(serviceClasses.Items) == 1 {
-		glog.V(4).Infof("Found single ClusterServiceClass as %+v", serviceClasses.Items[0])
+		klog.V(common.DebugInfoLogLevel).Infof("Found single ClusterServiceClass as %+v", serviceClasses.Items[0])
 		return &serviceClasses.Items[0], nil
 	}
 	msg := fmt.Sprintf("Could not find a single ClusterServiceClass with %q = %q, found %v", filterField, filterValue, len(serviceClasses.Items))
-	glog.V(4).Info(msg)
+	klog.V(common.ErrorDetailsInfoLogLevel).Infof(msg)
 	return nil, admission.NewNotFound(a)
 }
 
@@ -287,7 +288,7 @@ func (d *defaultServicePlan) getServiceClassByField(a admission.Attributes, ref 
 	filterField := ref.GetServiceClassFilterFieldName()
 	filterValue := ref.GetSpecifiedServiceClass()
 
-	glog.V(4).Infof("Fetching ServiceClass filtered by %q = %q", filterField, filterValue)
+	klog.V(common.DebugInfoLogLevel).Infof("Fetching ServiceClass filtered by %q = %q", filterField, filterValue)
 	fieldSet := fields.Set{
 		filterField: filterValue,
 	}
@@ -295,22 +296,22 @@ func (d *defaultServicePlan) getServiceClassByField(a admission.Attributes, ref 
 	listOpts := apimachineryv1.ListOptions{FieldSelector: fieldSelector}
 	serviceClasses, err := d.scClient.List(listOpts)
 	if err != nil {
-		glog.V(4).Infof("Listing ServiceClasses failed: %q", err)
+		klog.V(common.ErrorDetailsInfoLogLevel).Infof("Listing ServiceClasses failed: %q", err)
 		return nil, err
 	}
 	if len(serviceClasses.Items) == 1 {
-		glog.V(4).Infof("Found single ServiceClass as %+v", serviceClasses.Items[0])
+		klog.V(common.DebugInfoLogLevel).Infof("Found single ServiceClass as %+v", serviceClasses.Items[0])
 		return &serviceClasses.Items[0], nil
 	}
 	msg := fmt.Sprintf("Could not find a single ServiceClass with %q = %q, found %v", filterField, filterValue, len(serviceClasses.Items))
-	glog.V(4).Info(msg)
+	klog.V(common.ErrorDetailsInfoLogLevel).Infof(msg)
 	return nil, admission.NewNotFound(a)
 }
 
 // getClusterServicePlansByClusterServiceClassName() returns a list of
 // ServicePlans for the specified service class name
 func (d *defaultServicePlan) getClusterServicePlansByClusterServiceClassName(scName string) ([]servicecatalog.ClusterServicePlan, error) {
-	glog.V(4).Infof("Fetching ClusterServicePlans by class name %q", scName)
+	klog.V(common.DebugInfoLogLevel).Infof("Fetching ClusterServicePlans by class name %q", scName)
 	fieldSet := fields.Set{
 		"spec.clusterServiceClassRef.name": scName,
 	}
@@ -318,10 +319,10 @@ func (d *defaultServicePlan) getClusterServicePlansByClusterServiceClassName(scN
 	listOpts := apimachineryv1.ListOptions{FieldSelector: fieldSelector}
 	servicePlans, err := d.cspClient.List(listOpts)
 	if err != nil {
-		glog.Infof("Listing ClusterServicePlans failed: %q", err)
+		klog.Infof("Listing ClusterServicePlans failed: %q", err)
 		return nil, err
 	}
-	glog.V(4).Infof("ClusterServicePlans fetched by filtering classname: %+v", servicePlans.Items)
+	klog.V(common.DebugInfoLogLevel).Infof("ClusterServicePlans fetched by filtering classname: %+v", servicePlans.Items)
 	r := servicePlans.Items
 	return r, err
 }
@@ -329,7 +330,7 @@ func (d *defaultServicePlan) getClusterServicePlansByClusterServiceClassName(scN
 // getServicePlansByServiceClassName() returns a list of
 // ServicePlans for the specified service class name
 func (d *defaultServicePlan) getServicePlansByServiceClassName(scName string) ([]servicecatalog.ServicePlan, error) {
-	glog.V(4).Infof("Fetching ServicePlans by class name %q", scName)
+	klog.V(common.DebugInfoLogLevel).Infof("Fetching ServicePlans by class name %q", scName)
 	fieldSet := fields.Set{
 		"spec.serviceClassRef.name": scName,
 	}
@@ -337,10 +338,10 @@ func (d *defaultServicePlan) getServicePlansByServiceClassName(scName string) ([
 	listOpts := apimachineryv1.ListOptions{FieldSelector: fieldSelector}
 	servicePlans, err := d.spClient.List(listOpts)
 	if err != nil {
-		glog.Infof("Listing ServicePlans failed: %q", err)
+		klog.Infof("Listing ServicePlans failed: %q", err)
 		return nil, err
 	}
-	glog.V(4).Infof("ServicePlans fetched by filtering classname: %+v", servicePlans.Items)
+	klog.V(common.DebugInfoLogLevel).Infof("ServicePlans fetched by filtering classname: %+v", servicePlans.Items)
 	r := servicePlans.Items
 	return r, err
 }

--- a/plugin/pkg/admission/serviceplan/defaultserviceplan/admission_test.go
+++ b/plugin/pkg/admission/serviceplan/defaultserviceplan/admission_test.go
@@ -22,7 +22,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -408,12 +409,12 @@ func TestWithNoPlanWorksWithSinglePlan(t *testing.T) {
 			if tc.namespaced {
 				sc := newServiceClass("foo-id", "foo")
 				sps := newServicePlans(1, false)
-				glog.V(4).Infof("Created Service as %+v", sc)
+				klog.V(common.DefaultInfoLogLevel).Infof("Created Service as %+v", sc)
 				fakeClient = newFakeServiceCatalogClientForNamespacedTest(sc, sps, "" /* do not use get */)
 			} else {
 				csc := newClusterServiceClass("foo-id", "foo")
 				csps := newClusterServicePlans(1, false)
-				glog.V(4).Infof("Created Service as %+v", csc)
+				klog.V(common.DefaultInfoLogLevel).Infof("Created Service as %+v", csc)
 				fakeClient = newFakeServiceCatalogClientForTest(csc, csps, "" /* do not use get */)
 			}
 
@@ -462,12 +463,12 @@ func TestWithNoPlanFailsWithMultiplePlans(t *testing.T) {
 			if tc.namespaced {
 				sc := newServiceClass("foo-id", "foo")
 				sps := newServicePlans(2, false)
-				glog.V(4).Infof("Created Service as %+v", sc)
+				klog.V(common.DefaultInfoLogLevel).Infof("Created Service as %+v", sc)
 				fakeClient = newFakeServiceCatalogClientForNamespacedTest(sc, sps, "" /* do not use get */)
 			} else {
 				csc := newClusterServiceClass("foo-id", "foo")
 				csps := newClusterServicePlans(2, false)
-				glog.V(4).Infof("Created Service as %+v", csc)
+				klog.V(common.DefaultInfoLogLevel).Infof("Created Service as %+v", csc)
 				fakeClient = newFakeServiceCatalogClientForTest(csc, csps, "" /* do not use get */)
 			}
 			handler, informerFactory, err := newHandlerForTest(fakeClient)
@@ -525,12 +526,12 @@ func TestWithNoPlanSucceedsWithMultiplePlansFromDifferentClasses(t *testing.T) {
 			if tc.namespaced {
 				sc := newServiceClass("foo-id", "foo")
 				sps := newServicePlans(2, true)
-				glog.V(4).Infof("Created Service as %+v", sc)
+				klog.V(common.DefaultInfoLogLevel).Infof("Created Service as %+v", sc)
 				fakeClient = newFakeServiceCatalogClientForNamespacedTest(sc, sps, classFilter /* do not use get */)
 			} else {
 				csc := newClusterServiceClass("foo-id", "foo")
 				csps := newClusterServicePlans(2, true)
-				glog.V(4).Infof("Created Service as %+v", csc)
+				klog.V(common.DefaultInfoLogLevel).Infof("Created Service as %+v", csc)
 				fakeClient = newFakeServiceCatalogClientForTest(csc, csps, classFilter /* do not use get */)
 			}
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/kubernetes-incubator/service-catalog/test/e2e/framework"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/gomega"
@@ -42,6 +42,6 @@ func RunE2ETests(t *testing.T) {
 		config.GinkgoConfig.SkipString = `\[Flaky\]|\[Feature:.+\]`
 	}
 
-	glog.Infof("Starting e2e run %q on Ginkgo node %d", framework.RunId, config.GinkgoConfig.ParallelNode)
+	klog.Infof("Starting e2e run %q on Ginkgo node %d", framework.RunId, config.GinkgoConfig.ParallelNode)
 	ginkgo.RunSpecs(t, "Service Catalog e2e suite")
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -22,7 +22,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 	"github.com/kubernetes-incubator/service-catalog/test/e2e/framework"
 )
 
@@ -34,10 +34,10 @@ func init() {
 	framework.RegisterParseFlags()
 
 	if "" == framework.TestContext.KubeConfig {
-		glog.Fatalf("environment variable %v must be set", clientcmd.RecommendedConfigPathEnvVar)
+		klog.Errorf("environment variable %v must be set", clientcmd.RecommendedConfigPathEnvVar)
 	}
 	if "" == framework.TestContext.ServiceCatalogConfig {
-		glog.Fatalf("environment variable %v must be set", framework.RecommendedConfigPathEnvVar)
+		klog.Errorf("environment variable %v must be set", framework.RecommendedConfigPathEnvVar)
 	}
 }
 

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -35,7 +35,8 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 	// avoid error `servicecatalog/v1beta1 is not enabled`
 	_ "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/install"
 
@@ -617,11 +618,11 @@ func getProvisionResponseByPollCountReactions(numOfResponses int, stateProgressi
 		var reaction fakeosb.ProvisionReaction
 		if numberOfPolls > (numOfResponses*numberOfStates)-1 {
 			reaction = stateProgressions[numberOfStates-1]
-			glog.V(5).Infof("Provision instance state progressions done, ended on %v", reaction)
+			klog.V(common.StatesInfoLogLevel).Infof("Provision instance state progressions done, ended on %v", reaction)
 		} else {
 			idx := numberOfPolls / numOfResponses
 			reaction = stateProgressions[idx]
-			glog.V(5).Infof("Provision instance state progression on %v (polls:%v, idx:%v)", reaction, numberOfPolls, idx)
+			klog.V(common.StatesInfoLogLevel).Infof("Provision instance state progression on %v (polls:%v, idx:%v)", reaction, numberOfPolls, idx)
 		}
 		numberOfPolls++
 		if reaction.Response != nil {
@@ -642,11 +643,11 @@ func getDeprovisionResponseByPollCountReactions(numOfResponses int, stateProgres
 		var reaction fakeosb.DeprovisionReaction
 		if numberOfPolls > (numOfResponses*numberOfStates)-1 {
 			reaction = stateProgressions[numberOfStates-1]
-			glog.V(5).Infof("Deprovision instance state progressions done, ended on %v", reaction)
+			klog.V(common.StatesInfoLogLevel).Infof("Deprovision instance state progressions done, ended on %v", reaction)
 		} else {
 			idx := numberOfPolls / numOfResponses
 			reaction = stateProgressions[idx]
-			glog.V(5).Infof("Deprovision instance state progression on %v (polls:%v, idx:%v)", reaction, numberOfPolls, idx)
+			klog.V(common.StatesInfoLogLevel).Infof("Deprovision instance state progression on %v (polls:%v, idx:%v)", reaction, numberOfPolls, idx)
 		}
 		numberOfPolls++
 		if reaction.Response != nil {
@@ -667,11 +668,11 @@ func getUpdateInstanceResponseByPollCountReactions(numOfResponses int, stateProg
 		var reaction fakeosb.UpdateInstanceReaction
 		if numberOfPolls > (numOfResponses*numberOfStates)-1 {
 			reaction = stateProgressions[numberOfStates-1]
-			glog.V(5).Infof("Update instance state progressions done, ended on %v", reaction)
+			klog.V(common.StatesInfoLogLevel).Infof("Update instance state progressions done, ended on %v", reaction)
 		} else {
 			idx := numberOfPolls / numOfResponses
 			reaction = stateProgressions[idx]
-			glog.V(5).Infof("Update instance state progression on %v (polls:%v, idx:%v)", reaction, numberOfPolls, idx)
+			klog.V(common.StatesInfoLogLevel).Infof("Update instance state progression on %v (polls:%v, idx:%v)", reaction, numberOfPolls, idx)
 		}
 		numberOfPolls++
 		if reaction.Response != nil {
@@ -692,11 +693,11 @@ func getLastOperationResponseByPollCountReactions(numOfResponses int, stateProgr
 		var reaction fakeosb.PollLastOperationReaction
 		if numberOfPolls > (numOfResponses*numberOfStates)-1 {
 			reaction = stateProgressions[numberOfStates-1]
-			glog.V(5).Infof("Last operation state progressions done, ended on %v", reaction)
+			klog.V(common.StatesInfoLogLevel).Infof("Last operation state progressions done, ended on %v", reaction)
 		} else {
 			idx := numberOfPolls / numOfResponses
 			reaction = stateProgressions[idx]
-			glog.V(5).Infof("Last operation state progression on %v (polls:%v, idx:%v)", reaction, numberOfPolls, idx)
+			klog.V(common.StatesInfoLogLevel).Infof("Last operation state progression on %v (polls:%v, idx:%v)", reaction, numberOfPolls, idx)
 		}
 		numberOfPolls++
 		if reaction.Response != nil {
@@ -807,10 +808,10 @@ func newControllerTestTestController(ct *controllerTest) (
 
 	stopCh := make(chan struct{})
 
-	glog.V(4).Info("Waiting for caches to sync")
+	klog.V(common.StatesInfoLogLevel).Infof("Waiting for caches to sync")
 	informerFactory.Start(stopCh)
 
-	glog.V(4).Info("Waiting for caches to sync")
+	klog.V(common.StatesInfoLogLevel).Infof("Waiting for caches to sync")
 	informerFactory.WaitForCacheSync(stopCh)
 
 	controllerStopped := make(chan struct{})

--- a/test/integration/etcd_test.go
+++ b/test/integration/etcd_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/coreos/etcd/embed"
 	"github.com/coreos/pkg/capnslog"
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 )
 
 type EtcdContext struct {
@@ -52,10 +52,10 @@ func startEtcd() error {
 
 	select {
 	case <-etcdContext.etcd.Server.ReadyNotify():
-		glog.Info("server is ready!")
+		klog.Infof("server is ready!")
 	case <-time.After(60 * time.Second):
 		etcdContext.etcd.Server.Stop() // trigger a shutdown
-		glog.Error("server took too long to start!")
+		klog.Errorf("server took too long to start!")
 	}
 	return nil
 }
@@ -69,9 +69,9 @@ func stopEtcd() {
 
 	select {
 	case <-etcdContext.etcd.Server.StopNotify():
-		glog.Info("server is stopped!")
+		klog.Infof("server is stopped!")
 	case <-time.After(60 * time.Second):
-		glog.Error("server took too long to stop!")
+		klog.Errorf("server took too long to stop!")
 	}
 }
 

--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	restfullog "github.com/emicklei/go-restful/log"
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -160,14 +160,14 @@ func waitForApiserverUp(serverURL string, stopCh <-chan struct{}) error {
 			case <-stopCh:
 				return true, fmt.Errorf("apiserver failed")
 			default:
-				glog.Infof("Waiting for : %#v", serverURL)
+				klog.Infof("Waiting for : %#v", serverURL)
 				tr := &http.Transport{
 					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 				}
 				c := &http.Client{Transport: tr}
 				_, err := c.Get(serverURL)
 				if err == nil {
-					glog.Infof("Found server after %v tries and duration %v",
+					klog.Infof("Found server after %v tries and duration %v",
 						tries, time.Since(startWaiting))
 					return true, nil
 				}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/kubernetes/klog"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +31,7 @@ import (
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	v1beta1servicecatalog "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1beta1"
+	"github.com/kubernetes-incubator/service-catalog/pkg/common"
 	scfeatures "github.com/kubernetes-incubator/service-catalog/pkg/features"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -42,7 +43,7 @@ func WaitForBrokerCondition(client v1beta1servicecatalog.ServicecatalogV1beta1In
 	// GetCatalog default timeout time is 60 seconds, so the wait here must be at least that (previously set to 30 seconds)
 	return wait.PollImmediate(500*time.Millisecond, 3*time.Minute,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for broker %v condition %#v", name, condition)
+			klog.V(common.StatesInfoLogLevel).Infof("Waiting for broker %v condition %#v", name, condition)
 			broker, err := client.ClusterServiceBrokers().Get(name, metav1.GetOptions{})
 			if nil != err {
 				return false, fmt.Errorf("error getting Broker %v: %v", name, err)
@@ -52,7 +53,7 @@ func WaitForBrokerCondition(client v1beta1servicecatalog.ServicecatalogV1beta1In
 				return false, nil
 			}
 
-			glog.V(5).Infof("Conditions = %#v", broker.Status.Conditions)
+			klog.V(common.StatesDetailsInfoLogLevel).Infof("Conditions = %#v", broker.Status.Conditions)
 
 			for _, cond := range broker.Status.Conditions {
 				if condition.Type == cond.Type && condition.Status == cond.Status {
@@ -72,7 +73,7 @@ func WaitForBrokerCondition(client v1beta1servicecatalog.ServicecatalogV1beta1In
 func WaitForBrokerToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for broker %v to not exist", name)
+			klog.V(common.StatesInfoLogLevel).Infof("Waiting for broker %v to not exist", name)
 			_, err := client.ClusterServiceBrokers().Get(name, metav1.GetOptions{})
 			if nil == err {
 				return false, nil
@@ -92,7 +93,7 @@ func WaitForBrokerToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1I
 func WaitForClusterServiceClassToExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for serviceClass %v to exist", name)
+			klog.V(common.StatesInfoLogLevel).Infof("Waiting for serviceClass %v to exist", name)
 			_, err := client.ClusterServiceClasses().Get(name, metav1.GetOptions{})
 			if nil == err {
 				return true, nil
@@ -108,7 +109,7 @@ func WaitForClusterServiceClassToExist(client v1beta1servicecatalog.Servicecatal
 func WaitForClusterServicePlanToExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for ClusterServicePlan %v to exist", name)
+			klog.V(common.StatesInfoLogLevel).Infof("Waiting for ClusterServicePlan %v to exist", name)
 			_, err := client.ClusterServicePlans().Get(name, metav1.GetOptions{})
 			if nil == err {
 				return true, nil
@@ -124,7 +125,7 @@ func WaitForClusterServicePlanToExist(client v1beta1servicecatalog.Servicecatalo
 func WaitForClusterServicePlanToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for ClusterServicePlan %q to not exist", name)
+			klog.V(common.StatesInfoLogLevel).Infof("Waiting for ClusterServicePlan %q to not exist", name)
 			_, err := client.ClusterServicePlans().Get(name, metav1.GetOptions{})
 			if nil == err {
 				return false, nil
@@ -144,7 +145,7 @@ func WaitForClusterServicePlanToNotExist(client v1beta1servicecatalog.Servicecat
 func WaitForClusterServiceClassToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for serviceClass %v to not exist", name)
+			klog.V(common.StatesInfoLogLevel).Infof("Waiting for serviceClass %v to not exist", name)
 			_, err := client.ClusterServiceClasses().Get(name, metav1.GetOptions{})
 			if nil == err {
 				return false, nil
@@ -164,7 +165,7 @@ func WaitForClusterServiceClassToNotExist(client v1beta1servicecatalog.Serviceca
 func WaitForInstanceCondition(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, namespace, name string, condition v1beta1.ServiceInstanceCondition) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for instance %v/%v condition %#v", namespace, name, condition)
+			klog.V(common.StatesInfoLogLevel).Infof("Waiting for instance %v/%v condition %#v", namespace, name, condition)
 			instance, err := client.ServiceInstances(namespace).Get(name, metav1.GetOptions{})
 			if nil != err {
 				return false, fmt.Errorf("error getting Instance %v/%v: %v", namespace, name, err)
@@ -174,7 +175,7 @@ func WaitForInstanceCondition(client v1beta1servicecatalog.ServicecatalogV1beta1
 				return false, nil
 			}
 
-			glog.V(5).Infof("Conditions = %#v", instance.Status.Conditions)
+			klog.V(common.StatesDetailsInfoLogLevel).Infof("Conditions = %#v", instance.Status.Conditions)
 
 			for _, cond := range instance.Status.Conditions {
 				if condition.Type == cond.Type && condition.Status == cond.Status {
@@ -194,7 +195,7 @@ func WaitForInstanceCondition(client v1beta1servicecatalog.ServicecatalogV1beta1
 func WaitForInstanceToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, namespace, name string) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for instance %v/%v to not exist", namespace, name)
+			klog.V(common.StatesInfoLogLevel).Infof("Waiting for instance %v/%v to not exist", namespace, name)
 
 			_, err := client.ServiceInstances(namespace).Get(name, metav1.GetOptions{})
 			if nil == err {
@@ -215,7 +216,7 @@ func WaitForInstanceToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta
 func WaitForInstanceProcessedGeneration(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, namespace, name string, processedGeneration int64) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for instance %v/%v to have processed generation of %v", namespace, name, processedGeneration)
+			klog.V(common.StatesInfoLogLevel).Infof("Waiting for instance %v/%v to have processed generation of %v", namespace, name, processedGeneration)
 			instance, err := client.ServiceInstances(namespace).Get(name, metav1.GetOptions{})
 			if nil != err {
 				return false, fmt.Errorf("error getting Instance %v/%v: %v", namespace, name, err)
@@ -263,7 +264,7 @@ func WaitForBindingCondition(client v1beta1servicecatalog.ServicecatalogV1beta1I
 	var lastSeenCondition *v1beta1.ServiceBindingCondition
 	return lastSeenCondition, wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for binding %v/%v condition %#v", namespace, name, condition)
+			klog.V(common.StatesInfoLogLevel).Infof("Waiting for binding %v/%v condition %#v", namespace, name, condition)
 
 			binding, err := client.ServiceBindings(namespace).Get(name, metav1.GetOptions{})
 			if nil != err {
@@ -274,7 +275,7 @@ func WaitForBindingCondition(client v1beta1servicecatalog.ServicecatalogV1beta1I
 				return false, nil
 			}
 
-			glog.V(5).Infof("Conditions = %#v", binding.Status.Conditions)
+			klog.V(common.StatesDetailsInfoLogLevel).Infof("Conditions = %#v", binding.Status.Conditions)
 
 			for _, cond := range binding.Status.Conditions {
 				if condition.Type == cond.Type {
@@ -297,7 +298,7 @@ func WaitForBindingCondition(client v1beta1servicecatalog.ServicecatalogV1beta1I
 func WaitForBindingToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, namespace, name string) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for binding %v/%v to not exist", namespace, name)
+			klog.V(common.StatesInfoLogLevel).Infof("Waiting for binding %v/%v to not exist", namespace, name)
 
 			_, err := client.ServiceBindings(namespace).Get(name, metav1.GetOptions{})
 			if nil == err {
@@ -318,7 +319,7 @@ func WaitForBindingToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1
 func WaitForBindingReconciledGeneration(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, namespace, name string, reconciledGeneration int64) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for binding %v/%v to have reconciled generation of %v", namespace, name, reconciledGeneration)
+			klog.V(common.StatesInfoLogLevel).Infof("Waiting for binding %v/%v to have reconciled generation of %v", namespace, name, reconciledGeneration)
 			binding, err := client.ServiceBindings(namespace).Get(name, metav1.GetOptions{})
 			if nil != err {
 				return false, fmt.Errorf("error getting ServiceBinding %v/%v: %v", namespace, name, err)


### PR DESCRIPTION
This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

Replaced glog logger with klog.
Added constants for each info log level.
Replaced yardcoded log leveles with constants.

Fixes https://github.com/kubernetes-incubator/service-catalog/issues/2415

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
