### PR TITLE
Use 2 resources instead of a list

### DIFF
--- a/charts/catalog/templates/serviceaccounts.yaml
+++ b/charts/catalog/templates/serviceaccounts.yaml
@@ -1,13 +1,11 @@
+# The SA for the apiserver
 apiVersion: v1
-kind: List
-items:
-  # The SA for the apiserver
-  - apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: "{{ .Values.apiserver.serviceAccount }}"
-  # The SA for the controller-manager
-  - apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: "{{ .Values.controllerManager.serviceAccount }}"
+kind: ServiceAccount
+metadata:
+  name: "{{ .Values.apiserver.serviceAccount }}"
+---
+# The SA for the controller-manager
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ .Values.controllerManager.serviceAccount }}"


### PR DESCRIPTION
See #2603 for more details, but
- the indenting, while supported today, isn't 100% kosher and may not be supported in the future
- it's a bit odd to use a list, so while legal we should do what most people
  expect and do, just create two separate resources

Closes: #2603

Signed-off-by: Doug Davis <dug@us.ibm.com>