### PR TITLE
Remove side effect import that is not needed anymore

### DIFF
--- a/cmd/controller-manager/app/controller_manager.go
+++ b/cmd/controller-manager/app/controller_manager.go
@@ -49,12 +49,6 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
-	// The API groups for our API must be installed before we can use the
-	// client to work with them.  This needs to be done once per process; this
-	// is the point at which we handle this for the controller-manager
-	// process.  Please do not remove.
-	_ "github.com/kubernetes-incubator/service-catalog/pkg/api"
-
 	"github.com/kubernetes-incubator/service-catalog/cmd/controller-manager/app/options"
 	servicecatalogv1beta1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	settingsv1alpha1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/settings/v1alpha1"


### PR DESCRIPTION
**What this PR does / why we need it**:
Global scheme is no longer used, see https://github.com/kubernetes-incubator/service-catalog/commit/d337ec4588ef5e9c0e06efbfe55e37a1ba8857ef
That import is a no-op.

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
