### PR TITLE
Remove badge for unused Jenkins build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ## `service-catalog`
 
 [![Build Status](https://travis-ci.org/kubernetes-incubator/service-catalog.svg?branch=master)](https://travis-ci.org/kubernetes-incubator/service-catalog "Travis")
-[![Build Status](https://service-catalog-jenkins.appspot.com/buildStatus/icon?job=service-catalog-master-testing)](https://service-catalog-jenkins.appspot.com/job/service-catalog-master-testing/ "Jenkins")
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes-incubator/service-catalog)](https://goreportcard.com/report/github.com/kubernetes-incubator/service-catalog)
 
 <p align="center">


### PR DESCRIPTION
This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix (kinda?)
 - [ ] Documentation

**What this PR does / why we need it**:
The badge in the readme is broken. According to https://github.com/kubernetes-incubator/service-catalog/issues/2184, this build hasn't been in use since at least September.

**Which issue(s) this PR fixes** 
Fixes (none)

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
