### PR TITLE
Fix the missing flag in the instance tests from the svcat package

### DIFF
--- a/cmd/svcat/instance/provision_cmd_test.go
+++ b/cmd/svcat/instance/provision_cmd_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
 	. "github.com/kubernetes-incubator/service-catalog/cmd/svcat/instance"
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/test"
+	_ "github.com/kubernetes-incubator/service-catalog/internal/test"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/svcat"
 	servicecatalog "github.com/kubernetes-incubator/service-catalog/pkg/svcat/service-catalog"


### PR DESCRIPTION
This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

Right now when the `make verify` target is executed on the master branch then we getting such error:
```
flag provided but not defined: -update
Usage of /var/folders/b4/gzypn_8d29q4tg7z787_m2940000gn/T/go-build853518847/b473/instance.test:
  -ginkgo.dryRun
        If set, ginkgo will walk the test hierarchy without actually running anything.  Best paired with -v.
  -ginkgo.failFast
        If set, ginkgo will stop running a test suite after a failure occurs.
  -ginkgo.failOnPending
        If set, ginkgo will mark the test suite as failed if any specs are pending.
  -ginkgo.flakeAttempts int
        Make up to this many attempts to run each spec. Please note that if any of the attempts succeed, the suite will not be failed. But any failures will still be recorded. (default 1)
  -ginkgo.focus string
        If set, ginkgo will only run specs that match this regular expression.
  -ginkgo.noColor
        If set, suppress color output in default reporter.
  -ginkgo.noisyPendings
        If set, default reporter will shout about pending tests. (default true)
  -ginkgo.parallel.node int
        This worker node's (one-indexed) node number.  For running specs in parallel. (default 1)
  -ginkgo.parallel.streamhost string
        The address for the server that the running nodes should stream data to.
  -ginkgo.parallel.synchost string
        The address for the server that will synchronize the running nodes.
  -ginkgo.parallel.total int
        The total number of worker nodes.  For running specs in parallel. (default 1)
  -ginkgo.progress
        If set, ginkgo will emit progress information as each spec runs to the GinkgoWriter.
  -ginkgo.randomizeAllSpecs
        If set, ginkgo will randomize all specs together.  By default, ginkgo only randomizes the top level Describe/Context groups.
  -ginkgo.regexScansFilePath
        If set, ginkgo regex matching also will look at the file path (code location).
  -ginkgo.seed int
        The seed used to randomize the spec suite. (default 1558105367)
  -ginkgo.skip string
        If set, ginkgo will only run specs that do not match this regular expression.
  -ginkgo.skipMeasurements
        If set, ginkgo will skip any measurement specs.
  -ginkgo.slowSpecThreshold float
        (in seconds) Specs that take longer to run than this threshold are flagged as slow by the default reporter. (default 5)
  -ginkgo.succinct
        If set, default reporter prints out a very succinct report
  -ginkgo.trace
        If set, default reporter prints out the full stack trace when a failure occurs
  -ginkgo.v
        If set, default reporter print out all specs as they begin.
  -test.bench regexp
        run only benchmarks matching regexp
  -test.benchmem
        print memory allocations for benchmarks
  -test.benchtime d
        run each benchmark for duration d (default 1s)
  -test.blockprofile file
        write a goroutine blocking profile to file
  -test.blockprofilerate rate
        set blocking profile rate (see runtime.SetBlockProfileRate) (default 1)
  -test.count n
        run tests and benchmarks n times (default 1)
  -test.coverprofile file
        write a coverage profile to file
  -test.cpu list
        comma-separated list of cpu counts to run each test with
  -test.cpuprofile file
        write a cpu profile to file
  -test.failfast
        do not start new tests after the first test failure
  -test.list regexp
        list tests, examples, and benchmarks matching regexp then exit
  -test.memprofile file
        write an allocation profile to file
  -test.memprofilerate rate
        set memory allocation profiling rate (see runtime.MemProfileRate)
  -test.mutexprofile string
        write a mutex contention profile to the named file after execution
  -test.mutexprofilefraction int
        if >= 0, calls runtime.SetMutexProfileFraction() (default 1)
  -test.outputdir dir
        write profiles to dir
  -test.parallel n
        run at most n tests in parallel (default 12)
  -test.run regexp
        run only tests and examples matching regexp
  -test.short
        run smaller test suite to save time
  -test.testlogfile file
        write test action log to file (for use only by cmd/go)
  -test.timeout d
        panic test binary after duration d (default 0, timeout disabled)
  -test.trace file
        write an execution trace to file
  -test.v
        verbose: print additional output
FAIL    github.com/kubernetes-incubator/service-catalog/cmd/svcat/instance      0.028s
```

The problem is that in _verify_ action there is a step:
**Validating golden file flag is defined**

To make it consistent I've added import 
```go
_ "github.com/kubernetes-incubator/service-catalog/internal/test"
```

in _provision_cmd_test.go_ test. Thanks to that the `update` flag is registered. 

## Concerns 
**But still, I do not know if this is the best way to solve that issue. Why the _verify_ action has such step? It is really necessary?**

**Maybe a better way, will be to remove it?**

Additionally, why the CI didn't detect that before merging PR https://github.com/kubernetes-incubator/service-catalog/pull/2618 into master?