### PR TITLE
Bump debian-base images version to v1.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ FILE_EXT=
 endif
 
 # TODO: Consider using busybox instead of debian
-BASEIMAGE?=gcr.io/google-containers/debian-base-$(ARCH):0.3
+BASEIMAGE?=gcr.io/google-containers/debian-base-$(ARCH):v1.0.0
 
 GO_BUILD       = env CGO_ENABLED=0 GOOS=$(PLATFORM) GOARCH=$(ARCH) \
                   go build $(GOFLAGS) -a -tags netgo -installsuffix netgo \


### PR DESCRIPTION
See kubernetes/kubernetes commit d5546901104bc14a70699c301190c519cfa4abe7
master (#75678)

We should have upgraded to the 0.4 series a while ago, but didn't. Let's see how this goes.

This PR is a 
 - [x] chore

**What this PR does / why we need it**:
I'm thinking maybe it'll help with the xbuild errors, but then again, maybe not.