### PR TITLE
[Feature] Configurable Migration Timeout

### DIFF
--- a/cmd/migration/migration.go
+++ b/cmd/migration/migration.go
@@ -65,7 +65,7 @@ func RunCommand(opt *Options) error {
 	scInterface := scClient.ServicecatalogV1beta1()
 
 	svc := migration.NewMigrationService(scInterface, opt.StoragePath, opt.ReleaseNamespace, opt.ApiserverName, opt.WebhookServiceName, opt.WebhookServicePort, k8sCli)
-	scalingSvc := migration.NewScalingService(opt.ReleaseNamespace, opt.ControllerManagerName, k8sCli.AppsV1())
+	scalingSvc := migration.NewScalingService(opt.ReleaseNamespace, opt.ControllerManagerName, opt.MigrationTimeout, k8sCli.AppsV1())
 
 	switch opt.Action {
 	case backupActionName:

--- a/cmd/migration/options.go
+++ b/cmd/migration/options.go
@@ -35,7 +35,7 @@ const (
 	webhookServiceNameParameter      = "webhook-service-name"
 	webhookServicePortParameter      = "webhook-service-port"
 	pvcNameParameter                 = "pvc-name"
-	migrationTimeout                 = "migrationTimeout"
+	migrationTimeout                 = "migration-timeout"
 )
 
 // Options holds configuration for the migration job

--- a/cmd/migration/options.go
+++ b/cmd/migration/options.go
@@ -19,6 +19,7 @@ package migration
 import (
 	"fmt"
 	"github.com/spf13/pflag"
+	"time"
 )
 
 const (
@@ -34,6 +35,7 @@ const (
 	webhookServiceNameParameter      = "webhook-service-name"
 	webhookServicePortParameter      = "webhook-service-port"
 	pvcNameParameter                 = "pvc-name"
+	migrationTimeout                 = "migrationTimeout"
 )
 
 // Options holds configuration for the migration job
@@ -46,6 +48,7 @@ type Options struct {
 	WebhookServiceName        string
 	WebhookServicePort        string
 	PersistentVolumeClaimName string
+	MigrationTimeout          time.Duration
 }
 
 // NewMigrationOptions creates and returns a new Options
@@ -63,6 +66,7 @@ func (c *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.WebhookServiceName, webhookServiceNameParameter, "", "Name of webhook service")
 	fs.StringVar(&c.WebhookServicePort, webhookServicePortParameter, "", "Port of the webhook service")
 	fs.StringVar(&c.PersistentVolumeClaimName, pvcNameParameter, "", "Name of PersistentVolumeClaim in which resources will be stored")
+	fs.DurationVar(&c.MigrationTimeout, migrationTimeout, 45, "Time in seconds to wait for migration to complete")
 }
 
 // Validate checks flag has been set and has a proper value

--- a/pkg/migration/scale.go
+++ b/pkg/migration/scale.go
@@ -31,14 +31,16 @@ import (
 type ScalingService struct {
 	namespace      string
 	deploymentName string
+	timeout        time.Duration
 	appInterface   appsv1.AppsV1Interface
 }
 
 // NewScalingService creates a new ScalingService instance.
-func NewScalingService(namespace string, deploymentName string, appInterface appsv1.AppsV1Interface) *ScalingService {
+func NewScalingService(namespace string, deploymentName string, timeout time.Duration, appInterface appsv1.AppsV1Interface) *ScalingService {
 	return &ScalingService{
 		namespace:      namespace,
 		deploymentName: deploymentName,
+		timeout:        timeout,
 		appInterface:   appInterface,
 	}
 }
@@ -70,7 +72,7 @@ func (s *ScalingService) scaleTo(v int) error {
 		return err
 	}
 
-	err = wait.Poll(time.Second, time.Second*45, func() (bool, error) {
+	err = wait.Poll(time.Second, s.timeout, func() (bool, error) {
 		deploy, err := s.appInterface.Deployments(s.namespace).Get(context.Background(), s.deploymentName, metav1.GetOptions{})
 		if err != nil {
 			return false, err


### PR DESCRIPTION
This PR is a 
 - [x] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
In cases where an Istio proxy is injected to the controller-manager the time to migrate may take longer than 45 seconds. This strict limit should be configurable to allow for these cases.

This has been verified to resolve the issue in our environment.

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
