### PR TITLE
Add securityContext 

### DIFF
--- a/charts/catalog/Chart.yaml
+++ b/charts/catalog/Chart.yaml
@@ -1,3 +1,3 @@
 name: catalog
 description: service-catalog API server and controller-manager helm chart
-version: 0.1.42
+version: 0.1.43

--- a/charts/catalog/Chart.yaml
+++ b/charts/catalog/Chart.yaml
@@ -1,3 +1,3 @@
 name: catalog
 description: service-catalog API server and controller-manager helm chart
-version: 0.1.43
+version: 0.1.42

--- a/charts/catalog/templates/apiserver-deployment.yaml
+++ b/charts/catalog/templates/apiserver-deployment.yaml
@@ -28,6 +28,10 @@ spec:
 {{ toYaml .Values.apiserver.annotations | indent 8 }}
       {{- end }}
     spec:
+{{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}        
       serviceAccountName: "{{ .Values.apiserver.serviceAccount }}"
       containers:
       - name: apiserver

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -28,6 +28,10 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+{{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}        
       serviceAccountName: "{{ .Values.controllerManager.serviceAccount }}"
       containers:
       - name: controller-manager

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -179,3 +179,7 @@ asyncBindingOperationsEnabled: false
 namespacedServiceBrokerDisabled: false
 # Whether the ServicePlanDefaults alpha feature should be enabled
 servicePlanDefaultsEnabled: false
+## Security context give the opportunity to run container as nonroot by setting a securityContext 
+## by example :
+## securityContext: { runAsUser: 1001 }
+securityContext: {}


### PR DESCRIPTION
This PR is a 
 - [X] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
This PR add the opportunity to set a securityContext to be able to run serviceCatalog on a K8S with PodSecurityContext set as RunAsNonRoot
If you don't setup securityContext each deployment is staled with this :
![image](https://user-images.githubusercontent.com/23224162/50975652-658ca980-14ee-11e9-8ac9-4889d1ae5afa.png)
(see previous PR: https://github.com/kubernetes-incubator/service-catalog/pull/2545)
I do it again due to bad rebase

/assign kibbles-n-bytes 
@jberkhahn rebase done
@kibbles-n-bytes @pmorie

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [X] New feature 
   - [ ] Tests
   - [X] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
