### PR TITLE
Enable use of namespaced broker in healthchecker

### DIFF
--- a/charts/healthcheck/README.md
+++ b/charts/healthcheck/README.md
@@ -42,6 +42,7 @@ Flag | Description
 --log_backtrace_at traceLocation | when logging hits line file:N, emit a stack trace (default :0)
 --log_dir string | If non-empty, write log files in this directory
 --logtostderr | log to standard error instead of files
+--namespaced-broker | whether to use a namespaced service broker (default false)
 --secure-port int | The port on which to serve HTTPS with authentication and authorization. If 0, don't serve HTTPS at all. (default 443)
 --stderrthreshold severity | logs at or above this threshold go to stderr (default 2)
 --tls-cert-file string | File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert). If HTTPS serving is enabled, and --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key are generated for the public address and saved to the directory specified by --cert-dir.

--- a/cmd/healthcheck/framework/options.go
+++ b/cmd/healthcheck/framework/options.go
@@ -36,6 +36,7 @@ type HealthCheckServer struct {
 	HealthCheckInterval  time.Duration
 	SecureServingOptions *genericoptions.SecureServingOptions
 	TestBrokerName       string
+	UseNamespacedBroker  bool
 }
 
 const (
@@ -62,5 +63,6 @@ func (s *HealthCheckServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.KubeContext, "kubernetes-context", "", "config context to use for kubernetes. If unset, will use value from 'current-context'")
 	fs.DurationVar(&s.HealthCheckInterval, "healthcheck-interval", s.HealthCheckInterval, "How frequently the end to end health check should be performed")
 	fs.StringVar(&s.TestBrokerName, "broker-name", "ups-broker", "Broker Name to test against - can only be ups-broker or osb-stub.  You must ensure the specified broker is deployed.")
+	fs.BoolVar(&s.UseNamespacedBroker, "namespaced-broker", false, "Whether to use a namespaced service broker")
 	s.SecureServingOptions.AddFlags(fs)
 }


### PR DESCRIPTION
This was already mostly-functional, since I changed the check for condition helper methods a bit back.

Fixes #2327