### PR TITLE
Improve caching OSB clients

### DIFF
--- a/pkg/controller/controller_clusterservicebroker.go
+++ b/pkg/controller/controller_clusterservicebroker.go
@@ -124,10 +124,10 @@ func (c *controller) reconcileClusterServiceBrokerKey(key string) error {
 	return c.reconcileClusterServiceBroker(broker)
 }
 
-func (c *controller) updateClusterServiceBrokerClient(broker *v1beta1.ClusterServiceBroker) (osb.Client, error) {
+func (c *controller) clusterServiceBrokerClient(broker *v1beta1.ClusterServiceBroker) (osb.Client, error) {
 	pcb := pretty.NewClusterServiceBrokerContextBuilder(broker)
 	klog.V(4).Info(pcb.Message("Updating broker client"))
-	authConfig, err := getAuthCredentialsFromClusterServiceBroker(c.kubeClient, broker)
+	authConfig, err := c.getAuthCredentialsFromClusterServiceBroker(broker)
 	if err != nil {
 		s := fmt.Sprintf("Error getting broker auth credentials: %s", err)
 		klog.Info(pcb.Message(s))
@@ -169,7 +169,7 @@ func (c *controller) reconcileClusterServiceBroker(broker *v1beta1.ClusterServic
 	if broker.DeletionTimestamp == nil { // Add or update
 		klog.V(4).Info(pcb.Message("Processing adding/update event"))
 
-		brokerClient, err := c.updateClusterServiceBrokerClient(broker)
+		brokerClient, err := c.clusterServiceBrokerClient(broker)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -968,9 +968,9 @@ func (c *controller) pollServiceInstance(instance *v1beta1.ServiceInstance) erro
 	var brokerClient osb.Client
 	var err error
 	if instance.Spec.ClusterServiceClassSpecified() {
-		_, _, _, brokerClient, err = c.getClusterServiceClassPlanAndClusterServiceBroker(instance)
+		_, _, brokerClient, err = c.getClusterServiceClassAndClusterServiceBroker(instance)
 	} else {
-		_, _, _, brokerClient, err = c.getServiceClassPlanAndServiceBroker(instance)
+		_, _, brokerClient, err = c.getServiceClassAndServiceBroker(instance)
 	}
 	if err != nil {
 		return c.handleServiceInstanceReconciliationError(instance, err)

--- a/pkg/controller/controller_servicebroker.go
+++ b/pkg/controller/controller_servicebroker.go
@@ -114,9 +114,9 @@ func (c *controller) reconcileServiceBrokerKey(key string) error {
 	return c.reconcileServiceBroker(broker)
 }
 
-func (c *controller) updateServiceBrokerClient(broker *v1beta1.ServiceBroker) (osb.Client, error) {
+func (c *controller) serviceBrokerClient(broker *v1beta1.ServiceBroker) (osb.Client, error) {
 	pcb := pretty.NewServiceBrokerContextBuilder(broker)
-	authConfig, err := getAuthCredentialsFromServiceBroker(c.kubeClient, broker)
+	authConfig, err := c.getAuthCredentialsFromServiceBroker(broker)
 	if err != nil {
 		s := fmt.Sprintf("Error getting broker auth credentials: %s", err)
 		klog.Info(pcb.Message(s))
@@ -161,7 +161,7 @@ func (c *controller) reconcileServiceBroker(broker *v1beta1.ServiceBroker) error
 	if broker.DeletionTimestamp == nil { // Add or update
 		klog.V(4).Info(pcb.Message("Processing adding/update event"))
 
-		brokerClient, err := c.updateServiceBrokerClient(broker)
+		brokerClient, err := c.serviceBrokerClient(broker)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -45,6 +45,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
 	clientgofake "k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
@@ -2327,11 +2328,15 @@ func newTestController(t *testing.T, config fakeosb.FakeClientConfiguration) (
 	informerFactory := servicecataloginformers.NewSharedInformerFactory(fakeCatalogClient, 0)
 	serviceCatalogSharedInformers := informerFactory.Servicecatalog().V1beta1()
 
+	k8sInformerFactory := informers.NewSharedInformerFactory(fakeKubeClient, 0)
+	k8sInformers := k8sInformerFactory.Core().V1()
+
 	fakeRecorder := record.NewFakeRecorder(5)
 
 	// create a test controller
 	testController, err := NewController(
 		fakeKubeClient,
+		k8sInformers.Secrets(),
 		fakeCatalogClient.ServicecatalogV1beta1(),
 		serviceCatalogSharedInformers.ClusterServiceBrokers(),
 		serviceCatalogSharedInformers.ServiceBrokers(),


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
The idea of caching OSB clients was changed:
1. New client instance is created when it is not present in the cache
2. Secret with Auth data is alway fetched (from informer cache) - so there is no risk the auth data is outdated. If the auth data has beed changed - new OSB client will be created

**Which issue(s) this PR fixes** 
Fixes #2576 
Fixes #2563 



Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
