### PR TITLE
Fix RemoveFinalizerForBindings and RemoveBindingFinalizerByInstance tests

### DIFF
--- a/pkg/svcat/service-catalog/binding_test.go
+++ b/pkg/svcat/service-catalog/binding_test.go
@@ -359,9 +359,18 @@ var _ = Describe("Binding", func() {
 			}
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bindings).Should(ConsistOf(expectedBindingsToDelete[0], expectedBindingsToDelete[1]))
-			// The first action should be a get call because RemoveFinalizerForBinding calls RetrieveBinding to retrieve the ServiceBinding object
-			Expect(svcCatClient.Actions()[0].Matches("get", "servicebindings")).To(BeTrue())
-			Expect(svcCatClient.Actions()[1].Matches("update", "servicebindings")).To(BeTrue())
+			// Two of the actions should be get calls and the other two should be update calls
+			numGetCalls := 0
+			numUpdateCalls := 0
+			for _, action := range svcCatClient.Actions() {
+				if action.Matches("get", "servicebindings") {
+					numGetCalls++
+				} else if action.Matches("update", "servicebindings") {
+					numUpdateCalls++
+				}
+			}
+			Expect(numGetCalls).To(Equal(2))
+			Expect(numUpdateCalls).To(Equal(2))
 		})
 		It("Bubbles up errors", func() {
 			badClient := &fake.Clientset{}
@@ -379,9 +388,6 @@ var _ = Describe("Binding", func() {
 			Expect(bindings).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring(errorMessage))
-			// The first action should be a get call because RemoveFinalizerForBinding calls RetrieveBinding to retrieve the ServiceBinding object
-			Expect(badClient.Actions()[0].Matches("get", "servicebindings")).To(BeTrue())
-			Expect(badClient.Actions()[1].Matches("update", "servicebindings")).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**: 
@piotrmiskiewicz reported this problem to me earlier today. Because two goroutines of calling `RemoveFinalizerForBinding` are spawn from `RemoveFinalizerForBindings`, the order of `get` and `update` actions is indeterministic. This PR fixes the two tests of `RemoveFinalizerForBindings` and `RemoveBindingFinalizerByInstance` that are affected by this problem.

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
