### PR TITLE
Add namespaced e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ $(BINDIR)/%-gen: $$(shell find vendor/k8s.io/code-generator/cmd/$$*-gen vendor/k
 
 .PHONY: $(BINDIR)/e2e.test
 $(BINDIR)/e2e.test: .init
-	$(DOCKER_CMD) go test -c -o $@ $(SC_PKG)/test/e2e
+	$(DOCKER_CMD) env GOOS=$(CLIENT_PLATFORM) GOARCH=$(ARCH) go test -c -o $@ $(SC_PKG)/test/e2e
 
 # Regenerate all files if the gen exes changed or any "types.go" files changed
 .generate_files: .init generators $(TYPES_FILES)

--- a/cmd/healthcheck/framework/healthcheck.go
+++ b/cmd/healthcheck/framework/healthcheck.go
@@ -197,7 +197,7 @@ func (h *HealthCheck) verifyBrokerIsReady() error {
 		return h.setError("broker not ready: %v", err.Error())
 	}
 
-	err = util.WaitForClusterServiceClassToExist(h.serviceCatalogClientSet.ServicecatalogV1beta1(), h.serviceclassID)
+	err = util.WaitForServiceClassToExist(h.serviceCatalogClientSet.ServicecatalogV1beta1(), h.serviceclassID)
 	if err != nil {
 		return h.setError("service class not found: %v", err.Error())
 	}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -24,13 +24,13 @@ import (
 
 	"github.com/kubernetes-incubator/service-catalog/test/e2e/framework"
 
-	"k8s.io/klog"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/gomega"
+	"k8s.io/klog"
 )
 
-// TestE2E checks configuration parameters (specified through flags) and then runs
+// RunE2ETests checks configuration parameters (specified through flags) and then runs
 // E2E tests using the Ginkgo runner.
 func RunE2ETests(t *testing.T) {
 	logs.InitLogs()

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -17,20 +17,15 @@ limitations under the License.
 package e2e
 
 import (
-	"flag"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd"
 
-	"k8s.io/klog"
 	"github.com/kubernetes-incubator/service-catalog/test/e2e/framework"
+	"k8s.io/klog"
 )
 
-var brokerImageFlag string
-
 func init() {
-	flag.StringVar(&brokerImageFlag, "broker-image", "quay.io/kubernetes-service-catalog/user-broker:latest",
-		"The container image for the broker to test against")
 	framework.RegisterParseFlags()
 
 	if "" == framework.TestContext.KubeConfig {

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -30,6 +30,7 @@ const (
 )
 
 type TestContextType struct {
+	BrokerImage           string
 	KubeHost              string
 	KubeConfig            string
 	KubeContext           string
@@ -51,6 +52,8 @@ func RegisterCommonFlags() {
 	// Randomize specs as well as suites
 	config.GinkgoConfig.RandomizeAllSpecs = true
 
+	flag.StringVar(&TestContext.BrokerImage, "broker-image", "quay.io/kubernetes-service-catalog/user-broker:latest",
+		"The container image for the broker to test against")
 	flag.StringVar(&TestContext.KubeHost, "kubernetes-host", "http://127.0.0.1:8080", "The kubernetes host, or apiserver, to connect to")
 	flag.StringVar(&TestContext.KubeConfig, "kubernetes-config", os.Getenv(clientcmd.RecommendedConfigPathEnvVar), "Path to config containing embedded authinfo for kubernetes. Default value is from environment variable "+clientcmd.RecommendedConfigPathEnvVar)
 	flag.StringVar(&TestContext.KubeContext, "kubernetes-context", "", "config context to use for kubernetes. If unset, will use value from 'current-context'")

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e
 
 import (
+	"github.com/kubernetes-incubator/service-catalog/test/e2e/framework"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -34,7 +35,7 @@ func NewUPSBrokerPod(name string) *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:  name,
-					Image: brokerImageFlag,
+					Image: framework.TestContext.BrokerImage,
 					Args: []string{
 						"--port",
 						"8080",

--- a/test/e2e/walkthrough.go
+++ b/test/e2e/walkthrough.go
@@ -32,7 +32,21 @@ import (
 var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 	f := framework.NewDefaultFramework("walkthrough-example")
 
-	upsbrokername := "ups-broker"
+	var (
+		upsbrokername                  = "ups-broker"
+		brokerName                     = upsbrokername
+		serviceclassName               = "user-provided-service"
+		serviceclassID                 = "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
+		serviceplanID                  = "86064792-7ea2-467b-af93-ac9694d96d52"
+		serviceclassNameWithSinglePlan = "user-provided-service-single-plan"
+		serviceclassIDWithSinglePlan   = "5f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
+		testns                         = "test-ns"
+		instanceName                   = "ups-instance"
+		bindingName                    = "ups-binding"
+		instanceNameDef                = "ups-instance-def"
+		instanceNameK8sNames           = "ups-instance-k8s-names"
+		instanceNameK8sNamesDef        = "ups-instance-k8s-names-def"
+	)
 
 	BeforeEach(func() {
 		// Deploy the ups-broker
@@ -74,22 +88,7 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("Runs through the walkthrough", func() {
-		var (
-			brokerName                     = upsbrokername
-			serviceclassName               = "user-provided-service"
-			serviceclassID                 = "4f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
-			serviceplanID                  = "86064792-7ea2-467b-af93-ac9694d96d52"
-			serviceclassNameWithSinglePlan = "user-provided-service-single-plan"
-			serviceclassIDWithSinglePlan   = "5f6e6cf6-ffdd-425f-a2c7-3c9258ad2468"
-			testns                         = "test-ns"
-			instanceName                   = "ups-instance"
-			bindingName                    = "ups-binding"
-			instanceNameDef                = "ups-instance-def"
-			instanceNameK8sNames           = "ups-instance-k8s-names"
-			instanceNameK8sNamesDef        = "ups-instance-k8s-names-def"
-		)
-
+	It("Runs through the walkthrough with cluster resources", func() {
 		// Broker and ClusterServiceClass should become ready
 		By("Make sure the named ClusterServiceBroker does not exist before create")
 		if _, err := f.ServiceCatalogClientSet.ServicecatalogV1beta1().ClusterServiceBrokers().Get(brokerName, metav1.GetOptions{}); err == nil {
@@ -124,14 +123,14 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 				Status: v1beta1.ConditionTrue,
 			},
 		)
-		Expect(err).NotTo(HaveOccurred(), "failed to wait ClusterServiceBroker to be ready")
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for ClusterServiceBroker to be ready")
 
 		By("Waiting for ClusterServiceClass to be ready")
-		err = util.WaitForClusterServiceClassToExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), serviceclassID)
-		Expect(err).NotTo(HaveOccurred(), "failed to wait serviceclass to be ready")
+		err = util.WaitForServiceClassToExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), serviceclassID)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for ClusterServiceclass to be ready")
 
 		By("Waiting for ClusterServicePlan to be ready")
-		err = util.WaitForClusterServicePlanToExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), serviceplanID)
+		err = util.WaitForServicePlanToExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), serviceplanID)
 		Ω(err).ShouldNot(HaveOccurred(), "serviceplan never became ready")
 
 		// Provisioning a ServiceInstance and binding to it
@@ -165,7 +164,7 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 				Status: v1beta1.ConditionTrue,
 			},
 		)
-		Expect(err).NotTo(HaveOccurred(), "failed to wait instance to be ready")
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for instance to be ready")
 
 		// Make sure references have been resolved
 		By("References should have been resolved before ServiceInstance is ready ")
@@ -175,6 +174,278 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 		Expect(sc.Spec.ClusterServicePlanRef).NotTo(BeNil())
 		Expect(sc.Spec.ClusterServiceClassRef.Name).To(Equal(serviceclassID))
 		Expect(sc.Spec.ClusterServicePlanRef.Name).To(Equal(serviceplanID))
+
+		// Binding to the ServiceInstance
+		By("Creating a ServiceBinding")
+		binding := &v1beta1.ServiceBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bindingName,
+				Namespace: testnamespace.Name,
+			},
+			Spec: v1beta1.ServiceBindingSpec{
+				InstanceRef: v1beta1.LocalObjectReference{
+					Name: instanceName,
+				},
+				SecretName: "my-secret",
+			},
+		}
+		binding, err = f.ServiceCatalogClientSet.ServicecatalogV1beta1().ServiceBindings(testnamespace.Name).Create(binding)
+		Expect(err).NotTo(HaveOccurred(), "failed to create binding")
+		Expect(binding).NotTo(BeNil())
+
+		By("Waiting for ServiceBinding to be ready")
+		_, err = util.WaitForBindingCondition(f.ServiceCatalogClientSet.ServicecatalogV1beta1(),
+			testnamespace.Name,
+			bindingName,
+			v1beta1.ServiceBindingCondition{
+				Type:   v1beta1.ServiceBindingConditionReady,
+				Status: v1beta1.ConditionTrue,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for binding to be ready")
+
+		By("Secret should have been created after binding")
+		_, err = f.KubeClientSet.CoreV1().Secrets(testnamespace.Name).Get("my-secret", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred(), "failed to create secret after binding")
+
+		// Unbinding from the ServiceInstance
+		By("Deleting the ServiceBinding")
+		err = f.ServiceCatalogClientSet.ServicecatalogV1beta1().ServiceBindings(testnamespace.Name).Delete(bindingName, nil)
+		Expect(err).NotTo(HaveOccurred(), "failed to delete the binding")
+
+		By("Waiting for ServiceBinding to not exist")
+		err = util.WaitForBindingToNotExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), testnamespace.Name, bindingName)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Secret should been deleted after delete the binding")
+		_, err = f.KubeClientSet.CoreV1().Secrets(testnamespace.Name).Get("my-secret", metav1.GetOptions{})
+		Expect(err).To(HaveOccurred())
+
+		// Deprovisioning the ServiceInstance
+		By("Deleting the ServiceInstance")
+		err = f.ServiceCatalogClientSet.ServicecatalogV1beta1().ServiceInstances(testnamespace.Name).Delete(instanceName, nil)
+		Expect(err).NotTo(HaveOccurred(), "failed to delete the instance")
+
+		By("Waiting for ServiceInstance to not exist")
+		err = util.WaitForInstanceToNotExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), testnamespace.Name, instanceName)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a ServiceInstance using a default plan")
+		instanceDef := &v1beta1.ServiceInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      instanceNameDef,
+				Namespace: testnamespace.Name,
+			},
+			Spec: v1beta1.ServiceInstanceSpec{
+				PlanReference: v1beta1.PlanReference{
+					ClusterServiceClassExternalName: serviceclassNameWithSinglePlan,
+				},
+			},
+		}
+		instance, err = f.ServiceCatalogClientSet.ServicecatalogV1beta1().ServiceInstances(testnamespace.Name).Create(instanceDef)
+		Expect(err).NotTo(HaveOccurred(), "failed to create instance with default plan")
+		Expect(instanceDef).NotTo(BeNil())
+
+		By("Waiting for ServiceInstance to be ready")
+		err = util.WaitForInstanceCondition(f.ServiceCatalogClientSet.ServicecatalogV1beta1(),
+			testnamespace.Name,
+			instanceNameDef,
+			v1beta1.ServiceInstanceCondition{
+				Type:   v1beta1.ServiceInstanceConditionReady,
+				Status: v1beta1.ConditionTrue,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for instance with default plan to be ready")
+
+		// Deprovisioning the ServiceInstance with default plan
+		By("Deleting the ServiceInstance with default plan")
+		err = f.ServiceCatalogClientSet.ServicecatalogV1beta1().ServiceInstances(testnamespace.Name).Delete(instanceNameDef, nil)
+		Expect(err).NotTo(HaveOccurred(), "failed to delete the instance with default plan")
+
+		By("Waiting for ServiceInstance with default plan to not exist")
+		err = util.WaitForInstanceToNotExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), testnamespace.Name, instanceNameDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a ServiceInstance using k8s names plan")
+		instanceK8SNames := &v1beta1.ServiceInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      instanceNameK8sNames,
+				Namespace: testnamespace.Name,
+			},
+			Spec: v1beta1.ServiceInstanceSpec{
+				PlanReference: v1beta1.PlanReference{
+					ClusterServiceClassName: serviceclassID,
+					ClusterServicePlanName:  serviceplanID,
+				},
+			},
+		}
+		instance, err = f.ServiceCatalogClientSet.ServicecatalogV1beta1().ServiceInstances(testnamespace.Name).Create(instanceK8SNames)
+		Expect(err).NotTo(HaveOccurred(), "failed to create instance with K8S names")
+		Expect(instanceK8SNames).NotTo(BeNil())
+
+		By("Waiting for ServiceInstance with k8s names to be ready")
+		err = util.WaitForInstanceCondition(f.ServiceCatalogClientSet.ServicecatalogV1beta1(),
+			testnamespace.Name,
+			instanceNameK8sNames,
+			v1beta1.ServiceInstanceCondition{
+				Type:   v1beta1.ServiceInstanceConditionReady,
+				Status: v1beta1.ConditionTrue,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for instance with k8s names to be ready")
+
+		// Deprovisioning the ServiceInstance with k8s names
+		By("Deleting the ServiceInstance with k8s names")
+		err = f.ServiceCatalogClientSet.ServicecatalogV1beta1().ServiceInstances(testnamespace.Name).Delete(instanceNameK8sNames, nil)
+		Expect(err).NotTo(HaveOccurred(), "failed to delete the instance with k8s names")
+
+		By("Waiting for ServiceInstance with k8s names to not exist")
+		err = util.WaitForInstanceToNotExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), testnamespace.Name, instanceNameK8sNames)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a ServiceInstance using k8s name and default plan")
+		instanceK8SNamesDef := &v1beta1.ServiceInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      instanceNameK8sNamesDef,
+				Namespace: testnamespace.Name,
+			},
+			Spec: v1beta1.ServiceInstanceSpec{
+				PlanReference: v1beta1.PlanReference{
+					ClusterServiceClassName: serviceclassIDWithSinglePlan,
+				},
+			},
+		}
+		instance, err = f.ServiceCatalogClientSet.ServicecatalogV1beta1().ServiceInstances(testnamespace.Name).Create(instanceK8SNamesDef)
+		Expect(err).NotTo(HaveOccurred(), "failed to create instance with K8S name and default plan")
+		Expect(instanceK8SNamesDef).NotTo(BeNil())
+
+		By("Waiting for ServiceInstance with k8s name and default plan to be ready")
+		err = util.WaitForInstanceCondition(f.ServiceCatalogClientSet.ServicecatalogV1beta1(),
+			testnamespace.Name,
+			instanceNameK8sNamesDef,
+			v1beta1.ServiceInstanceCondition{
+				Type:   v1beta1.ServiceInstanceConditionReady,
+				Status: v1beta1.ConditionTrue,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for instance with k8s name and default plan to be ready")
+
+		// Deprovisioning the ServiceInstance with k8s name and default plan
+		By("Deleting the ServiceInstance with k8s name and default plan")
+		err = f.ServiceCatalogClientSet.ServicecatalogV1beta1().ServiceInstances(testnamespace.Name).Delete(instanceNameK8sNamesDef, nil)
+		Expect(err).NotTo(HaveOccurred(), "failed to delete the instance with k8s name and default plan")
+
+		By("Waiting for ServiceInstance with k8s name and default plan to not exist")
+		err = util.WaitForInstanceToNotExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), testnamespace.Name, instanceNameK8sNamesDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Deleting the test namespace")
+		err = framework.DeleteKubeNamespace(f.KubeClientSet, testnamespace.Name)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Deleting ClusterServiceBroker and ClusterServiceClass
+		By("Deleting the ClusterServiceBroker")
+		err = f.ServiceCatalogClientSet.ServicecatalogV1beta1().ClusterServiceBrokers().Delete(brokerName, nil)
+		Expect(err).NotTo(HaveOccurred(), "failed to delete the broker")
+
+		By("Waiting for ClusterServiceBroker to not exist")
+		err = util.WaitForBrokerToNotExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), brokerName)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for ClusterServiceClass to not exist")
+		err = util.WaitForServiceClassToNotExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), serviceclassID)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Runs through the walkthrough with namespaced resources", func() {
+		// Everything has to run in a namespace
+		By("Creating a namespace")
+		testnamespace, err := framework.CreateKubeNamespace(testns, f.KubeClientSet)
+		Expect(err).NotTo(HaveOccurred(), "failed to create kube namespace")
+
+		// Broker and ServiceClass should become ready
+		By("Make sure the named ServiceBroker does not exist before create")
+		if _, err := f.ServiceCatalogClientSet.ServicecatalogV1beta1().ServiceBrokers(testnamespace.Name).Get(brokerName, metav1.GetOptions{}); err == nil {
+			err = f.ServiceCatalogClientSet.ServicecatalogV1beta1().ServiceBrokers(testnamespace.Name).Delete(brokerName, nil)
+			Expect(err).NotTo(HaveOccurred(), "failed to delete the broker")
+
+			By("Waiting for ServiceBroker to not exist")
+			err = util.WaitForBrokerToNotExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), brokerName, testnamespace.Name)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("Creating a ServiceBroker")
+		url := "http://" + upsbrokername + "." + f.Namespace.Name + ".svc.cluster.local"
+		broker := &v1beta1.ServiceBroker{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      brokerName,
+				Namespace: testnamespace.Name,
+			},
+			Spec: v1beta1.ServiceBrokerSpec{
+				CommonServiceBrokerSpec: v1beta1.CommonServiceBrokerSpec{
+					URL: url,
+				},
+			},
+		}
+		broker, err = f.ServiceCatalogClientSet.ServicecatalogV1beta1().ServiceBrokers(testnamespace.Name).Create(broker)
+		Expect(err).NotTo(HaveOccurred(), "failed to create ServiceBroker")
+
+		By("Waiting for ServiceBroker to be ready")
+		err = util.WaitForBrokerCondition(f.ServiceCatalogClientSet.ServicecatalogV1beta1(),
+			broker.Name,
+			v1beta1.ServiceBrokerCondition{
+				Type:   v1beta1.ServiceBrokerConditionReady,
+				Status: v1beta1.ConditionTrue,
+			},
+			testnamespace.Name,
+		)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for ServiceBroker to be ready")
+
+		By("Waiting for ServiceClass to be ready")
+		err = util.WaitForServiceClassToExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), serviceclassID, testnamespace.Name)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for ServiceClass to be ready")
+
+		By("Waiting for ServicePlan to be ready")
+		err = util.WaitForServicePlanToExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), serviceplanID, testnamespace.Name)
+		Ω(err).ShouldNot(HaveOccurred(), "serviceplan never became ready")
+
+		// Provisioning a ServiceInstance and binding to it
+		By("Creating a ServiceInstance")
+		instance := &v1beta1.ServiceInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      instanceName,
+				Namespace: testnamespace.Name,
+			},
+			Spec: v1beta1.ServiceInstanceSpec{
+				PlanReference: v1beta1.PlanReference{
+					ServiceClassExternalName: serviceclassName,
+					ServicePlanExternalName:  "default",
+				},
+			},
+		}
+		instance, err = f.ServiceCatalogClientSet.ServicecatalogV1beta1().ServiceInstances(testnamespace.Name).Create(instance)
+		Expect(err).NotTo(HaveOccurred(), "failed to create instance")
+		Expect(instance).NotTo(BeNil())
+
+		By("Waiting for ServiceInstance to be ready")
+		err = util.WaitForInstanceCondition(f.ServiceCatalogClientSet.ServicecatalogV1beta1(),
+			testnamespace.Name,
+			instanceName,
+			v1beta1.ServiceInstanceCondition{
+				Type:   v1beta1.ServiceInstanceConditionReady,
+				Status: v1beta1.ConditionTrue,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait instance to be ready")
+
+		// Make sure references have been resolved
+		By("References should have been resolved before ServiceInstance is ready ")
+		sc, err := f.ServiceCatalogClientSet.ServicecatalogV1beta1().ServiceInstances(testnamespace.Name).Get(instanceName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred(), "failed to get ServiceInstance after binding")
+		Expect(sc.Spec.ServiceClassRef).NotTo(BeNil())
+		Expect(sc.Spec.ServicePlanRef).NotTo(BeNil())
+		Expect(sc.Spec.ServiceClassRef.Name).To(Equal(serviceclassID))
+		Expect(sc.Spec.ServicePlanRef.Name).To(Equal(serviceplanID))
 
 		// Binding to the ServiceInstance
 		By("Creating a ServiceBinding")
@@ -239,7 +510,7 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 			},
 			Spec: v1beta1.ServiceInstanceSpec{
 				PlanReference: v1beta1.PlanReference{
-					ClusterServiceClassExternalName: serviceclassNameWithSinglePlan,
+					ServiceClassExternalName: serviceclassNameWithSinglePlan,
 				},
 			},
 		}
@@ -275,8 +546,8 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 			},
 			Spec: v1beta1.ServiceInstanceSpec{
 				PlanReference: v1beta1.PlanReference{
-					ClusterServiceClassName: serviceclassID,
-					ClusterServicePlanName:  serviceplanID,
+					ServiceClassName: serviceclassID,
+					ServicePlanName:  serviceplanID,
 				},
 			},
 		}
@@ -312,7 +583,7 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 			},
 			Spec: v1beta1.ServiceInstanceSpec{
 				PlanReference: v1beta1.PlanReference{
-					ClusterServiceClassName: serviceclassIDWithSinglePlan,
+					ServiceClassName: serviceclassIDWithSinglePlan,
 				},
 			},
 		}
@@ -344,17 +615,17 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 		err = framework.DeleteKubeNamespace(f.KubeClientSet, testnamespace.Name)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Deleting ClusterServiceBroker and ClusterServiceClass
-		By("Deleting the ClusterServiceBroker")
-		err = f.ServiceCatalogClientSet.ServicecatalogV1beta1().ClusterServiceBrokers().Delete(brokerName, nil)
+		// Deleting ServiceBroker and ServiceClass
+		By("Deleting the ServiceBroker")
+		err = f.ServiceCatalogClientSet.ServicecatalogV1beta1().ServiceBrokers(testnamespace.Name).Delete(brokerName, nil)
 		Expect(err).NotTo(HaveOccurred(), "failed to delete the broker")
 
-		By("Waiting for ClusterServiceBroker to not exist")
-		err = util.WaitForBrokerToNotExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), brokerName)
+		By("Waiting for ServiceBroker to not exist")
+		err = util.WaitForBrokerToNotExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), brokerName, testnamespace.Name)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for ClusterServiceClass to not exist")
-		err = util.WaitForClusterServiceClassToNotExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), serviceclassID)
+		By("Waiting for ServiceClass to not exist")
+		err = util.WaitForServiceClassToNotExist(f.ServiceCatalogClientSet.ServicecatalogV1beta1(), serviceclassID, testnamespace.Name)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/integration/controller_instance_test.go
+++ b/test/integration/controller_instance_test.go
@@ -185,7 +185,7 @@ func TestCreateServiceInstanceNonExistentClusterServiceBroker(t *testing.T) {
 				t.Fatalf("error creating ClusterServiceClass: %v", err)
 			}
 
-			if err := util.WaitForClusterServiceClassToExist(ct.client, testClusterServiceClassGUID); err != nil {
+			if err := util.WaitForServiceClassToExist(ct.client, testClusterServiceClassGUID); err != nil {
 				t.Fatalf("error waiting for ClusterServiceClass to exist: %v", err)
 			}
 
@@ -206,7 +206,7 @@ func TestCreateServiceInstanceNonExistentClusterServiceBroker(t *testing.T) {
 			if _, err := ct.client.ClusterServicePlans().Create(servicePlan); err != nil {
 				t.Fatalf("error creating ClusterServicePlan: %v", err)
 			}
-			if err := util.WaitForClusterServicePlanToExist(ct.client, testPlanExternalID); err != nil {
+			if err := util.WaitForServicePlanToExist(ct.client, testPlanExternalID); err != nil {
 				t.Fatalf("error waiting for ClusterServicePlan to exist: %v", err)
 			}
 		},
@@ -1312,10 +1312,10 @@ func TestCreateServiceInstanceFailsWithNonexistentPlan(t *testing.T) {
 			if _, err := ct.client.ClusterServiceBrokers().Update(ct.broker); err != nil {
 				t.Fatalf("error updating Broker: %v", err)
 			}
-			if err := util.WaitForClusterServicePlanToExist(ct.client, otherPlanID); err != nil {
+			if err := util.WaitForServicePlanToExist(ct.client, otherPlanID); err != nil {
 				t.Fatalf("error waiting for ClusterServiceClass to exist: %v", err)
 			}
-			if err := util.WaitForClusterServicePlanToNotExist(ct.client, testPlanExternalID); err != nil {
+			if err := util.WaitForServicePlanToNotExist(ct.client, testPlanExternalID); err != nil {
 				t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
 			}
 

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -1161,7 +1161,7 @@ func verifyBrokerCreated(t *testing.T, client clientsetsc.ServicecatalogV1beta1I
 		t.Fatalf("error waiting for broker to become ready: %v", err)
 	}
 
-	if err := util.WaitForClusterServiceClassToExist(client, testClusterServiceClassGUID); err != nil {
+	if err := util.WaitForServiceClassToExist(client, testClusterServiceClassGUID); err != nil {
 		t.Fatalf("error waiting from ClusterServiceClass to exist: %v", err)
 	}
 
@@ -1179,7 +1179,7 @@ func deleteBroker(t *testing.T, client clientsetsc.ServicecatalogV1beta1Interfac
 		t.Fatalf("broker should be deleted (%s)", err)
 	}
 
-	if err := util.WaitForClusterServiceClassToNotExist(client, testClusterServiceClassName); err != nil {
+	if err := util.WaitForServiceClassToNotExist(client, testClusterServiceClassName); err != nil {
 		t.Fatalf("error waiting for ClusterServiceClass to not exist: %v", err)
 	}
 

--- a/test/integration/deleted_services_and_plans_test.go
+++ b/test/integration/deleted_services_and_plans_test.go
@@ -41,7 +41,7 @@ func TestClusterServicePlanRemovedFromCatalogWithoutInstances(t *testing.T) {
 			t.Fatalf("error creating ClusterServicePlan: %v", err)
 		}
 
-		err = util.WaitForClusterServicePlanToExist(ct.client, testRemovedClusterServicePlanGUID)
+		err = util.WaitForServicePlanToExist(ct.client, testRemovedClusterServicePlanGUID)
 		if err != nil {
 			t.Fatalf("error waiting for ClusterServicePlan to exist: %v", err)
 		}
@@ -53,7 +53,7 @@ func TestClusterServicePlanRemovedFromCatalogWithoutInstances(t *testing.T) {
 			t.Fatalf("error marking ClusterServicePlan as removed from catalog: %v", err)
 		}
 
-		err = util.WaitForClusterServicePlanToNotExist(ct.client, testRemovedClusterServicePlanGUID)
+		err = util.WaitForServicePlanToNotExist(ct.client, testRemovedClusterServicePlanGUID)
 		if err != nil {
 			t.Fatalf("error waiting for remove ClusterServicePlan to not exist: %v", err)
 		}
@@ -99,7 +99,7 @@ func TestClusterServiceClassRemovedFromCatalogWithoutInstances(t *testing.T) {
 			t.Fatalf("error creating ClusterServiceClass: %v", err)
 		}
 
-		err = util.WaitForClusterServiceClassToExist(ct.client, testRemovedClusterServiceClassGUID)
+		err = util.WaitForServiceClassToExist(ct.client, testRemovedClusterServiceClassGUID)
 		if err != nil {
 			t.Fatalf("error waiting for ClusterServiceClass to exist: %v", err)
 		}
@@ -111,7 +111,7 @@ func TestClusterServiceClassRemovedFromCatalogWithoutInstances(t *testing.T) {
 			t.Fatalf("error marking ClusterServiceClass as removed from catalog: %v", err)
 		}
 
-		err = util.WaitForClusterServiceClassToNotExist(ct.client, testRemovedClusterServiceClassGUID)
+		err = util.WaitForServiceClassToNotExist(ct.client, testRemovedClusterServiceClassGUID)
 		if err != nil {
 			t.Fatalf("error waiting for remove ClusterServiceClass to not exist: %v", err)
 		}

--- a/test/integration/filtered_services_and_plans_test.go
+++ b/test/integration/filtered_services_and_plans_test.go
@@ -56,7 +56,7 @@ func TestClusterServiceClassRemovedFromCatalogAfterFiltering(t *testing.T) {
 
 		time.Sleep(time.Millisecond * 300)
 
-		err := util.WaitForClusterServiceClassToNotExist(ct.client, uuid)
+		err := util.WaitForServiceClassToNotExist(ct.client, uuid)
 		if err != nil {
 			t.Fatalf("error waiting for remove ClusterServiceClass to not exist: %v", err)
 		}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -32,29 +32,38 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	v1beta1servicecatalog "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1beta1"
 	scfeatures "github.com/kubernetes-incubator/service-catalog/pkg/features"
+	servicecatalog "github.com/kubernetes-incubator/service-catalog/pkg/svcat/service-catalog"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 // WaitForBrokerCondition waits for the status of the named broker to contain
-// a condition whose type and status matches the supplied one.
-func WaitForBrokerCondition(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string, condition v1beta1.ServiceBrokerCondition) error {
+// a condition whose type and status matches the supplied one. Checks for a
+// ClusterServiceBroker by default, a ServiceBroker if a namespace is provided
+func WaitForBrokerCondition(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string, condition v1beta1.ServiceBrokerCondition, namespace ...string) error {
 	// GetCatalog default timeout time is 60 seconds, so the wait here must be at least that (previously set to 30 seconds)
+	var err error
+	var broker servicecatalog.Broker
 	return wait.PollImmediate(500*time.Millisecond, 3*time.Minute,
 		func() (bool, error) {
-			klog.V(5).Infof("Waiting for broker %v condition %#v", name, condition)
-			broker, err := client.ClusterServiceBrokers().Get(name, metav1.GetOptions{})
+			if len(namespace) == 0 {
+				klog.V(5).Infof("Waiting for ClusterServiceBroker %v condition %#v", name, condition)
+				broker, err = client.ClusterServiceBrokers().Get(name, metav1.GetOptions{})
+			} else {
+				klog.V(5).Infof("Waiting for ServiceBroker %v in namespace %v to have condition %#v", name, namespace[0], condition)
+				broker, err = client.ServiceBrokers(namespace[0]).Get(name, metav1.GetOptions{})
+			}
 			if nil != err {
 				return false, fmt.Errorf("error getting Broker %v: %v", name, err)
 			}
 
-			if len(broker.Status.Conditions) == 0 {
+			if len(broker.GetStatus().Conditions) == 0 {
 				return false, nil
 			}
 
-			klog.V(5).Infof("Conditions = %#v", broker.Status.Conditions)
+			klog.V(5).Infof("Conditions = %#v", broker.GetStatus().Conditions)
 
-			for _, cond := range broker.Status.Conditions {
+			for _, cond := range broker.GetStatus().Conditions {
 				if condition.Type == cond.Type && condition.Status == cond.Status {
 					if condition.Reason == "" || condition.Reason == cond.Reason {
 						return true, nil
@@ -68,12 +77,19 @@ func WaitForBrokerCondition(client v1beta1servicecatalog.ServicecatalogV1beta1In
 }
 
 // WaitForBrokerToNotExist waits for the Broker with the given name to no
-// longer exist.
-func WaitForBrokerToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {
+// longer exist. Checks for ClusterServiceBrokers by default, ServiceBrokers
+// if a namespace is provided
+func WaitForBrokerToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string, namespace ...string) error {
+	var err error
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			klog.V(5).Infof("Waiting for broker %v to not exist", name)
-			_, err := client.ClusterServiceBrokers().Get(name, metav1.GetOptions{})
+			if len(namespace) == 0 {
+				klog.V(5).Infof("Waiting for ClusterServiceBroker %v to not exist", name)
+				_, err = client.ClusterServiceBrokers().Get(name, metav1.GetOptions{})
+			} else {
+				klog.V(5).Infof("Waiting for ServiceBroker %v in namespace %v to not exist", name, namespace[0])
+				_, err = client.ServiceBrokers(namespace[0]).Get(name, metav1.GetOptions{})
+			}
 			if nil == err {
 				return false, nil
 			}
@@ -87,13 +103,20 @@ func WaitForBrokerToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1I
 	)
 }
 
-// WaitForClusterServiceClassToExist waits for the ClusterServiceClass with the given name
-// to exist.
-func WaitForClusterServiceClassToExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {
+// WaitForServiceClassToExist waits for the ServiceClass with the given name
+// to exist. Checks for a ClusterServiceClass by default, a ServiceClass if
+// a namespace is provided
+func WaitForServiceClassToExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string, namespace ...string) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			klog.V(5).Infof("Waiting for serviceClass %v to exist", name)
-			_, err := client.ClusterServiceClasses().Get(name, metav1.GetOptions{})
+			var err error
+			if len(namespace) == 0 {
+				klog.V(5).Infof("Waiting for ClusterServiceClass %v to exist", name)
+				_, err = client.ClusterServiceClasses().Get(name, metav1.GetOptions{})
+			} else {
+				klog.V(5).Infof("Waiting for ServiceClass %v in namespace %v to exist", name, namespace[0])
+				_, err = client.ServiceClasses(namespace[0]).Get(name, metav1.GetOptions{})
+			}
 			if nil == err {
 				return true, nil
 			}
@@ -103,13 +126,20 @@ func WaitForClusterServiceClassToExist(client v1beta1servicecatalog.Servicecatal
 	)
 }
 
-// WaitForClusterServicePlanToExist waits for the ClusterServicePlan
-// with the given name to exist.
-func WaitForClusterServicePlanToExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {
+// WaitForServicePlanToExist waits for the ServicePlan
+// with the given name to exist. Checks for ClusterServicePlans
+// by default, ServicePlans if a namespace is provided
+func WaitForServicePlanToExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string, namespace ...string) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			klog.V(5).Infof("Waiting for ClusterServicePlan %v to exist", name)
-			_, err := client.ClusterServicePlans().Get(name, metav1.GetOptions{})
+			var err error
+			if len(namespace) == 0 {
+				klog.V(5).Infof("Waiting for ClusterServicePlan %v to exist", name)
+				_, err = client.ClusterServicePlans().Get(name, metav1.GetOptions{})
+			} else {
+				klog.V(5).Infof("Waiting for ServicePlan %v in namespace %v to exist", name, namespace[0])
+				_, err = client.ServicePlans(namespace[0]).Get(name, metav1.GetOptions{})
+			}
 			if nil == err {
 				return true, nil
 			}
@@ -119,13 +149,20 @@ func WaitForClusterServicePlanToExist(client v1beta1servicecatalog.Servicecatalo
 	)
 }
 
-// WaitForClusterServicePlanToNotExist waits for the ClusterServicePlan with the given name
-// to not exist.
-func WaitForClusterServicePlanToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {
+// WaitForServicePlanToNotExist waits for the plan with the given name
+// to not exist. Looks for ClusterServicePlans by default, ServicePlans if a
+// namespace is provided
+func WaitForServicePlanToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string, namespace ...string) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			klog.V(5).Infof("Waiting for ClusterServicePlan %q to not exist", name)
-			_, err := client.ClusterServicePlans().Get(name, metav1.GetOptions{})
+			var err error
+			if len(namespace) == 0 {
+				klog.V(5).Infof("Waiting for ClusterServicePlan %q to not exist", name)
+				_, err = client.ClusterServicePlans().Get(name, metav1.GetOptions{})
+			} else {
+				klog.V(5).Infof("Waiting for ServicePlan %q in namespace %v to not exist", name, namespace[0])
+				_, err = client.ServicePlans(namespace[0]).Get(name, metav1.GetOptions{})
+			}
 			if nil == err {
 				return false, nil
 			}
@@ -139,13 +176,20 @@ func WaitForClusterServicePlanToNotExist(client v1beta1servicecatalog.Servicecat
 	)
 }
 
-// WaitForClusterServiceClassToNotExist waits for the ClusterServiceClass with the given
-// name to no longer exist.
-func WaitForClusterServiceClassToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string) error {
+// WaitForServiceClassToNotExist waits for the class with the given
+// name to no longer exist. Looks for ClusterServiceClasses by default,
+// ServiceClasses if a namespace is provided
+func WaitForServiceClassToNotExist(client v1beta1servicecatalog.ServicecatalogV1beta1Interface, name string, namespace ...string) error {
 	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
 		func() (bool, error) {
-			klog.V(5).Infof("Waiting for serviceClass %v to not exist", name)
-			_, err := client.ClusterServiceClasses().Get(name, metav1.GetOptions{})
+			var err error
+			if len(namespace) == 0 {
+				klog.V(5).Infof("Waiting for ClusterServiceClass %v to not exist", name)
+				_, err = client.ClusterServiceClasses().Get(name, metav1.GetOptions{})
+			} else {
+				klog.V(5).Infof("Waiting for ServiceClass %v in namespace %v to not exist", name, namespace[0])
+				_, err = client.ServiceClasses(namespace[0]).Get(name, metav1.GetOptions{})
+			}
 			if nil == err {
 				return false, nil
 			}


### PR DESCRIPTION
- add e2e tests that use namespace resources
- change build-e2e make target to compile on host os/arch
- refactor test/util helper methods to work on both cluster/ns resources

This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

Fixes #2408 

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
