### PR TITLE
add default values for apiVersion to be able to use helm template

### DIFF
--- a/charts/catalog/templates/_helpers.tpl
+++ b/charts/catalog/templates/_helpers.tpl
@@ -17,5 +17,7 @@ This will select v1 before v1beta1 if both are available.
 rbac.authorization.k8s.io/v1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" -}}
 rbac.authorization.k8s.io/v1beta1
+{{- else -}}
+rbac.authorization.k8s.io/v1beta1
 {{- end -}}
 {{- end -}}

--- a/charts/catalog/templates/apiregistration.yaml
+++ b/charts/catalog/templates/apiregistration.yaml
@@ -8,6 +8,8 @@
 apiVersion: apiregistration.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "apiregistration.k8s.io/v1alpha1" }}
 apiVersion: apiregistration.k8s.io/v1alpha1
+{{- else }}
+apiVersion: apiregistration.k8s.io/v1beta1
 {{- end }}
 kind: APIService
 metadata:
@@ -22,6 +24,9 @@ spec:
   {{ if .Capabilities.APIVersions.Has "apiregistration.k8s.io/v1alpha1" -}}
   priority: {{ .Values.apiserver.aggregator.priority }}
   {{ else if .Capabilities.APIVersions.Has "apiregistration.k8s.io/v1beta1" -}}
+  groupPriorityMinimum: {{ .Values.apiserver.aggregator.groupPriorityMinimum }}
+  versionPriority: {{ .Values.apiserver.aggregator.versionPriority }}
+  {{ else -}}
   groupPriorityMinimum: {{ .Values.apiserver.aggregator.groupPriorityMinimum }}
   versionPriority: {{ .Values.apiserver.aggregator.versionPriority }}
   {{- end }}


### PR DESCRIPTION
add default values in Helm chart `service-catalog` for apiVersion to be able to use helm template without talking to API

 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
The issue described in #2592. This PR adds default values for `apiVersion` that currently are not set when using `helm template` because `.Capabilities.APIVersions.Has` is empty:
```console
$ helm template --name=catalog --namespace=default . | kubectl apply --dry-run -f -
service/catalog-catalog-apiserver created (dry run)
deployment.extensions/catalog-catalog-apiserver created (dry run)
deployment.extensions/catalog-catalog-controller-manager created (dry run)
error: error validating "STDIN": error validating data: apiVersion not set; if you choose to ignore these errors, turn validation off with --validate=false
```
After fixing it:
```console
$ helm template --name=catalog --namespace=default . | kubectl apply --dry-run -f -
service/catalog-catalog-apiserver created (dry run)
deployment.extensions/catalog-catalog-apiserver created (dry run)
deployment.extensions/catalog-catalog-controller-manager created (dry run)
apiservice.apiregistration.k8s.io/v1beta1.servicecatalog.k8s.io created (dry run)
secret/catalog-catalog-apiserver-cert created (dry run)
clusterrole.rbac.authorization.k8s.io/servicecatalog.k8s.io:apiserver created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/servicecatalog.k8s.io:apiserver created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/servicecatalog.k8s.io:apiserver-auth-delegator created (dry run)
rolebinding.rbac.authorization.k8s.io/servicecatalog.k8s.io:apiserver-authentication-reader created (dry run)
clusterrole.rbac.authorization.k8s.io/servicecatalog.k8s.io:controller-manager created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/servicecatalog.k8s.io:controller-manager created (dry run)
role.rbac.authorization.k8s.io/servicecatalog.k8s.io:cluster-info-configmap created (dry run)
rolebinding.rbac.authorization.k8s.io/service-catalog-controller-manager-cluster-info created (dry run)
role.rbac.authorization.k8s.io/servicecatalog.k8s.io:leader-locking-controller-manager created (dry run)
rolebinding.rbac.authorization.k8s.io/service-catalog-controller-manager-leader-election created (dry run)
clusterrole.rbac.authorization.k8s.io/servicecatalog.k8s.io:service-catalog-readiness created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/servicecatalog.k8s.io:service-catalog-readiness created (dry run)
serviceaccount/service-catalog-apiserver created (dry run)
serviceaccount/service-catalog-controller-manager created (dry run)
```

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #2592

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
