### PR TITLE
Use TRAVIS_TAG for svcat version when publishing

### DIFF
--- a/contrib/travis/deploy.sh
+++ b/contrib/travis/deploy.sh
@@ -24,7 +24,7 @@ docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
 
 if [[ "${TRAVIS_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[a-z]*(-(r|R)(c|C)[0-9]+)*$ ]]; then
     echo "Pushing images with tags '${TRAVIS_TAG}' and 'latest'."
-    VERSION="${TRAVIS_TAG}" MUTABLE_TAG="latest" make release-push svcat-publish
+    TAG_VERSION="${TRAVIS_TAG}" VERSION="${TRAVIS_TAG}" MUTABLE_TAG="latest" make release-push svcat-publish
 elif [[ "${TRAVIS_BRANCH}" == "master" ]]; then
     echo "Pushing images with default tags (git sha and 'canary')."
     make push svcat-publish


### PR DESCRIPTION
This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
This lets us redo an older build and still have the version used match what was expected. It is a reaction to what happened when we realized a week later that a release didn't deploy and we reran it in travis.

```
docker run --security-opt label:disable --rm -v /home/travis/build/kubernetes-incubator/service-catalog:/go/src/github.com/kubernetes-incubator/service-catalog -v /home/travis/build/kubernetes-incubator/service-catalog/.cache:/root/.cache/ -v /home/travis/build/kubernetes-incubator/service-catalog/.pkg:/go/pkg --env AZURE_STORAGE_CONNECTION_STRING scbuildimage az storage blob upload-batch -d cli -s bin/svcat
uploaded bin/svcat/latest/linux/amd64/svcat to https://svcat.blob.core.windows.net/cli/latest/linux/amd64/svcat
uploaded bin/svcat/latest/darwin/amd64/svcat to https://svcat.blob.core.windows.net/cli/latest/darwin/amd64/svcat
uploaded bin/svcat/v0.1.40-dirty/darwin/amd64/svcat to https://svcat.blob.core.windows.net/cli/v0.1.40-dirty/darwin/amd64/svcat
uploaded bin/svcat/v0.1.40-dirty/linux/amd64/svcat to https://svcat.blob.core.windows.net/cli/v0.1.40-dirty/linux/amd64/svcat
uploaded bin/svcat/latest/windows/amd64/svcat.exe to https://svcat.blob.core.windows.net/cli/latest/windows/amd64/svcat.exe
uploaded bin/svcat/v0.1.40-dirty/windows/amd64/svcat.exe to https://svcat.blob.core.windows.net/cli/v0.1.40-dirty/windows/amd64/svcat.exe
```

Note that the svcat version has -dirty on it, because it used git to figure out the version number. This ensures that we use the tag passed in from the travis environment variable instead.

**Which issue(s) this PR fixes** 
None.

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
