### PR TITLE
Fix the test-broker flags parsing

### DIFF
--- a/contrib/cmd/test-broker/test-broker.go
+++ b/contrib/cmd/test-broker/test-broker.go
@@ -41,10 +41,10 @@ var options struct {
 }
 
 func init() {
-	flags := flag.NewFlagSet("test-broker", flag.ExitOnError)
-	flag.IntVar(&options.Port, "port", 8005, "use '--port' option to specify the port for broker to listen on")
-	flag.StringVar(&options.TLSCert, "tlsCert", "", "base-64 encoded PEM block to use as the certificate for TLS. If '--tlsCert' is used, then '--tlsKey' must also be used. If '--tlsCert' is not used, then TLS will not be used.")
-	flag.StringVar(&options.TLSKey, "tlsKey", "", "base-64 encoded PEM block to use as the private key matching the TLS certificate. If '--tlsKey' is used, then '--tlsCert' must also be used")
+	flags = flag.NewFlagSet("test-broker", flag.ExitOnError)
+	flags.IntVar(&options.Port, "port", 8005, "use '--port' option to specify the port for broker to listen on")
+	flags.StringVar(&options.TLSCert, "tlsCert", "", "base-64 encoded PEM block to use as the certificate for TLS. If '--tlsCert' is used, then '--tlsKey' must also be used. If '--tlsCert' is not used, then TLS will not be used.")
+	flags.StringVar(&options.TLSKey, "tlsKey", "", "base-64 encoded PEM block to use as the private key matching the TLS certificate. If '--tlsKey' is used, then '--tlsCert' must also be used")
 	klog.InitFlags(flags)
 }
 
@@ -53,7 +53,6 @@ func main() {
 	if err != nil {
 		klog.Fatalln(err)
 	}
-	flag.Parse()
 	if err := run(); err != nil && err != context.Canceled && err != context.DeadlineExceeded {
 		klog.Fatalln(err)
 	}


### PR DESCRIPTION
This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

Right now when the test-broker will be executed then it always will throw the panic error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x10c4a36]

goroutine 1 [running]:
flag.(*FlagSet).Parse(0x0, 0xc000010150, 0x3, 0x3, 0xc0000200b8, 0x0)
        /usr/local/go/src/flag/flag.go:922 +0x26
main.main()
        /go/src/github.com/kubernetes-incubator/service-catalog/contrib/cmd/test-broker/test-broker.go:52 +0x77
exit status 2
```

This PR is fixing that problem.

