### PR TITLE
Init klog flags in ups-broker and test-broker

### DIFF
--- a/contrib/cmd/test-broker/test-broker.go
+++ b/contrib/cmd/test-broker/test-broker.go
@@ -32,6 +32,8 @@ import (
 	"k8s.io/klog"
 )
 
+var flags *flag.FlagSet
+
 var options struct {
 	Port    int
 	TLSCert string
@@ -39,13 +41,19 @@ var options struct {
 }
 
 func init() {
+	flags := flag.NewFlagSet("test-broker", flag.ExitOnError)
 	flag.IntVar(&options.Port, "port", 8005, "use '--port' option to specify the port for broker to listen on")
 	flag.StringVar(&options.TLSCert, "tlsCert", "", "base-64 encoded PEM block to use as the certificate for TLS. If '--tlsCert' is used, then '--tlsKey' must also be used. If '--tlsCert' is not used, then TLS will not be used.")
 	flag.StringVar(&options.TLSKey, "tlsKey", "", "base-64 encoded PEM block to use as the private key matching the TLS certificate. If '--tlsKey' is used, then '--tlsCert' must also be used")
-	flag.Parse()
+	klog.InitFlags(flags)
 }
 
 func main() {
+	err := flags.Parse(os.Args[1:])
+	if err != nil {
+		klog.Fatalln(err)
+	}
+	flag.Parse()
 	if err := run(); err != nil && err != context.Canceled && err != context.DeadlineExceeded {
 		klog.Fatalln(err)
 	}

--- a/contrib/cmd/user-broker/user-broker.go
+++ b/contrib/cmd/user-broker/user-broker.go
@@ -32,6 +32,8 @@ import (
 	"k8s.io/klog"
 )
 
+var flags *flag.FlagSet
+
 var options struct {
 	Port    int
 	TLSCert string
@@ -39,15 +41,19 @@ var options struct {
 }
 
 func init() {
-	flag.IntVar(&options.Port, "port", 8005, "use '--port' option to specify the port for broker to listen on")
-	flag.StringVar(&options.TLSCert, "tlsCert", "", "base-64 encoded PEM block to use as the certificate for TLS. If '--tlsCert' is used, then '--tlsKey' must also be used. If '--tlsCert' is not used, then TLS will not be used.")
-	flag.StringVar(&options.TLSKey, "tlsKey", "", "base-64 encoded PEM block to use as the private key matching the TLS certificate. If '--tlsKey' is used, then '--tlsCert' must also be used")
-	flag.Parse()
+	flags = flag.NewFlagSet("ups-broker", flag.ExitOnError)
+	flags.IntVar(&options.Port, "port", 8005, "use '--port' option to specify the port for broker to listen on")
+	flags.StringVar(&options.TLSCert, "tlsCert", "", "base-64 encoded PEM block to use as the certificate for TLS. If '--tlsCert' is used, then '--tlsKey' must also be used. If '--tlsCert' is not used, then TLS will not be used.")
+	flags.StringVar(&options.TLSKey, "tlsKey", "", "base-64 encoded PEM block to use as the private key matching the TLS certificate. If '--tlsKey' is used, then '--tlsCert' must also be used")
+	klog.InitFlags(flags)
 }
 
 func main() {
-	klog.InitFlags(nil)
-	if err := run(); err != nil && err != context.Canceled && err != context.DeadlineExceeded {
+	err := flags.Parse(os.Args[1:])
+	if err != nil {
+		klog.Fatalln(err)
+	}
+	if err = run(); err != nil && err != context.Canceled && err != context.DeadlineExceeded {
 		klog.Fatalln(err)
 	}
 }


### PR DESCRIPTION
Initting the logger flags works different in klog vs glog. In glog these were initted by default, but with klog these have to be manually added to the flag set for the executable.