### PR TITLE
Move closing stream after error handling, add container name in e2e scenario

### DIFF
--- a/test/e2e/walkthrough.go
+++ b/test/e2e/walkthrough.go
@@ -68,11 +68,13 @@ var _ = framework.ServiceCatalogDescribe("walkthrough", func() {
 	})
 
 	AfterEach(func() {
-		rc, err := f.KubeClientSet.CoreV1().Pods(f.Namespace.Name).GetLogs(upsbrokername, &v1.PodLogOptions{}).Stream()
-		defer rc.Close()
+		rc, err := f.KubeClientSet.CoreV1().Pods(f.Namespace.Name).GetLogs(upsbrokername, &v1.PodLogOptions{
+			Container: upsbrokername,
+		}).Stream()
 		if err != nil {
 			framework.Logf("Error getting logs for pod %s: %v", upsbrokername, err)
 		} else {
+			defer rc.Close()
 			buf := new(bytes.Buffer)
 			buf.ReadFrom(rc)
 			framework.Logf("Pod %s has the following logs:\n%sEnd %s logs", upsbrokername, buf.String(), upsbrokername)


### PR DESCRIPTION
This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

In e2e scenario:
- add container name while fetching the logs. If you do not specify the container name then the function can return an error when pod has multiple container, e.g. when u have enabled sidecar injection
  ```
  Error getting logs for pod ups-broker: a container name must be specified for pod ups-broker, choose one of: [ups-broker istio-proxy] or one of the init containers: [istio-init]
  ```
- move closing stream after error handling. If `GetLogs` command will fail then returned stream is `nil` and you cannot defer `Close` function on it because the panic will be thrown
  ```
  •! Panic in Spec Teardown (AfterEach) [24.577 seconds]
  [service-catalog] walkthrough
  /go/src/github.com/kubernetes-incubator/service-catalog/test/e2e/framework/framework.go:94
  Runs through the walkthrough with namespaced resources [AfterEach]
  /go/src/github.com/kubernetes-incubator/service-catalog/test/e2e/walkthrough.go:360

  Test Panicked
  runtime error: invalid memory address or nil pointer dereference
  /usr/local/go/src/runtime/panic.go:513

  Full Stack Trace
  /usr/local/go/src/runtime/panic.go:513 +0x1b9
  github.com/kubernetes-incubator/service-catalog/test/e2e.glob..func3.2()
  /go/src/github.com/kubernetes-incubator/service-catalog/test/e2e/walkthrough.go:72 +0x105
  github.com/kubernetes-incubator/service-catalog/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc000358660, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
  /go/src/github.com/kubernetes-incubator/service-catalog/test/e2e/e2e.go:46 +0x16c
  github.com/kubernetes-incubator/service-catalog/test/e2e.TestE2E(0xc000211100)
  /go/src/github.com/kubernetes-incubator/service-catalog/test/e2e/e2e_test.go:40 +0x2b
  testing.tRunner(0xc000211100, 0x1ef7f88)
  /usr/local/go/src/testing/testing.go:827 +0xbf
  created by testing.(*T).Run
  /usr/local/go/src/testing/testing.go:878 +0x353
  ```
