### PR TITLE
Increase apiserver resource requests and limits

### DIFF
--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -121,10 +121,10 @@ apiserver:
   resources:
     requests:
       cpu: 100m
-      memory: 20Mi
+      memory: 40Mi
     limits:
       cpu: 100m
-      memory: 30Mi
+      memory: 50Mi
 controllerManager:
   replicas: 1
   # updateStrategy for service-catalog; value values are "RollingUpdate" and "Recreate"


### PR DESCRIPTION
This PR is a 
 - [x] Bug Fix

**What this PR does / why we need it**:
We are using the service catalog with a catalog with two brokers and a catalog comprising a total of ~150 plans and ~5 services. With the default configuration, the apiserver is forcibly restarted every 30 mins by k8s due to an OOM error. This happens because the apiserver requires around ~35MB, but only has a resource memory limit of 30.
This PR increases the default memory resource request from 20 to 40 and the memory resource limit from 30 to 50 MB.


Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [x] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
