### PR TITLE
Make svcat broker commands with --wait support namespaced brokers

### DIFF
--- a/cmd/svcat/broker/register_cmd.go
+++ b/cmd/svcat/broker/register_cmd.go
@@ -145,7 +145,7 @@ func (c *RegisterCmd) Run() error {
 
 	if c.Wait {
 		fmt.Fprintln(c.Output, "Waiting for the broker to be registered...")
-		finalBroker, err := c.Context.App.WaitForBroker(c.BrokerName, c.Interval, c.Timeout)
+		finalBroker, err := c.Context.App.WaitForBroker(c.BrokerName, scopeOpts, c.Interval, c.Timeout)
 		if err == nil {
 			broker = finalBroker.(*v1beta1.ClusterServiceBroker)
 		}

--- a/cmd/svcat/broker/register_cmd_test.go
+++ b/cmd/svcat/broker/register_cmd_test.go
@@ -314,6 +314,7 @@ var _ = Describe("Register Command", func() {
 			}
 			cmd.Wait = true
 			cmd.Namespaced.ApplyNamespaceFlags(&pflag.FlagSet{})
+			cmd.Scope = servicecatalog.NamespaceScope
 			cmd.Waitable.ApplyWaitFlags()
 			cmd.Interval = interval
 			cmd.Timeout = &timeout
@@ -331,8 +332,13 @@ var _ = Describe("Register Command", func() {
 			Expect(*returnedOpts).To(Equal(opts))
 
 			Expect(fakeSDK.WaitForBrokerCallCount()).To(Equal(1))
-			waitName, waitInterval, waitTimeout := fakeSDK.WaitForBrokerArgsForCall(0)
+			waitName, returnedScope, waitInterval, waitTimeout := fakeSDK.WaitForBrokerArgsForCall(0)
+
 			Expect(waitName).To(Equal(brokerName))
+			Expect(returnedScope).To(Equal(&servicecatalog.ScopeOptions{
+				Namespace: namespace,
+				Scope:     servicecatalog.NamespaceScope,
+			}))
 			Expect(waitInterval).To(Equal(interval))
 			Expect(*waitTimeout).To(Equal(timeout))
 

--- a/pkg/svcat/service-catalog/broker.go
+++ b/pkg/svcat/service-catalog/broker.go
@@ -310,14 +310,14 @@ func (sdk *SDK) Sync(name string, scopeOpts ScopeOptions, retries int) error {
 }
 
 // WaitForBroker waits for the specified broker to be Ready or Failed
-func (sdk *SDK) WaitForBroker(name string, interval time.Duration, timeout *time.Duration) (broker Broker, err error) {
+func (sdk *SDK) WaitForBroker(name string, opts *ScopeOptions, interval time.Duration, timeout *time.Duration) (broker Broker, err error) {
 	if timeout == nil {
 		notimeout := time.Duration(math.MaxInt64)
 		timeout = &notimeout
 	}
 	err = wait.PollImmediate(interval, *timeout,
 		func() (bool, error) {
-			broker, err = sdk.retrieveBroker(name)
+			broker, err = sdk.RetrieveBrokerByID(name, *opts)
 			if err != nil {
 				if apierrors.IsNotFound(errors.Cause(err)) {
 					err = nil

--- a/pkg/svcat/service-catalog/sdk.go
+++ b/pkg/svcat/service-catalog/sdk.go
@@ -53,7 +53,7 @@ type SvcatClient interface {
 	RetrieveBrokerByClass(*apiv1beta1.ClusterServiceClass) (*apiv1beta1.ClusterServiceBroker, error)
 	Register(string, string, *RegisterOptions, *ScopeOptions) (Broker, error)
 	Sync(string, ScopeOptions, int) error
-	WaitForBroker(string, time.Duration, *time.Duration) (Broker, error)
+	WaitForBroker(string, *ScopeOptions, time.Duration, *time.Duration) (Broker, error)
 
 	RetrieveClasses(ScopeOptions) ([]Class, error)
 	RetrieveClassByName(string, ScopeOptions) (Class, error)

--- a/pkg/svcat/service-catalog/service-catalogfakes/fake_svcat_client.go
+++ b/pkg/svcat/service-catalog/service-catalogfakes/fake_svcat_client.go
@@ -303,12 +303,13 @@ type FakeSvcatClient struct {
 	syncReturnsOnCall map[int]struct {
 		result1 error
 	}
-	WaitForBrokerStub        func(string, time.Duration, *time.Duration) (servicecatalog.Broker, error)
+	WaitForBrokerStub        func(string, *servicecatalog.ScopeOptions, time.Duration, *time.Duration) (servicecatalog.Broker, error)
 	waitForBrokerMutex       sync.RWMutex
 	waitForBrokerArgsForCall []struct {
 		arg1 string
-		arg2 time.Duration
-		arg3 *time.Duration
+		arg2 *servicecatalog.ScopeOptions
+		arg3 time.Duration
+		arg4 *time.Duration
 	}
 	waitForBrokerReturns struct {
 		result1 servicecatalog.Broker
@@ -1707,18 +1708,19 @@ func (fake *FakeSvcatClient) SyncReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeSvcatClient) WaitForBroker(arg1 string, arg2 time.Duration, arg3 *time.Duration) (servicecatalog.Broker, error) {
+func (fake *FakeSvcatClient) WaitForBroker(arg1 string, arg2 *servicecatalog.ScopeOptions, arg3 time.Duration, arg4 *time.Duration) (servicecatalog.Broker, error) {
 	fake.waitForBrokerMutex.Lock()
 	ret, specificReturn := fake.waitForBrokerReturnsOnCall[len(fake.waitForBrokerArgsForCall)]
 	fake.waitForBrokerArgsForCall = append(fake.waitForBrokerArgsForCall, struct {
 		arg1 string
-		arg2 time.Duration
-		arg3 *time.Duration
-	}{arg1, arg2, arg3})
-	fake.recordInvocation("WaitForBroker", []interface{}{arg1, arg2, arg3})
+		arg2 *servicecatalog.ScopeOptions
+		arg3 time.Duration
+		arg4 *time.Duration
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("WaitForBroker", []interface{}{arg1, arg2, arg3, arg4})
 	fake.waitForBrokerMutex.Unlock()
 	if fake.WaitForBrokerStub != nil {
-		return fake.WaitForBrokerStub(arg1, arg2, arg3)
+		return fake.WaitForBrokerStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1732,10 +1734,10 @@ func (fake *FakeSvcatClient) WaitForBrokerCallCount() int {
 	return len(fake.waitForBrokerArgsForCall)
 }
 
-func (fake *FakeSvcatClient) WaitForBrokerArgsForCall(i int) (string, time.Duration, *time.Duration) {
+func (fake *FakeSvcatClient) WaitForBrokerArgsForCall(i int) (string, *servicecatalog.ScopeOptions, time.Duration, *time.Duration) {
 	fake.waitForBrokerMutex.RLock()
 	defer fake.waitForBrokerMutex.RUnlock()
-	return fake.waitForBrokerArgsForCall[i].arg1, fake.waitForBrokerArgsForCall[i].arg2, fake.waitForBrokerArgsForCall[i].arg3
+	return fake.waitForBrokerArgsForCall[i].arg1, fake.waitForBrokerArgsForCall[i].arg2, fake.waitForBrokerArgsForCall[i].arg3, fake.waitForBrokerArgsForCall[i].arg4
 }
 
 func (fake *FakeSvcatClient) WaitForBrokerReturns(result1 servicecatalog.Broker, result2 error) {


### PR DESCRIPTION
This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
svcat broker commands with the --wait flag now wait for namespaced brokers

**Which issue(s) this PR fixes** 
fixes #2593

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
